### PR TITLE
Add unit tests for Backtrace

### DIFF
--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -29,7 +29,7 @@ trait ClassResolverExceptionTrait
             $this->findClassNameExample($callerClassInfo, $resolvableType)
         ) . PHP_EOL;
 
-        return $message . Backtrace::get();
+        return $message . (new Backtrace())->get();
     }
 
     private function findClassNameExample(ClassInfo $classInfo, string $resolvableType): string

--- a/src/Framework/Exception/Backtrace.php
+++ b/src/Framework/Exception/Backtrace.php
@@ -4,55 +4,42 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Exception;
 
-/**
- * @codeCoverageIgnore
- */
-final class Backtrace
+class Backtrace
 {
     private string $backtrace = '';
 
-    public static function get(): string
+    public function get(): string
     {
-        return (new self())->backtrace;
-    }
-
-    private function __construct()
-    {
-        $backtraceCollection = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-
-        foreach ($backtraceCollection as $backtrace) {
+        foreach ($this->getBacktraces() as $backtrace) {
             $this->backtrace .= $this->getTraceLine($backtrace) . PHP_EOL;
         }
+
+        return $this->backtrace;
     }
 
     /**
-     * @param array<array-key,mixed> $backtrace
+     * @param array{file:string, line:int} $backtrace
      */
     private function getTraceLine(array $backtrace): string
     {
-        /** @var null|string $file */
-        $file = $backtrace['file'];
-        if (isset($file)) {
-            /** @var string $line */
-            $line = $backtrace['line'];
-            return $file . ':' . $line;
-        }
-
-        return $this->getTraceLineFromTestCase($backtrace);
+        return $backtrace['file'] . ':' . $backtrace['line'];
     }
 
     /**
-     * @param array<array-key,mixed> $backtrace
+     * @return list<array{
+     *     args?: list<mixed>,
+     *     class?: class-string,
+     *     file: string,
+     *     function: string,
+     *     line: int,
+     *     object?: object,
+     *     type?: string
+     * }>
+     *
+     * @internal for testing purposes
      */
-    private function getTraceLineFromTestCase(array $backtrace): string
+    public function getBacktraces(): array
     {
-        /** @var string $class */
-        $class = $backtrace['class'];
-        /** @var string $type */
-        $type = $backtrace['type'];
-        /** @var string $function */
-        $function = $backtrace['function'];
-
-        return $class . $type . $function;
+        return debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);//@phpstan-ignore-line
     }
 }

--- a/tests/Unit/Framework/Exception/BacktraceTest.php
+++ b/tests/Unit/Framework/Exception/BacktraceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Exception;
+
+use Gacela\Framework\Exception\Backtrace;
+use PHPUnit\Framework\TestCase;
+
+final class BacktraceTest extends TestCase
+{
+    public function test_backtrace(): void
+    {
+        $backtrace = $this->createPartialMock(Backtrace::class, ['getBacktraces']);
+        $backtrace->method('getBacktraces')->willReturn([
+            ['line' => 10, 'file' => 'file-name-1'],
+            ['line' => 11, 'file' => 'file-name-1'],
+            ['line' => 20, 'file' => 'file-name-2'],
+        ]);
+
+        $expected = <<<TXT
+file-name-1:10
+file-name-1:11
+file-name-2:20
+
+TXT;
+        self::assertEquals($expected, $backtrace->get());
+    }
+}


### PR DESCRIPTION
## 📚 Description

The current Backtrace class is not testable, because it depends on the `\debug_backtrace()` native function.

## 🔖 Changes

- Move the `\debug_backtrace()` into a function, so it can be mocked and by doing so we can write tests for the `get()` behaviour.

### What I learned
If you use `createMock()` all methods are override in the mock, so if you want to mock only a certain function while keeping the real functionality from other methods, you have to use `createPartialMock`.
```php
# see: tests/Unit/Framework/Exception/BacktraceTest.php:14
$backtrace = $this->createPartialMock(Backtrace::class, ['getBacktraces']);
```
