### PR TITLE
Rename ConfigInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+### Unreleased
+
+- Add getAppRootDir() to AbstractConfig.
+- Deprecate getApplicationRootDir() from Config. Use getAppRootDir() instead.
+
 ### 0.11.0
 #### 2022-01-18
 
-- Deleted deprecated array config in gacela.php
-- Allow null as default config value
+- Deleted deprecated array config in gacela.php.
+- Allow null as default config value.
 - The globalServices are passed into mappingInterfaces() and not as constructor argument.
 
 ### 0.10.0

--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -43,7 +43,7 @@ final class CodeGeneratorConfig extends AbstractConfig
      */
     public function getComposerJsonContentAsArray(): array
     {
-        $filename = Config::getInstance()->getApplicationRootDir() . '/composer.json';
+        $filename = Config::getInstance()->getAppRootDir() . '/composer.json';
         if (!file_exists($filename)) {
             throw new LogicException('composer.json file not found but it is required');
         }

--- a/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\CodeGenerator\Domain\CommandArguments;
 
 use InvalidArgumentException;
+use function count;
 
 final class CommandArgumentsParser implements CommandArgumentsParserInterface
 {

--- a/src/Framework/AbstractConfig.php
+++ b/src/Framework/AbstractConfig.php
@@ -22,6 +22,6 @@ abstract class AbstractConfig
 
     protected function getAppRootDir(): string
     {
-        return Config::getInstance()->getApplicationRootDir();
+        return Config::getInstance()->getAppRootDir();
     }
 }

--- a/src/Framework/AbstractFacade.php
+++ b/src/Framework/AbstractFacade.php
@@ -19,6 +19,9 @@ abstract class AbstractFacade
         return $this->factory;
     }
 
+    /**
+     * @throws ClassResolver\Factory\FactoryNotFoundException
+     */
     private function resolveFactory(): AbstractFactory
     {
         return $this->createFactoryResolver()->resolve($this);

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -12,7 +12,7 @@ abstract class AbstractFactory
 {
     use ConfigResolverAwareTrait;
 
-    /** @var Container[] */
+    /** @var array<string,Container> */
     private static array $containers = [];
 
     /**
@@ -22,9 +22,7 @@ abstract class AbstractFactory
      */
     protected function getProvidedDependency(string $key)
     {
-        $container = $this->getContainer();
-
-        return $container->get($key);
+        return $this->getContainer()->get($key);
     }
 
     private function getContainer(): Container
@@ -47,6 +45,9 @@ abstract class AbstractFactory
         return $container;
     }
 
+    /**
+     * @throws ClassResolver\DependencyProvider\DependencyProviderNotFoundException
+     */
     private function resolveDependencyProvider(): AbstractDependencyProvider
     {
         return $this->createDependencyProviderResolver()->resolve($this);

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -128,7 +128,10 @@ final class Config
     public function getFactory(): ConfigFactory
     {
         if (null === $this->configFactory) {
-            $this->configFactory = new ConfigFactory($this->globalConfigServices);
+            $this->configFactory = new ConfigFactory(
+                $this->getApplicationRootDir(),
+                $this->globalConfigServices
+            );
         }
 
         return $this->configFactory;

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Gacela\Framework\Config\ConfigFactory;
-use Gacela\Framework\Config\ConfigInit;
+use Gacela\Framework\Config\ConfigLoader;
 use Gacela\Framework\Config\ConfigReader\EnvConfigReader;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\ConfigReaderInterface;
@@ -19,19 +19,19 @@ final class Config
 
     private string $applicationRootDir = '';
 
-    /** @var array<string, mixed> */
+    /** @var array<string,mixed> */
     private array $config = [];
 
-    /** @var array<string, ConfigReaderInterface> */
+    /** @var array<string,ConfigReaderInterface> */
     private array $configReaders;
 
-    /** @var array<string, mixed> */
+    /** @var array<string,mixed> */
     private array $globalConfigServices = [];
 
     private ?ConfigFactory $configFactory = null;
 
     /**
-     * @param array<string, ConfigReaderInterface> $configReaders
+     * @param array<string,ConfigReaderInterface> $configReaders
      */
     private function __construct(array $configReaders)
     {
@@ -56,7 +56,7 @@ final class Config
     }
 
     /**
-     * @param array<string, ConfigReaderInterface> $configReaders
+     * @param array<string,ConfigReaderInterface> $configReaders
      */
     public static function setConfigReaders(array $configReaders = []): void
     {
@@ -94,12 +94,7 @@ final class Config
     {
         $this->setApplicationRootDir($applicationRootDir);
 
-        $this->config = (new ConfigInit(
-            $this->getApplicationRootDir(),
-            $this->getFactory()->createGacelaConfigFileFactory(),
-            $this->getFactory()->createPathFinder(),
-            $this->configReaders
-        ))->readAll();
+        $this->config = $this->loadAllConfigValues();
     }
 
     public function setApplicationRootDir(string $dir): void
@@ -117,7 +112,7 @@ final class Config
     }
 
     /**
-     * @param array<string, mixed> $globalConfigServices
+     * @param array<string,mixed> $globalConfigServices
      */
     public function setGlobalConfigServices(array $globalConfigServices): self
     {
@@ -142,5 +137,20 @@ final class Config
     private function hasValue(string $key): bool
     {
         return isset($this->config[$key]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadAllConfigValues(): array
+    {
+        $configLoader = new ConfigLoader(
+            $this->getApplicationRootDir(),
+            $this->getFactory()->createGacelaConfigFileFactory(),
+            $this->getFactory()->createPathFinder(),
+            $this->configReaders
+        );
+
+        return $configLoader->loadAll();
     }
 }

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -17,7 +17,7 @@ final class Config
 
     private static ?self $instance = null;
 
-    private string $applicationRootDir = '';
+    private string $appRootDir = '';
 
     /** @var array<string,mixed> */
     private array $config = [];
@@ -73,7 +73,7 @@ final class Config
     public function get(string $key, $default = self::DEFAULT_CONFIG_VALUE)
     {
         if (empty($this->config)) {
-            $this->init($this->getApplicationRootDir());
+            $this->init($this->getAppRootDir());
         }
 
         if ($default !== self::DEFAULT_CONFIG_VALUE && !$this->hasValue($key)) {
@@ -90,25 +90,41 @@ final class Config
     /**
      * @throws ConfigException
      */
-    public function init(string $applicationRootDir): void
+    public function init(string $appRootDir): void
     {
-        $this->setApplicationRootDir($applicationRootDir);
+        $this->setAppRootDir($appRootDir);
 
         $this->config = $this->loadAllConfigValues();
     }
 
-    public function setApplicationRootDir(string $dir): void
+    public function setAppRootDir(string $dir): void
     {
-        $this->applicationRootDir = $dir;
+        $this->appRootDir = $dir;
     }
 
-    public function getApplicationRootDir(): string
+    public function getAppRootDir(): string
     {
-        if (empty($this->applicationRootDir)) {
-            $this->applicationRootDir = getcwd() ?: '';
+        if (empty($this->appRootDir)) {
+            $this->appRootDir = getcwd() ?: '';
         }
 
-        return $this->applicationRootDir;
+        return $this->appRootDir;
+    }
+
+    /**
+     * @deprecated Use `setAppRootDir(string $dir)` instead
+     */
+    public function setApplicationRootDir(string $dir): void
+    {
+        $this->setAppRootDir($dir);
+    }
+
+    /**
+     * @deprecated use `getAppRootDir()` instead
+     */
+    public function getApplicationRootDir(): string
+    {
+        return $this->getAppRootDir();
     }
 
     /**
@@ -129,7 +145,7 @@ final class Config
     {
         if (null === $this->configFactory) {
             $this->configFactory = new ConfigFactory(
-                $this->getApplicationRootDir(),
+                $this->getAppRootDir(),
                 $this->globalConfigServices
             );
         }
@@ -148,7 +164,7 @@ final class Config
     private function loadAllConfigValues(): array
     {
         $configLoader = new ConfigLoader(
-            $this->getApplicationRootDir(),
+            $this->getAppRootDir(),
             $this->getFactory()->createGacelaConfigFileFactory(),
             $this->getFactory()->createPathFinder(),
             $this->configReaders

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
-use Gacela\Framework\Config;
-
 final class ConfigFactory
 {
     private const GACELA_PHP_CONFIG_FILENAME = 'gacela.php';
+
+    private string $appRootDir;
 
     /** @var array<string,mixed> */
     private array $globalServices;
@@ -16,15 +16,16 @@ final class ConfigFactory
     /**
      * @param array<string,mixed> $globalServices
      */
-    public function __construct(array $globalServices)
+    public function __construct(string $appRootDir, array $globalServices)
     {
+        $this->appRootDir = $appRootDir;
         $this->globalServices = $globalServices;
     }
 
     public function createGacelaConfigFileFactory(): GacelaConfigFileFactoryInterface
     {
         return new GacelaConfigFileFactory(
-            Config::getInstance()->getApplicationRootDir(),
+            $this->appRootDir,
             self::GACELA_PHP_CONFIG_FILENAME,
             $this->globalServices,
             $this->createConfigGacelaMapper()

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -10,11 +10,11 @@ final class ConfigFactory
 {
     private const GACELA_PHP_CONFIG_FILENAME = 'gacela.php';
 
-    /** @var array<string, mixed> */
+    /** @var array<string,mixed> */
     private array $globalServices;
 
     /**
-     * @param array<string, mixed> $globalServices
+     * @param array<string,mixed> $globalServices
      */
     public function __construct(array $globalServices)
     {

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -7,7 +7,7 @@ namespace Gacela\Framework\Config;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 
-final class ConfigInit
+final class ConfigLoader
 {
     private string $applicationRootDir;
 
@@ -15,11 +15,11 @@ final class ConfigInit
 
     private PathFinderInterface $pathFinder;
 
-    /** @var array<string, ConfigReaderInterface> */
+    /** @var array<string,ConfigReaderInterface> */
     private array $configReaders;
 
     /**
-     * @param array<string, ConfigReaderInterface> $configReaders
+     * @param array<string,ConfigReaderInterface> $configReaders
      */
     public function __construct(
         string $applicationRootDir,
@@ -34,9 +34,9 @@ final class ConfigInit
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string,mixed>
      */
-    public function readAll(): array
+    public function loadAll(): array
     {
         $gacelaFileConfig = $this->configFactory->createGacelaFileConfig();
         $configs = [];
@@ -73,7 +73,7 @@ final class ConfigInit
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string,mixed>
      */
     private function readConfigFromFile(GacelaConfigFile $gacelaConfigFile, string $absolutePath): array
     {
@@ -95,7 +95,7 @@ final class ConfigInit
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string,mixed>
      */
     private function readLocalConfigFile(GacelaConfigFile $gacelaConfigFile): array
     {

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -15,13 +15,13 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
 
     private string $gacelaPhpConfigFilename;
 
-    /** @var array<string, mixed> */
+    /** @var array<string,mixed> */
     private array $globalServices;
 
     private ConfigGacelaMapper $configGacelaMapper;
 
     /**
-     * @param array<string, mixed> $globalServices
+     * @param array<string,mixed> $globalServices
      */
     public function __construct(
         string $applicationRootDir,

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
@@ -26,7 +26,7 @@ final class GacelaConfigItem
     }
 
     /**
-     * @param array<array-key, mixed> $item
+     * @param array<array-key,mixed> $item
      */
     public static function fromArray(array $item): self
     {

--- a/src/Framework/Exception/Backtrace.php
+++ b/src/Framework/Exception/Backtrace.php
@@ -26,7 +26,7 @@ final class Backtrace
     }
 
     /**
-     * @param array<array-key, mixed> $backtrace
+     * @param array<array-key,mixed> $backtrace
      */
     private function getTraceLine(array $backtrace): string
     {
@@ -42,7 +42,7 @@ final class Backtrace
     }
 
     /**
-     * @param array<array-key, mixed> $backtrace
+     * @param array<array-key,mixed> $backtrace
      */
     private function getTraceLineFromTestCase(array $backtrace): string
     {

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -7,12 +7,15 @@ namespace Gacela\Framework;
 final class Gacela
 {
     /**
+     * Define the entry point of Gacela.
+     * Mainly to define the application root directory and optional global services.
+     *
      * @param array<string,mixed> $globalServices
      */
-    public static function bootstrap(string $applicationRootDir, array $globalServices = []): void
+    public static function bootstrap(string $appRootDir, array $globalServices = []): void
     {
         Config::getInstance()
             ->setGlobalConfigServices($globalServices)
-            ->init($applicationRootDir);
+            ->init($appRootDir);
     }
 }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -7,7 +7,7 @@ namespace Gacela\Framework;
 final class Gacela
 {
     /**
-     * @param array<string, mixed> $globalServices
+     * @param array<string,mixed> $globalServices
      */
     public static function bootstrap(string $applicationRootDir, array $globalServices = []): void
     {

--- a/tests/Unit/Framework/Config/ConfigInitTest.php
+++ b/tests/Unit/Framework/Config/ConfigInitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Config;
 
-use Gacela\Framework\Config\ConfigInit;
+use Gacela\Framework\Config\ConfigLoader;
 use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
@@ -25,14 +25,14 @@ final class ConfigInitTest extends TestCase
             'php' => $this->createStub(ConfigReaderInterface::class),
         ];
 
-        $configInit = new ConfigInit(
+        $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
             $readers
         );
 
-        self::assertSame([], $configInit->readAll());
+        self::assertSame([], $configInit->loadAll());
     }
 
     public function test_one_reader_linked_to_unsupported_type_is_ignored(): void
@@ -49,14 +49,14 @@ final class ConfigInitTest extends TestCase
             'unsupported_type' => $this->createStub(ConfigReaderInterface::class),
         ];
 
-        $configInit = new ConfigInit(
+        $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $pathFinder,
             $readers
         );
 
-        self::assertSame([], $configInit->readAll());
+        self::assertSame([], $configInit->loadAll());
     }
 
     public function test_no_readers_returns_empty_array(): void
@@ -71,14 +71,14 @@ final class ConfigInitTest extends TestCase
 
         $readers = [];
 
-        $configInit = new ConfigInit(
+        $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $pathFinder,
             $readers
         );
 
-        self::assertSame([], $configInit->readAll());
+        self::assertSame([], $configInit->loadAll());
     }
 
     public function test_read_single_config(): void
@@ -99,14 +99,14 @@ final class ConfigInitTest extends TestCase
             'supported-type' => $reader,
         ];
 
-        $configInit = new ConfigInit(
+        $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
             $readers
         );
 
-        self::assertSame(['key' => 'value'], $configInit->readAll());
+        self::assertSame(['key' => 'value'], $configInit->loadAll());
     }
 
     public function test_read_multiple_config(): void
@@ -133,7 +133,7 @@ final class ConfigInitTest extends TestCase
             'supported-type2' => $reader2,
         ];
 
-        $configInit = new ConfigInit(
+        $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
@@ -143,6 +143,6 @@ final class ConfigInitTest extends TestCase
         self::assertSame([
             'key1' => 'value1',
             'key2' => 'value2',
-        ], $configInit->readAll());
+        ], $configInit->loadAll());
     }
 }


### PR DESCRIPTION
## 🔖 Changes

- Rename `ConfigInit` to `ConfigLoader`
- Rename `getApplicationRootDir` to `getAppRootDir`
- Unify `array<>` syntax without space between the key and value types
- Minor clean up to `Config`
