### PR TITLE
Allow using config from custom env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ### Unreleased
 
-- Add getAppRootDir() to AbstractConfig.
-- Deprecate getApplicationRootDir() from Config. Use getAppRootDir() instead.
-- The Gacela::bootstrap() now accepts to add config readers as `config-readers` key in the globalServices array
-- Remove `EnvConfigReader`, if you want to read .env values, you should require `gacela-project/gacela-env-config-reader`
+- Added getAppRootDir() to AbstractConfig.
+- Deprecated getApplicationRootDir() from Config. Use getAppRootDir() instead.
+- Gacela::bootstrap() now accepts to add config readers as 'config-readers' key in the globalServices array.
+- Remove EnvConfigReader, if you want to read .env values, you should require `gacela-project/gacela-env-config-reader`.
+- Added APPLICATION_ENV env key, to define different config files on different environments.
 
 ### 0.11.0
 #### 2022-01-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Deprecated getApplicationRootDir() from Config. Use getAppRootDir() instead.
 - Gacela::bootstrap() now accepts to add config readers as 'config-readers' key in the globalServices array.
 - Remove EnvConfigReader, if you want to read .env values, you should require `gacela-project/gacela-env-config-reader`.
-- Added APPLICATION_ENV env key, to define different config files on different environments.
+- Added APP_ENV env key, to define different config files on different environments.
 
 ### 0.11.0
 #### 2022-01-18

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Gacela\Framework\Config\ConfigFactory;
-use Gacela\Framework\Config\ConfigLoader;
 use Gacela\Framework\Exception\ConfigException;
 
 final class Config
@@ -63,6 +62,7 @@ final class Config
         }
 
         if (!$this->hasValue($key)) {
+            dump($this->config);
             throw ConfigException::keyNotFound($key, self::class);
         }
 
@@ -147,13 +147,8 @@ final class Config
      */
     private function loadAllConfigValues(): array
     {
-        $configLoader = new ConfigLoader(
-            $this->getAppRootDir(),
-            $this->getFactory()->createGacelaConfigFileFactory(),
-            $this->getFactory()->createPathFinder(),
-            $this->getFactory()->getEnvironment(),
-        );
-
-        return $configLoader->loadAll();
+        return $this->getFactory()
+            ->createConfigLoader()
+            ->loadAll();
     }
 }

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -62,7 +62,6 @@ final class Config
         }
 
         if (!$this->hasValue($key)) {
-            dump($this->config);
             throw ConfigException::keyNotFound($key, self::class);
         }
 

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -151,6 +151,7 @@ final class Config
             $this->getAppRootDir(),
             $this->getFactory()->createGacelaConfigFileFactory(),
             $this->getFactory()->createPathFinder(),
+            $this->getFactory()->getEnvironment(),
         );
 
         return $configLoader->loadAll();

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -66,6 +66,6 @@ final class ConfigFactory
 
     private function getEnv(): string
     {
-        return getenv('APPLICATION_ENV') ?: '';
+        return getenv('APP_ENV') ?: '';
     }
 }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -41,4 +41,9 @@ final class ConfigFactory
     {
         return new ConfigGacelaMapper();
     }
+
+    public function getEnvironment(): string
+    {
+        return getenv('APPLICATION_ENV') ?: '';
+    }
 }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
+use Gacela\Framework\Config\PathNormalizer\AbsolutePathNormalizer;
+use Gacela\Framework\Config\PathNormalizer\NoEnvAbsolutePathStrategy;
+use Gacela\Framework\Config\PathNormalizer\SuffixAbsolutePathStrategy;
+
 final class ConfigFactory
 {
     private const GACELA_PHP_CONFIG_FILENAME = 'gacela.php';
@@ -22,6 +26,15 @@ final class ConfigFactory
         $this->globalServices = $globalServices;
     }
 
+    public function createConfigLoader(): ConfigLoader
+    {
+        return new ConfigLoader(
+            $this->createGacelaConfigFileFactory(),
+            $this->createPathFinder(),
+            $this->createPathNormalizer(),
+        );
+    }
+
     public function createGacelaConfigFileFactory(): GacelaConfigFileFactoryInterface
     {
         return new GacelaConfigFileFactory(
@@ -32,7 +45,7 @@ final class ConfigFactory
         );
     }
 
-    public function createPathFinder(): PathFinderInterface
+    private function createPathFinder(): PathFinderInterface
     {
         return new PathFinder();
     }
@@ -42,7 +55,16 @@ final class ConfigFactory
         return new ConfigGacelaMapper();
     }
 
-    public function getEnvironment(): string
+    private function createPathNormalizer(): PathNormalizerInterface
+    {
+        return new AbsolutePathNormalizer([
+            AbsolutePathNormalizer::PATTERN => new NoEnvAbsolutePathStrategy($this->appRootDir),
+            AbsolutePathNormalizer::PATTERN_WITH_ENV => new SuffixAbsolutePathStrategy($this->appRootDir, $this->getEnv()),
+            AbsolutePathNormalizer::LOCAL => new NoEnvAbsolutePathStrategy($this->appRootDir),
+        ]);
+    }
+
+    private function getEnv(): string
     {
         return getenv('APPLICATION_ENV') ?: '';
     }

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -14,14 +14,18 @@ final class ConfigLoader
 
     private PathFinderInterface $pathFinder;
 
+    private string $configFileNameSuffix;
+
     public function __construct(
         string $applicationRootDir,
         GacelaConfigFileFactoryInterface $configFactory,
-        PathFinderInterface $pathFinder
+        PathFinderInterface $pathFinder,
+        string $configFileNameSuffix = ''
     ) {
         $this->applicationRootDir = $applicationRootDir;
         $this->configFactory = $configFactory;
         $this->pathFinder = $pathFinder;
+        $this->configFileNameSuffix = $configFileNameSuffix;
     }
 
     /**
@@ -109,10 +113,29 @@ final class ConfigLoader
 
     private function generateAbsolutePath(string $relativePath): string
     {
+        // place the file suffix right before the file extension
+        $dotPos = strpos($relativePath, '.');
+        $suffix = $this->getConfigFileNameSuffix();
+
+        if ($dotPos !== false && !empty($suffix)) {
+            $relativePathWithFileSuffix = substr($relativePath, 0, $dotPos)
+                . '-' . $this->getConfigFileNameSuffix()
+                . substr($relativePath, $dotPos);
+        } elseif (!empty($suffix)) {
+            $relativePathWithFileSuffix = $relativePath . $this->getConfigFileNameSuffix();
+        } else {
+            $relativePathWithFileSuffix = $relativePath;
+        }
+
         return sprintf(
             '%s/%s',
             $this->applicationRootDir,
-            $relativePath
+            $relativePathWithFileSuffix
         );
+    }
+
+    private function getConfigFileNameSuffix(): string
+    {
+        return $this->configFileNameSuffix;
     }
 }

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -54,7 +54,7 @@ final class ConfigLoader
     {
         $configGroup = [];
         foreach ($gacelaFileConfig->getConfigItems() as $configItem) {
-            $absolutePath = $this->generateAbsolutePath($configItem->path());
+            $absolutePath = $this->generateAbsolutePathWithSuffix($configItem->path());
             $matchingPattern = $this->pathFinder->matchingPattern($absolutePath);
             $excludePattern = [$this->generateAbsolutePath($configItem->pathLocal())];
 
@@ -111,7 +111,7 @@ final class ConfigLoader
         return array_merge(...array_filter($result));
     }
 
-    private function generateAbsolutePath(string $relativePath): string
+    private function generateAbsolutePathWithSuffix(string $relativePath): string
     {
         // place the file suffix right before the file extension
         $dotPos = strpos($relativePath, '.');
@@ -127,10 +127,15 @@ final class ConfigLoader
             $relativePathWithFileSuffix = $relativePath;
         }
 
+        return $this->generateAbsolutePath($relativePathWithFileSuffix);
+    }
+
+    private function generateAbsolutePath(string $relativePath): string
+    {
         return sprintf(
             '%s/%s',
             $this->applicationRootDir,
-            $relativePathWithFileSuffix
+            $relativePath
         );
     }
 

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -54,7 +54,7 @@ final class ConfigLoader
     {
         $configGroup = [];
         $configGroup[] = $this->scanAllConfigFileWithPattern($gacelaFileConfig);
-        $configGroup[] = $this->scanAllConfigFileWithEnvPattern($gacelaFileConfig);
+        $configGroup[] = $this->scanAllConfigFileWithEnvironmentPattern($gacelaFileConfig);
 
         foreach (array_merge(...$configGroup) as $path) {
             yield $path;
@@ -81,11 +81,11 @@ final class ConfigLoader
     /**
      * @return list<string>
      */
-    private function scanAllConfigFileWithEnvPattern(GacelaConfigFile $gacelaFileConfig): array
+    private function scanAllConfigFileWithEnvironmentPattern(GacelaConfigFile $gacelaFileConfig): array
     {
         $configGroup = [];
         foreach ($gacelaFileConfig->getConfigItems() as $configItem) {
-            $absolutePatternPath = $this->normalizePathPatternWithEnv($configItem);
+            $absolutePatternPath = $this->normalizePathPatternWithEnvironment($configItem);
             $matchingPattern = $this->pathFinder->matchingPattern($absolutePatternPath);
             $excludePattern = [$this->normalizePathLocal($configItem)];
 
@@ -150,8 +150,8 @@ final class ConfigLoader
         return $this->pathNormalizer->normalizePathPattern($configItem);
     }
 
-    private function normalizePathPatternWithEnv(GacelaConfigItem $configItem): string
+    private function normalizePathPatternWithEnvironment(GacelaConfigItem $configItem): string
     {
-        return $this->pathNormalizer->normalizePathPatternWithEnv($configItem);
+        return $this->pathNormalizer->normalizePathPatternWithEnvironment($configItem);
     }
 }

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -32,8 +32,14 @@ final class ConfigLoader
     {
         $gacelaFileConfig = $this->configFactory->createGacelaFileConfig();
         $configs = [];
+        $cacheConfigFileContent = [];
+
         foreach ($this->scanAllPatternConfigFiles($gacelaFileConfig) as $absolutePath) {
-            $configs[] = $this->readConfigFromFile($gacelaFileConfig, $absolutePath);
+            if (!isset($cacheConfigFileContent[$absolutePath])) {
+                $fileResult = $this->readConfigFromFile($gacelaFileConfig, $absolutePath);
+                $cacheConfigFileContent[$absolutePath] = $fileResult;
+            }
+            $configs[] = $cacheConfigFileContent[$absolutePath];
         }
 
         $configs[] = $this->readLocalConfigFile($gacelaFileConfig);

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -12,7 +12,7 @@ use function is_callable;
 
 final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
 {
-    private string $applicationRootDir;
+    private string $appRootDir;
 
     private string $gacelaPhpConfigFilename;
 
@@ -25,12 +25,12 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
      * @param array<string,mixed> $globalServices
      */
     public function __construct(
-        string $applicationRootDir,
+        string $appRootDir,
         string $gacelaPhpConfigFilename,
         array $globalServices,
         ConfigGacelaMapper $configGacelaMapper
     ) {
-        $this->applicationRootDir = $applicationRootDir;
+        $this->appRootDir = $appRootDir;
         $this->gacelaPhpConfigFilename = $gacelaPhpConfigFilename;
         $this->globalServices = $globalServices;
         $this->configGacelaMapper = $configGacelaMapper;
@@ -38,7 +38,7 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
 
     public function createGacelaFileConfig(): GacelaConfigFile
     {
-        $gacelaPhpPath = $this->applicationRootDir . '/' . $this->gacelaPhpConfigFilename;
+        $gacelaPhpPath = $this->appRootDir . '/' . $this->gacelaPhpConfigFilename;
 
         if (!is_file($gacelaPhpPath)) {
             return $this->createDefaultGacelaPhpConfig();

--- a/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
+++ b/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\PathNormalizer;
+
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use Gacela\Framework\Config\PathNormalizerInterface;
+
+final class AbsolutePathNormalizer implements PathNormalizerInterface
+{
+    public const PATTERN = 'PATTERN';
+    public const PATTERN_WITH_ENV = 'PATTERN_WITH_ENV';
+    public const LOCAL = 'LOCAL';
+
+    /** @var array<string,AbsolutePathStrategyInterface> */
+    private array $absolutePathStrategies;
+
+    /**
+     * @param array<string,AbsolutePathStrategyInterface> $absolutePathStrategies
+     */
+    public function __construct(array $absolutePathStrategies)
+    {
+        $this->absolutePathStrategies = $absolutePathStrategies;
+    }
+
+    public function normalizePathPattern(GacelaConfigItem $configItem): string
+    {
+        return $this->absolutePathStrategies[self::PATTERN]
+            ->generateAbsolutePath($configItem->path());
+    }
+
+    public function normalizePathPatternWithEnv(GacelaConfigItem $configItem): string
+    {
+        return $this->absolutePathStrategies[self::PATTERN_WITH_ENV]
+            ->generateAbsolutePath($configItem->path());
+    }
+
+    public function normalizePathLocal(GacelaConfigItem $configItem): string
+    {
+        return $this->absolutePathStrategies[self::LOCAL]
+            ->generateAbsolutePath($configItem->pathLocal());
+    }
+}

--- a/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
+++ b/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
@@ -30,7 +30,7 @@ final class AbsolutePathNormalizer implements PathNormalizerInterface
             ->generateAbsolutePath($configItem->path());
     }
 
-    public function normalizePathPatternWithEnv(GacelaConfigItem $configItem): string
+    public function normalizePathPatternWithEnvironment(GacelaConfigItem $configItem): string
     {
         return $this->absolutePathStrategies[self::PATTERN_WITH_ENV]
             ->generateAbsolutePath($configItem->path());

--- a/src/Framework/Config/PathNormalizer/AbsolutePathStrategyInterface.php
+++ b/src/Framework/Config/PathNormalizer/AbsolutePathStrategyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\PathNormalizer;
+
+interface AbsolutePathStrategyInterface
+{
+    public function generateAbsolutePath(string $relativePath): string;
+}

--- a/src/Framework/Config/PathNormalizer/NoEnvAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/NoEnvAbsolutePathStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\PathNormalizer;
+
+final class NoEnvAbsolutePathStrategy implements AbsolutePathStrategyInterface
+{
+    private string $applicationRootDir;
+
+    public function __construct(string $applicationRootDir)
+    {
+        $this->applicationRootDir = $applicationRootDir;
+    }
+
+    public function generateAbsolutePath(string $relativePath): string
+    {
+        return sprintf(
+            '%s/%s',
+            $this->applicationRootDir,
+            $relativePath
+        );
+    }
+}

--- a/src/Framework/Config/PathNormalizer/NoEnvAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/NoEnvAbsolutePathStrategy.php
@@ -6,19 +6,19 @@ namespace Gacela\Framework\Config\PathNormalizer;
 
 final class NoEnvAbsolutePathStrategy implements AbsolutePathStrategyInterface
 {
-    private string $applicationRootDir;
+    private string $appRootDir;
 
-    public function __construct(string $applicationRootDir)
+    public function __construct(string $appRootDir)
     {
-        $this->applicationRootDir = $applicationRootDir;
+        $this->appRootDir = $appRootDir;
     }
 
     public function generateAbsolutePath(string $relativePath): string
     {
         return sprintf(
             '%s/%s',
-            $this->applicationRootDir,
-            $relativePath
+            rtrim($this->appRootDir, '/'),
+            ltrim($relativePath, '/')
         );
     }
 }

--- a/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
@@ -6,15 +6,15 @@ namespace Gacela\Framework\Config\PathNormalizer;
 
 final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
 {
-    private string $applicationRootDir;
+    private string $appRootDir;
 
     private string $configFileNameSuffix;
 
     public function __construct(
-        string $applicationRootDir,
+        string $appRootDir,
         string $configFileNameSuffix = ''
     ) {
-        $this->applicationRootDir = $applicationRootDir;
+        $this->appRootDir = $appRootDir;
         $this->configFileNameSuffix = $configFileNameSuffix;
     }
 
@@ -29,15 +29,15 @@ final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
                 . '-' . $this->getConfigFileNameSuffix()
                 . substr($relativePath, $dotPos);
         } elseif (!empty($suffix)) {
-            $relativePathWithFileSuffix = $relativePath . $suffix;
+            $relativePathWithFileSuffix = $relativePath . '-' . $suffix;
         } else {
             $relativePathWithFileSuffix = $relativePath;
         }
 
         return sprintf(
             '%s/%s',
-            $this->applicationRootDir,
-            $relativePathWithFileSuffix
+            rtrim($this->appRootDir, '/'),
+            ltrim($relativePathWithFileSuffix, '/')
         );
     }
 

--- a/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\PathNormalizer;
+
+final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
+{
+    private string $applicationRootDir;
+
+    private string $configFileNameSuffix;
+
+    public function __construct(
+        string $applicationRootDir,
+        string $configFileNameSuffix = ''
+    ) {
+        $this->applicationRootDir = $applicationRootDir;
+        $this->configFileNameSuffix = $configFileNameSuffix;
+    }
+
+    public function generateAbsolutePath(string $relativePath): string
+    {
+        // place the file suffix right before the file extension
+        $dotPos = strpos($relativePath, '.');
+        $suffix = $this->getConfigFileNameSuffix();
+
+        if ($dotPos !== false && !empty($suffix)) {
+            $relativePathWithFileSuffix = substr($relativePath, 0, $dotPos)
+                . '-' . $this->getConfigFileNameSuffix()
+                . substr($relativePath, $dotPos);
+        } elseif (!empty($suffix)) {
+            $relativePathWithFileSuffix = $relativePath . $this->getConfigFileNameSuffix();
+        } else {
+            $relativePathWithFileSuffix = $relativePath;
+        }
+
+        return sprintf(
+            '%s/%s',
+            $this->applicationRootDir,
+            $relativePathWithFileSuffix
+        );
+    }
+
+    private function getConfigFileNameSuffix(): string
+    {
+        return $this->configFileNameSuffix;
+    }
+}

--- a/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
@@ -29,7 +29,7 @@ final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
                 . '-' . $this->getConfigFileNameSuffix()
                 . substr($relativePath, $dotPos);
         } elseif (!empty($suffix)) {
-            $relativePathWithFileSuffix = $relativePath . $this->getConfigFileNameSuffix();
+            $relativePathWithFileSuffix = $relativePath . $suffix;
         } else {
             $relativePathWithFileSuffix = $relativePath;
         }

--- a/src/Framework/Config/PathNormalizerInterface.php
+++ b/src/Framework/Config/PathNormalizerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+
+interface PathNormalizerInterface
+{
+    public function normalizePathPattern(GacelaConfigItem $configItem): string;
+
+    public function normalizePathPatternWithEnv(GacelaConfigItem $configItem): string;
+
+    public function normalizePathLocal(GacelaConfigItem $configItem): string;
+}

--- a/src/Framework/Config/PathNormalizerInterface.php
+++ b/src/Framework/Config/PathNormalizerInterface.php
@@ -10,7 +10,7 @@ interface PathNormalizerInterface
 {
     public function normalizePathPattern(GacelaConfigItem $configItem): string;
 
-    public function normalizePathPatternWithEnv(GacelaConfigItem $configItem): string;
+    public function normalizePathPatternWithEnvironment(GacelaConfigItem $configItem): string;
 
     public function normalizePathLocal(GacelaConfigItem $configItem): string;
 }

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\UsingConfigFromCustomEnv;
+
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class IntegrationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        putenv('APPLICATION_ENV=dev');
+        Gacela::bootstrap(__DIR__);
+    }
+
+    public function tearDown(): void
+    {
+        putenv('APPLICATION_ENV');
+    }
+
+    public function test_load_config_from_custom_env_dev(): void
+    {
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'config-php' => 2,
+                'override' => 2,
+            ],
+            $facade->doSomething()
+        );
+    }
+}

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
@@ -23,8 +23,9 @@ final class IntegrationTest extends TestCase
 
         self::assertSame(
             [
-                'config-php' => 2,
-                'override' => 4,
+                'from-default' => 1,
+                'from-default-env-override' => 2,
+                'from-local-override' => 4,
             ],
             $facade->doSomething()
         );
@@ -38,8 +39,9 @@ final class IntegrationTest extends TestCase
 
         self::assertSame(
             [
-                'config-php' => 3,
-                'override' => 4,
+                'from-default' => 1,
+                'from-default-env-override' => 3,
+                'from-local-override' => 4,
             ],
             $facade->doSomething()
         );

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
@@ -11,13 +11,13 @@ final class IntegrationTest extends TestCase
 {
     public function tearDown(): void
     {
-        # Remove the APPLICATION_ENV
-        putenv('APPLICATION_ENV');
+        # Remove the APP_ENV
+        putenv('APP_ENV');
     }
 
     public function test_load_config_from_custom_env_dev(): void
     {
-        putenv('APPLICATION_ENV=dev');
+        putenv('APP_ENV=dev');
         Gacela::bootstrap(__DIR__);
         $facade = new LocalConfig\Facade();
 
@@ -33,7 +33,7 @@ final class IntegrationTest extends TestCase
 
     public function test_load_config_from_custom_env_prod(): void
     {
-        putenv('APPLICATION_ENV=prod');
+        putenv('APP_ENV=prod');
         Gacela::bootstrap(__DIR__);
         $facade = new LocalConfig\Facade();
 

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/IntegrationTest.php
@@ -9,25 +9,37 @@ use PHPUnit\Framework\TestCase;
 
 final class IntegrationTest extends TestCase
 {
-    public function setUp(): void
-    {
-        putenv('APPLICATION_ENV=dev');
-        Gacela::bootstrap(__DIR__);
-    }
-
     public function tearDown(): void
     {
+        # Remove the APPLICATION_ENV
         putenv('APPLICATION_ENV');
     }
 
     public function test_load_config_from_custom_env_dev(): void
     {
+        putenv('APPLICATION_ENV=dev');
+        Gacela::bootstrap(__DIR__);
         $facade = new LocalConfig\Facade();
 
         self::assertSame(
             [
                 'config-php' => 2,
-                'override' => 2,
+                'override' => 4,
+            ],
+            $facade->doSomething()
+        );
+    }
+
+    public function test_load_config_from_custom_env_prod(): void
+    {
+        putenv('APPLICATION_ENV=prod');
+        Gacela::bootstrap(__DIR__);
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'config-php' => 3,
+                'override' => 4,
             ],
             $facade->doSomething()
         );

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Config.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Config.php
@@ -11,8 +11,9 @@ final class Config extends AbstractConfig
     public function getArrayConfig(): array
     {
         return [
-            'config-php' => (int) $this->get('config-php'),
-            'override' => (int) $this->get('override'),
+            'from-default' => (int)$this->get('from-default'),
+            'from-default-env-override' => (int)$this->get('from-default-env-override'),
+            'from-local-override' => (int)$this->get('from-local-override'),
         ];
     }
 }

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Config.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\UsingConfigFromCustomEnv\LocalConfig;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+    public function getArrayConfig(): array
+    {
+        return [
+            'config-php' => (int) $this->get('config-php'),
+            'override' => (int) $this->get('override'),
+        ];
+    }
+}

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Facade.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\UsingConfigFromCustomEnv\LocalConfig;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function doSomething(): array
+    {
+        return $this->getFactory()->getArrayConfig();
+    }
+}

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Factory.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/LocalConfig/Factory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\UsingConfigFromCustomEnv\LocalConfig;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method Config getConfig()
+ */
+final class Factory extends AbstractFactory
+{
+    public function getArrayConfig(): array
+    {
+        return $this->getConfig()->getArrayConfig();
+    }
+}

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-dev.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-dev.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config-php' => 2,
+    'override' => 2,
+];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-dev.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-dev.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'config-php' => 2,
-    'override' => 2,
+    'from-default-env-override' => 2,
+    'from-local-override' => 2,
 ];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-prod.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-prod.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config-php' => 3,
+    'override' => 3,
+];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-prod.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default-prod.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'config-php' => 3,
-    'override' => 3,
+    'from-default-env-override' => 3,
+    'from-local-override' => 3,
 ];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config-php' => 1,
+    'override' => 1,
+];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/default.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'config-php' => 1,
-    'override' => 1,
+    'from-default' => 1,
+    'from-default-env-override' => 1,
+    'from-local-override' => 1,
 ];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/local.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/local.php
@@ -3,5 +3,5 @@
 declare(strict_types=1);
 
 return [
-    'override' => 4,
+    'from-local-override' => 4,
 ];

--- a/tests/Integration/Framework/UsingConfigFromCustomEnv/config/local.php
+++ b/tests/Integration/Framework/UsingConfigFromCustomEnv/config/local.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'override' => 4,
+];

--- a/tests/Unit/Framework/Config/ConfigInitTest.php
+++ b/tests/Unit/Framework/Config/ConfigInitTest.php
@@ -21,15 +21,10 @@ final class ConfigInitTest extends TestCase
             ->method('createGacelaFileConfig')
             ->willReturn(GacelaConfigFile::withDefaults());
 
-        $readers = [
-            'php' => $this->createStub(ConfigReaderInterface::class),
-        ];
-
         $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
-            $this->createMock(PathFinderInterface::class),
-            $readers
+            $this->createMock(PathFinderInterface::class)
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -45,15 +40,10 @@ final class ConfigInitTest extends TestCase
         $pathFinder = $this->createMock(PathFinderInterface::class);
         $pathFinder->method('matchingPattern')->willReturn(['path1']);
 
-        $readers = [
-            'unsupported_type' => $this->createStub(ConfigReaderInterface::class),
-        ];
-
         $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
             $pathFinder,
-            $readers
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -69,13 +59,10 @@ final class ConfigInitTest extends TestCase
         $pathFinder = $this->createMock(PathFinderInterface::class);
         $pathFinder->method('matchingPattern')->willReturn(['path1']);
 
-        $readers = [];
-
         $configInit = new ConfigLoader(
             'application_root_dir',
             $gacelaJsonConfigCreator,
-            $pathFinder,
-            $readers
+            $pathFinder
         );
 
         self::assertSame([], $configInit->loadAll());

--- a/tests/Unit/Framework/Config/ConfigInitTest.php
+++ b/tests/Unit/Framework/Config/ConfigInitTest.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 use Gacela\Framework\Config\PathFinderInterface;
+use Gacela\Framework\Config\PathNormalizerInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigInitTest extends TestCase
@@ -22,9 +23,9 @@ final class ConfigInitTest extends TestCase
             ->willReturn(GacelaConfigFile::withDefaults());
 
         $configInit = new ConfigLoader(
-            'application_root_dir',
             $gacelaJsonConfigCreator,
-            $this->createMock(PathFinderInterface::class)
+            $this->createMock(PathFinderInterface::class),
+            $this->createMock(PathNormalizerInterface::class)
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -41,9 +42,9 @@ final class ConfigInitTest extends TestCase
         $pathFinder->method('matchingPattern')->willReturn(['path1']);
 
         $configInit = new ConfigLoader(
-            'application_root_dir',
             $gacelaJsonConfigCreator,
             $pathFinder,
+            $this->createMock(PathNormalizerInterface::class)
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -60,9 +61,9 @@ final class ConfigInitTest extends TestCase
         $pathFinder->method('matchingPattern')->willReturn(['path1']);
 
         $configInit = new ConfigLoader(
-            'application_root_dir',
             $gacelaJsonConfigCreator,
-            $pathFinder
+            $pathFinder,
+            $this->createMock(PathNormalizerInterface::class),
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -86,9 +87,9 @@ final class ConfigInitTest extends TestCase
                 ]));
 
         $configInit = new ConfigLoader(
-            'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
+            $this->createMock(PathNormalizerInterface::class)
         );
 
         self::assertSame(['key' => 'value'], $configInit->loadAll());
@@ -118,9 +119,9 @@ final class ConfigInitTest extends TestCase
                 ]));
 
         $configInit = new ConfigLoader(
-            'application_root_dir',
             $gacelaJsonConfigCreator,
             $this->createMock(PathFinderInterface::class),
+            $this->createMock(PathNormalizerInterface::class),
         );
 
         self::assertSame([

--- a/tests/Unit/Framework/Config/PathNormalizer/NoEnvAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/NoEnvAbsolutePathStrategyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\PathNormalizer;
+
+use Gacela\Framework\Config\PathNormalizer\NoEnvAbsolutePathStrategy;
+use PHPUnit\Framework\TestCase;
+
+final class NoEnvAbsolutePathStrategyTest extends TestCase
+{
+    public function test_file_without_extension(): void
+    {
+        $strategy = new NoEnvAbsolutePathStrategy('/app/root/');
+        $relativePath = '/file-name';
+
+        self::assertSame(
+            '/app/root/file-name',
+            $strategy->generateAbsolutePath($relativePath)
+        );
+    }
+
+    public function test_file_with_extension(): void
+    {
+        $strategy = new NoEnvAbsolutePathStrategy('/app/root/');
+        $relativePath = '/file-name.ext';
+
+        self::assertSame(
+            '/app/root/file-name.ext',
+            $strategy->generateAbsolutePath($relativePath)
+        );
+    }
+}

--- a/tests/Unit/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\PathNormalizer;
+
+use Gacela\Framework\Config\PathNormalizer\SuffixAbsolutePathStrategy;
+use PHPUnit\Framework\TestCase;
+
+final class SuffixAbsolutePathStrategyTest extends TestCase
+{
+    public function test_file_without_extension_neither_suffix(): void
+    {
+        $strategy = new SuffixAbsolutePathStrategy('/app/root/');
+        $relativePath = '/file-name';
+
+        self::assertSame(
+            '/app/root/file-name',
+            $strategy->generateAbsolutePath($relativePath)
+        );
+    }
+
+    public function test_file_without_extension_but_suffix(): void
+    {
+        $strategy = new SuffixAbsolutePathStrategy('/app/root/', 'suffix');
+        $relativePath = '/file-name';
+
+        self::assertSame(
+            '/app/root/file-name-suffix',
+            $strategy->generateAbsolutePath($relativePath)
+        );
+    }
+
+    public function test_file_with_extension_but_no_suffix(): void
+    {
+        $strategy = new SuffixAbsolutePathStrategy('/app/root/');
+        $relativePath = '/file-name.ext';
+
+        self::assertSame(
+            '/app/root/file-name.ext',
+            $strategy->generateAbsolutePath($relativePath)
+        );
+    }
+
+    public function test_file_with_extension_and_suffix(): void
+    {
+        $strategy = new SuffixAbsolutePathStrategy('/app/root/', 'suffix');
+        $relativePath = '/file-name.ext';
+
+        self::assertSame(
+            '/app/root/file-name-suffix.ext',
+            $strategy->generateAbsolutePath($relativePath)
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Description

Currently there is no possibility of defining some config for certain specific environment. So you end-up having the same config in all possible environments.

## 🔖 Changes

Added `APP_ENV` environment key, where you can define a value that you want, and that value will be added as suffix for your config file patterns.

#### For example

When `APP_ENV=env` then this is order of reading the config files, so the latest overrides the previous key-values:

- default.php
- default-dev.php
- local.php (defined in the gacela.php under path_local key)

> Check the UsingConfigFromCustomEnv Integration tests.

### 🤔 Follow up

Expose the possibility of creating custom `AbsolutePathStrategyInterface` via the globalInterfaces (when bootstrapping), and so, it would be interesting to be able to assign a particular path strategy to a concrete config-file-extension somehow.