### PR TITLE
Decouple the "maker templates" from the domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.idea/
 /.vscode/
 /vendor/
+/TestModule/
 .phpunit.*
 .php_cs.cache

--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator;
+
+use Gacela\Framework\AbstractConfig;
+
+final class CodeGeneratorConfig extends AbstractConfig
+{
+    public function getFacadeMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('facade-maker.txt');
+    }
+
+    public function getFactoryMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('factory-maker.txt');
+    }
+
+    public function getConfigMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('config-maker.txt');
+    }
+
+    public function getDependencyProviderMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('dependency-provider-maker.txt');
+    }
+
+    private function getCommandTemplateContent(string $filename): string
+    {
+        return file_get_contents(__DIR__ . '/Infrastructure/Template/Command/' . $filename);
+    }
+}

--- a/src/CodeGenerator/CodeGeneratorFacade.php
+++ b/src/CodeGenerator/CodeGeneratorFacade.php
@@ -48,17 +48,11 @@ HELP;
      */
     public function runCommand(string $commandName, array $arguments = []): void
     {
-        [$rootNamespace, $targetDirectory] = array_pad($arguments, 2, null);
+        $commandArguments = $this->getFactory()
+            ->createCommandArgumentsParser()
+            ->parse($arguments);
 
-        if ($rootNamespace === null) {
-            throw new InvalidArgumentException('Expected 1st argument to be root-namespace of the project');
-        }
-
-        if ($targetDirectory === null) {
-            throw new InvalidArgumentException('Expected 2nd argument to be target-directory inside the project');
-        }
-
-        $this->createMaker($commandName)->make($rootNamespace, $targetDirectory);
+        $this->createMaker($commandName)->make($commandArguments);
     }
 
     private function createMaker(string $commandName): MakerInterface

--- a/src/CodeGenerator/CodeGeneratorFactory.php
+++ b/src/CodeGenerator/CodeGeneratorFactory.php
@@ -9,6 +9,7 @@ use Gacela\CodeGenerator\Domain\Command\DependencyProviderMaker;
 use Gacela\CodeGenerator\Domain\Command\FacadeMaker;
 use Gacela\CodeGenerator\Domain\Command\FactoryMaker;
 use Gacela\CodeGenerator\Domain\Command\ModuleMaker;
+use Gacela\CodeGenerator\Domain\Io\CommandArgumentsParser;
 use Gacela\CodeGenerator\Domain\Io\MakerIoInterface;
 use Gacela\CodeGenerator\Infrastructure\Io\SystemMakerIo;
 use Gacela\Framework\AbstractFactory;
@@ -59,5 +60,10 @@ final class CodeGeneratorFactory extends AbstractFactory
     private function createGeneratorIo(): MakerIoInterface
     {
         return new SystemMakerIo();
+    }
+
+    public function createCommandArgumentsParser(): CommandArgumentsParser
+    {
+        return new CommandArgumentsParser();
     }
 }

--- a/src/CodeGenerator/CodeGeneratorFactory.php
+++ b/src/CodeGenerator/CodeGeneratorFactory.php
@@ -14,6 +14,9 @@ use Gacela\CodeGenerator\Domain\Io\MakerIoInterface;
 use Gacela\CodeGenerator\Infrastructure\Io\SystemMakerIo;
 use Gacela\Framework\AbstractFactory;
 
+/**
+ * @method CodeGeneratorConfig getConfig()
+ */
 final class CodeGeneratorFactory extends AbstractFactory
 {
     public function createModuleMaker(): ModuleMaker
@@ -32,28 +35,32 @@ final class CodeGeneratorFactory extends AbstractFactory
     public function createFacadeMaker(): FacadeMaker
     {
         return new FacadeMaker(
-            $this->createGeneratorIo()
+            $this->createGeneratorIo(),
+            $this->getConfig()->getFacadeMakerTemplate()
         );
     }
 
     public function createFactoryMaker(): FactoryMaker
     {
         return new FactoryMaker(
-            $this->createGeneratorIo()
+            $this->createGeneratorIo(),
+            $this->getConfig()->getFactoryMakerTemplate()
         );
     }
 
     public function createConfigMaker(): ConfigMaker
     {
         return new ConfigMaker(
-            $this->createGeneratorIo()
+            $this->createGeneratorIo(),
+            $this->getConfig()->getConfigMakerTemplate()
         );
     }
 
     public function createDependencyProviderMaker(): DependencyProviderMaker
     {
         return new DependencyProviderMaker(
-            $this->createGeneratorIo()
+            $this->createGeneratorIo(),
+            $this->getConfig()->getDependencyProviderMakerTemplate()
         );
     }
 

--- a/src/CodeGenerator/Domain/Command/AbstractMaker.php
+++ b/src/CodeGenerator/Domain/Command/AbstractMaker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\CodeGenerator\Domain\Command;
 
 use Gacela\CodeGenerator\Domain\Io\MakerIoInterface;
+use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
 
 abstract class AbstractMaker implements MakerInterface
 {
@@ -15,15 +16,15 @@ abstract class AbstractMaker implements MakerInterface
         $this->io = $io;
     }
 
-    public function make(string $rootNamespace, string $targetDirectory): void
+    public function make(CommandArguments $commandArguments): void
     {
-        $pieces = explode('/', $targetDirectory);
+        $pieces = explode('/', $commandArguments->targetDirectory());
         $moduleName = end($pieces);
 
-        $this->io->createDirectory($targetDirectory);
+        $this->io->createDirectory($commandArguments->targetDirectory());
 
-        $path = sprintf('%s/%s.php', $targetDirectory, $this->className());
-        $this->io->filePutContents($path, $this->generateFileContent("$rootNamespace\\$moduleName"));
+        $path = sprintf('%s/%s.php', $commandArguments->targetDirectory(), $this->className());
+        $this->io->filePutContents($path, $this->generateFileContent("{$commandArguments->rootNamespace()}\\$moduleName"));
 
         $this->io->writeln("> Path '$path' created successfully");
     }

--- a/src/CodeGenerator/Domain/Command/AbstractMaker.php
+++ b/src/CodeGenerator/Domain/Command/AbstractMaker.php
@@ -10,9 +10,11 @@ use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
 abstract class AbstractMaker implements MakerInterface
 {
     private MakerIoInterface $io;
+    private string $template;
 
-    public function __construct(MakerIoInterface $io)
+    public function __construct(MakerIoInterface $io, string $template)
     {
+        $this->template = $template;
         $this->io = $io;
     }
 
@@ -29,7 +31,13 @@ abstract class AbstractMaker implements MakerInterface
         $this->io->writeln("> Path '$path' created successfully");
     }
 
-    abstract protected function generateFileContent(string $namespace): string;
-
     abstract protected function className(): string;
+
+    private function generateFileContent(string $namespace): string
+    {
+        $search = ['$NAMESPACE$', '$CLASS_NAME$'];
+        $replace = [$namespace, $this->className()];
+
+        return str_replace($search, $replace, $this->template);
+    }
 }

--- a/src/CodeGenerator/Domain/Command/ConfigMaker.php
+++ b/src/CodeGenerator/Domain/Command/ConfigMaker.php
@@ -6,24 +6,6 @@ namespace Gacela\CodeGenerator\Domain\Command;
 
 final class ConfigMaker extends AbstractMaker
 {
-    protected function generateFileContent(string $namespace): string
-    {
-        return <<<TEXT
-<?php
-
-declare(strict_types=1);
-
-namespace {$namespace};
-
-use Gacela\Framework\AbstractConfig;
-
-final class {$this->className()} extends AbstractConfig
-{
-}
-
-TEXT;
-    }
-
     protected function className(): string
     {
         return 'Config';

--- a/src/CodeGenerator/Domain/Command/DependencyProviderMaker.php
+++ b/src/CodeGenerator/Domain/Command/DependencyProviderMaker.php
@@ -6,28 +6,6 @@ namespace Gacela\CodeGenerator\Domain\Command;
 
 final class DependencyProviderMaker extends AbstractMaker
 {
-    protected function generateFileContent(string $namespace): string
-    {
-        return <<<TEXT
-<?php
-
-declare(strict_types=1);
-
-namespace {$namespace};
-
-use Gacela\Framework\AbstractDependencyProvider;
-use Gacela\Framework\Container\Container;
-
-final class {$this->className()} extends AbstractDependencyProvider
-{
-    public function provideModuleDependencies(Container \$container): void
-    {
-    }
-}
-
-TEXT;
-    }
-
     protected function className(): string
     {
         return 'DependencyProvider';

--- a/src/CodeGenerator/Domain/Command/FacadeMaker.php
+++ b/src/CodeGenerator/Domain/Command/FacadeMaker.php
@@ -6,27 +6,6 @@ namespace Gacela\CodeGenerator\Domain\Command;
 
 final class FacadeMaker extends AbstractMaker
 {
-    protected function generateFileContent(string $namespace): string
-    {
-        return <<<TEXT
-<?php
-
-declare(strict_types=1);
-
-namespace {$namespace};
-
-use Gacela\Framework\AbstractFacade;
-
-/**
- * @method Factory getFactory()
- */
-final class {$this->className()} extends AbstractFacade
-{
-}
-
-TEXT;
-    }
-
     protected function className(): string
     {
         return 'Facade';

--- a/src/CodeGenerator/Domain/Command/FactoryMaker.php
+++ b/src/CodeGenerator/Domain/Command/FactoryMaker.php
@@ -6,27 +6,6 @@ namespace Gacela\CodeGenerator\Domain\Command;
 
 final class FactoryMaker extends AbstractMaker
 {
-    protected function generateFileContent(string $namespace): string
-    {
-        return <<<TEXT
-<?php
-
-declare(strict_types=1);
-
-namespace {$namespace};
-
-use Gacela\Framework\AbstractFactory;
-
-/**
- * @method Config getConfig()
- */
-final class {$this->className()} extends AbstractFactory
-{
-}
-
-TEXT;
-    }
-
     protected function className(): string
     {
         return 'Factory';

--- a/src/CodeGenerator/Domain/Command/MakerInterface.php
+++ b/src/CodeGenerator/Domain/Command/MakerInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\CodeGenerator\Domain\Command;
 
+use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
+
 interface MakerInterface
 {
-    public function make(string $rootNamespace, string $targetDirectory): void;
+    public function make(CommandArguments $commandArguments): void;
 }

--- a/src/CodeGenerator/Domain/Command/ModuleMaker.php
+++ b/src/CodeGenerator/Domain/Command/ModuleMaker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\CodeGenerator\Domain\Command;
 
 use Gacela\CodeGenerator\Domain\Io\MakerIoInterface;
+use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
 
 final class ModuleMaker implements MakerInterface
 {
@@ -22,13 +23,13 @@ final class ModuleMaker implements MakerInterface
         $this->generators = $generators;
     }
 
-    public function make(string $rootNamespace, string $targetDirectory): void
+    public function make(CommandArguments $commandArguments): void
     {
         foreach ($this->generators as $generator) {
-            $generator->make($rootNamespace, $targetDirectory);
+            $generator->make($commandArguments);
         }
 
-        $pieces = explode('/', $targetDirectory);
+        $pieces = explode('/', $commandArguments->targetDirectory());
         $moduleName = end($pieces);
         $this->io->writeln("Module $moduleName created successfully");
     }

--- a/src/CodeGenerator/Domain/Io/CommandArgumentsParser.php
+++ b/src/CodeGenerator/Domain/Io/CommandArgumentsParser.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\Io;
+
+use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
+use InvalidArgumentException;
+
+final class CommandArgumentsParser
+{
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function parse(array $arguments): CommandArguments
+    {
+        [$rootNamespace, $targetDirectory] = array_pad($arguments, 2, null);
+
+        if ($rootNamespace === null) {
+            throw new InvalidArgumentException('Expected 1st argument to be root-namespace of the project');
+        }
+
+        if ($targetDirectory === null) {
+            throw new InvalidArgumentException('Expected 2nd argument to be target-directory inside the project');
+        }
+
+        return new CommandArguments($rootNamespace, $targetDirectory);
+    }
+}

--- a/src/CodeGenerator/Domain/ReadModel/CommandArguments.php
+++ b/src/CodeGenerator/Domain/ReadModel/CommandArguments.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\ReadModel;
+
+final class CommandArguments
+{
+    private string $rootNamespace;
+    private string $targetDirectory;
+
+    public function __construct(string $rootNamespace, string $targetDirectory)
+    {
+        $this->rootNamespace = $rootNamespace;
+        $this->targetDirectory = $targetDirectory;
+    }
+
+    public function rootNamespace(): string
+    {
+        return $this->rootNamespace;
+    }
+
+    public function targetDirectory(): string
+    {
+        return $this->targetDirectory;
+    }
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/config-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/config-maker.txt
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractConfig;
+
+final class $CLASS_NAME$ extends AbstractConfig
+{
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/dependency-provider-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/dependency-provider-maker.txt
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class $CLASS_NAME$ extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/facade-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/facade-maker.txt
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class $CLASS_NAME$ extends AbstractFacade
+{
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/factory-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/factory-maker.txt
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method Config getConfig()
+ */
+final class $CLASS_NAME$ extends AbstractFactory
+{
+}


### PR DESCRIPTION
## 🔖 Changes

- Decouple the maker templates from the domain. Inject them instead.

I will create a follow-up PR refactoring the `CommandArgumentsParser` in order to achieve what we talked a few days ago about the "1 argument only needed":
> php gacela make:module Gacela/TestModule