### PR TITLE
Refactor Config: extract ConfigInit logic

### DIFF
--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
+use Gacela\Framework\Config\ConfigInit;
 use Gacela\Framework\Config\ConfigReader\EnvConfigReader;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
-use Gacela\Framework\Config\ConfigReaderException;
 use Gacela\Framework\Config\ConfigReaderInterface;
-use Gacela\Framework\Config\GacelaJsonConfig;
-use Gacela\Framework\Config\GacelaJsonConfigItem;
+use Gacela\Framework\Config\GacelaJsonConfigFactory;
+use Gacela\Framework\Config\GacelaJsonConfigFactoryInterface;
+use Gacela\Framework\Config\PathFinder;
+use Gacela\Framework\Config\PathFinderInterface;
 use Gacela\Framework\Exception\ConfigException;
 
 final class Config
@@ -20,29 +22,20 @@ final class Config
 
     private static ?self $instance = null;
 
-    /** @var array<string,ConfigReaderInterface> */
-    private array $readers;
-
     private array $config = [];
-
-    /**
-     * @param array<string,ConfigReaderInterface> $readers
-     */
-    private function __construct(array $readers)
-    {
-        $this->readers = $readers;
-    }
 
     public static function getInstance(): self
     {
         if (self::$instance === null) {
-            self::$instance = new self([
-                'php' => new PhpConfigReader(),
-                'env' => new EnvConfigReader(),
-            ]);
+            self::$instance = new self();
         }
 
         return self::$instance;
+    }
+
+    public static function setApplicationRootDir(string $dir): void
+    {
+        self::$applicationRootDir = $dir;
     }
 
     public static function getApplicationRootDir(): string
@@ -52,11 +45,6 @@ final class Config
         }
 
         return self::$applicationRootDir;
-    }
-
-    public static function setApplicationRootDir(string $dir): void
-    {
-        self::$applicationRootDir = $dir;
     }
 
     /**
@@ -88,105 +76,40 @@ final class Config
      */
     public function init(): void
     {
-        $gacelaJson = $this->createGacelaJsonConfig();
-        $configs = [];
+        $this->config = (new ConfigInit(
+            self::getApplicationRootDir(),
+            $this->createGacelaJsonConfigCreator(),
+            $this->createPathFinder(),
+            $this->createConfigReaders()
+        ))->readAll();
+    }
 
-        foreach ($this->scanAllConfigFiles($gacelaJson) as $absolutePath) {
-            $configs[] = $this->readConfigFromFile($gacelaJson, $absolutePath);
-        }
+    private function createGacelaJsonConfigCreator(): GacelaJsonConfigFactoryInterface
+    {
+        return new GacelaJsonConfigFactory(
+            self::$applicationRootDir,
+            self::GACELA_CONFIG_FILENAME
+        );
+    }
 
-        $configs[] = $this->loadLocalConfigFile($gacelaJson);
+    private function createPathFinder(): PathFinderInterface
+    {
+        return new PathFinder();
+    }
 
-        $this->config = array_merge(...$configs);
+    /**
+     * @return array<string, ConfigReaderInterface>
+     */
+    private function createConfigReaders(): array
+    {
+        return [
+            'php' => new PhpConfigReader(),
+            'env' => new EnvConfigReader(),
+        ];
     }
 
     private function hasValue(string $key): bool
     {
         return isset($this->config[$key]);
-    }
-
-    private function createGacelaJsonConfig(): GacelaJsonConfig
-    {
-        $gacelaJsonPath = self::getApplicationRootDir() . '/' . self::GACELA_CONFIG_FILENAME;
-
-        if (is_file($gacelaJsonPath)) {
-            /** @psalm-suppress MixedArgumentTypeCoercion */
-            return GacelaJsonConfig::fromArray(
-                (array)json_decode(file_get_contents($gacelaJsonPath), true)
-            );
-        }
-
-        return GacelaJsonConfig::withDefaults();
-    }
-
-    /**
-     * @throws ConfigException
-     *
-     * @return string[]
-     */
-    private function scanAllConfigFiles(GacelaJsonConfig $gacelaJsonConfig): array
-    {
-        $configGroup = array_map(
-            fn (GacelaJsonConfigItem $config): array => array_map(
-                static fn ($p): string => (string)$p,
-                array_diff(
-                    glob($this->generateAbsolutePath($config->path())),
-                    [$this->generateAbsolutePath($config->pathLocal())]
-                )
-            ),
-            $gacelaJsonConfig->configs()
-        );
-
-        return array_merge(...$configGroup);
-    }
-
-    private function readConfigFromFile(GacelaJsonConfig $gacelaJson, string $absolutePath): array
-    {
-        $result = [];
-
-        foreach ($gacelaJson->configs() as $config) {
-            $result[] = $this->readConfigItem($config, $absolutePath);
-        }
-
-        return array_merge(...array_filter($result));
-    }
-
-    private function loadLocalConfigFile(GacelaJsonConfig $gacelaJson): array
-    {
-        $result = [];
-
-        foreach ($gacelaJson->configs() as $config) {
-            $configLocalAbsolutePath = $this->generateAbsolutePath($config->pathLocal());
-
-            if (is_file($configLocalAbsolutePath)) {
-                $result[] = $this->readConfigItem($config, $configLocalAbsolutePath);
-            }
-        }
-
-        return array_merge(...array_filter($result));
-    }
-
-    private function generateAbsolutePath(string $relativePath): string
-    {
-        return sprintf(
-            '%s/%s',
-            self::getApplicationRootDir(),
-            $relativePath
-        );
-    }
-
-    private function readConfigItem(GacelaJsonConfigItem $config, string $absolutePath): array
-    {
-        $reader = $this->readers[$config->type()] ?? null;
-
-        if ($reader === null) {
-            throw ConfigReaderException::notSupported($config->type(), $this->readers);
-        }
-
-        if ($reader->canRead($absolutePath)) {
-            return $reader->read($absolutePath);
-        }
-
-        return [];
     }
 }

--- a/src/Framework/Config/ConfigInit.php
+++ b/src/Framework/Config/ConfigInit.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+final class ConfigInit
+{
+    private string $applicationRootDir;
+
+    private GacelaJsonConfigFactoryInterface $configFactory;
+
+    private PathFinderInterface $pathFinder;
+
+    /** @var array<string,ConfigReaderInterface> */
+    private array $readers;
+
+    /**
+     * @param array<string,ConfigReaderInterface> $readers
+     */
+    public function __construct(
+        string $applicationRootDir,
+        GacelaJsonConfigFactoryInterface $configFactory,
+        PathFinderInterface $pathFinder,
+        array $readers
+    ) {
+        $this->applicationRootDir = $applicationRootDir;
+        $this->configFactory = $configFactory;
+        $this->pathFinder = $pathFinder;
+        $this->readers = $readers;
+    }
+
+    public function readAll(): array
+    {
+        $gacelaJsonConfig = $this->configFactory->createGacelaJsonConfig();
+        $configs = [];
+
+        foreach ($this->scanAllConfigFiles($gacelaJsonConfig) as $absolutePath) {
+            $configs[] = $this->readConfigFromFile($gacelaJsonConfig, $absolutePath);
+        }
+
+        $configs[] = $this->readLocalConfigFile($gacelaJsonConfig);
+
+        return array_merge(...$configs);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function scanAllConfigFiles(GacelaJsonConfig $gacelaJsonConfig): array
+    {
+        $configGroup = array_map(
+            fn (GacelaJsonConfigItem $config): array => array_map(
+                static fn ($p): string => (string)$p,
+                array_diff(
+                    $this->pathFinder->matchingPattern($this->generateAbsolutePath($config->path())),
+                    [$this->generateAbsolutePath($config->pathLocal())]
+                )
+            ),
+            $gacelaJsonConfig->configs()
+        );
+
+        return array_merge(...$configGroup);
+    }
+
+    private function readConfigFromFile(GacelaJsonConfig $gacelaJson, string $absolutePath): array
+    {
+        $result = [];
+
+        foreach ($gacelaJson->configs() as $config) {
+            $result[] = $this->readConfigItem($config, $absolutePath);
+        }
+
+        return array_merge(...array_filter($result));
+    }
+
+    private function readLocalConfigFile(GacelaJsonConfig $gacelaJson): array
+    {
+        $result = [];
+
+        foreach ($gacelaJson->configs() as $config) {
+            $absolutePath = $this->generateAbsolutePath($config->pathLocal());
+
+            $result[] = $this->readConfigItem($config, $absolutePath);
+        }
+
+        return array_merge(...array_filter($result));
+    }
+
+    private function generateAbsolutePath(string $relativePath): string
+    {
+        return sprintf(
+            '%s/%s',
+            $this->applicationRootDir,
+            $relativePath
+        );
+    }
+
+    private function readConfigItem(GacelaJsonConfigItem $config, string $absolutePath): array
+    {
+        $reader = $this->readers[$config->type()] ?? null;
+
+        if ($reader === null) {
+            throw ConfigReaderException::notSupported($config->type(), $this->readers);
+        }
+
+        if ($reader->canRead($absolutePath)) {
+            return $reader->read($absolutePath);
+        }
+
+        return [];
+    }
+}

--- a/src/Framework/Config/ConfigReader/EnvConfigReader.php
+++ b/src/Framework/Config/ConfigReader/EnvConfigReader.php
@@ -15,9 +15,13 @@ final class EnvConfigReader implements ConfigReaderInterface
 
     public function read(string $absolutePath): array
     {
-        $config = [];
+        if (!is_file($absolutePath)) {
+            return [];
+        }
 
+        $config = [];
         $lines = file($absolutePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
         foreach ($lines as $line) {
             if (strpos(trim($line), '#') === 0) {
                 continue;

--- a/src/Framework/Config/ConfigReader/PhpConfigReader.php
+++ b/src/Framework/Config/ConfigReader/PhpConfigReader.php
@@ -17,13 +17,13 @@ final class PhpConfigReader implements ConfigReaderInterface
 
     public function read(string $absolutePath): array
     {
-        if (file_exists($absolutePath)) {
-            /** @var null|array $content */
-            $content = include $absolutePath;
-
-            return is_array($content) ? $content : [];
+        if (!file_exists($absolutePath)) {
+            return [];
         }
 
-        return [];
+        /** @var null|array $content */
+        $content = include $absolutePath;
+
+        return is_array($content) ? $content : [];
     }
 }

--- a/src/Framework/Config/GacelaJsonConfigFactory.php
+++ b/src/Framework/Config/GacelaJsonConfigFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+final class GacelaJsonConfigFactory implements GacelaJsonConfigFactoryInterface
+{
+    private string $applicationRootDir;
+    private string $gacelaConfigFilename;
+
+    public function __construct(
+        string $applicationRootDir,
+        string $gacelaConfigFilename
+    ) {
+        $this->applicationRootDir = $applicationRootDir;
+        $this->gacelaConfigFilename = $gacelaConfigFilename;
+    }
+
+    public function createGacelaJsonConfig(): GacelaJsonConfig
+    {
+        $gacelaJsonPath = $this->applicationRootDir . '/' . $this->gacelaConfigFilename;
+
+        if (is_file($gacelaJsonPath)) {
+            /** @psalm-suppress MixedArgumentTypeCoercion */
+            return GacelaJsonConfig::fromArray(
+                (array)json_decode(file_get_contents($gacelaJsonPath), true)
+            );
+        }
+
+        return GacelaJsonConfig::withDefaults();
+    }
+}

--- a/src/Framework/Config/GacelaJsonConfigFactoryInterface.php
+++ b/src/Framework/Config/GacelaJsonConfigFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+interface GacelaJsonConfigFactoryInterface
+{
+    public function createGacelaJsonConfig(): GacelaJsonConfig;
+}

--- a/src/Framework/Config/PathFinder.php
+++ b/src/Framework/Config/PathFinder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+final class PathFinder implements PathFinderInterface
+{
+    public function matchingPattern(string $pattern): array
+    {
+        return glob($pattern);
+    }
+}

--- a/src/Framework/Config/PathFinderInterface.php
+++ b/src/Framework/Config/PathFinderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+interface PathFinderInterface
+{
+    public function matchingPattern(string $pattern): array;
+}

--- a/tests/Unit/Framework/Config/ConfigReaderTest.php
+++ b/tests/Unit/Framework/Config/ConfigReaderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Config\ConfigInit;
+use Gacela\Framework\Config\ConfigReaderException;
+use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaJsonConfig;
+use Gacela\Framework\Config\GacelaJsonConfigFactoryInterface;
+use Gacela\Framework\Config\PathFinderInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigReaderTest extends TestCase
+{
+    public function test_no_config(): void
+    {
+        $gacelaJsonConfigCreator = $this->createStub(GacelaJsonConfigFactoryInterface::class);
+        $gacelaJsonConfigCreator
+            ->method('createGacelaJsonConfig')
+            ->willReturn(GacelaJsonConfig::withDefaults());
+
+        $configInit = new ConfigInit(
+            'application_root_dir',
+            $gacelaJsonConfigCreator,
+            $this->createMock(PathFinderInterface::class),
+            [
+                'php' => $this->createStub(ConfigReaderInterface::class),
+            ]
+        );
+
+        self::assertSame([], $configInit->readAll());
+    }
+
+    public function test_non_supported_reader_type(): void
+    {
+        $gacelaJsonConfigCreator = $this->createStub(GacelaJsonConfigFactoryInterface::class);
+        $gacelaJsonConfigCreator
+            ->method('createGacelaJsonConfig')
+            ->willReturn(GacelaJsonConfig::fromArray([
+                'config' => [
+                    'type' => 'non-supported-type',
+                    'path' => 'path-value',
+                    'path_local' => 'path_local-value',
+                ],
+            ]));
+
+        $pathFinder = $this->createMock(PathFinderInterface::class);
+        $pathFinder->method('matchingPattern')->willReturn(['path1']);
+
+        $configInit = new ConfigInit(
+            'application_root_dir',
+            $gacelaJsonConfigCreator,
+            $pathFinder,
+            []
+        );
+
+        $this->expectException(ConfigReaderException::class);
+        $configInit->readAll();
+    }
+
+    public function test_read_single_config(): void
+    {
+        $gacelaJsonConfigCreator = $this->createStub(GacelaJsonConfigFactoryInterface::class);
+        $gacelaJsonConfigCreator
+            ->method('createGacelaJsonConfig')
+            ->willReturn(GacelaJsonConfig::fromArray([
+                'config' => [
+                    [
+                        'type' => 'supported-type',
+                    ],
+                ],
+            ]));
+
+        $reader = $this->createStub(ConfigReaderInterface::class);
+        $reader->method('canRead')->willReturn(true);
+        $reader->method('read')->willReturn(['key' => 'value']);
+
+        $configInit = new ConfigInit(
+            'application_root_dir',
+            $gacelaJsonConfigCreator,
+            $this->createMock(PathFinderInterface::class),
+            [
+                'supported-type' => $reader,
+            ]
+        );
+
+        self::assertSame(['key' => 'value'], $configInit->readAll());
+    }
+
+    public function test_read_multiple_config(): void
+    {
+        $gacelaJsonConfigCreator = $this->createStub(GacelaJsonConfigFactoryInterface::class);
+        $gacelaJsonConfigCreator
+            ->method('createGacelaJsonConfig')
+            ->willReturn(GacelaJsonConfig::fromArray([
+                'config' => [
+                    [
+                        'type' => 'supported-type1',
+                    ],
+                    [
+                        'type' => 'supported-type2',
+                    ],
+                ],
+            ]));
+
+        $reader1 = $this->createStub(ConfigReaderInterface::class);
+        $reader1->method('canRead')->willReturn(true);
+        $reader1->method('read')->willReturn(['key1' => 'value1']);
+
+        $reader2 = $this->createStub(ConfigReaderInterface::class);
+        $reader2->method('canRead')->willReturn(true);
+        $reader2->method('read')->willReturn(['key2' => 'value2']);
+
+        $configInit = new ConfigInit(
+            'application_root_dir',
+            $gacelaJsonConfigCreator,
+            $this->createMock(PathFinderInterface::class),
+            [
+                'supported-type1' => $reader1,
+                'supported-type2' => $reader2,
+            ]
+        );
+
+        self::assertSame([
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ], $configInit->readAll());
+    }
+}


### PR DESCRIPTION
## 📚 Description

The current Config class has a lot of responsibilities and it's almost impossible to write isolated tests (unit) for some of its crucial logic. For example, the logic responsible to read different configs by their types.

## 🔖 Changes

- Apply extract class refactoring pattern, moving out the logic that initializes the config key-values to another class. 
- `ConfigInit` depends on abstractions like `PathFinderInterface` and `GacelaJsonConfigFactoryInterface` so it can be easily mock in its unit tests.
