### PR TITLE
Create basic AbstractTransfer

### DIFF
--- a/src/Framework/Transfer/AbstractTransfer.php
+++ b/src/Framework/Transfer/AbstractTransfer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Transfer;
 
+use RuntimeException;
+
 abstract class AbstractTransfer
 {
     /**
@@ -52,6 +54,6 @@ abstract class AbstractTransfer
             return $this;
         }
 
-        throw new \RuntimeException("Unknown property with name: $normalizedName");
+        throw new RuntimeException("Unknown property with name: $normalizedName");
     }
 }

--- a/src/Framework/Transfer/AbstractTransfer.php
+++ b/src/Framework/Transfer/AbstractTransfer.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Transfer;
 
-use RuntimeException;
+use function get_object_vars;
+use function lcfirst;
+use function preg_replace;
+use function property_exists;
+use function reset;
 
 abstract class AbstractTransfer
 {
@@ -35,7 +39,7 @@ abstract class AbstractTransfer
     }
 
     /**
-     * @return mixed
+     * @return mixed|static
      */
     public function __call(string $name, array $arguments = [])
     {
@@ -54,6 +58,29 @@ abstract class AbstractTransfer
             return $this;
         }
 
-        throw new RuntimeException("Unknown property with name: $normalizedName");
+        throw UnknownPropertyException::withName($normalizedName);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        return $this->__call($name);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed|static
+     */
+    public function __set(string $name, $value)
+    {
+        return $this->__call($name, [$value]);
+    }
+
+    public function __isset(string $name): bool
+    {
+        return $this->__call($name) !== null;
     }
 }

--- a/src/Framework/Transfer/AbstractTransfer.php
+++ b/src/Framework/Transfer/AbstractTransfer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Transfer;
+
+abstract class AbstractTransfer
+{
+    /**
+     * @param array<string,mixed> $array
+     *
+     * @return static
+     *
+     * @psalm-suppress MixedAssignment
+     */
+    public function fromArray(array $array)
+    {
+        foreach ($array as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __call(string $name, array $arguments = [])
+    {
+        // fluent getters
+        $withoutPrefix = (string)preg_replace('/^get/', '', $name);
+        $normalizedName = lcfirst($withoutPrefix);
+        if (property_exists($this, $normalizedName)) {
+            return $this->{$normalizedName};
+        }
+
+        // fluent setters
+        $withoutPrefix = (string)preg_replace('/^set/', '', $name);
+        $normalizedName = lcfirst($withoutPrefix);
+        if (property_exists($this, $normalizedName)) {
+            $this->{$normalizedName} = reset($arguments);
+            return $this;
+        }
+
+        throw new \RuntimeException("Unknown property with name: $normalizedName");
+    }
+}

--- a/src/Framework/Transfer/UnknownPropertyException.php
+++ b/src/Framework/Transfer/UnknownPropertyException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Transfer;
+
+use RuntimeException;
+
+final class UnknownPropertyException extends RuntimeException
+{
+    public static function withName(string $name): self
+    {
+        return new self("Unknown property with name: $name");
+    }
+}

--- a/tests/Unit/Framework/Transfer/AbstractTransferTest.php
+++ b/tests/Unit/Framework/Transfer/AbstractTransferTest.php
@@ -52,14 +52,14 @@ final class AbstractTransferTest extends TestCase
 
     public function test_set_wrong_type_from_setter(): void
     {
-        $this->expectErrorMessageMatches('/.*Typed property .*PersonTransfer.*age must be int or null, float used/');
+        $this->expectErrorMessageMatches('/.*PersonTransfer.*age.*/');
 
         (new PersonTransfer())->setAge(10.5);
     }
 
     public function test_set_wrong_type_from_array(): void
     {
-        $this->expectErrorMessageMatches('/.*Typed property .*PersonTransfer.*age must be int or null, float used/');
+        $this->expectErrorMessageMatches('/.*PersonTransfer.*age.*/');
 
         (new PersonTransfer())->fromArray(['age' => 10.5]);
     }

--- a/tests/Unit/Framework/Transfer/AbstractTransferTest.php
+++ b/tests/Unit/Framework/Transfer/AbstractTransferTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Transfer;
+
+use GacelaTest\Unit\Framework\Transfer\Fixtures\PersonTransfer;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractTransferTest extends TestCase
+{
+    public function test_fluent_setters(): void
+    {
+        $person = (new PersonTransfer())
+            ->setAge(10)
+            ->setName('gacela');
+
+        self::assertSame(10, $person->age);
+        self::assertSame('gacela', $person->name);
+    }
+
+    public function test_getters(): void
+    {
+        $person = new PersonTransfer();
+        $person->age = 10;
+        $person->name = 'gacela';
+
+        self::assertSame(10, $person->getAge());
+        self::assertSame('gacela', $person->getName());
+    }
+
+    public function test_from_array(): void
+    {
+        $person = (new PersonTransfer())
+            ->fromArray(['age' => 10, 'name' => 'gacela']);
+
+        self::assertSame(10, $person->age);
+        self::assertSame('gacela', $person->name);
+    }
+
+    public function test_to_array(): void
+    {
+        $person = new PersonTransfer();
+        $person->age = 10;
+        $person->name = 'gacela';
+
+        self::assertSame(
+            ['id' => null, 'name' => 'gacela', 'age' => 10],
+            $person->toArray()
+        );
+    }
+
+    public function test_set_wrong_type_from_setter(): void
+    {
+        $this->expectErrorMessageMatches('/.*Typed property .*PersonTransfer.*age must be int or null, float used/');
+
+        (new PersonTransfer())->setAge(10.5);
+    }
+
+    public function test_set_wrong_type_from_array(): void
+    {
+        $this->expectErrorMessageMatches('/.*Typed property .*PersonTransfer.*age must be int or null, float used/');
+
+        (new PersonTransfer())->fromArray(['age' => 10.5]);
+    }
+
+    public function test_set_nonexistent_property_from_array(): void
+    {
+        $person = (new PersonTransfer())->fromArray(['non-existent' => 123]);
+
+        self::assertInstanceOf(PersonTransfer::class, $person);
+    }
+
+    public function test_set_nonexistent_property(): void
+    {
+        $this->expectErrorMessageMatches('/.*Unknown property with name: nonExistentProperty/');
+
+        (new PersonTransfer())->setNonExistentProperty(123);
+    }
+}

--- a/tests/Unit/Framework/Transfer/AbstractTransferTest.php
+++ b/tests/Unit/Framework/Transfer/AbstractTransferTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Transfer;
 
+use Gacela\Framework\Transfer\UnknownPropertyException;
 use GacelaTest\Unit\Framework\Transfer\Fixtures\PersonTransfer;
 use PHPUnit\Framework\TestCase;
 
@@ -71,9 +72,19 @@ final class AbstractTransferTest extends TestCase
         self::assertInstanceOf(PersonTransfer::class, $person);
     }
 
-    public function test_set_nonexistent_property(): void
+    public function test_set_nonexistent_property_using_public_property(): void
     {
-        $this->expectErrorMessageMatches('/.*Unknown property with name: nonExistentProperty/');
+        $this->expectException(UnknownPropertyException::class);
+        $this->expectExceptionMessage('Unknown property with name: nonExistentProperty');
+
+        $person = new PersonTransfer();
+        $person->nonExistentProperty = 123;
+    }
+
+    public function test_set_nonexistent_property_using_setter(): void
+    {
+        $this->expectException(UnknownPropertyException::class);
+        $this->expectExceptionMessage('Unknown property with name: nonExistentProperty');
 
         (new PersonTransfer())->setNonExistentProperty(123);
     }

--- a/tests/Unit/Framework/Transfer/Fixtures/PersonTransfer.php
+++ b/tests/Unit/Framework/Transfer/Fixtures/PersonTransfer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Transfer\Fixtures;
+
+use Gacela\Framework\Transfer\AbstractTransfer;
+
+/**
+ * @method int|null getId()
+ * @method string|null getName()
+ * @method self setName(string $name)
+ * @method int|null getAge()
+ * @method self setAge(int $age)
+ */
+final class PersonTransfer extends AbstractTransfer
+{
+    public ?int $id = null;
+
+    public ?string $name = null;
+
+    public ?int $age = null;
+}


### PR DESCRIPTION
## 📚 Description

I was thinking about adding a complete new feature to Gacela like an abstract class which facilitates the creation of DTOs.

## 🔖 Changes

- Added `AbstractTransfer` class.
  - The suffix `Transfer` is from "Data Transfer Object", not from "Transportation" or similar.

I was thinking about using `AbstractDto`, or `AbstractDTO`, or `AbstractTransfer`...


## 🤔 Follow up ideas

As follow up, we could think about creating a Gacela command, where you specify a file which is suppose to extend the `AbstractTransfer`, and then alter it to add the PHPDoc above the class name to add all getters and setters. 

We could even pass a directory/ies and search in all those possible classes of interest.