### PR TITLE
Allow return JsonSerializable objects in PHP config files

### DIFF
--- a/src/Framework/Config/ConfigReader/EnvConfigReader.php
+++ b/src/Framework/Config/ConfigReader/EnvConfigReader.php
@@ -14,7 +14,7 @@ final class EnvConfigReader implements ConfigReaderInterface
     }
 
     /**
-     * @return array<array-key, string>
+     * @return array<string,mixed>
      */
     public function read(string $absolutePath): array
     {

--- a/src/Framework/Config/ConfigReaderInterface.php
+++ b/src/Framework/Config/ConfigReaderInterface.php
@@ -6,10 +6,10 @@ namespace Gacela\Framework\Config;
 
 interface ConfigReaderInterface
 {
+    public function canRead(string $absolutePath): bool;
+
     /**
-     * @return array<array-key, string>
+     * @return array<string,mixed>
      */
     public function read(string $absolutePath): array;
-
-    public function canRead(string $absolutePath): bool;
 }

--- a/tests/Integration/Framework/UsingConfigTypePhp/config/local.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/config/local.php
@@ -2,7 +2,12 @@
 
 declare(strict_types=1);
 
-return [
-    'config_local' => 2,
-    'override' => 5,
-];
+return new class() implements JsonSerializable {
+    public function jsonSerialize(): array
+    {
+        return [
+            'config_local' => 2,
+            'override' => 5,
+        ];
+    }
+};


### PR DESCRIPTION
## 📚 Description

In Phel, @jenshaase mentioned returning a `ProjectConfiguration` object directly in the config file ([link](https://github.com/phel-lang/phel-lang/pull/332#discussion_r695425739)). In the beginning, I thought there is no need for that, but later I realized that offering this behavior for the end-user might be also interesting.

## 🔖 Changes

- Extend" the usability of the current PHP config reader by allowing returning an object which implements `JsonSerializable`.