### PR TITLE
Minor clean up and test improvement

### DIFF
--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -19,7 +19,7 @@ final class Config
 
     private string $applicationRootDir = '';
 
-    /** @var array<array-key, mixed> */
+    /** @var array<string, mixed> */
     private array $config = [];
 
     /** @var array<string, ConfigReaderInterface> */

--- a/src/Framework/Config/ConfigInit.php
+++ b/src/Framework/Config/ConfigInit.php
@@ -15,11 +15,11 @@ final class ConfigInit
 
     private PathFinderInterface $pathFinder;
 
-    /** @var array<string,ConfigReaderInterface> */
+    /** @var array<string, ConfigReaderInterface> */
     private array $readers;
 
     /**
-     * @param array<string,ConfigReaderInterface> $readers
+     * @param array<string, ConfigReaderInterface> $readers
      */
     public function __construct(
         string $applicationRootDir,
@@ -34,7 +34,7 @@ final class ConfigInit
     }
 
     /**
-     * @return array<array-key, mixed>
+     * @return array<string, mixed>
      */
     public function readAll(): array
     {
@@ -51,26 +51,25 @@ final class ConfigInit
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     private function scanAllConfigFiles(GacelaConfigFile $gacelaFileConfig): array
     {
         $configGroup = array_map(
-            fn (GacelaConfigItem $config): array => array_map(
-                static fn ($p): string => $p,
-                array_diff(
-                    $this->pathFinder->matchingPattern($this->generateAbsolutePath($config->path())),
-                    [$this->generateAbsolutePath($config->pathLocal())]
-                )
+            fn (GacelaConfigItem $config): array => array_diff(
+                $this->pathFinder->matchingPattern($this->generateAbsolutePath($config->path())),
+                [$this->generateAbsolutePath($config->pathLocal())]
             ),
             $gacelaFileConfig->getConfigs()
         );
 
-        return array_merge(...array_values($configGroup));
+        $groupsValues = array_values($configGroup);
+
+        return array_merge(...$groupsValues);
     }
 
     /**
-     * @return array<array-key, mixed>
+     * @return array<string, mixed>
      */
     private function readConfigFromFile(GacelaConfigFile $gacelaConfigFile, string $absolutePath): array
     {
@@ -92,7 +91,7 @@ final class ConfigInit
     }
 
     /**
-     * @return array<array-key, mixed>
+     * @return array<string, mixed>
      */
     private function readLocalConfigFile(GacelaConfigFile $gacelaConfigFile): array
     {

--- a/src/Framework/Config/ConfigInit.php
+++ b/src/Framework/Config/ConfigInit.php
@@ -51,9 +51,11 @@ final class ConfigInit
     }
 
     /**
-     * @return array<string>
+     * All config files except the local config file.
+     *
+     * @return iterable<string>
      */
-    private function scanAllConfigFiles(GacelaConfigFile $gacelaFileConfig): array
+    private function scanAllConfigFiles(GacelaConfigFile $gacelaFileConfig): iterable
     {
         $configGroup = array_map(
             fn (GacelaConfigItem $config): array => array_diff(
@@ -65,7 +67,9 @@ final class ConfigInit
 
         $groupsValues = array_values($configGroup);
 
-        return array_merge(...$groupsValues);
+        foreach (array_merge(...$groupsValues) as $path) {
+            yield $path;
+        }
     }
 
     /**

--- a/tests/Integration/Framework/UsingConfigTypePhp/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/IntegrationTest.php
@@ -21,8 +21,9 @@ final class IntegrationTest extends TestCase
         self::assertSame(
             [
                 'config' => 1,
-                'config_local' => 2,
-                'override' => 5,
+                'override' => 2,
+                'local' => 3,
+                'override_from_local' => 4,
             ],
             $facade->doSomething()
         );

--- a/tests/Integration/Framework/UsingConfigTypePhp/LocalConfig/Config.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/LocalConfig/Config.php
@@ -11,9 +11,10 @@ final class Config extends AbstractConfig
     public function getArrayConfig(): array
     {
         return [
-            'config' => (int) $this->get('config'),
-            'config_local' => (int) $this->get('config_local'),
-            'override' => (int) $this->get('override'),
+            'config' => (int) $this->get('config_key'),
+            'override' => (int) $this->get('override_key'),
+            'local' => (int) $this->get('local_key'),
+            'override_from_local' => (int) $this->get('override_key_from_local'),
         ];
     }
 }

--- a/tests/Integration/Framework/UsingConfigTypePhp/config/default.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/config/default.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'config' => 1,
-    'override' => 3,
+    'config_key' => 1,
+    'override_key' => 1,
+    'local_key' => 1,
 ];

--- a/tests/Integration/Framework/UsingConfigTypePhp/config/local.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/config/local.php
@@ -6,8 +6,8 @@ return new class () implements JsonSerializable {
     public function jsonSerialize(): array
     {
         return [
-            'config_local' => 2,
-            'override' => 5,
+            'local_key' => 3,
+            'override_key_from_local' => 4,
         ];
     }
 };

--- a/tests/Integration/Framework/UsingConfigTypePhp/config/override.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/config/override.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'override_key' => 2,
+    'override_key_from_local' => 2,
+];


### PR DESCRIPTION
## 🔖 Changes

- Improve performance on Config->scanAllConfigFiles()
- Add an extra config file for `Integration/Framework/UsingConfigTypePhp` test
  - This ensures/proof multi config file loading, overriding the previous one alphabetically
  - The "local config file" will win the last override
