### PR TITLE
Pass only one argument to the "maker command"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 /.idea/
 /.vscode/
 /vendor/
-/TestModule/
 .phpunit.*
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         ],
         "test-unit": "./vendor/bin/phpunit --testsuite=unit",
         "test-integration": "./vendor/bin/phpunit --testsuite=integration",
-        "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=integration --coverage-html=coverage",
+        "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=unit,integration --coverage-html=coverage",
         "psalm": "./vendor/bin/psalm",
         "csfix": "./vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "csrun": "./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "php": ">=7.4"
     },
     "require-dev": {
@@ -39,12 +40,14 @@
     "scripts": {
         "test-all": [
             "@test-quality",
+            "@test-unit",
             "@test-integration"
         ],
         "test-quality": [
             "@csrun",
             "@psalm"
         ],
+        "test-unit": "./vendor/bin/phpunit --testsuite=unit",
         "test-integration": "./vendor/bin/phpunit --testsuite=integration",
         "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=integration --coverage-html=coverage",
         "psalm": "./vendor/bin/psalm",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,10 @@
     </php>
 
     <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
+
         <testsuite name="integration">
             <directory suffix="Test.php">tests/Integration</directory>
         </testsuite>

--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -6,6 +6,7 @@ namespace Gacela\CodeGenerator;
 
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\Config;
+use LogicException;
 
 final class CodeGeneratorConfig extends AbstractConfig
 {
@@ -38,7 +39,7 @@ final class CodeGeneratorConfig extends AbstractConfig
     {
         $filename = Config::getApplicationRootDir() . '/composer.json';
         if (!file_exists($filename)) {
-            return [];
+            throw new LogicException('composer.json file not found but it is required');
         }
 
         return json_decode(file_get_contents($filename), true);

--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\CodeGenerator;
 
 use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\Config;
 
 final class CodeGeneratorConfig extends AbstractConfig
 {
@@ -31,5 +32,15 @@ final class CodeGeneratorConfig extends AbstractConfig
     private function getCommandTemplateContent(string $filename): string
     {
         return file_get_contents(__DIR__ . '/Infrastructure/Template/Command/' . $filename);
+    }
+
+    public function getComposerJsonContentAsArray(): array
+    {
+        $filename = Config::getApplicationRootDir() . '/composer.json';
+        if (!file_exists($filename)) {
+            return [];
+        }
+
+        return json_decode(file_get_contents($filename), true);
     }
 }

--- a/src/CodeGenerator/CodeGeneratorFactory.php
+++ b/src/CodeGenerator/CodeGeneratorFactory.php
@@ -9,7 +9,7 @@ use Gacela\CodeGenerator\Domain\Command\DependencyProviderMaker;
 use Gacela\CodeGenerator\Domain\Command\FacadeMaker;
 use Gacela\CodeGenerator\Domain\Command\FactoryMaker;
 use Gacela\CodeGenerator\Domain\Command\ModuleMaker;
-use Gacela\CodeGenerator\Domain\Io\CommandArgumentsParser;
+use Gacela\CodeGenerator\Domain\Io\CommandArguments\CommandArgumentsParser;
 use Gacela\CodeGenerator\Domain\Io\MakerIoInterface;
 use Gacela\CodeGenerator\Infrastructure\Io\SystemMakerIo;
 use Gacela\Framework\AbstractFactory;

--- a/src/CodeGenerator/CodeGeneratorFactory.php
+++ b/src/CodeGenerator/CodeGeneratorFactory.php
@@ -71,6 +71,8 @@ final class CodeGeneratorFactory extends AbstractFactory
 
     public function createCommandArgumentsParser(): CommandArgumentsParser
     {
-        return new CommandArgumentsParser();
+        return new CommandArgumentsParser(
+            $this->getConfig()->getComposerJsonContentAsArray()
+        );
     }
 }

--- a/src/CodeGenerator/Domain/Command/AbstractMaker.php
+++ b/src/CodeGenerator/Domain/Command/AbstractMaker.php
@@ -20,13 +20,10 @@ abstract class AbstractMaker implements MakerInterface
 
     public function make(CommandArguments $commandArguments): void
     {
-        $pieces = explode('/', $commandArguments->targetDirectory());
-        $moduleName = end($pieces);
+        $this->io->createDirectory($commandArguments->directory());
 
-        $this->io->createDirectory($commandArguments->targetDirectory());
-
-        $path = sprintf('%s/%s.php', $commandArguments->targetDirectory(), $this->className());
-        $this->io->filePutContents($path, $this->generateFileContent("{$commandArguments->rootNamespace()}\\$moduleName"));
+        $path = sprintf('%s/%s.php', $commandArguments->directory(), $this->className());
+        $this->io->filePutContents($path, $this->generateFileContent($commandArguments->namespace()));
 
         $this->io->writeln("> Path '$path' created successfully");
     }

--- a/src/CodeGenerator/Domain/Command/ModuleMaker.php
+++ b/src/CodeGenerator/Domain/Command/ModuleMaker.php
@@ -29,7 +29,7 @@ final class ModuleMaker implements MakerInterface
             $generator->make($commandArguments);
         }
 
-        $pieces = explode('/', $commandArguments->targetDirectory());
+        $pieces = explode('/', $commandArguments->directory());
         $moduleName = end($pieces);
         $this->io->writeln("Module $moduleName created successfully");
     }

--- a/src/CodeGenerator/Domain/Io/CommandArguments/CommandArgumentsParser.php
+++ b/src/CodeGenerator/Domain/Io/CommandArguments/CommandArgumentsParser.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Gacela\CodeGenerator\Domain\Io;
+namespace Gacela\CodeGenerator\Domain\Io\CommandArguments;
 
+use Gacela\CodeGenerator\Domain\Io\CommandArguments\Exception\CommandArgumentsException;
 use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
 use InvalidArgumentException;
-use LogicException;
 
 final class CommandArgumentsParser
 {
@@ -31,6 +31,14 @@ final class CommandArgumentsParser
 
     private function createCommandArguments(string $desiredNamespace): CommandArguments
     {
+        if (!isset($this->composerJson['autoload'])) {
+            throw CommandArgumentsException::noAutoloadFound();
+        }
+
+        if (!isset($this->composerJson['autoload']['psr-4'])) {
+            throw CommandArgumentsException::noAutoloadPsr4Found();
+        }
+
         $psr4 = $this->composerJson['autoload']['psr-4'];
         $allPsr4Combinations = $this->allPossiblePsr4Combinations($desiredNamespace);
 
@@ -41,7 +49,7 @@ final class CommandArgumentsParser
             }
         }
 
-        throw new LogicException('No autoload psr-4 match found for ' . $desiredNamespace);
+        throw CommandArgumentsException::noAutoloadPsr4MatchFound($desiredNamespace);
     }
 
     /**

--- a/src/CodeGenerator/Domain/Io/CommandArguments/Exception/CommandArgumentsException.php
+++ b/src/CodeGenerator/Domain/Io/CommandArguments/Exception/CommandArgumentsException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\Io\CommandArguments\Exception;
+
+use RuntimeException;
+
+final class CommandArgumentsException extends RuntimeException
+{
+    public static function noAutoloadFound(): self
+    {
+        return new self('No autoload found in your composer.json');
+    }
+
+    public static function noAutoloadPsr4Found(): self
+    {
+        return new self('No autoload psr-4 match found in your composer.json');
+    }
+
+    public static function noAutoloadPsr4MatchFound(string $desiredNamespace): self
+    {
+        return new self('No autoload psr-4 match found for ' . $desiredNamespace);
+    }
+}

--- a/src/CodeGenerator/Domain/Io/CommandArgumentsParser.php
+++ b/src/CodeGenerator/Domain/Io/CommandArgumentsParser.php
@@ -6,24 +6,77 @@ namespace Gacela\CodeGenerator\Domain\Io;
 
 use Gacela\CodeGenerator\Domain\ReadModel\CommandArguments;
 use InvalidArgumentException;
+use LogicException;
 
 final class CommandArgumentsParser
 {
+    private array $composerJson;
+
+    public function __construct(array $composerJson)
+    {
+        $this->composerJson = $composerJson;
+    }
+
     /**
      * @throws InvalidArgumentException
      */
     public function parse(array $arguments): CommandArguments
     {
-        [$rootNamespace, $targetDirectory] = array_pad($arguments, 2, null);
-
-        if ($rootNamespace === null) {
-            throw new InvalidArgumentException('Expected 1st argument to be root-namespace of the project');
+        if (empty($arguments)) {
+            throw new InvalidArgumentException('Expected argument to be the location of the new module. For example: App/TestModule');
         }
 
-        if ($targetDirectory === null) {
-            throw new InvalidArgumentException('Expected 2nd argument to be target-directory inside the project');
+        return $this->createCommandArguments($arguments[0]);
+    }
+
+    private function createCommandArguments(string $desiredNamespace): CommandArguments
+    {
+        $psr4 = $this->composerJson['autoload']['psr-4'];
+        $allPsr4Combinations = $this->allPossiblePsr4Combinations($desiredNamespace);
+
+        foreach ($allPsr4Combinations as $psr4Combination) {
+            $psr4Key = $psr4Combination . '\\';
+            if (isset($psr4[$psr4Key])) {
+                return $this->foundPsr4($psr4Key, $psr4[$psr4Key], $desiredNamespace);
+            }
         }
 
-        return new CommandArguments($rootNamespace, $targetDirectory);
+        throw new LogicException('No autoload psr-4 match found for ' . $desiredNamespace);
+    }
+
+    /**
+     * Combine all possible psr-4 combinations and return them ordered by longer to shorter.
+     * This way we'll be able to find the longer match first.
+     * For example: App/TestModule/TestSubModule will produce an array such as:
+     * [
+     *   'App/TestModule/TestSubModule',
+     *   'App/TestModule',
+     *   'App',
+     * ].
+     */
+    private function allPossiblePsr4Combinations(string $desiredNamespace): array
+    {
+        $result = [];
+
+        foreach (explode('/', $desiredNamespace) as $explodedArg) {
+            if (empty($result)) {
+                $result[] = $explodedArg;
+            } else {
+                $prevValue = $result[count($result) - 1];
+                $result[] = $prevValue . '\\' . $explodedArg;
+            }
+        }
+
+        return array_reverse($result);
+    }
+
+    private function foundPsr4(string $psr4Key, string $psr4Value, string $desiredNamespace): CommandArguments
+    {
+        $rootDir = substr($psr4Value, 0, -1);
+        $rootNamespace = substr($psr4Key, 0, -1);
+        $targetDirectory = str_replace(['/', $rootNamespace, '\\'], ['\\', $rootDir, '/'], $desiredNamespace);
+        $namespace = str_replace([$rootDir, '/'], [$rootNamespace, '\\'], $targetDirectory);
+
+        return new CommandArguments($namespace, $targetDirectory);
     }
 }

--- a/src/CodeGenerator/Domain/ReadModel/CommandArguments.php
+++ b/src/CodeGenerator/Domain/ReadModel/CommandArguments.php
@@ -6,22 +6,22 @@ namespace Gacela\CodeGenerator\Domain\ReadModel;
 
 final class CommandArguments
 {
-    private string $rootNamespace;
-    private string $targetDirectory;
+    private string $namespace;
+    private string $directory;
 
-    public function __construct(string $rootNamespace, string $targetDirectory)
+    public function __construct(string $namespace, string $directory)
     {
-        $this->rootNamespace = $rootNamespace;
-        $this->targetDirectory = $targetDirectory;
+        $this->namespace = $namespace;
+        $this->directory = $directory;
     }
 
-    public function rootNamespace(): string
+    public function namespace(): string
     {
-        return $this->rootNamespace;
+        return $this->namespace;
     }
 
-    public function targetDirectory(): string
+    public function directory(): string
     {
-        return $this->targetDirectory;
+        return $this->directory;
     }
 }

--- a/tests/Integration/CodeGenerator/UsingIncorrectConfigurationTest.php
+++ b/tests/Integration/CodeGenerator/UsingIncorrectConfigurationTest.php
@@ -5,32 +5,37 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\Framework\Config;
 use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 final class UsingIncorrectConfigurationTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Config::setApplicationRootDir(__DIR__);
+    }
+
     public function test_make_unknown_command(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $codeGeneratorConfig = new CodeGeneratorFacade();
-        $codeGeneratorConfig->runCommand('make:unknown', [__NAMESPACE__, __DIR__ . '/Generated']);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:unknown', ['GacelaTest/Integration/CodeGenerator/Generated']);
     }
 
-    public function test_missing_target_directory(): void
+    public function test_missing_target(): void
     {
         $this->expectException(InvalidArgumentException::class);
-
-        $codeGeneratorConfig = new CodeGeneratorFacade();
-        $codeGeneratorConfig->runCommand('', [__NAMESPACE__]);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:module', []);
     }
 
-    public function test_missing_root_namespace_and_target_directory(): void
+    public function test_unknown_target(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $codeGeneratorConfig = new CodeGeneratorFacade();
-        $codeGeneratorConfig->runCommand('', []);
+        $this->expectException(LogicException::class);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:module', ['UnknownNamespace']);
     }
 }

--- a/tests/Integration/CodeGenerator/UsingIncorrectConfigurationTest.php
+++ b/tests/Integration/CodeGenerator/UsingIncorrectConfigurationTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\CodeGenerator\Domain\Io\CommandArguments\Exception\CommandArgumentsException;
 use Gacela\Framework\Config;
 use InvalidArgumentException;
-use LogicException;
 use PHPUnit\Framework\TestCase;
 
 final class UsingIncorrectConfigurationTest extends TestCase
@@ -34,7 +34,7 @@ final class UsingIncorrectConfigurationTest extends TestCase
 
     public function test_unknown_target(): void
     {
-        $this->expectException(LogicException::class);
+        $this->expectExceptionObject(CommandArgumentsException::noAutoloadPsr4MatchFound('UnknownNamespace'));
         $facade = new CodeGeneratorFacade();
         $facade->runCommand('make:module', ['UnknownNamespace']);
     }

--- a/tests/Integration/CodeGenerator/UsingMakeConfigTest.php
+++ b/tests/Integration/CodeGenerator/UsingMakeConfigTest.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\Framework\Config;
 use GacelaTest\Integration\CodeGenerator\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class UsingMakeConfigTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Config::setApplicationRootDir(__DIR__);
+    }
+
     public function test_make_config(): void
     {
         self::assertFileDoesNotExist(__DIR__ . '/Generated/Config.php');
 
-        $codeGeneratorConfig = new CodeGeneratorFacade();
-        $codeGeneratorConfig->runCommand('make:config', [__NAMESPACE__, __DIR__ . '/Generated']);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:config', ['GacelaTest/Integration/CodeGenerator/Generated']);
 
         $this->expectOutputRegex("~/Generated/Config.php' created successfully~");
         self::assertFileExists(__DIR__ . '/Generated/Config.php');

--- a/tests/Integration/CodeGenerator/UsingMakeDependencyProviderTest.php
+++ b/tests/Integration/CodeGenerator/UsingMakeDependencyProviderTest.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\Framework\Config;
 use GacelaTest\Integration\CodeGenerator\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class UsingMakeDependencyProviderTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Config::setApplicationRootDir(__DIR__);
+    }
+
     public function test_make_dependency_provider(): void
     {
         self::assertFileDoesNotExist(__DIR__ . '/Generated/DependencyProvider.php');
 
-        $codeGeneratorDependencyProvider = new CodeGeneratorFacade();
-        $codeGeneratorDependencyProvider->runCommand('make:dependency-provider', [__NAMESPACE__, __DIR__ . '/Generated']);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:dependency-provider', ['GacelaTest/Integration/CodeGenerator/Generated']);
 
         $this->expectOutputRegex("~/Generated/DependencyProvider.php' created successfully~");
         self::assertFileExists(__DIR__ . '/Generated/DependencyProvider.php');

--- a/tests/Integration/CodeGenerator/UsingMakeFacadeTest.php
+++ b/tests/Integration/CodeGenerator/UsingMakeFacadeTest.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\Framework\Config;
 use GacelaTest\Integration\CodeGenerator\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class UsingMakeFacadeTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Config::setApplicationRootDir(__DIR__);
+    }
+
     public function test_make_facade(): void
     {
         self::assertFileDoesNotExist(__DIR__ . '/Generated/Facade.php');
 
-        $codeGeneratorFacade = new CodeGeneratorFacade();
-        $codeGeneratorFacade->runCommand('make:facade', [__NAMESPACE__, __DIR__ . '/Generated']);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:facade', ['GacelaTest/Integration/CodeGenerator/Generated']);
 
         $this->expectOutputRegex("~/Generated/Facade.php' created successfully~");
         self::assertFileExists(__DIR__ . '/Generated/Facade.php');

--- a/tests/Integration/CodeGenerator/UsingMakeFactoryTest.php
+++ b/tests/Integration/CodeGenerator/UsingMakeFactoryTest.php
@@ -5,21 +5,27 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\Framework\Config;
 use GacelaTest\Integration\CodeGenerator\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class UsingMakeFactoryTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Config::setApplicationRootDir(__DIR__);
+    }
+
     public function test_make_factory(): void
     {
         self::assertFileDoesNotExist(__DIR__ . '/Generated/Factory.php');
 
-        $codeGeneratorFactory = new CodeGeneratorFacade();
-        $codeGeneratorFactory->runCommand('make:factory', [__NAMESPACE__, __DIR__ . '/Generated']);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:factory', ['GacelaTest/Integration/CodeGenerator/Generated']);
 
         $this->expectOutputRegex("~/Generated/Factory.php' created successfully~");
         self::assertFileExists(__DIR__ . '/Generated/Factory.php');
 
-        DirectoryUtil::removeDir(__DIR__ . '/Generated');
+        DirectoryUtil::removeDir(__DIR__ . '/Generated/');
     }
 }

--- a/tests/Integration/CodeGenerator/UsingMakeModuleTest.php
+++ b/tests/Integration/CodeGenerator/UsingMakeModuleTest.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\CodeGenerator;
 
 use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\Framework\Config;
 use GacelaTest\Integration\CodeGenerator\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class UsingMakeModuleTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Config::setApplicationRootDir(__DIR__);
+    }
+
     public function test_make_module(): void
     {
         self::assertFileDoesNotExist(__DIR__ . '/Generated/Module.php');
 
-        $codeGeneratorModule = new CodeGeneratorFacade();
-        $codeGeneratorModule->runCommand('make:module', [__NAMESPACE__, __DIR__ . '/Generated']);
+        $facade = new CodeGeneratorFacade();
+        $facade->runCommand('make:module', ['GacelaTest/Integration/CodeGenerator/Generated']);
 
         $this->expectOutputRegex("~/Generated/Facade.php' created successfully~");
         $this->expectOutputRegex("~/Generated/Factory.php' created successfully~");

--- a/tests/Integration/CodeGenerator/composer.json
+++ b/tests/Integration/CodeGenerator/composer.json
@@ -1,0 +1,7 @@
+{
+  "autoload": {
+    "psr-4": {
+      "GacelaTest\\": "tests/"
+    }
+  }
+}

--- a/tests/Integration/Framework/UsingConfig/LocalConfig/Config.php
+++ b/tests/Integration/Framework/UsingConfig/LocalConfig/Config.php
@@ -11,9 +11,9 @@ final class Config extends AbstractConfig
     public function getArrayConfig(): array
     {
         return [
-            'config' => (int) $this->get('config'),
-            'config_local' => (int) $this->get('config_local'),
-            'override' => (int) $this->get('override'),
+            'config' => (int)$this->get('config'),
+            'config_local' => (int)$this->get('config_local'),
+            'override' => (int)$this->get('override'),
         ];
     }
 }

--- a/tests/Unit/CodeGenerator/Io/CommandArguments/CommandArgumentsParserTest.php
+++ b/tests/Unit/CodeGenerator/Io/CommandArguments/CommandArgumentsParserTest.php
@@ -2,15 +2,38 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Unit\CodeGenerator\Io;
+namespace GacelaTest\Unit\CodeGenerator\Io\CommandArguments;
 
-use Gacela\CodeGenerator\Domain\Io\CommandArgumentsParser;
+use Gacela\CodeGenerator\Domain\Io\CommandArguments\CommandArgumentsParser;
+use Gacela\CodeGenerator\Domain\Io\CommandArguments\Exception\CommandArgumentsException;
 use Generator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use function json_decode;
 
 final class CommandArgumentsParserTest extends TestCase
 {
+    public function test_exception_when_no_arguments_are_given(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $parser = new CommandArgumentsParser([]);
+        $parser->parse([]);
+    }
+
+    public function test_exception_when_no_autoload_found(): void
+    {
+        $this->expectExceptionObject(CommandArgumentsException::noAutoloadFound());
+        $parser = new CommandArgumentsParser([]);
+        $parser->parse(['']);
+    }
+
+    public function test_exception_when_no_psr4_found(): void
+    {
+        $this->expectExceptionObject(CommandArgumentsException::noAutoloadPsr4Found());
+        $parser = new CommandArgumentsParser(['autoload' => []]);
+        $parser->parse(['']);
+    }
+
     /**
      * @dataProvider providerOneLevelRootNamespace
      */

--- a/tests/Unit/CodeGenerator/Io/CommandArgumentsParserTest.php
+++ b/tests/Unit/CodeGenerator/Io/CommandArgumentsParserTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\CodeGenerator\Io;
+
+use Gacela\CodeGenerator\Domain\Io\CommandArgumentsParser;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use function json_decode;
+
+final class CommandArgumentsParserTest extends TestCase
+{
+    /**
+     * @dataProvider providerOneLevelRootNamespace
+     */
+    public function test_parse_one_level_root_namespace(array $arguments, string $expected): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse($arguments);
+
+        self::assertSame($expected, $args->namespace());
+    }
+
+    public function providerOneLevelRootNamespace(): Generator
+    {
+        yield 'One level composer psr-4 and one level namespace' => [
+            'arguments' => ['App/TestModule'],
+            'expected' => 'App\TestModule',
+        ];
+
+        yield 'One level composer psr-4 but multiple level namespace' => [
+            'arguments' => ['App/TestModule/TestSubModule'],
+            'expected' => 'App\TestModule\TestSubModule',
+        ];
+    }
+
+    /**
+     * @dataProvider providerOneLevelTargetDirectory
+     */
+    public function test_parse_one_level_target_directory(array $arguments, string $expected): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse($arguments);
+
+        self::assertSame($expected, $args->directory());
+    }
+
+    public function providerOneLevelTargetDirectory(): Generator
+    {
+        yield 'One level composer psr-4 and one level namespace' => [
+            'arguments' => ['App/TestModule'],
+            'expected' => 'src/TestModule',
+        ];
+
+        yield 'One level composer psr-4 but multiple level namespace' => [
+            'arguments' => ['App/TestModule/TestSubModule'],
+            'expected' => 'src/TestModule/TestSubModule',
+        ];
+    }
+
+    private function exampleOneLevelComposerJson(): array
+    {
+        $composerJson = <<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+JSON;
+        return json_decode($composerJson, true);
+    }
+
+    public function test_parse_multilevel_root_namespace(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleMultiLevelComposerJson());
+        $args = $parser->parse(['App/TestModule/TestSubModule']);
+
+        self::assertSame('App\TestModule\TestSubModule', $args->namespace());
+    }
+
+    public function test_parse_multilevel_target_directory(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleMultiLevelComposerJson());
+        $args = $parser->parse(['App/TestModule/TestSubModule']);
+
+        self::assertSame('src/TestSubModule', $args->directory());
+    }
+
+    private function exampleMultiLevelComposerJson(): array
+    {
+        $composerJson = <<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\TestModule\\": "src/"
+        }
+    }
+}
+JSON;
+        return json_decode($composerJson, true);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Read the composer.json autoload psr-4 to get the directory target from the known namespace. 
This way we have to provide only one argument to the maker command. 
For example: `php gacela make:module App/TestModule` 

## 🔖 Changes

- Refactor the `CommandArgumentsParser` to find all possible psr-4 combinations and take the better fit. Then perform some logic to discover the desired target directory and namespace based on the given "desired new module namespace". 
