### PR TITLE
Improve some config errors

### DIFF
--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -27,11 +27,6 @@ final class Config
         return self::$instance;
     }
 
-    public static function getApplicationRootDir(): string
-    {
-        return self::$applicationRootDir;
-    }
-
     public static function setApplicationRootDir(string $dir): void
     {
         self::$applicationRootDir = $dir;
@@ -86,19 +81,28 @@ final class Config
     private static function scanAllConfigFiles(): array
     {
         return array_diff(
-            scandir(self::$applicationRootDir . '/config/'),
+            scandir(self::getApplicationRootDir() . '/config/'),
             ['..', '.', self::CONFIG_LOCAL_FILENAME]
         );
     }
 
     private static function readConfigFromFile(string $type): array
     {
-        $fileName = self::$applicationRootDir . '/config/' . $type;
+        $fileName = self::getApplicationRootDir() . '/config/' . $type;
 
         if (file_exists($fileName)) {
             return include $fileName;
         }
 
         return [];
+    }
+
+    public static function getApplicationRootDir(): string
+    {
+        if (empty(self::$applicationRootDir)) {
+            self::$applicationRootDir = getcwd();
+        }
+
+        return self::$applicationRootDir;
     }
 }

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -80,8 +80,13 @@ final class Config
 
     private static function scanAllConfigFiles(): array
     {
+        $configDir = self::getApplicationRootDir() . '/config/';
+        if (!is_dir($configDir)) {
+            throw new RuntimeException('"config" directory not found on application root dir');
+        }
+
         return array_diff(
-            scandir(self::getApplicationRootDir() . '/config/'),
+            scandir($configDir),
             ['..', '.', self::CONFIG_LOCAL_FILENAME]
         );
     }
@@ -100,7 +105,7 @@ final class Config
     public static function getApplicationRootDir(): string
     {
         if (empty(self::$applicationRootDir)) {
-            self::$applicationRootDir = getcwd();
+            self::$applicationRootDir = getcwd() ?: '';
         }
 
         return self::$applicationRootDir;


### PR DESCRIPTION
## 🔖 Changes

- Use `getcwd()` by default as "ApplicationRootDir"
- Improve error message when `config` dir is missing
