### PR TITLE
Remove unnecesary type key from config

### DIFF
--- a/src/Framework/Config/ConfigGacelaMapper.php
+++ b/src/Framework/Config/ConfigGacelaMapper.php
@@ -9,36 +9,33 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 final class ConfigGacelaMapper
 {
     /**
-     * @param array<array>|array{type:string,path:string,path_local:string} $config
+     * @param array<array>|array{path:string,path_local:string} $config
      *
-     * @return array<string,GacelaConfigItem>
+     * @return list<GacelaConfigItem>
      */
     public function mapConfigItems(array $config): array
     {
         if ($this->isSingleConfigFile($config)) {
-            /** @var array $config */
-            $c = GacelaConfigItem::fromArray($config);
-            return [$c->type() => $c];
+            return [GacelaConfigItem::fromArray($config)];
         }
 
         $result = [];
 
-        /** @var array<array{type:string,path:string,path_local:string}> $config */
+        /** @var array<array{path:string,path_local:string}> $config */
         foreach ($config as $configItem) {
             $c = GacelaConfigItem::fromArray($configItem);
-            $result[$c->type()] = $c;
+            $result[] = $c;
         }
 
         return $result;
     }
 
     /**
-     * @param array<array>|array{type:string,path:string,path_local:string} $config
+     * @param array<array>|array{path:string,path_local:string} $config
      */
     private function isSingleConfigFile(array $config): bool
     {
-        return isset($config['type'])
-            || isset($config['path'])
+        return isset($config['path'])
             || isset($config['path_local']);
     }
 }

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -84,6 +84,7 @@ final class ConfigLoader
     private function scanAllConfigFileWithEnvironmentPattern(GacelaConfigFile $gacelaFileConfig): array
     {
         $configGroup = [];
+
         foreach ($gacelaFileConfig->getConfigItems() as $configItem) {
             $absolutePatternPath = $this->normalizePathPatternWithEnvironment($configItem);
             $matchingPattern = $this->pathFinder->matchingPattern($absolutePatternPath);
@@ -101,14 +102,7 @@ final class ConfigLoader
     private function readConfigFromFile(GacelaConfigFile $gacelaConfigFile, string $absolutePath): array
     {
         $result = [];
-        $configItems = $gacelaConfigFile->getConfigItems();
-
-        foreach ($gacelaConfigFile->getConfigReaders() as $type => $reader) {
-            $config = $configItems[$type] ?? null;
-            if ($config === null) {
-                continue;
-            }
-
+        foreach ($gacelaConfigFile->getConfigReaders() as $reader) {
             $result[] = $reader->canRead($absolutePath)
                 ? $reader->read($absolutePath)
                 : [];
@@ -125,16 +119,14 @@ final class ConfigLoader
         $result = [];
         $configItems = $gacelaConfigFile->getConfigItems();
 
-        foreach ($gacelaConfigFile->getConfigReaders() as $type => $reader) {
-            $config = $configItems[$type] ?? null;
-            if ($config === null) {
-                continue;
-            }
-            $absolutePath = $this->normalizePathLocal($config);
+        foreach ($configItems as $config) {
+            foreach ($gacelaConfigFile->getConfigReaders() as $reader) {
+                $absolutePath = $this->normalizePathLocal($config);
 
-            $result[] = $reader->canRead($absolutePath)
-                ? $reader->read($absolutePath)
-                : [];
+                $result[] = $reader->canRead($absolutePath)
+                    ? $reader->read($absolutePath)
+                    : [];
+            }
         }
 
         return array_merge(...array_filter($result));

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -79,7 +79,7 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
     }
 
     /**
-     * @param array<string,GacelaConfigItem> $configItems
+     * @param list<GacelaConfigItem> $configItems
      * @param array<string,ConfigReaderInterface> $configReaders
      * @param array<class-string,class-string|callable> $mappingInterfaces
      */

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -9,7 +9,7 @@ use Gacela\Framework\Config\ConfigReaderInterface;
 
 final class GacelaConfigFile
 {
-    /** @var array<string,GacelaConfigItem> */
+    /** @var list<GacelaConfigItem> */
     private array $configItems = [];
 
     /** @var array<class-string,class-string|callable> */
@@ -20,15 +20,13 @@ final class GacelaConfigFile
 
     public static function withDefaults(): self
     {
-        $configItem = GacelaConfigItem::withDefaults();
-
         return (new self())
-            ->setConfigItems([$configItem->type() => $configItem])
+            ->setConfigItems([GacelaConfigItem::withDefaults()])
             ->setConfigReaders(['php' => new PhpConfigReader()]);
     }
 
     /**
-     * @param array<string,GacelaConfigItem> $configItems
+     * @param list<GacelaConfigItem> $configItems
      */
     public function setConfigItems(array $configItems): self
     {
@@ -38,7 +36,7 @@ final class GacelaConfigFile
     }
 
     /**
-     * @return array<string,GacelaConfigItem>
+     * @return list<GacelaConfigItem>
      */
     public function getConfigItems(): array
     {

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
@@ -11,16 +11,13 @@ final class GacelaConfigItem
     private const DEFAULT_PATH = 'config/*.php';
     private const DEFAULT_PATH_LOCAL = 'config/local.php';
 
-    private string $type;
     private string $path;
     private string $pathLocal;
 
     public function __construct(
-        string $type = self::DEFAULT_TYPE,
         string $path = self::DEFAULT_PATH,
         string $pathLocal = self::DEFAULT_PATH_LOCAL
     ) {
-        $this->type = $type;
         $this->path = $path;
         $this->pathLocal = $pathLocal;
     }
@@ -30,15 +27,12 @@ final class GacelaConfigItem
      */
     public static function fromArray(array $item): self
     {
-        /** @var null|string $type */
-        $type = $item['type'] ?? null;
         /** @var null|string $path */
         $path = $item['path'] ?? null;
         /** @var null|string $pathLocal */
         $pathLocal = $item['path_local'] ?? null;
 
         return new self(
-            $type ?? self::DEFAULT_TYPE,
             $path ?? self::DEFAULT_PATH,
             $pathLocal ?? self::DEFAULT_PATH_LOCAL
         );
@@ -47,11 +41,6 @@ final class GacelaConfigItem
     public static function withDefaults(): self
     {
         return new self();
-    }
-
-    public function type(): string
-    {
-        return $this->type;
     }
 
     public function path(): string
@@ -67,8 +56,7 @@ final class GacelaConfigItem
     public function __toString(): string
     {
         return sprintf(
-            'GacelaConfigItem{ type:%s, path:%s, pathLocal:%s }',
-            $this->type,
+            'GacelaConfigItem{ path:%s, pathLocal:%s }',
             $this->path,
             $this->pathLocal
         );

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -35,7 +35,7 @@ final class ConfigTest extends TestCase
     {
         Config::getInstance()->setGlobalServices([
             'config-readers' => [
-                Config\GacelaFileConfig\GacelaConfigItem::DEFAULT_TYPE => new class () implements ConfigReaderInterface {
+                new class () implements ConfigReaderInterface {
                     public function read(string $absolutePath): array
                     {
                         return ['key' => 'value'];

--- a/tests/Integration/Framework/UsingConfigTypePhp/gacela.php
+++ b/tests/Integration/Framework/UsingConfigTypePhp/gacela.php
@@ -8,7 +8,6 @@ return static fn () => new class () extends AbstractConfigGacela {
     public function config(): array
     {
         return [
-            'type' => 'php',
             'path' => 'config/*.php',
             'path_local' => 'config/local.php',
         ];

--- a/tests/Integration/Framework/UsingConfigWithBootstrapSetup/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingConfigWithBootstrapSetup/IntegrationTest.php
@@ -13,7 +13,6 @@ final class IntegrationTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, [
             'config' => [
-                'type' => 'php',
                 'path' => 'custom-config.php',
                 'path_local' => 'custom-config_local.php',
             ],

--- a/tests/Integration/Framework/UsingMultipleConfig/IntegrationTest.php
+++ b/tests/Integration/Framework/UsingMultipleConfig/IntegrationTest.php
@@ -15,18 +15,12 @@ final class IntegrationTest extends TestCase
     {
         $globalServices = [
             'config' => [
-                [
-                    'type' => 'env',
-                    'path' => 'config/.env*',
-                ],
-                [
-                    'type' => 'php',
-                    'path' => 'config/*.php',
-                ],
+                ['path' => 'config/.env*'],
+                ['path' => 'config/*.php'],
             ],
             'config-readers' =>  [
-                'php' => new PhpConfigReader(),
-                'env' => new SimpleEnvConfigReader(),
+                new PhpConfigReader(),
+                new SimpleEnvConfigReader(),
             ],
         ];
 


### PR DESCRIPTION
## 🤔 Background

The current `ConfigReaderInterface` has a method `canRead(): bool` which knows basically if they should read a file or not. There is no need to group them by file type.

## 🔖 Changes

- Remove unnecessary `type` key from the config
