### PR TITLE
Custom services must implement CustomServiceInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Unreleased
+
+- Added `CustomServiceInterface` that custom services must implement.
+  - Although, the `AbstractCustomService` implements that interface.
+
 ### 0.12.0
 #### 2022-02-13
 

--- a/src/Framework/AbstractCustomService.php
+++ b/src/Framework/AbstractCustomService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
-abstract class AbstractCustomService
+abstract class AbstractCustomService implements CustomServiceInterface
 {
     use ConfigResolverAwareTrait;
     use FactoryResolverAwareTrait;

--- a/src/Framework/ClassResolver/CustomService/CustomServiceNotValidException.php
+++ b/src/Framework/ClassResolver/CustomService/CustomServiceNotValidException.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Gacela\Framework\ClassResolver\CustomService;
 
 use Exception;
-use Gacela\Framework\AbstractCustomService;
 use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\CustomServiceInterface;
 
 final class CustomServiceNotValidException extends Exception
 {
@@ -16,10 +16,10 @@ final class CustomServiceNotValidException extends Exception
 
         $message = 'ClassResolver Exception' . PHP_EOL;
         $message .= sprintf(
-            'Is your custom service "%s" from your module "%s" extending %s?',
+            'Is your custom service "%s" from your module "%s" implementing %s?',
             $resolvableType,
             $callerClassInfo->getModule(),
-            AbstractCustomService::class
+            CustomServiceInterface::class
         ) . PHP_EOL;
 
         parent::__construct($message);

--- a/src/Framework/ClassResolver/CustomService/CustomServiceResolver.php
+++ b/src/Framework/ClassResolver/CustomService/CustomServiceResolver.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver\CustomService;
 
-use Gacela\Framework\AbstractCustomService;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\CustomServiceInterface;
 
 final class CustomServiceResolver extends AbstractClassResolver
 {
@@ -20,16 +20,16 @@ final class CustomServiceResolver extends AbstractClassResolver
      * @throws CustomServiceNotFoundException
      * @throws CustomServiceNotValidException
      */
-    public function resolve(object $callerClass): AbstractCustomService
+    public function resolve(object $callerClass): CustomServiceInterface
     {
-        /** @var ?AbstractCustomService $resolved */
+        /** @var ?CustomServiceInterface $resolved */
         $resolved = $this->doResolve($callerClass);
 
         if (null === $resolved) {
             throw new CustomServiceNotFoundException($callerClass, $this->resolvableType);
         }
 
-        if (!$resolved instanceof AbstractCustomService) {
+        if (!$resolved instanceof CustomServiceInterface) {
             throw new CustomServiceNotValidException($callerClass, $this->resolvableType);
         }
 

--- a/src/Framework/CustomServiceAwareTrait.php
+++ b/src/Framework/CustomServiceAwareTrait.php
@@ -8,10 +8,10 @@ use Gacela\Framework\ClassResolver\CustomService\CustomServiceResolver;
 
 trait CustomServiceAwareTrait
 {
-    /** @var array<string,AbstractCustomService> */
+    /** @var array<string,CustomServiceInterface> */
     private array $customServices = [];
 
-    public function __call(string $name, array $arguments = []): AbstractCustomService
+    public function __call(string $name, array $arguments = []): CustomServiceInterface
     {
         $resolvableType = ltrim($name, 'get');
 

--- a/src/Framework/CustomServiceInterface.php
+++ b/src/Framework/CustomServiceInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework;
+
+interface CustomServiceInterface
+{
+}

--- a/tests/Feature/Framework/CustomServices/CustomModule/Application/InvalidGreeter.php
+++ b/tests/Feature/Framework/CustomServices/CustomModule/Application/InvalidGreeter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\CustomServices\CustomModule\Application;
 
-final class Greeter
+final class InvalidGreeter
 {
     public function greet(string $name): string
     {

--- a/tests/Feature/Framework/CustomServices/CustomModule/Application/ValidGreeter.php
+++ b/tests/Feature/Framework/CustomServices/CustomModule/Application/ValidGreeter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\CustomServices\CustomModule\Application;
+
+use Gacela\Framework\CustomServiceInterface;
+
+final class ValidGreeter implements CustomServiceInterface
+{
+    private string $start;
+
+    public function __construct(string $start = 'Hi')
+    {
+        $this->start = $start;
+    }
+
+    public function greet(string $name): string
+    {
+        return sprintf('%s, %s!', $this->start, $name);
+    }
+}

--- a/tests/Feature/Framework/CustomServices/CustomModule/Facade.php
+++ b/tests/Feature/Framework/CustomServices/CustomModule/Facade.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\CustomServices\CustomModule;
 
 use Gacela\Framework\AbstractFacade;
-use GacelaTest\Feature\Framework\CustomServices\CustomModule\Application\Greeter;
+use GacelaTest\Feature\Framework\CustomServices\CustomModule\Application\InvalidGreeter;
 use GacelaTest\Feature\Framework\CustomServices\CustomModule\Application\Repository;
+use GacelaTest\Feature\Framework\CustomServices\CustomModule\Application\ValidGreeter;
 use GacelaTest\Feature\Framework\CustomServices\CustomModule\Infrastructure\Persistence\EntityManager;
 
 /**
+ * @method Factory getFactory()
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
- * @method Greeter getGreeter()
+ * @method InvalidGreeter getInvalidGreeter()
+ * @method ValidGreeter getValidGreeter()
  */
 final class Facade extends AbstractFacade
 {
@@ -33,8 +36,21 @@ final class Facade extends AbstractFacade
         return $this->getFactory()->findAllKeyValuesUsingRepositoryFromFactory();
     }
 
-    public function greetUsingPlainCustomService(string $name): string
+    /**
+     * When `getInvalidGreeter()` is trying to be resolved as `Application/InvalidGreeter`, it will throw an
+     * CustomServiceNotValidException because it's not implementing `CustomServiceInterface`.
+     */
+    public function greetUsingInvalidCustomService(string $name): string
     {
-        return $this->getGreeter()->greet($name);
+        return $this->getInvalidGreeter()->greet($name);
+    }
+
+    /**
+     * The `getValidGreeter()` will be resolved successfully as `Application/ValidGreeter` because it's
+     * implementing `CustomServiceInterface`.
+     */
+    public function greetUsingValidCustomService(string $name): string
+    {
+        return $this->getValidGreeter()->greet($name);
     }
 }

--- a/tests/Feature/Framework/CustomServices/FeatureTest.php
+++ b/tests/Feature/Framework/CustomServices/FeatureTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
 {
+    private Facade $facade;
+
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, [
@@ -21,12 +23,11 @@ final class FeatureTest extends TestCase
                 'Infrastructure\Persistence',
             ],
         ]);
+        $this->facade = new Facade();
     }
 
     public function test_using_custom_services_from_facade(): void
     {
-        $facade = new Facade();
-
         self::assertSame(
             [
                 'from-application-repository' => [
@@ -38,14 +39,12 @@ final class FeatureTest extends TestCase
                     'from-infrastructure-factory' => 3,
                 ],
             ],
-            $facade->usingCustomServicesFromFacade()
+            $this->facade->usingCustomServicesFromFacade()
         );
     }
 
     public function test_using_custom_services_from_factory(): void
     {
-        $facade = new Facade();
-
         self::assertSame(
             [
                 'from-application-repository' => [
@@ -53,15 +52,23 @@ final class FeatureTest extends TestCase
                     'from-application-factory' => 2,
                 ],
             ],
-            $facade->usingCustomServicesFromFactory()
+            $this->facade->usingCustomServicesFromFactory()
         );
     }
 
-    public function test_custom_service_which_does_not_extends_abstract_custom_service(): void
+    public function test_custom_service_which_does_not_implement_custom_service_interface(): void
     {
         $this->expectException(CustomServiceNotValidException::class);
-        $this->expectErrorMessageMatches('~"Greeter".*"CustomModule".*AbstractCustomService~');
-        $facade = new Facade();
-        $facade->greetUsingPlainCustomService('Gacela');
+        $this->expectErrorMessageMatches('~"InvalidGreeter".*"CustomModule".*CustomServiceInterface~');
+
+        $this->facade->greetUsingInvalidCustomService('Gacela');
+    }
+
+    public function test_custom_service_which_implements_custom_service_interface(): void
+    {
+        self::assertSame(
+            'Hi, Gacela!',
+            $this->facade->greetUsingValidCustomService('Gacela')
+        );
     }
 }


### PR DESCRIPTION
## 📚 Description

Currently the custom services must extend from AbstractCustomService, but it would be nice to don't force inheritance when it's not required. Although, with the AbstractCustomService you can use the getFactory() and getConfig() of the module, your custom services might don't need that, so the interface might be sufficient.

## 🔖 Changes

- Change from forcing extending `AbstractCustomService` to just implement `CustomServiceInterface`.

The advantage of using custom services is that they are accesible from gacela services AND they have an autoloader for their dependencies. The mapping-interfaces config is also available for the custom services too.

> 💡 Kudos to @JesusValera who gave me the idea.