### PR TITLE
Move ConfigReader next to the config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Moved the "config readers" next to their config item itself.
+  - Performance improvement specially when using different config readers in the same project.
 - Deprecated and removed `CustomService` feature. Use `MappingInterfaces` feature instead.
   - Why? Too much magic.
 - Removed deprecated methods `getApplicationRootDir()` & `setApplicationRootDir()` from Config.

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,10 @@
         }
     },
     "scripts": {
+        "ctal": [
+            "@csfix",
+            "@test-all"
+        ],
         "test-all": [
             "@quality",
             "@phpunit",

--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -12,18 +12,21 @@ abstract class AbstractConfigGacela
      * e.g:
      * <code>
      * return [
-     *   'path' => '.env*',
-     *   'path_local' => '.env',
-     * ];
+     *   'path' => 'config/*.php',
+     *   'path_local' => 'config/local.php',
+     *   'reader' => new PhpConfigReader(),
+     * ],
      * # OR
      * return [
      *   [
      *     'path' => '.env*',
      *     'path_local' => '.env',
+     *     'reader' => new EnvConfigReader(),
      *   ],
      *   [
      *     'path' => 'config/*.php',
      *     'path_local' => 'config/local.php',
+     *     'reader' => new PhpConfigReader(),
      *   ],
      * ];
      * </code>
@@ -31,10 +34,7 @@ abstract class AbstractConfigGacela
      * <b>path</b>: Define the path where Gacela will read all the config files. Default: <i>config/*.php</i><br>
      * <b>path_local</b>: Define the path where Gacela will read the local config file. Default: <i>config/local.php</i>
      *
-     * @return array<array>|array{
-     *     path?:string,
-     *     path_local?:string
-     * }
+     * @return list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface}
      */
     public function config(): array
     {

--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -32,28 +32,12 @@ abstract class AbstractConfigGacela
      * </code>
      *
      * <b>path</b>: Define the path where Gacela will read all the config files. Default: <i>config/*.php</i><br>
-     * <b>path_local</b>: Define the path where Gacela will read the local config file. Default: <i>config/local.php</i>
+     * <b>path_local</b>: Define the path where Gacela will read the local config file. Default: <i>config/local.php</i><br>
+     * <b>reader</b>: Define the reader class which will read and parse the config files. Default: <i>new PhpConfigReader()</i><br>
      *
      * @return list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface}
      */
     public function config(): array
-    {
-        return [];
-    }
-
-    /**
-     * e.g:
-     * <code>
-     * return [
-     *     'php' => new \Gacela\Framework\Config\ConfigReader\PhpConfigReader(),
-     * ];
-     * </code>
-     *
-     * Define the reader class which will read and parse the config files. Default: <i>PhpConfigReader</i>
-     *
-     * @return array<string,ConfigReaderInterface>
-     */
-    public function configReaders(): array
     {
         return [];
     }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Config\PathNormalizer\AbsolutePathNormalizer;
-use Gacela\Framework\Config\PathNormalizer\NoEnvAbsolutePathStrategy;
-use Gacela\Framework\Config\PathNormalizer\SuffixAbsolutePathStrategy;
+use Gacela\Framework\Config\PathNormalizer\WithoutSuffixAbsolutePathStrategy;
+use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
 
 final class ConfigFactory
 {
@@ -58,13 +58,12 @@ final class ConfigFactory
     private function createPathNormalizer(): PathNormalizerInterface
     {
         return new AbsolutePathNormalizer([
-            AbsolutePathNormalizer::PATTERN => new NoEnvAbsolutePathStrategy($this->appRootDir),
-            AbsolutePathNormalizer::PATTERN_WITH_ENV => new SuffixAbsolutePathStrategy($this->appRootDir, $this->getEnv()),
-            AbsolutePathNormalizer::LOCAL => new NoEnvAbsolutePathStrategy($this->appRootDir),
+            AbsolutePathNormalizer::WITHOUT_SUFFIX => new WithoutSuffixAbsolutePathStrategy($this->appRootDir),
+            AbsolutePathNormalizer::WITH_SUFFIX => new WithSuffixAbsolutePathStrategy($this->appRootDir, $this->env()),
         ]);
     }
 
-    private function getEnv(): string
+    private function env(): string
     {
         return getenv('APP_ENV') ?: '';
     }

--- a/src/Framework/Config/ConfigGacelaMapper.php
+++ b/src/Framework/Config/ConfigGacelaMapper.php
@@ -9,33 +9,25 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 final class ConfigGacelaMapper
 {
     /**
-     * @param array<array>|array{path:string,path_local:string} $config
+     * @param list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface} $config
      *
      * @return list<GacelaConfigItem>
      */
     public function mapConfigItems(array $config): array
     {
-        if ($this->isSingleConfigFile($config)) {
-            return [GacelaConfigItem::fromArray($config)];
+        if (isset($config['path']) || isset($config['path_local'])) {
+            /** @psalm-suppress InvalidArgument */
+            return [GacelaConfigItem::fromArray($config)];//@phpstan-ignore-line
         }
 
         $result = [];
 
-        /** @var array<array{path:string,path_local:string}> $config */
+        /** @var list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}> $config */
         foreach ($config as $configItem) {
             $c = GacelaConfigItem::fromArray($configItem);
             $result[] = $c;
         }
 
         return $result;
-    }
-
-    /**
-     * @param array<array>|array{path:string,path_local:string} $config
-     */
-    private function isSingleConfigFile(array $config): bool
-    {
-        return isset($config['path'])
-            || isset($config['path_local']);
     }
 }

--- a/src/Framework/Config/ConfigGacelaMapper.php
+++ b/src/Framework/Config/ConfigGacelaMapper.php
@@ -17,7 +17,7 @@ final class ConfigGacelaMapper
     {
         if (isset($config['path']) || isset($config['path_local'])) {
             /** @psalm-suppress InvalidArgument */
-            return [GacelaConfigItem::fromArray($config)];//@phpstan-ignore-line
+            return [GacelaConfigItem::fromArray($config)]; // @phpstan-ignore-line
         }
 
         $result = [];

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -47,7 +47,7 @@ final class ConfigLoader
         }
 
         /** @psalm-suppress MixedArgument */
-        $configs[] = array_merge(...array_merge(...$result));//@phpstan-ignore-line
+        $configs[] = array_merge(...array_merge(...$result)); // @phpstan-ignore-line
         $configs[] = $this->readLocalConfigFile($gacelaFileConfig);
 
         /** @var array<string,mixed> $allConfigKeyValues */

--- a/src/Framework/Config/ConfigReader/PhpConfigReader.php
+++ b/src/Framework/Config/ConfigReader/PhpConfigReader.php
@@ -11,23 +11,20 @@ use function is_array;
 
 final class PhpConfigReader implements ConfigReaderInterface
 {
-    public function canRead(string $absolutePath): bool
-    {
-        $extension = pathinfo($absolutePath, PATHINFO_EXTENSION);
-
-        return 'php' === $extension;
-    }
-
     /**
      * @return array<string,mixed>
      */
     public function read(string $absolutePath): array
     {
-        if (!file_exists($absolutePath)) {
+        if (!$this->canRead($absolutePath)) {
             return [];
         }
 
-        /** @var null|string[]|JsonSerializable|mixed $content */
+        /**
+         * @psalm-suppress UnresolvableInclude
+         *
+         * @var null|string[]|JsonSerializable|mixed $content
+         */
         $content = include $absolutePath;
 
         if (null === $content) {
@@ -46,5 +43,12 @@ final class PhpConfigReader implements ConfigReaderInterface
 
         /** @var array<string,mixed> $content */
         return $content;
+    }
+
+    private function canRead(string $absolutePath): bool
+    {
+        $extension = pathinfo($absolutePath, PATHINFO_EXTENSION);
+
+        return 'php' === $extension && file_exists($absolutePath);
     }
 }

--- a/src/Framework/Config/ConfigReaderInterface.php
+++ b/src/Framework/Config/ConfigReaderInterface.php
@@ -6,8 +6,6 @@ namespace Gacela\Framework\Config;
 
 interface ConfigReaderInterface
 {
-    public function canRead(string $absolutePath): bool;
-
     /**
      * @return array<string,mixed>
      */

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -56,45 +56,38 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
         }
 
         $configItems = $this->configGacelaMapper->mapConfigItems($configGacelaClass->config());
-        $configReaders = $configGacelaClass->configReaders();
         $mappingInterfaces = $configGacelaClass->mappingInterfaces($this->globalServices);
 
-        return $this->createWithDefaultIfEmpty($configItems, $configReaders, $mappingInterfaces);
+        return $this->createWithDefaultIfEmpty($configItems, $mappingInterfaces);
     }
 
     private function createDefaultGacelaPhpConfig(): GacelaConfigFile
     {
-        /** @var array{
-         *     config?: array<array>|array{type:string,path:string,path_local:string},
-         *     config-readers?: array<string,ConfigReaderInterface>,
+        /**
+         * @var array{
+         *     config?: list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface},
          *     mapping-interfaces?: array<class-string,class-string|callable>,
          * } $configFromGlobalServices
          */
         $configFromGlobalServices = $this->globalServices;
         $configItems = $this->configGacelaMapper->mapConfigItems($configFromGlobalServices['config'] ?? []);
-        $configReaders = $configFromGlobalServices['config-readers'] ?? [];
         $mappingInterfaces = $configFromGlobalServices['mapping-interfaces'] ?? [];
 
-        return $this->createWithDefaultIfEmpty($configItems, $configReaders, $mappingInterfaces);
+        return $this->createWithDefaultIfEmpty($configItems, $mappingInterfaces);
     }
 
     /**
      * @param list<GacelaConfigItem> $configItems
-     * @param array<string,ConfigReaderInterface> $configReaders
      * @param array<class-string,class-string|callable> $mappingInterfaces
      */
     private function createWithDefaultIfEmpty(
         array $configItems,
-        array $configReaders,
         array $mappingInterfaces
     ): GacelaConfigFile {
         $gacelaConfigFile = GacelaConfigFile::withDefaults();
 
         if (!empty($configItems)) {
             $gacelaConfigFile->setConfigItems($configItems);
-        }
-        if (!empty($configReaders)) {
-            $gacelaConfigFile->setConfigReaders($configReaders);
         }
         if (!empty($mappingInterfaces)) {
             $gacelaConfigFile->setMappingInterfaces($mappingInterfaces);

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig;
 
-use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
-use Gacela\Framework\Config\ConfigReaderInterface;
-
 final class GacelaConfigFile
 {
     /** @var list<GacelaConfigItem> */
@@ -15,14 +12,10 @@ final class GacelaConfigFile
     /** @var array<class-string,class-string|callable> */
     private array $mappingInterfaces = [];
 
-    /** @var array<string,ConfigReaderInterface> */
-    private array $configReaders = [];
-
     public static function withDefaults(): self
     {
         return (new self())
-            ->setConfigItems([GacelaConfigItem::withDefaults()])
-            ->setConfigReaders(['php' => new PhpConfigReader()]);
+            ->setConfigItems([GacelaConfigItem::withDefaults()]);
     }
 
     /**
@@ -41,24 +34,6 @@ final class GacelaConfigFile
     public function getConfigItems(): array
     {
         return $this->configItems;
-    }
-
-    /**
-     * @param array<string,ConfigReaderInterface> $configReaders
-     */
-    public function setConfigReaders(array $configReaders): self
-    {
-        $this->configReaders = $configReaders;
-
-        return $this;
-    }
-
-    /**
-     * @return array<string,ConfigReaderInterface>
-     */
-    public function getConfigReaders(): array
-    {
-        return $this->configReaders;
     }
 
     /**

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
@@ -4,43 +4,44 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig;
 
+use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
+use Gacela\Framework\Config\ConfigReaderInterface;
+use function get_class;
+
 final class GacelaConfigItem
 {
-    public const DEFAULT_TYPE = 'php';
-
     private const DEFAULT_PATH = 'config/*.php';
     private const DEFAULT_PATH_LOCAL = 'config/local.php';
 
     private string $path;
     private string $pathLocal;
+    private ConfigReaderInterface $reader;
 
     public function __construct(
         string $path = self::DEFAULT_PATH,
-        string $pathLocal = self::DEFAULT_PATH_LOCAL
+        string $pathLocal = self::DEFAULT_PATH_LOCAL,
+        ?ConfigReaderInterface $reader = null
     ) {
         $this->path = $path;
         $this->pathLocal = $pathLocal;
+        $this->reader = $reader ?? new PhpConfigReader();
     }
 
     /**
-     * @param array<array-key,mixed> $item
+     * @param array{path?:string, path_local?:string, reader?:ConfigReaderInterface} $item
      */
     public static function fromArray(array $item): self
     {
-        /** @var null|string $path */
-        $path = $item['path'] ?? null;
-        /** @var null|string $pathLocal */
-        $pathLocal = $item['path_local'] ?? null;
-
         return new self(
-            $path ?? self::DEFAULT_PATH,
-            $pathLocal ?? self::DEFAULT_PATH_LOCAL
+            $item['path'] ?? self::DEFAULT_PATH,
+            $item['path_local'] ?? self::DEFAULT_PATH_LOCAL,
+            $item['reader'] ?? new PhpConfigReader(),
         );
     }
 
     public static function withDefaults(): self
     {
-        return new self();
+        return self::fromArray([]);
     }
 
     public function path(): string
@@ -53,12 +54,18 @@ final class GacelaConfigItem
         return $this->pathLocal;
     }
 
+    public function reader(): ConfigReaderInterface
+    {
+        return $this->reader;
+    }
+
     public function __toString(): string
     {
         return sprintf(
-            'GacelaConfigItem{ path:%s, pathLocal:%s }',
+            'GacelaConfigItem{path:%s, pathLocal:%s, reader:%s}',
             $this->path,
-            $this->pathLocal
+            $this->pathLocal,
+            get_class($this->reader)
         );
     }
 }

--- a/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
+++ b/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
@@ -9,9 +9,8 @@ use Gacela\Framework\Config\PathNormalizerInterface;
 
 final class AbsolutePathNormalizer implements PathNormalizerInterface
 {
-    public const PATTERN = 'PATTERN';
-    public const PATTERN_WITH_ENV = 'PATTERN_WITH_ENV';
-    public const LOCAL = 'LOCAL';
+    public const WITHOUT_SUFFIX = 'WITHOUT_SUFFIX';
+    public const WITH_SUFFIX = 'WITH_SUFFIX';
 
     /** @var array<string,AbsolutePathStrategyInterface> */
     private array $absolutePathStrategies;
@@ -26,19 +25,19 @@ final class AbsolutePathNormalizer implements PathNormalizerInterface
 
     public function normalizePathPattern(GacelaConfigItem $configItem): string
     {
-        return $this->absolutePathStrategies[self::PATTERN]
+        return $this->absolutePathStrategies[self::WITHOUT_SUFFIX]
             ->generateAbsolutePath($configItem->path());
     }
 
     public function normalizePathPatternWithEnvironment(GacelaConfigItem $configItem): string
     {
-        return $this->absolutePathStrategies[self::PATTERN_WITH_ENV]
+        return $this->absolutePathStrategies[self::WITH_SUFFIX]
             ->generateAbsolutePath($configItem->path());
     }
 
     public function normalizePathLocal(GacelaConfigItem $configItem): string
     {
-        return $this->absolutePathStrategies[self::LOCAL]
+        return $this->absolutePathStrategies[self::WITHOUT_SUFFIX]
             ->generateAbsolutePath($configItem->pathLocal());
     }
 }

--- a/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategy.php
@@ -20,18 +20,20 @@ final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
 
     public function generateAbsolutePath(string $relativePath): string
     {
+        $suffix = $this->configFileNameSuffix;
+        if ($suffix === '') {
+            return '';
+        }
+
         // place the file suffix right before the file extension
         $dotPos = strpos($relativePath, '.');
-        $suffix = $this->getConfigFileNameSuffix();
 
-        if ($dotPos !== false && !empty($suffix)) {
+        if ($dotPos !== false) {
             $relativePathWithFileSuffix = substr($relativePath, 0, $dotPos)
-                . '-' . $this->getConfigFileNameSuffix()
+                . '-' . $suffix
                 . substr($relativePath, $dotPos);
-        } elseif (!empty($suffix)) {
-            $relativePathWithFileSuffix = $relativePath . '-' . $suffix;
         } else {
-            $relativePathWithFileSuffix = $relativePath;
+            $relativePathWithFileSuffix = $relativePath . '-' . $suffix;
         }
 
         return sprintf(
@@ -39,10 +41,5 @@ final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
             rtrim($this->appRootDir, '/'),
             ltrim($relativePathWithFileSuffix, '/')
         );
-    }
-
-    private function getConfigFileNameSuffix(): string
-    {
-        return $this->configFileNameSuffix;
     }
 }

--- a/src/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\PathNormalizer;
 
-final class SuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
+final class WithSuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
 {
     private string $appRootDir;
 

--- a/src/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\PathNormalizer;
 
-final class NoEnvAbsolutePathStrategy implements AbsolutePathStrategyInterface
+final class WithoutSuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
 {
     private string $appRootDir;
 

--- a/src/Framework/Exception/Backtrace.php
+++ b/src/Framework/Exception/Backtrace.php
@@ -40,6 +40,6 @@ class Backtrace
      */
     public function getBacktraces(): array
     {
-        return debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);//@phpstan-ignore-line
+        return debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS); // @phpstan-ignore-line
     }
 }

--- a/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
@@ -15,6 +15,21 @@ final class FeatureTest extends TestCase
         putenv('APP_ENV');
     }
 
+    public function test_load_config_from_custom_env_default(): void
+    {
+        Gacela::bootstrap(__DIR__);
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'from-default' => 1,
+                'from-default-env-override' => 1,
+                'from-local-override' => 4,
+            ],
+            $facade->doSomething()
+        );
+    }
+
     public function test_load_config_from_custom_env_dev(): void
     {
         putenv('APP_ENV=dev');

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -15,12 +15,8 @@ final class FeatureTest extends TestCase
     {
         $globalServices = [
             'config' => [
-                ['path' => 'config/.env*'],
-                ['path' => 'config/*.php'],
-            ],
-            'config-readers' =>  [
-                new PhpConfigReader(),
-                new SimpleEnvConfigReader(),
+                ['path' => 'config/.env*', 'reader' => new SimpleEnvConfigReader()],
+                ['path' => 'config/*.php', 'reader' => new PhpConfigReader()],
             ],
         ];
 
@@ -36,6 +32,7 @@ final class FeatureTest extends TestCase
                 'config-env' => 1,
                 'config-php' => 3,
                 'override' => 4,
+                'local' => 5,
             ],
             $facade->doSomething()
         );

--- a/tests/Feature/Framework/UsingMultipleConfig/LocalConfig/Config.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/LocalConfig/Config.php
@@ -14,6 +14,7 @@ final class Config extends AbstractConfig
             'config-env' => (int) $this->get('config-env'),
             'config-php' => (int) $this->get('config-php'),
             'override' => (int) $this->get('override'),
+            'local' => (int) $this->get('local'),
         ];
     }
 }

--- a/tests/Feature/Framework/UsingMultipleConfig/LocalConfig/Domain/SimpleEnvConfigReader.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/LocalConfig/Domain/SimpleEnvConfigReader.php
@@ -8,17 +8,12 @@ use Gacela\Framework\Config\ConfigReaderInterface;
 
 final class SimpleEnvConfigReader implements ConfigReaderInterface
 {
-    public function canRead(string $absolutePath): bool
-    {
-        return false !== strpos($absolutePath, '.env');
-    }
-
     /**
      * @return array<string,mixed>
      */
     public function read(string $absolutePath): array
     {
-        if (!is_file($absolutePath)) {
+        if (!$this->canRead($absolutePath)) {
             return [];
         }
 
@@ -28,7 +23,7 @@ final class SimpleEnvConfigReader implements ConfigReaderInterface
         $lines = file($absolutePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         foreach ($lines as $line) {
-            if (strpos(trim($line), '#') === 0) {
+            if (strncmp(trim($line), '#', 1) === 0) {
                 continue;
             }
 
@@ -37,5 +32,11 @@ final class SimpleEnvConfigReader implements ConfigReaderInterface
         }
 
         return $config;
+    }
+
+    private function canRead(string $absolutePath): bool
+    {
+        return false !== strpos($absolutePath, '.env')
+            && is_file($absolutePath);
     }
 }

--- a/tests/Feature/Framework/UsingMultipleConfig/config/local.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/config/local.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'local' => 5,
+];

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Framework\Config;
 
 use Gacela\Framework\Config;
-use Gacela\Framework\Config\ConfigReaderInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
@@ -29,26 +28,5 @@ final class ConfigTest extends TestCase
     public function test_null_as_default_value_from_undefined_key(): void
     {
         self::assertNull(Config::getInstance()->get('undefined-key', null));
-    }
-
-    public function test_get_using_custom_reader(): void
-    {
-        Config::getInstance()->setGlobalServices([
-            'config-readers' => [
-                new class () implements ConfigReaderInterface {
-                    public function read(string $absolutePath): array
-                    {
-                        return ['key' => 'value'];
-                    }
-
-                    public function canRead(string $absolutePath): bool
-                    {
-                        return true;
-                    }
-                },
-            ],
-        ]);
-
-        self::assertSame('value', Config::getInstance()->get('key'));
     }
 }

--- a/tests/Unit/Framework/Config/ConfigInitTest.php
+++ b/tests/Unit/Framework/Config/ConfigInitTest.php
@@ -72,18 +72,14 @@ final class ConfigInitTest extends TestCase
     public function test_read_single_config(): void
     {
         $reader = $this->createStub(ConfigReaderInterface::class);
-        $reader->method('canRead')->willReturn(true);
         $reader->method('read')->willReturn(['key' => 'value']);
 
         $gacelaJsonConfigCreator = $this->createStub(GacelaConfigFileFactoryInterface::class);
         $gacelaJsonConfigCreator
             ->method('createGacelaFileConfig')
             ->willReturn((new GacelaConfigFile())
-                ->setConfigReaders([
-                    'supported-type' => $reader,
-                ])
                 ->setConfigItems([
-                    'supported-type' => new GacelaConfigItem('supported-type'),
+                    new GacelaConfigItem('path', 'path_local', $reader),
                 ]));
 
         $configInit = new ConfigLoader(
@@ -98,24 +94,18 @@ final class ConfigInitTest extends TestCase
     public function test_read_multiple_config(): void
     {
         $reader1 = $this->createStub(ConfigReaderInterface::class);
-        $reader1->method('canRead')->willReturn(true);
         $reader1->method('read')->willReturn(['key1' => 'value1']);
 
         $reader2 = $this->createStub(ConfigReaderInterface::class);
-        $reader2->method('canRead')->willReturn(true);
         $reader2->method('read')->willReturn(['key2' => 'value2']);
 
         $gacelaJsonConfigCreator = $this->createStub(GacelaConfigFileFactoryInterface::class);
         $gacelaJsonConfigCreator
             ->method('createGacelaFileConfig')
             ->willReturn((new GacelaConfigFile())
-                ->setConfigReaders([
-                    'supported-type1' => $reader1,
-                    'supported-type2' => $reader2,
-                ])
                 ->setConfigItems([
-                    'supported-type1' => new GacelaConfigItem('supported-type1'),
-                    'supported-type2' => new GacelaConfigItem('supported-type2'),
+                    new GacelaConfigItem('path', 'path_local', $reader1),
+                    new GacelaConfigItem('path', 'path_local', $reader2),
                 ]));
 
         $configInit = new ConfigLoader(

--- a/tests/Unit/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/SuffixAbsolutePathStrategyTest.php
@@ -9,15 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 final class SuffixAbsolutePathStrategyTest extends TestCase
 {
-    public function test_file_without_extension_neither_suffix(): void
+    public function test_file_without_extension_neither_suffix_then_empty_string(): void
     {
         $strategy = new SuffixAbsolutePathStrategy('/app/root/');
         $relativePath = '/file-name';
 
-        self::assertSame(
-            '/app/root/file-name',
-            $strategy->generateAbsolutePath($relativePath)
-        );
+        self::assertSame('', $strategy->generateAbsolutePath($relativePath));
     }
 
     public function test_file_without_extension_but_suffix(): void
@@ -31,15 +28,12 @@ final class SuffixAbsolutePathStrategyTest extends TestCase
         );
     }
 
-    public function test_file_with_extension_but_no_suffix(): void
+    public function test_file_with_extension_but_no_suffix_then_empty_string(): void
     {
         $strategy = new SuffixAbsolutePathStrategy('/app/root/');
         $relativePath = '/file-name.ext';
 
-        self::assertSame(
-            '/app/root/file-name.ext',
-            $strategy->generateAbsolutePath($relativePath)
-        );
+        self::assertSame('', $strategy->generateAbsolutePath($relativePath));
     }
 
     public function test_file_with_extension_and_suffix(): void

--- a/tests/Unit/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategyTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Config\PathNormalizer;
 
-use Gacela\Framework\Config\PathNormalizer\SuffixAbsolutePathStrategy;
+use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
 use PHPUnit\Framework\TestCase;
 
-final class SuffixAbsolutePathStrategyTest extends TestCase
+final class WithSuffixAbsolutePathStrategyTest extends TestCase
 {
     public function test_file_without_extension_neither_suffix_then_empty_string(): void
     {
-        $strategy = new SuffixAbsolutePathStrategy('/app/root/');
+        $strategy = new WithSuffixAbsolutePathStrategy('/app/root/');
         $relativePath = '/file-name';
 
         self::assertSame('', $strategy->generateAbsolutePath($relativePath));
@@ -19,7 +19,7 @@ final class SuffixAbsolutePathStrategyTest extends TestCase
 
     public function test_file_without_extension_but_suffix(): void
     {
-        $strategy = new SuffixAbsolutePathStrategy('/app/root/', 'suffix');
+        $strategy = new WithSuffixAbsolutePathStrategy('/app/root/', 'suffix');
         $relativePath = '/file-name';
 
         self::assertSame(
@@ -30,7 +30,7 @@ final class SuffixAbsolutePathStrategyTest extends TestCase
 
     public function test_file_with_extension_but_no_suffix_then_empty_string(): void
     {
-        $strategy = new SuffixAbsolutePathStrategy('/app/root/');
+        $strategy = new WithSuffixAbsolutePathStrategy('/app/root/');
         $relativePath = '/file-name.ext';
 
         self::assertSame('', $strategy->generateAbsolutePath($relativePath));
@@ -38,7 +38,7 @@ final class SuffixAbsolutePathStrategyTest extends TestCase
 
     public function test_file_with_extension_and_suffix(): void
     {
-        $strategy = new SuffixAbsolutePathStrategy('/app/root/', 'suffix');
+        $strategy = new WithSuffixAbsolutePathStrategy('/app/root/', 'suffix');
         $relativePath = '/file-name.ext';
 
         self::assertSame(

--- a/tests/Unit/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategyTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Config\PathNormalizer;
 
-use Gacela\Framework\Config\PathNormalizer\NoEnvAbsolutePathStrategy;
+use Gacela\Framework\Config\PathNormalizer\WithoutSuffixAbsolutePathStrategy;
 use PHPUnit\Framework\TestCase;
 
-final class NoEnvAbsolutePathStrategyTest extends TestCase
+final class WithoutSuffixAbsolutePathStrategyTest extends TestCase
 {
     public function test_file_without_extension(): void
     {
-        $strategy = new NoEnvAbsolutePathStrategy('/app/root/');
+        $strategy = new WithoutSuffixAbsolutePathStrategy('/app/root/');
         $relativePath = '/file-name';
 
         self::assertSame(
@@ -22,7 +22,7 @@ final class NoEnvAbsolutePathStrategyTest extends TestCase
 
     public function test_file_with_extension(): void
     {
-        $strategy = new NoEnvAbsolutePathStrategy('/app/root/');
+        $strategy = new WithoutSuffixAbsolutePathStrategy('/app/root/');
         $relativePath = '/file-name.ext';
 
         self::assertSame(


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/gacela-project/gacela/issues/96

Currently, we have ConfigReaders as a separate key-value on gacela bootstrap level. This means that we iterate over all possible config paths across all existing ConfigReaders. This is not optimal for performance, because one ConfigReader wont be used for different file types.

### Before
```php
$globalServices = [
    'config' => [
        ['path' => 'config/.env*'],
        ['path' => 'config/*.php'],
    ],
    'config-readers' =>  [
        new PhpConfigReader(),
        new EnvConfigReader(),
    ],
];
```

### After
```php
$globalServices = [
    'config' => [
        [
            'reader' => new EnvConfigReader(),
            'path' => 'config/.env*',
            'path_local' => 'config/.env.local',
        ],
        [
            'reader' => new PhpConfigReader(),
            'path' => 'config/*/*.php',
            'path_local' => 'config/*/override.php',
        ],
    ],
];
```

## 💡 Goal

Declare explicitly the `ConfigReader` you want to use on each config item (for each path).
Also, remove the 'config-readers' key from `globalServices/Gacela::bootstrap()`.