### PR TITLE
Move config-readers as globalServices and gacela.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Add getAppRootDir() to AbstractConfig.
 - Deprecate getApplicationRootDir() from Config. Use getAppRootDir() instead.
-- The Gacela::bootstrap() now accepts a 3rd parameter to add config readers
-- Remove EnvConfigReader, if you want to read .env values, you should require `gacela-project/gacela-env-config-reader`
+- The Gacela::bootstrap() now accepts to add config readers as `config-readers` key in the globalServices array
+- Remove `EnvConfigReader`, if you want to read .env values, you should require `gacela-project/gacela-env-config-reader`
 
 ### 0.11.0
 #### 2022-01-18

--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
+use Gacela\Framework\Config\ConfigReaderInterface;
+
 abstract class AbstractConfigGacela
 {
     /**
-     * @return array<array>|array{type:string,path:string,path_local:string}
+     * @return array<array>|array{
+     *     type?:string,
+     *     path?:string,
+     *     path_local?:string
+     * }
      */
     public function config(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string,ConfigReaderInterface>
+     */
+    public function configReaders(): array
     {
         return [];
     }

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -6,8 +6,6 @@ namespace Gacela\Framework;
 
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Config\ConfigLoader;
-use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
-use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Exception\ConfigException;
 
 final class Config
@@ -21,17 +19,13 @@ final class Config
     /** @var array<string,mixed> */
     private array $config = [];
 
-    /** @var array<string,ConfigReaderInterface> */
-    private array $configReaders;
-
     /** @var array<string,mixed> */
-    private array $globalConfigServices = [];
+    private array $globalServices = [];
 
     private ?ConfigFactory $configFactory = null;
 
     private function __construct()
     {
-        $this->setConfigReaders([]);
     }
 
     public static function getInstance(): self
@@ -41,20 +35,6 @@ final class Config
         }
 
         return self::$instance;
-    }
-
-    /**
-     * @param array<string,ConfigReaderInterface> $configReaders
-     */
-    public function setConfigReaders(array $configReaders = []): self
-    {
-        if (empty($configReaders)) {
-            $configReaders = ['php' => new PhpConfigReader()];
-        }
-
-        $this->configReaders = $configReaders;
-
-        return $this;
     }
 
     /**
@@ -122,12 +102,12 @@ final class Config
     }
 
     /**
-     * @param array<string,mixed> $globalConfigServices
+     * @param array<string,mixed> $globalServices
      */
-    public function setGlobalConfigServices(array $globalConfigServices): self
+    public function setGlobalServices(array $globalServices): self
     {
         $this->configFactory = null;
-        $this->globalConfigServices = $globalConfigServices;
+        $this->globalServices = $globalServices;
 
         return $this;
     }
@@ -140,7 +120,7 @@ final class Config
         if (null === $this->configFactory) {
             $this->configFactory = new ConfigFactory(
                 $this->getAppRootDir(),
-                $this->globalConfigServices
+                $this->globalServices
             );
         }
 
@@ -161,7 +141,6 @@ final class Config
             $this->getAppRootDir(),
             $this->getFactory()->createGacelaConfigFileFactory(),
             $this->getFactory()->createPathFinder(),
-            $this->configReaders
         );
 
         return $configLoader->loadAll();

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -15,22 +15,14 @@ final class ConfigLoader
 
     private PathFinderInterface $pathFinder;
 
-    /** @var array<string,ConfigReaderInterface> */
-    private array $configReaders;
-
-    /**
-     * @param array<string,ConfigReaderInterface> $configReaders
-     */
     public function __construct(
         string $applicationRootDir,
         GacelaConfigFileFactoryInterface $configFactory,
-        PathFinderInterface $pathFinder,
-        array $configReaders
+        PathFinderInterface $pathFinder
     ) {
         $this->applicationRootDir = $applicationRootDir;
         $this->configFactory = $configFactory;
         $this->pathFinder = $pathFinder;
-        $this->configReaders = $configReaders;
     }
 
     /**
@@ -80,7 +72,7 @@ final class ConfigLoader
         $result = [];
         $configItems = $gacelaConfigFile->getConfigItems();
 
-        foreach ($this->configReaders as $type => $reader) {
+        foreach ($gacelaConfigFile->getConfigReaders() as $type => $reader) {
             $config = $configItems[$type] ?? null;
             if ($config === null) {
                 continue;
@@ -102,7 +94,7 @@ final class ConfigLoader
         $result = [];
         $configItems = $gacelaConfigFile->getConfigItems();
 
-        foreach ($this->configReaders as $type => $reader) {
+        foreach ($gacelaConfigFile->getConfigReaders() as $type => $reader) {
             $config = $configItems[$type] ?? null;
             if ($config === null) {
                 continue;

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig;
 
+use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
+use Gacela\Framework\Config\ConfigReaderInterface;
+
 final class GacelaConfigFile
 {
     /** @var array<string,GacelaConfigItem> */
@@ -11,6 +14,18 @@ final class GacelaConfigFile
 
     /** @var array<class-string,class-string|callable> */
     private array $mappingInterfaces = [];
+
+    /** @var array<string,ConfigReaderInterface> */
+    private array $configReaders = [];
+
+    public static function withDefaults(): self
+    {
+        $configItem = GacelaConfigItem::withDefaults();
+
+        return (new self())
+            ->setConfigItems([$configItem->type() => $configItem])
+            ->setConfigReaders(['php' => new PhpConfigReader()]);
+    }
 
     /**
      * @param array<string,GacelaConfigItem> $configItems
@@ -23,6 +38,32 @@ final class GacelaConfigFile
     }
 
     /**
+     * @return array<string,GacelaConfigItem>
+     */
+    public function getConfigItems(): array
+    {
+        return $this->configItems;
+    }
+
+    /**
+     * @param array<string,ConfigReaderInterface> $configReaders
+     */
+    public function setConfigReaders(array $configReaders): self
+    {
+        $this->configReaders = $configReaders;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string,ConfigReaderInterface>
+     */
+    public function getConfigReaders(): array
+    {
+        return $this->configReaders;
+    }
+
+    /**
      * @param array<class-string,class-string|callable> $mappingInterfaces
      */
     public function setMappingInterfaces(array $mappingInterfaces): self
@@ -30,22 +71,6 @@ final class GacelaConfigFile
         $this->mappingInterfaces = $mappingInterfaces;
 
         return $this;
-    }
-
-    public static function withDefaults(): self
-    {
-        $configItem = GacelaConfigItem::withDefaults();
-
-        return (new self())
-            ->setConfigItems([$configItem->type() => $configItem]);
-    }
-
-    /**
-     * @return array<string,GacelaConfigItem>
-     */
-    public function getConfigItems(): array
-    {
-        return $this->configItems;
     }
 
     /**

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
-use Gacela\Framework\Config\ConfigReaderInterface;
-
 final class Gacela
 {
     /**
      * Define the entry point of Gacela.
      *
      * @param array<string,mixed> $globalServices
-     * @param array<string,ConfigReaderInterface> $configReaders
      */
-    public static function bootstrap(string $appRootDir, array $globalServices = [], array $configReaders = []): void
+    public static function bootstrap(string $appRootDir, array $globalServices = []): void
     {
         Config::getInstance()
             ->setAppRootDir($appRootDir)
-            ->setGlobalConfigServices($globalServices)
-            ->setConfigReaders($configReaders)
+            ->setGlobalServices($globalServices)
             ->init();
     }
 }

--- a/tests/Integration/Framework/UsingMultipleConfig/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingMultipleConfig/IntegrationTest.php
@@ -24,14 +24,13 @@ final class IntegrationTest extends TestCase
                     'path' => 'config/*.php',
                 ],
             ],
+            'config-readers' =>  [
+                'php' => new PhpConfigReader(),
+                'env' => new SimpleEnvConfigReader(),
+            ],
         ];
 
-        $configReaders = [
-            'php' => new PhpConfigReader(),
-            'env' => new SimpleEnvConfigReader(),
-        ];
-
-        Gacela::bootstrap(__DIR__, $globalServices, $configReaders);
+        Gacela::bootstrap(__DIR__, $globalServices);
     }
 
     public function test_load_multiple_config_files(): void

--- a/tests/Unit/Framework/Config/ConfigInitTest.php
+++ b/tests/Unit/Framework/Config/ConfigInitTest.php
@@ -83,27 +83,25 @@ final class ConfigInitTest extends TestCase
 
     public function test_read_single_config(): void
     {
-        $gacelaJsonConfigCreator = $this->createStub(GacelaConfigFileFactoryInterface::class);
-        $gacelaJsonConfigCreator
-            ->method('createGacelaFileConfig')
-            ->willReturn((new GacelaConfigFile())
-                ->setConfigItems([
-                    'supported-type' => new GacelaConfigItem('supported-type'),
-                ]));
-
         $reader = $this->createStub(ConfigReaderInterface::class);
         $reader->method('canRead')->willReturn(true);
         $reader->method('read')->willReturn(['key' => 'value']);
 
-        $readers = [
-            'supported-type' => $reader,
-        ];
+        $gacelaJsonConfigCreator = $this->createStub(GacelaConfigFileFactoryInterface::class);
+        $gacelaJsonConfigCreator
+            ->method('createGacelaFileConfig')
+            ->willReturn((new GacelaConfigFile())
+                ->setConfigReaders([
+                    'supported-type' => $reader,
+                ])
+                ->setConfigItems([
+                    'supported-type' => new GacelaConfigItem('supported-type'),
+                ]));
 
         $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
-            $readers
         );
 
         self::assertSame(['key' => 'value'], $configInit->loadAll());
@@ -111,15 +109,6 @@ final class ConfigInitTest extends TestCase
 
     public function test_read_multiple_config(): void
     {
-        $gacelaJsonConfigCreator = $this->createStub(GacelaConfigFileFactoryInterface::class);
-        $gacelaJsonConfigCreator
-            ->method('createGacelaFileConfig')
-            ->willReturn((new GacelaConfigFile())
-                ->setConfigItems([
-                    'supported-type1' => new GacelaConfigItem('supported-type1'),
-                    'supported-type2' => new GacelaConfigItem('supported-type2'),
-                ]));
-
         $reader1 = $this->createStub(ConfigReaderInterface::class);
         $reader1->method('canRead')->willReturn(true);
         $reader1->method('read')->willReturn(['key1' => 'value1']);
@@ -128,16 +117,23 @@ final class ConfigInitTest extends TestCase
         $reader2->method('canRead')->willReturn(true);
         $reader2->method('read')->willReturn(['key2' => 'value2']);
 
-        $readers = [
-            'supported-type1' => $reader1,
-            'supported-type2' => $reader2,
-        ];
+        $gacelaJsonConfigCreator = $this->createStub(GacelaConfigFileFactoryInterface::class);
+        $gacelaJsonConfigCreator
+            ->method('createGacelaFileConfig')
+            ->willReturn((new GacelaConfigFile())
+                ->setConfigReaders([
+                    'supported-type1' => $reader1,
+                    'supported-type2' => $reader2,
+                ])
+                ->setConfigItems([
+                    'supported-type1' => new GacelaConfigItem('supported-type1'),
+                    'supported-type2' => new GacelaConfigItem('supported-type2'),
+                ]));
 
         $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
-            $readers
         );
 
         self::assertSame([

--- a/tests/Unit/Framework/ConfigTest.php
+++ b/tests/Unit/Framework/ConfigTest.php
@@ -28,18 +28,20 @@ final class ConfigTest extends TestCase
 
     public function test_get_using_custom_reader(): void
     {
-        Config::getInstance()->setConfigReaders([
-            Config\GacelaFileConfig\GacelaConfigItem::DEFAULT_TYPE => new class () implements ConfigReaderInterface {
-                public function read(string $absolutePath): array
-                {
-                    return ['key' => 'value'];
-                }
+        Config::getInstance()->setGlobalServices([
+            'config-readers' => [
+                Config\GacelaFileConfig\GacelaConfigItem::DEFAULT_TYPE => new class () implements ConfigReaderInterface {
+                    public function read(string $absolutePath): array
+                    {
+                        return ['key' => 'value'];
+                    }
 
-                public function canRead(string $absolutePath): bool
-                {
-                    return true;
-                }
-            },
+                    public function canRead(string $absolutePath): bool
+                    {
+                        return true;
+                    }
+                },
+            ],
         ]);
 
         self::assertSame('value', Config::getInstance()->get('key'));


### PR DESCRIPTION
## 📚 Description

We define custom configReaders as 3rd param in `Gacela::bootstrap()`. There are some disadvantages on this:
- More arguments for the `bootstrap()` increase the complexity of the main entry point of Gacela
- The configReaders are not possible to be defined in `gacela.php`
For these reasons, for example, I thought it will be better treating the `configReaders` the same as the existing `config` or `mappingInterfaces` concepts, which you are able to alter in your `gacela.php`, and also inside the `globalServices`.

## 🔖 Changes

- You can define in your `gacela.php` the `configReaders()` method
- You can define the `config-readers` as key in the `$globalServices`
- Change the bootstrap signature to this:

```php
final class Gacela
{
    /**
     * Define the entry point of Gacela.
     *
     * @param array<string,mixed> $globalServices
     */
    public static function bootstrap(string $appRootDir, array $globalServices = []): void
    {/* ... */}
}
```
