### PR TITLE
Infer the resolvedClass type when using addAnonymousGlobal()

### DIFF
--- a/src/Framework/ClassResolver/GlobalKey.php
+++ b/src/Framework/ClassResolver/GlobalKey.php
@@ -7,50 +7,26 @@ namespace Gacela\Framework\ClassResolver;
 use function ltrim;
 use function preg_match;
 use function sprintf;
-use function strlen;
-use function strpos;
 
 final class GlobalKey
 {
-    private const RESOLVABLE_TYPES =  [
-        'Facade',
-        'Factory',
-        'Config',
-        'DependencyProvider',
-    ];
-
+    /**
+     * Unify the keys for the class resolver.
+     */
     public static function fromClassName(string $fullClassName): string
     {
         preg_match('~(?<pre_namespace>.*)\\\(?<resolvable_type>.*)~', $fullClassName, $matches);
-        $matchResolvableType = $matches['resolvable_type'] ?? '';
 
-        ['module_name' => $moduleName, 'resolvable_type' => $resolvableType]
-            = self::splitModuleAndResolvableType($matchResolvableType);
+        $resolvableType = ResolvableType::fromClassName($matches['resolvable_type'] ?? '');
 
-        if (empty($moduleName)) {
+        if (empty($resolvableType->moduleName())) {
             return sprintf('\\%s', ltrim($fullClassName, '\\'));
         }
 
-        return sprintf('\\%s\\%s', ltrim($matches['pre_namespace'], '\\'), $resolvableType);
-    }
-
-    /**
-     * @return array{module_name:string, resolvable_type:string}
-     */
-    private static function splitModuleAndResolvableType(string $className): array
-    {
-        foreach (self::RESOLVABLE_TYPES as $resolvableType) {
-            if (false !== strpos($className, $resolvableType)) {
-                return [
-                    'module_name' => substr($className, 0, strlen($className) - strlen($resolvableType)),
-                    'resolvable_type' => $resolvableType,
-                ];
-            }
-        }
-
-        return [
-            'module_name' => $className,
-            'resolvable_type' => '',
-        ];
+        return sprintf(
+            '\\%s\\%s',
+            ltrim($matches['pre_namespace'], '\\'),
+            $resolvableType->resolvableType()
+        );
     }
 }

--- a/src/Framework/ClassResolver/ResolvableType.php
+++ b/src/Framework/ClassResolver/ResolvableType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+use function strlen;
+
+final class ResolvableType
+{
+    private const ALLOWED_TYPES = [
+        'Facade',
+        'Factory',
+        'Config',
+        'DependencyProvider',
+    ];
+
+    private string $resolvableType;
+    private string $moduleName;
+
+    /**
+     * Split the moduleName and resolvableType from a className.
+     */
+    public static function fromClassName(string $className): self
+    {
+        foreach (self::ALLOWED_TYPES as $resolvableType) {
+            if (false !== strpos($className, $resolvableType)) {
+                return new self(
+                    $resolvableType,
+                    substr($className, 0, strlen($className) - strlen($resolvableType))
+                );
+            }
+        }
+
+        return new self('', $className);
+    }
+
+    private function __construct(
+        string $resolvableType,
+        string $moduleName
+    ) {
+        $this->resolvableType = $resolvableType;
+        $this->moduleName = $moduleName;
+    }
+
+    public function resolvableType(): string
+    {
+        return $this->resolvableType;
+    }
+
+    public function moduleName(): string
+    {
+        return $this->moduleName;
+    }
+}

--- a/tests/Integration/Framework/GlobalServices/AnonymousClassesTest.php
+++ b/tests/Integration/Framework/GlobalServices/AnonymousClassesTest.php
@@ -47,7 +47,6 @@ final class AnonymousClassesTest extends TestCase
     {
         AbstractClassResolver::addAnonymousGlobal(
             $this,
-            'Config',
             new class() extends AbstractConfig {
                 /**
                  * @return int[]
@@ -67,7 +66,6 @@ final class AnonymousClassesTest extends TestCase
     {
         AbstractClassResolver::addAnonymousGlobal(
             'AnonymousClassesTest',
-            'Factory',
             new class() extends AbstractFactory {
                 public function createDomainClass(): object
                 {
@@ -109,7 +107,6 @@ final class AnonymousClassesTest extends TestCase
     {
         AbstractClassResolver::addAnonymousGlobal(
             $this,
-            'DependencyProvider',
             new class() extends AbstractDependencyProvider {
                 public function provideModuleDependencies(Container $container): void
                 {

--- a/tests/Unit/Framework/ClassResolver/AbstractClassResolverTest.php
+++ b/tests/Unit/Framework/ClassResolver/AbstractClassResolverTest.php
@@ -4,22 +4,31 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\ClassResolver;
 
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\Container\Container;
 use PHPUnit\Framework\TestCase;
 
 final class AbstractClassResolverTest extends TestCase
 {
+    /**
+     * The anon-class is not extending from Abstract[Factory,Config,DependencyProvider]
+     * For this reason, the context of this anon-global will be the one of this (test)class
+     * therefore it's not allowed.
+     */
     public function test_error_when_non_allowed_anon_global_type(): void
     {
-        $this->expectErrorMessage("Type 'Custom' not allowed");
+        $this->expectErrorMessage("Type 'AbstractClassResolverTest' not allowed");
 
-        AbstractClassResolver::addAnonymousGlobal($this, 'Custom', new class() {
+        AbstractClassResolver::addAnonymousGlobal($this, new class() {
         });
     }
 
     public function test_allowed_factory_anon_global(): void
     {
-        AbstractClassResolver::addAnonymousGlobal($this, 'Factory', new class() {
+        AbstractClassResolver::addAnonymousGlobal($this, new class() extends AbstractFactory {
         });
 
         self::assertTrue(true); # Assert non error is thrown
@@ -27,7 +36,7 @@ final class AbstractClassResolverTest extends TestCase
 
     public function test_allowed_config_anon_global(): void
     {
-        AbstractClassResolver::addAnonymousGlobal($this, 'Config', new class() {
+        AbstractClassResolver::addAnonymousGlobal($this, new class() extends AbstractConfig {
         });
 
         self::assertTrue(true); # Assert non error is thrown
@@ -35,7 +44,10 @@ final class AbstractClassResolverTest extends TestCase
 
     public function test_allowed_dependency_provider_anon_global(): void
     {
-        AbstractClassResolver::addAnonymousGlobal($this, 'DependencyProvider', new class() {
+        AbstractClassResolver::addAnonymousGlobal($this, new class() extends AbstractDependencyProvider {
+            public function provideModuleDependencies(Container $container): void
+            {
+            }
         });
 
         self::assertTrue(true); # Assert non error is thrown

--- a/tests/Unit/Framework/ClassResolver/GlobalKeyTest.php
+++ b/tests/Unit/Framework/ClassResolver/GlobalKeyTest.php
@@ -12,65 +12,48 @@ final class GlobalKeyTest extends TestCase
     public function test_using_the_module_prefix(): void
     {
         self::assertSame(
-            '\App\Module\Facade',
-            GlobalKey::fromClassName('App\Module\ModuleFacade')
+            '\App\ModuleExample\Facade',
+            GlobalKey::fromClassName('App\ModuleExample\ModuleFacade')
         );
     }
 
     public function test_starting_with_slash_and_using_module_prefix(): void
     {
         self::assertSame(
-            '\App\Module\Facade',
-            GlobalKey::fromClassName('\App\Module\ModuleFacade')
+            '\App\ModuleExample\Facade',
+            GlobalKey::fromClassName('\App\ModuleExample\ModuleFacade')
         );
     }
 
     public function test_not_using_the_module_prefix_in_the_class(): void
     {
         self::assertSame(
-            '\App\Module\Facade',
-            GlobalKey::fromClassName('App\Module\Facade')
+            '\App\ModuleExample\Facade',
+            GlobalKey::fromClassName('App\ModuleExample\Facade')
         );
     }
 
     public function test_starting_with_slash_and_not_using_the_module_prefix_in_the_class(): void
     {
         self::assertSame(
-            '\App\Module\Facade',
-            GlobalKey::fromClassName('\App\Module\Facade')
+            '\App\ModuleExample\Facade',
+            GlobalKey::fromClassName('\App\ModuleExample\Facade')
         );
     }
-
 
     public function test_dependency_provider_using_module_prefix(): void
     {
         self::assertSame(
-            '\App\Module\DependencyProvider',
-            GlobalKey::fromClassName('\App\Module\ModuleDependencyProvider')
+            '\App\ModuleExample\DependencyProvider',
+            GlobalKey::fromClassName('\App\ModuleExample\ModuleDependencyProvider')
         );
     }
 
     public function test_dependency_provider_not_using_module_prefix(): void
     {
         self::assertSame(
-            '\App\Module\DependencyProvider',
-            GlobalKey::fromClassName('\App\Module\DependencyProvider')
-        );
-    }
-
-    public function test_using_a_multi_word_module_prefix(): void
-    {
-        self::assertSame(
-            '\App\PriceListChecker\Facade',
-            GlobalKey::fromClassName('\App\PriceListChecker\PriceListCheckerFacade')
-        );
-    }
-
-    public function test_dependency_provider_using_a_multi_word_module_prefix(): void
-    {
-        self::assertSame(
-            '\App\PriceListChecker\DependencyProvider',
-            GlobalKey::fromClassName('\App\PriceListChecker\PriceListCheckerDependencyProvider')
+            '\App\ModuleExample\DependencyProvider',
+            GlobalKey::fromClassName('\App\ModuleExample\DependencyProvider')
         );
     }
 }

--- a/tests/Unit/Framework/ClassResolver/ResolvableTypeTest.php
+++ b/tests/Unit/Framework/ClassResolver/ResolvableTypeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver;
+
+use Gacela\Framework\ClassResolver\ResolvableType;
+use PHPUnit\Framework\TestCase;
+
+final class ResolvableTypeTest extends TestCase
+{
+    public function test_empty_class_name(): void
+    {
+        $actual = ResolvableType::fromClassName('');
+
+        self::assertSame('', $actual->moduleName());
+        self::assertSame('', $actual->resolvableType());
+    }
+
+    public function test_using_module_prefix_custom_without_any_resolvable_type(): void
+    {
+        $actual = ResolvableType::fromClassName('Custom');
+
+        self::assertSame('Custom', $actual->moduleName());
+        self::assertSame('', $actual->resolvableType());
+    }
+
+    public function test_not_using_the_module_prefix_facade(): void
+    {
+        $actual = ResolvableType::fromClassName('Facade');
+
+        self::assertSame('', $actual->moduleName());
+        self::assertSame('Facade', $actual->resolvableType());
+    }
+
+    public function test_not_using_the_module_prefix_factory(): void
+    {
+        $actual = ResolvableType::fromClassName('Factory');
+
+        self::assertSame('', $actual->moduleName());
+        self::assertSame('Factory', $actual->resolvableType());
+    }
+
+    public function test_not_using_the_module_prefix_config(): void
+    {
+        $actual = ResolvableType::fromClassName('Config');
+
+        self::assertSame('', $actual->moduleName());
+        self::assertSame('Config', $actual->resolvableType());
+    }
+
+    public function test_not_using_module_prefix_dependency_provider(): void
+    {
+        $actual = ResolvableType::fromClassName('DependencyProvider');
+
+        self::assertSame('', $actual->moduleName());
+        self::assertSame('DependencyProvider', $actual->resolvableType());
+    }
+
+    public function test_using_the_module_prefix_facade(): void
+    {
+        $actual = ResolvableType::fromClassName('ModuleExampleFacade');
+
+        self::assertSame('ModuleExample', $actual->moduleName());
+        self::assertSame('Facade', $actual->resolvableType());
+    }
+
+    public function test_using_the_module_prefix_factory(): void
+    {
+        $actual = ResolvableType::fromClassName('ModuleExampleFactory');
+
+        self::assertSame('ModuleExample', $actual->moduleName());
+        self::assertSame('Factory', $actual->resolvableType());
+    }
+
+    public function test_using_the_module_prefix_config(): void
+    {
+        $actual = ResolvableType::fromClassName('ModuleExampleConfig');
+
+        self::assertSame('ModuleExample', $actual->moduleName());
+        self::assertSame('Config', $actual->resolvableType());
+    }
+
+    public function test_using_module_prefix_dependency_provider(): void
+    {
+        $actual = ResolvableType::fromClassName('ModuleExampleDependencyProvider');
+
+        self::assertSame('ModuleExample', $actual->moduleName());
+        self::assertSame('DependencyProvider', $actual->resolvableType());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Currently, you have to pass the resolvable type as the second argument when using `addAnonymousGlobal()`. This shouldn't be necessary if it could be inferred from the parent class of the anonymous class that it's been passed.

## 🔖 Changes

- Removed the second argument `string $type` from `addAnonymousGlobal()`
- Infer the parent class from the `object $resolvedClass`
- Separate some logic from `GlobalKey` into a new value object: `ResolvableType`