### PR TITLE
Allow subfolders on config dir

### DIFF
--- a/tests/Integration/Framework/UsingConfig/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfig/IntegrationTest.php
@@ -24,6 +24,7 @@ final class IntegrationTest extends TestCase
                 'config' => 1,
                 'config_local' => 2,
                 'override' => 5,
+                'subfolder' => 1,
             ],
             $facade->doSomething()
         );

--- a/tests/Integration/Framework/UsingConfig/LocalConfig/Config.php
+++ b/tests/Integration/Framework/UsingConfig/LocalConfig/Config.php
@@ -14,6 +14,7 @@ final class Config extends AbstractConfig
             'config' => (int)$this->get('config'),
             'config_local' => (int)$this->get('config_local'),
             'override' => (int)$this->get('override'),
+            'subfolder' => (int)$this->get('subfolder'),
         ];
     }
 }

--- a/tests/Integration/Framework/UsingConfig/config/omit.yml
+++ b/tests/Integration/Framework/UsingConfig/config/omit.yml
@@ -1,0 +1,1 @@
+# I am not a PHP file. I will be omitted.

--- a/tests/Integration/Framework/UsingConfig/config/subfolder/default.php
+++ b/tests/Integration/Framework/UsingConfig/config/subfolder/default.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'subfolder' => 1,
+];


### PR DESCRIPTION
## 📚 Description

Read-only `.php` files and don't throw an exception, but read recursively when a folder is found.