### PR TITLE
Fix bug in GlobalKey for Modules with multi names

### DIFF
--- a/src/Framework/ClassResolver/GlobalKey.php
+++ b/src/Framework/ClassResolver/GlobalKey.php
@@ -4,15 +4,53 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
+use function ltrim;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function strpos;
+
 final class GlobalKey
 {
-    public static function fromClassName(string $className): string
-    {
-        preg_match('~(?<pre_namespace>.*)\\\((?:^|[A-Z])[a-z]+)(?<resolvable_type>.*)~', $className, $matches);
-        $resolvableType = $matches['resolvable_type'] ?? '';
+    private const RESOLVABLE_TYPES =  [
+        'Facade',
+        'Factory',
+        'Config',
+        'DependencyProvider',
+    ];
 
-        return (empty($resolvableType) || $resolvableType === 'Provider')
-            ? sprintf('\\%s', ltrim($className, '\\'))
-            : sprintf('\\%s\\%s', ltrim($matches['pre_namespace'], '\\'), $resolvableType);
+    public static function fromClassName(string $fullClassName): string
+    {
+        preg_match('~(?<pre_namespace>.*)\\\(?<resolvable_type>.*)~', $fullClassName, $matches);
+        $matchResolvableType = $matches['resolvable_type'] ?? '';
+
+        ['module_name' => $moduleName, 'resolvable_type' => $resolvableType]
+            = self::splitModuleAndResolvableType($matchResolvableType);
+
+        if (empty($moduleName)) {
+            return sprintf('\\%s', ltrim($fullClassName, '\\'));
+        }
+
+        return sprintf('\\%s\\%s', ltrim($matches['pre_namespace'], '\\'), $resolvableType);
+    }
+
+    /**
+     * @return array{module_name:string, resolvable_type:string}
+     */
+    private static function splitModuleAndResolvableType(string $className): array
+    {
+        foreach (self::RESOLVABLE_TYPES as $resolvableType) {
+            if (false !== strpos($className, $resolvableType)) {
+                return [
+                    'module_name' => substr($className, 0, strlen($className) - strlen($resolvableType)),
+                    'resolvable_type' => $resolvableType,
+                ];
+            }
+        }
+
+        return [
+            'module_name' => $className,
+            'resolvable_type' => '',
+        ];
     }
 }

--- a/tests/Unit/Framework/ClassResolver/AbstractClassResolverTest.php
+++ b/tests/Unit/Framework/ClassResolver/AbstractClassResolverTest.php
@@ -56,19 +56,19 @@ final class AbstractClassResolverTest extends TestCase
     public function providerOverrideExistingResolvedClass(): iterable
     {
         yield 'using the module prefix' => [
-            'App\Module\ModuleClassName',
+            'App\Module\ModuleClassNameFacade',
         ];
 
         yield 'not using the module prefix in the class' => [
-            'App\Module\ClassName',
+            'App\Module\ClassNameFacade',
         ];
 
         yield 'starting with \ and using the module prefix' => [
-            '\App\Module\ModuleClassName',
+            '\App\Module\ModuleClassNameFacade',
         ];
 
         yield 'starting with \ and not using the module prefix in the class' => [
-            '\App\Module\ClassName',
+            '\App\Module\ClassNameFacade',
         ];
     }
 }

--- a/tests/Unit/Framework/ClassResolver/GlobalKeyTest.php
+++ b/tests/Unit/Framework/ClassResolver/GlobalKeyTest.php
@@ -57,4 +57,20 @@ final class GlobalKeyTest extends TestCase
             GlobalKey::fromClassName('\App\Module\DependencyProvider')
         );
     }
+
+    public function test_using_a_multi_word_module_prefix(): void
+    {
+        self::assertSame(
+            '\App\PriceListChecker\Facade',
+            GlobalKey::fromClassName('\App\PriceListChecker\PriceListCheckerFacade')
+        );
+    }
+
+    public function test_dependency_provider_using_a_multi_word_module_prefix(): void
+    {
+        self::assertSame(
+            '\App\PriceListChecker\DependencyProvider',
+            GlobalKey::fromClassName('\App\PriceListChecker\PriceListCheckerDependencyProvider')
+        );
+    }
 }


### PR DESCRIPTION
## 🤔 Context

The `GlobalKey::fromClassName()` wasn't working as expected for modules with more than one word. 

## 🔖 Changes

- Fix the bug that should unify all keys for the class resolver.
