### PR TITLE
Use Config::resetInstance() to test the Config singleton

### DIFF
--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -38,6 +38,14 @@ final class Config
     }
 
     /**
+     * @internal for testing purposes
+     */
+    public static function resetInstance(): void
+    {
+        self::$instance = null;
+    }
+
+    /**
      * @param null|mixed $default
      *
      * @throws ConfigException
@@ -62,10 +70,13 @@ final class Config
     }
 
     /**
+     * Force loading all config values in memory.
+     *
      * @throws ConfigException
      */
     public function init(): void
     {
+        $this->configFactory = null;
         $this->config = $this->loadAllConfigValues();
     }
 
@@ -106,7 +117,6 @@ final class Config
      */
     public function setGlobalServices(array $globalServices): self
     {
-        $this->configFactory = null;
         $this->globalServices = $globalServices;
 
         return $this;

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Unit\Framework;
+namespace GacelaTest\Integration\Framework\Config;
 
 use Gacela\Framework\Config;
 use Gacela\Framework\Config\ConfigReaderInterface;
@@ -10,6 +10,11 @@ use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+    }
+
     public function test_get_undefined_key(): void
     {
         $this->expectExceptionMessageMatches('/Could not find config key "undefined-key"/');


### PR DESCRIPTION
## 📚 Description

We discover some flaky tests failing on Scrutinizer. Actually the tests in `ConfigTest` were failing randomly, so there was a clear problem with this singleton...
<img width="849" alt="Screenshot 2022-02-07 at 15 28 12" src="https://user-images.githubusercontent.com/5256287/152807002-a60419f2-70e3-4d1f-8da7-d4f77302352a.png">


## 🔖 Changes

- Added `resetInstance()` to be able to write independent tests for the `Config`
