### PR TITLE
Rename custom-service-paths to custom-services-location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
 ### 0.12.0
-#### 2022-02-XX
+#### 2022-02-13
 
 - Added `getAppRootDir()` to AbstractConfig.
 - Added `APP_ENV` environment key, to define different config files on different environments.
 - Added `'config-readers'` key in the globalServices and `gacela.php`.
-- Added `'custom-service-paths'` key in the globalServices and `gacela.php`.
+- Added `'custom-services-location'` key in the globalServices and `gacela.php`.
+  - Define namespaces (relative to a module) where Gacela should check for custom services that will be auto-resolved.
 - Deprecated `getApplicationRootDir()` from Config. Use `getAppRootDir()` instead.
-- Removed `EnvConfigReader` from `gacela-project/gacela`. 
+- Removed `EnvConfigReader` from `gacela-project/gacela`.
   - If you want to read `.env` values, you should require `gacela-project/gacela-env-config-reader`.
 
 ### 0.11.0

--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -90,12 +90,12 @@ abstract class AbstractConfigGacela
      * ];
      * </code>
      *
-     * Define paths (relative to each module) where Gacela should check for custom services that will be auto-resolved.
-     * The classes must extend `Gacela\Framework\AbstractCustomService`.
+     * Define namespaces (relative to a module) where Gacela should check for custom services that will be auto-resolved.
+     * The classes that you want to use as custom services must extend `Gacela\Framework\AbstractCustomService`.
      *
      * @return list<string>
      */
-    public function customServicePaths(): array
+    public function customServicesLocation(): array
     {
         return [];
     }

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -13,16 +13,16 @@ final class ClassNameFinder implements ClassNameFinderInterface
     private array $finderRules;
 
     /** @var list<string> */
-    private $customServicePaths;
+    private $customServicesLocation;
 
     /**
      * @param list<FinderRuleInterface> $finderRules
-     * @param list<string> $customServicePaths
+     * @param list<string> $customServicesLocation
      */
-    public function __construct(array $finderRules, array $customServicePaths)
+    public function __construct(array $finderRules, array $customServicesLocation)
     {
         $this->finderRules = $finderRules;
-        $this->customServicePaths = $customServicePaths;
+        $this->customServicesLocation = $customServicesLocation;
     }
 
     public function findClassName(ClassInfo $classInfo, string $resolvableType): ?string
@@ -34,8 +34,8 @@ final class ClassNameFinder implements ClassNameFinderInterface
                 return $className;
             }
 
-            // Otherwise, look for customServicePaths
-            foreach ($this->customServicePaths as $customServicePath) {
+            // Otherwise, look for customServicesLocation
+            foreach ($this->customServicesLocation as $customServicePath) {
                 $className = $finderRule->buildClassCandidate(
                     $classInfo,
                     $resolvableType,

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -24,7 +24,7 @@ final class ClassResolverFactory
     {
         return new ClassNameFinder(
             $this->createFinderRules(),
-            $this->gacelaConfigFile->getCustomServicePaths()
+            $this->gacelaConfigFile->getCustomServicesLocation()
         );
     }
 

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -58,9 +58,9 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
         $configItems = $this->configGacelaMapper->mapConfigItems($configGacelaClass->config());
         $configReaders = $configGacelaClass->configReaders();
         $mappingInterfaces = $configGacelaClass->mappingInterfaces($this->globalServices);
-        $customServicePaths = $configGacelaClass->customServicePaths();
+        $customServicesLocation = $configGacelaClass->customServicesLocation();
 
-        return $this->createWithDefaultIfEmpty($configItems, $configReaders, $mappingInterfaces, $customServicePaths);
+        return $this->createWithDefaultIfEmpty($configItems, $configReaders, $mappingInterfaces, $customServicesLocation);
     }
 
     private function createDefaultGacelaPhpConfig(): GacelaConfigFile
@@ -69,29 +69,29 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
          *     config?: array<array>|array{type:string,path:string,path_local:string},
          *     config-readers?: array<string,ConfigReaderInterface>,
          *     mapping-interfaces?: array<class-string,class-string|callable>,
-         *     custom-service-paths?: list<string>,
+         *     custom-services-location?: list<string>,
          * } $configFromGlobalServices
          */
         $configFromGlobalServices = $this->globalServices;
         $configItems = $this->configGacelaMapper->mapConfigItems($configFromGlobalServices['config'] ?? []);
         $configReaders = $configFromGlobalServices['config-readers'] ?? [];
         $mappingInterfaces = $configFromGlobalServices['mapping-interfaces'] ?? [];
-        $customServicePaths = $configFromGlobalServices['custom-service-paths'] ?? [];
+        $customServicesLocation = $configFromGlobalServices['custom-services-location'] ?? [];
 
-        return $this->createWithDefaultIfEmpty($configItems, $configReaders, $mappingInterfaces, $customServicePaths);
+        return $this->createWithDefaultIfEmpty($configItems, $configReaders, $mappingInterfaces, $customServicesLocation);
     }
 
     /**
      * @param list<GacelaConfigItem> $configItems
      * @param array<string,ConfigReaderInterface> $configReaders
      * @param array<class-string,class-string|callable> $mappingInterfaces
-     * @param list<string> $customServicePaths
+     * @param list<string> $customServicesLocation
      */
     private function createWithDefaultIfEmpty(
         array $configItems,
         array $configReaders,
         array $mappingInterfaces,
-        array $customServicePaths
+        array $customServicesLocation
     ): GacelaConfigFile {
         $gacelaConfigFile = GacelaConfigFile::withDefaults();
 
@@ -104,8 +104,8 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
         if (!empty($mappingInterfaces)) {
             $gacelaConfigFile->setMappingInterfaces($mappingInterfaces);
         }
-        if (!empty($customServicePaths)) {
-            $gacelaConfigFile->setCustomServicePaths($customServicePaths);
+        if (!empty($customServicesLocation)) {
+            $gacelaConfigFile->setCustomServicesLocation($customServicesLocation);
         }
 
         return $gacelaConfigFile;

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -18,8 +18,8 @@ final class GacelaConfigFile
     /** @var array<string,ConfigReaderInterface> */
     private array $configReaders = [];
 
-    /** @var list<string> */
-    private array $customServicePaths = [];
+    /** @var list<string> Namespaces relative to a module */
+    private array $customServicesLocation = [];
 
     public static function withDefaults(): self
     {
@@ -86,11 +86,11 @@ final class GacelaConfigFile
     }
 
     /**
-     * @param list<string> $customServicePaths
+     * @param list<string> $customServicesLocation
      */
-    public function setCustomServicePaths(array $customServicePaths): self
+    public function setCustomServicesLocation(array $customServicesLocation): self
     {
-        $this->customServicePaths = $customServicePaths;
+        $this->customServicesLocation = $customServicesLocation;
 
         return $this;
     }
@@ -98,8 +98,8 @@ final class GacelaConfigFile
     /**
      * @return list<string>
      */
-    public function getCustomServicePaths(): array
+    public function getCustomServicesLocation(): array
     {
-        return $this->customServicePaths;
+        return $this->customServicesLocation;
     }
 }

--- a/tests/Feature/Framework/CustomServices/FeatureTest.php
+++ b/tests/Feature/Framework/CustomServices/FeatureTest.php
@@ -16,7 +16,7 @@ final class FeatureTest extends TestCase
         Gacela::bootstrap(__DIR__, [
             // The order is relevant for the priority in case the same
             // class name is found in both. The first found will be used.
-            'custom-service-paths' => [
+            'custom-services-location' => [
                 'Application',
                 'Infrastructure\Persistence',
             ],


### PR DESCRIPTION
## 📚 Description

The custom services are relative to the module level using the namespace, not the paths. 
This is important because of the backslash that it's used such as:
- 'Infrastructure/Persistence' <- path
- 'Infrastructure\Persistence' <- namespace

## 🔖 Changes

- Renamed `custom-service-paths` to `custom-services-location` to make it clear that it's not linked to the path system.
- Set the day (today) for the new release version: 0.12.0 💡
