### PR TITLE
Allow null as default config value

### DIFF
--- a/src/Framework/AbstractConfig.php
+++ b/src/Framework/AbstractConfig.php
@@ -17,7 +17,7 @@ abstract class AbstractConfig
      *
      * @return mixed
      */
-    protected function get(string $key, $default = null)
+    protected function get(string $key, $default = Config::DEFAULT_CONFIG_VALUE)
     {
         return Config::getInstance()->get($key, $default);
     }

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -13,6 +13,8 @@ use Gacela\Framework\Exception\ConfigException;
 
 final class Config
 {
+    public const DEFAULT_CONFIG_VALUE = 'Gacela\Framework\Config::DEFAULT_CONFIG_VALUE';
+
     private static ?self $instance = null;
 
     private string $applicationRootDir = '';
@@ -68,13 +70,13 @@ final class Config
      *
      * @return mixed
      */
-    public function get(string $key, $default = null)
+    public function get(string $key, $default = self::DEFAULT_CONFIG_VALUE)
     {
         if (empty($this->config)) {
             $this->init($this->getApplicationRootDir());
         }
 
-        if ($default !== null && !$this->hasValue($key)) {
+        if ($default !== self::DEFAULT_CONFIG_VALUE && !$this->hasValue($key)) {
             return $default;
         }
 

--- a/tests/Integration/Framework/UsingConfigWithDefaultValues/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigWithDefaultValues/IntegrationTest.php
@@ -23,6 +23,7 @@ final class IntegrationTest extends TestCase
                 'config' => 1,
                 'config_local' => 2,
                 'override' => 5,
+                'allowing_null_as_default_value' => null,
             ],
             $facade->doSomething()
         );

--- a/tests/Integration/Framework/UsingConfigWithDefaultValues/LocalConfig/Config.php
+++ b/tests/Integration/Framework/UsingConfigWithDefaultValues/LocalConfig/Config.php
@@ -14,6 +14,7 @@ final class Config extends AbstractConfig
             'config' => (int)$this->get('config'),
             'config_local' => (int)$this->get('config_local'),
             'override' => (int)$this->get('override'),
+            'allowing_null_as_default_value' => $this->get('allowing_null_as_default_value', null),
         ];
     }
 }

--- a/tests/Unit/Framework/ConfigTest.php
+++ b/tests/Unit/Framework/ConfigTest.php
@@ -34,6 +34,11 @@ final class ConfigTest extends TestCase
         self::assertSame('default', $this->config->get('key', 'default'));
     }
 
+    public function test_null_as_default_value_from_undefined_key(): void
+    {
+        self::assertNull($this->config->get('key', null));
+    }
+
     public function test_get_using_custom_reader(): void
     {
         Config::setConfigReaders([


### PR DESCRIPTION
## 📚 Description

Currently, it's not possible to use `null` as default value for a non-defined config key.

## 🔖 Changes

- Allow `null` as default value as any other default value for config values.
