### PR TITLE
Add phpbench tests for a normal module

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -5,6 +5,7 @@
   "runner.iterations": 3,
   "runner.revs": 10,
   "runner.time_unit": "time",
+  "runner.file_pattern": "*Bench.php",
   "runner.assert": [
     "mode(variant.time.avg) <= mode(baseline.time.avg) +/- 15%"
   ],

--- a/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Benchmark\Framework\ClassResolver;
+namespace GacelaTest\Benchmark\Framework\ClassResolver\AnonymousGlobal;
 
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractDependencyProvider;

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/Domain/DomainClass.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/Domain/DomainClass.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\NormalModule\Domain;
+
+final class DomainClass
+{
+    private array $configValues;
+    private string $valueFromDependencyProvider;
+
+    public function __construct(
+        array $configValues,
+        string $valueFromDependencyProvider
+    ) {
+        $this->configValues = $configValues;
+        $this->valueFromDependencyProvider = $valueFromDependencyProvider;
+    }
+
+    public function getConfigValues(): array
+    {
+        return $this->configValues;
+    }
+
+    public function getValueFromDependencyProvider(): string
+    {
+        return $this->valueFromDependencyProvider;
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleBench.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\NormalModule;
+
+/**
+ * @BeforeMethods("setUp")
+ * @Revs(100)
+ * @Iterations(10)
+ */
+final class NormalModuleBench
+{
+    private NormalModuleFacade $facade;
+
+    public function setUp(): void
+    {
+        $this->facade = new NormalModuleFacade();
+    }
+
+    public function bench_class_resolving(): void
+    {
+        $this->facade->getConfigValues();
+        $this->facade->getValueFromDependencyProvider();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleConfig.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\NormalModule;
+
+use Gacela\Framework\AbstractConfig;
+
+final class NormalModuleConfig extends AbstractConfig
+{
+    public function getValues(): array
+    {
+        return ['1', 2, [3]];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleDependencyProvider.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleDependencyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\NormalModule;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class NormalModuleDependencyProvider extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('key', 'value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleFacade.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleFacade.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\NormalModule;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method NormalModuleFactory getFactory()
+ */
+final class NormalModuleFacade extends AbstractFacade
+{
+    public function getConfigValues(): array
+    {
+        return $this->getFactory()
+            ->createDomainClass()
+            ->getConfigValues();
+    }
+
+    public function getValueFromDependencyProvider(): string
+    {
+        return $this->getFactory()
+            ->createDomainClass()
+            ->getValueFromDependencyProvider();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleFactory.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/NormalModuleFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\NormalModule;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Benchmark\Framework\ClassResolver\NormalModule\Domain\DomainClass;
+
+/**
+ * @method NormalModuleConfig getConfig()
+ */
+final class NormalModuleFactory extends AbstractFactory
+{
+    public function createDomainClass(): DomainClass
+    {
+        $configValues = $this->getConfig()->getValues();
+
+        /** @var string $valueFromDependencyProvider */
+        $valueFromDependencyProvider = $this->getProvidedDependency('key');
+
+        return new DomainClass($configValues, $valueFromDependencyProvider);
+    }
+}


### PR DESCRIPTION
## 🔖 Changes

We had phpbench tests for anonymous globals but not for a normal module before. So I added the same for a normal module structure.
