### PR TITLE
Refactoring Config::setConfigReaders()

### DIFF
--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -41,7 +41,7 @@ final class CodeGeneratorConfig extends AbstractConfig implements CodeTemplateIn
      */
     public function getComposerJsonContentAsArray(): array
     {
-        $filename = Config::getApplicationRootDir() . '/composer.json';
+        $filename = Config::getInstance()->getApplicationRootDir() . '/composer.json';
         if (!file_exists($filename)) {
             throw new LogicException('composer.json file not found but it is required');
         }

--- a/tests/Integration/Framework/UsingConfigWithoutGacelaJsonFile/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigWithoutGacelaJsonFile/IntegrationTest.php
@@ -11,8 +11,7 @@ final class IntegrationTest extends TestCase
 {
     public function setUp(): void
     {
-        Config::setApplicationRootDir(__DIR__);
-        Config::getInstance()->init();
+        Config::getInstance()->init(__DIR__);
     }
 
     public function test_remove_key_from_container(): void

--- a/tests/Integration/Framework/UsingEnvConfig/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingEnvConfig/IntegrationTest.php
@@ -11,8 +11,7 @@ final class IntegrationTest extends TestCase
 {
     public function setUp(): void
     {
-        Config::setApplicationRootDir(__DIR__);
-        Config::getInstance()->init();
+        Config::getInstance()->init(__DIR__);
     }
 
     public function test_remove_key_from_container(): void

--- a/tests/Integration/Framework/UsingMultipleConfig/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingMultipleConfig/IntegrationTest.php
@@ -11,8 +11,7 @@ final class IntegrationTest extends TestCase
 {
     public function setUp(): void
     {
-        Config::setApplicationRootDir(__DIR__);
-        Config::getInstance()->init();
+        Config::getInstance()->init(__DIR__);
     }
 
     public function test_remove_key_from_container(): void

--- a/tests/Integration/Framework/UsingPhpConfig/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingPhpConfig/IntegrationTest.php
@@ -11,8 +11,7 @@ final class IntegrationTest extends TestCase
 {
     public function setUp(): void
     {
-        Config::setApplicationRootDir(__DIR__);
-        Config::getInstance()->init();
+        Config::getInstance()->init(__DIR__);
     }
 
     public function test_remove_key_from_container(): void

--- a/tests/Unit/Framework/ConfigTest.php
+++ b/tests/Unit/Framework/ConfigTest.php
@@ -36,7 +36,7 @@ final class ConfigTest extends TestCase
 
     public function test_get_using_custom_reader(): void
     {
-        $this->config->setConfigReaders([
+        Config::setConfigReaders([
             Config\GacelaJsonConfigItem::DEFAULT_TYPE => new class() implements ConfigReaderInterface {
                 public function read(string $absolutePath): array
                 {
@@ -50,8 +50,6 @@ final class ConfigTest extends TestCase
             },
         ]);
 
-        $this->config->init();
-
-        self::assertSame('value', $this->config->get('key'));
+        self::assertSame('value', Config::getInstance()->get('key'));
     }
 }


### PR DESCRIPTION
## 🔖 Changes

- `Config::setConfigReaders()` creates a new config instance singleton, so there is no need to call `init()` right after
