### PR TITLE
Set Risky Allowed in php-cs-fixer file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,7 +50,7 @@ $ ./vendor/bin/psalm
 This project comes with a configuration file (located at `/.php_cs.dist` in the repository) that you can use to (re)format your source code for compliance with this project's coding guidelines:
 
 ```bash
-$ ./vendor/bin/php-cs-fixer fix --allow-risky=yes
+$ ./vendor/bin/php-cs-fixer fix
 ```
 
 Please understand that we will not accept a pull request when its changes violate this project's coding guidelines.

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,6 +12,7 @@ $finder = Finder::create()
 
 return (new Config())
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/composer.json
+++ b/composer.json
@@ -70,8 +70,8 @@
         "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=unit,integration,feature --coverage-html=coverage",
         "psalm": "./vendor/bin/psalm",
         "phpstan": "./vendor/bin/phpstan analyze -c phpstan.neon src",
-        "csfix": "./vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "csrun": "./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run",
+        "csfix": "./vendor/bin/php-cs-fixer fix",
+        "csrun": "./vendor/bin/php-cs-fixer fix --dry-run",
         "phpbench": "vendor/bin/phpbench run --report=aggregate --ansi"
     }
 }


### PR DESCRIPTION
## 📚 Description

Add `->setRiskyAllowed(true)` to `.php-cs-fixer.dist.php` file, 
so, we can drop now the `--allow-risky=yes` from composer.json 😄 