### PR TITLE
Using long name by default in the generator code commands

### DIFF
--- a/src/CodeGenerator/Domain/FileContentGenerator.php
+++ b/src/CodeGenerator/Domain/FileContentGenerator.php
@@ -19,11 +19,11 @@ final class FileContentGenerator
     /**
      * @return string path result where the file was generated
      */
-    public function generate(CommandArguments $commandArguments, string $filename, bool $withLongName): string
+    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName): string
     {
         $this->mkdir($commandArguments->directory());
 
-        $moduleName = $withLongName ? $commandArguments->basename() : '';
+        $moduleName = $withShortName ? '' : $commandArguments->basename();
         $className = $moduleName . $filename;
 
         $path = sprintf('%s/%s.php', $commandArguments->directory(), $className);

--- a/src/CodeGenerator/Infrastructure/Command/MakeFileCommand.php
+++ b/src/CodeGenerator/Infrastructure/Command/MakeFileCommand.php
@@ -35,7 +35,7 @@ final class MakeFileCommand extends Command
         $this->setDescription('Generate a ' . FilenameSanitizer::expectedFilenames())
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
             ->addArgument('filenames', InputArgument::REQUIRED | InputArgument::IS_ARRAY, FilenameSanitizer::expectedFilenames(' | '))
-            ->addOption('long-name', 'l', InputOption::VALUE_NONE, 'Add module as prefix to the class name');
+            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -48,16 +48,17 @@ final class MakeFileCommand extends Command
         /** @var string $path */
         $path = $input->getArgument('path');
         $commandArguments = $this->argumentsParser->parse($path);
+        $shortName = (bool)$input->getOption('short-name');
 
         foreach ($filenames as $filename) {
             $fullPath = $this->fileContentGenerator->generate(
                 $commandArguments,
                 $filename,
-                (bool)$input->getOption('long-name')
+                $shortName
             );
             $output->writeln("> Path '$fullPath' created successfully");
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/CodeGenerator/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/CodeGenerator/Infrastructure/Command/MakeModuleCommand.php
@@ -31,7 +31,7 @@ final class MakeModuleCommand extends Command
     {
         $this->setDescription('Generate a basic module with an empty ' . FilenameSanitizer::expectedFilenames())
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
-            ->addOption('long-name', 'l', InputOption::VALUE_NONE, 'Add module as prefix to the class name');
+            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -39,12 +39,13 @@ final class MakeModuleCommand extends Command
         /** @var string $path */
         $path = $input->getArgument('path');
         $commandArguments = $this->argumentsParser->parse($path);
+        $shortName = (bool)$input->getOption('short-name');
 
         foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
             $fullPath = $this->fileContentGenerator->generate(
                 $commandArguments,
                 $filename,
-                (bool)$input->getOption('long-name')
+                $shortName
             );
             $output->writeln("> Path '$fullPath' created successfully");
         }
@@ -53,6 +54,6 @@ final class MakeModuleCommand extends Command
         $moduleName = end($pieces);
         $output->writeln("Module '$moduleName' created successfully");
 
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
## 📚 Description

Before the code generator was using short names by default. But long class names seem to be a bit more readable, so I would prefer to keep the long names by default and give the possibility of generating them short by using the `-s` option.

## 🔖 Changes

- Use long names for the classes by default when using the code generator.
