### PR TITLE
Allow optional config readers in gacela.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Non released yet
+
+- Allow optional config readers in gacela.json
+
 ### 0.6.0
 ##### 2021-07-27
 

--- a/src/Framework/Config/ConfigInit.php
+++ b/src/Framework/Config/ConfigInit.php
@@ -101,13 +101,15 @@ final class ConfigInit
         $reader = $this->readers[$config->type()] ?? null;
 
         if ($reader === null) {
+            if ($config->isOptional()) {
+                return [];
+            }
+
             throw ConfigReaderException::notSupported($config->type(), $this->readers);
         }
 
-        if ($reader->canRead($absolutePath)) {
-            return $reader->read($absolutePath);
-        }
-
-        return [];
+        return $reader->canRead($absolutePath)
+            ? $reader->read($absolutePath)
+            : [];
     }
 }

--- a/src/Framework/Config/GacelaJsonConfigItem.php
+++ b/src/Framework/Config/GacelaJsonConfigItem.php
@@ -10,30 +10,38 @@ final class GacelaJsonConfigItem
 
     private const DEFAULT_PATH = 'config/*.php';
     private const DEFAULT_PATH_LOCAL = 'config/local.php';
+    private const DEFAULT_IS_OPTIONAL = false;
 
     private string $type;
     private string $path;
     private string $pathLocal;
+    private bool $isOptional;
 
     public static function fromArray(array $json): self
     {
-        $type = (string)($json['type'] ?? '');
-        $path = (string)($json['path'] ?? '');
-        $pathLocal = (string)($json['path_local'] ?? '');
-
-        return new self($type, $path, $pathLocal);
+        return new self(
+            (string)($json['type'] ?? self::DEFAULT_TYPE),
+            (string)($json['path'] ?? self::DEFAULT_PATH),
+            (string)($json['path_local'] ?? self::DEFAULT_PATH_LOCAL),
+            (bool)($json['optional'] ?? self::DEFAULT_IS_OPTIONAL)
+        );
     }
 
     public static function withDefaults(): self
     {
-        return new self('', '', '');
+        return new self();
     }
 
-    private function __construct(string $type, string $path, string $pathLocal)
-    {
-        $this->type = $type ?: self::DEFAULT_TYPE;
-        $this->path = $path ?: self::DEFAULT_PATH;
-        $this->pathLocal = $pathLocal ?: self::DEFAULT_PATH_LOCAL;
+    private function __construct(
+        string $type = self::DEFAULT_TYPE,
+        string $path = self::DEFAULT_PATH,
+        string $pathLocal = self::DEFAULT_PATH_LOCAL,
+        bool $isOptional = self::DEFAULT_IS_OPTIONAL
+    ) {
+        $this->type = $type;
+        $this->path = $path;
+        $this->pathLocal = $pathLocal;
+        $this->isOptional = $isOptional;
     }
 
     public function type(): string
@@ -49,5 +57,10 @@ final class GacelaJsonConfigItem
     public function pathLocal(): string
     {
         return $this->pathLocal;
+    }
+
+    public function isOptional(): bool
+    {
+        return $this->isOptional;
     }
 }


### PR DESCRIPTION
## 📚  Context

If a "config reader item" is specified in `gacela.json` it must be set up in the script as, for example:
```php
/*
 * This is an example of how can you create your own config reader.
 * The key 'custom' in the ConfigReaders will parse the files found
 * by the gacela.json config:
 * {
 *   "type": "custom",
 *   "path": "config/*.custom"
 * }
 */
Config::setConfigReaders([
    'php' => new PhpConfigReader(),
    'custom' => new CustomConfigReader(),
]);
```

But, what happens if you have that "custom config reader item" BUT you don't set up using `Config::setConfigReaders()`? It will simply throw a `ConfigReaderException` because the config files were fetched from `config/*.custom` but there is no ConfigReader assigned to read that file. 

## 💡 Goal

Make it possible to define optional "config reader items" so in case there is no ConfigReader found for a file, it will simply skip them and move to the next config file without throwing an error.

## 🔖 Changes

-  Throw a `ConfigReaderException::notSupported()` if the config reader item is non optional.

