### PR TITLE
Improved type annotation in AbstractClassResolver and Locator

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -79,15 +79,24 @@ abstract class AbstractClassResolver
     }
 
     /**
+     * @template T
+     *
+     * @param class-string<T> $className
+     *
      * @internal so the Locator can access to the global instances before creating a new instance
+     *
+     * @return ?T
      */
-    public static function getCachedGlobalInstance(string $className): ?object
+    public static function getCachedGlobalInstance(string $className)
     {
         $key = self::getGlobalKeyFromClassName($className);
 
-        return self::$cachedGlobalInstances[$key]
+        /** @var ?T $instance */
+        $instance = self::$cachedGlobalInstances[$key]
             ?? self::$cachedGlobalInstances['\\' . $key]
             ?? null;
+
+        return $instance;
     }
 
     private static function getGlobalKeyFromClassName(string $className): string

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -41,17 +41,24 @@ final class Locator
     }
 
     /**
-     * @return mixed
+     * @template T
+     *
+     * @param class-string<T> $className
+     *
+     * @return ?T
      */
     public function get(string $className)
     {
+        /** @var class-string<T> $concreteClass */
         $concreteClass = $this->getConcreteClass($className);
 
         if (isset($this->instanceCache[$concreteClass])) {
-            return $this->instanceCache[$concreteClass];
+            /** @var T $instance */
+            $instance = $this->instanceCache[$concreteClass];
+
+            return $instance;
         }
 
-        /** @var mixed $locatedInstance */
         $locatedInstance = AbstractClassResolver::getCachedGlobalInstance($concreteClass)
             ?? $this->newInstance($concreteClass);
 
@@ -61,6 +68,9 @@ final class Locator
         return $locatedInstance;
     }
 
+    /**
+     * @template T
+     */
     private function getConcreteClass(string $className): string
     {
         if ($this->isInterface($className)) {
@@ -71,7 +81,11 @@ final class Locator
     }
 
     /**
-     * @return mixed
+     * @template T
+     *
+     * @param class-string<T> $className
+     *
+     * @return ?T
      */
     private function newInstance(string $className)
     {
@@ -80,7 +94,7 @@ final class Locator
             return new $className();
         }
 
-        return $className;
+        return null;
     }
 
     private function isInterface(string $className): bool

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -68,9 +68,6 @@ final class Locator
         return $locatedInstance;
     }
 
-    /**
-     * @template T
-     */
     private function getConcreteClass(string $className): string
     {
         if ($this->isInterface($className)) {

--- a/tests/Unit/Framework/Container/LocatorTest.php
+++ b/tests/Unit/Framework/Container/LocatorTest.php
@@ -52,8 +52,8 @@ final class LocatorTest extends TestCase
 
     public function test_get_singleton_from_string(): void
     {
-        /** @var string $stringValue */
-        $stringValue = $this->locator->get('NonExistingClass');
-        self::assertSame('NonExistingClass', $stringValue);
+        /** @var null $nullValue */
+        $nullValue = $this->locator->get('NonExistingClass');
+        self::assertNull($nullValue);
     }
 }


### PR DESCRIPTION
## 📚 Description

Improves the type annotation in `AbstractClassResolver` and `Locator` to have better psalm support. Additionally the method `Locator::newInstance` will now return `null` instead of a string if the class doesn't exists.

## 🔖 Changes

- Added type annotation in `AbstractClassResolver`
- Added type annotation in `Locator`
- `Locator::newInstance` returns `null` if the class doesn't exist.
