### PR TITLE
Allow define reader as class-string or instance of ConfigReaderInterface

### DIFF
--- a/src/Framework/Config/ConfigGacelaMapper.php
+++ b/src/Framework/Config/ConfigGacelaMapper.php
@@ -9,7 +9,7 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 final class ConfigGacelaMapper
 {
     /**
-     * @param list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface} $config
+     * @param list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string} $config
      *
      * @return list<GacelaConfigItem>
      */
@@ -22,7 +22,7 @@ final class ConfigGacelaMapper
 
         $result = [];
 
-        /** @var list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}> $config */
+        /** @var list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string}> $config */
         foreach ($config as $configItem) {
             $c = GacelaConfigItem::fromArray($configItem);
             $result[] = $c;

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -66,7 +66,7 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
     {
         /**
          * @var array{
-         *     config?: list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface},
+         *     config?: list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string},
          *     mapping-interfaces?: array<class-string,class-string|callable>,
          *     override-resolvable-types?: array{Factory?:string,Config?:string,DependencyProvider?:string}
          * } $configFromGlobalServices

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
@@ -28,14 +28,22 @@ final class GacelaConfigItem
     }
 
     /**
-     * @param array{path?:string, path_local?:string, reader?:ConfigReaderInterface} $item
+     * @param array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string} $item
      */
     public static function fromArray(array $item): self
     {
+        $reader = new PhpConfigReader();
+
+        if (isset($item['reader']) && is_string($item['reader'])) {
+            /** @psalm-suppress MixedMethodCall */
+            $reader = new $item['reader']();
+            assert($reader instanceof ConfigReaderInterface);
+        }
+
         return new self(
             $item['path'] ?? self::DEFAULT_PATH,
             $item['path_local'] ?? self::DEFAULT_PATH_LOCAL,
-            $item['reader'] ?? new PhpConfigReader(),
+            $reader
         );
     }
 

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -15,8 +15,8 @@ final class FeatureTest extends TestCase
     {
         $globalServices = [
             'config' => [
-                ['path' => 'config/.env*', 'reader' => new SimpleEnvConfigReader()],
-                ['path' => 'config/*.php', 'reader' => new PhpConfigReader()],
+                ['reader' => SimpleEnvConfigReader::class, 'path' => 'config/.env*'],
+                ['reader' => new PhpConfigReader(), 'path' => 'config/*.php'],
             ],
         ];
 


### PR DESCRIPTION
## 📚 Description

Now it's possible to define the `$globalServices['reader']` as `class-string` or `ConfigReaderInterface` instance, e.g:

```php
$globalServices = [
    'config' => [
        ['reader' => SimpleEnvConfigReader::class], // <- class-string
        ['reader' => new PhpConfigReader()],        // <- instance
    ],
];

Gacela::bootstrap(__DIR__, $globalServices);
``` 