### PR TITLE
Allow multiple overriding resolvable types

### DIFF
--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -70,14 +70,24 @@ abstract class AbstractConfigGacela
      * <code>
      * return [
      *     'Factory' => 'Creator',
-     *     'Config' => 'Configuration',
+     *     'Config' => 'Conf',
      *     'DependencyProvider' => 'Binding',
+     * ];
+     * // OR
+     * return [
+     *     'Factory' => ['Creator', '...'],
+     *     'Config' => ['Conf', '...'],
+     *     'DependencyProvider' => ['Binding', '...'],
      * ];
      * </code>
      *
      * Allow overriding gacela resolvable types.
      *
-     * @return array{Factory?:string,Config?:string,DependencyProvider?:string}
+     * @return array{
+     *     Factory?:list<string>|string,
+     *     Config?:list<string>|string,
+     *     DependencyProvider?:list<string>|string
+     * }
      */
     public function overrideResolvableTypes(): array
     {

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -123,8 +123,8 @@ abstract class AbstractClassResolver
 
     public function doResolve(object $callerClass): ?object
     {
-        $classInfo = ClassInfo::fromObject($callerClass);
-        $cacheKey = $this->getCacheKey($classInfo);
+        $classInfo = ClassInfo::fromObject($callerClass, $this->getResolvableType());
+        $cacheKey = $classInfo->getCacheKey();
         if (isset(self::$cachedInstances[$cacheKey])) {
             return self::$cachedInstances[$cacheKey];
         }
@@ -155,11 +155,6 @@ abstract class AbstractClassResolver
         self::$cachedInstances[$cacheKey] = $resolvedClass;
 
         return self::$cachedInstances[$cacheKey];
-    }
-
-    private function getCacheKey(ClassInfo $classInfo): string
-    {
-        return $classInfo->getCacheKey($this->getResolvableType());
     }
 
     private function findClassName(ClassInfo $classInfo): ?string

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -86,9 +86,9 @@ abstract class AbstractClassResolver
      *
      * @param class-string<T> $className
      *
-     * @internal so the Locator can access to the global instances before creating a new instance
-     *
      * @return ?T
+     *
+     * @internal so the Locator can access to the global instances before creating a new instance
      */
     public static function getCachedGlobalInstance(string $className)
     {
@@ -123,7 +123,7 @@ abstract class AbstractClassResolver
 
     public function doResolve(object $callerClass): ?object
     {
-        $classInfo = new ClassInfo($callerClass);
+        $classInfo = ClassInfo::fromObject($callerClass);
         $cacheKey = $this->getCacheKey($classInfo);
         if (isset(self::$cachedInstances[$cacheKey])) {
             return self::$cachedInstances[$cacheKey];
@@ -159,14 +159,14 @@ abstract class AbstractClassResolver
 
     private function getCacheKey(ClassInfo $classInfo): string
     {
-        return $classInfo->getCacheKey($this->getFinalResolvableType());
+        return $classInfo->getCacheKey($this->getResolvableType());
     }
 
     private function findClassName(ClassInfo $classInfo): ?string
     {
         return $this->getClassNameFinder()->findClassName(
             $classInfo,
-            $this->getFinalResolvableType()
+            $this->getFinalResolvableTypes()
         );
     }
 
@@ -182,12 +182,20 @@ abstract class AbstractClassResolver
 
     /**
      * Allow overriding gacela resolvable types.
+     *
+     * @return list<string>
      */
-    private function getFinalResolvableType(): string
+    private function getFinalResolvableTypes(): array
     {
         $overrideResolvableTypes = $this->getGacelaConfigFile()->getOverrideResolvableTypes();
 
-        return $overrideResolvableTypes[$this->getResolvableType()] ?? $this->getResolvableType();
+        $overrideResolvable = $overrideResolvableTypes[$this->getResolvableType()] ?? $this->getResolvableType();
+
+        if (is_string($overrideResolvable)) {
+            $overrideResolvable = [$overrideResolvable];
+        }
+
+        return $overrideResolvable;
     }
 
     private function createInstance(string $resolvedClassName): ?object

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework\ClassResolver;
 use function array_slice;
 use function count;
 use function get_class;
+use function is_string;
 
 final class ClassInfo
 {
@@ -16,7 +17,13 @@ final class ClassInfo
     private string $callerModuleName;
     private string $callerNamespace;
 
-    public function __construct(object $callerObject)
+    public function __construct(string $callerNamespace, string $callerModuleName)
+    {
+        $this->callerNamespace = $callerNamespace;
+        $this->callerModuleName = $callerModuleName;
+    }
+
+    public static function fromObject(object $callerObject): self
     {
         $callerClass = get_class($callerObject);
 
@@ -24,7 +31,7 @@ final class ClassInfo
         $callerClassParts = explode('\\', ltrim($callerClass, '\\'));
         $lastCallerClassPart = end($callerClassParts);
         $filepath = is_string($lastCallerClassPart) ? $lastCallerClassPart : '';
-        $filename = $this->normalizeFilename($filepath);
+        $filename = self::normalizeFilename($filepath);
 
         if (false !== strpos($filepath, 'anonymous')) {
             $callerClassParts = [
@@ -33,8 +40,22 @@ final class ClassInfo
             ];
         }
 
-        $this->callerNamespace = $this->normalizeCallerNamespace(...$callerClassParts);
-        $this->callerModuleName = $this->normalizeCallerModuleName(...$callerClassParts);
+        $callerNamespace = implode('\\', array_slice($callerClassParts, 0, count($callerClassParts) - 1));
+        $callerModuleName = $callerClassParts[count($callerClassParts) - 2] ?? '';
+
+        return new self($callerNamespace, $callerModuleName);
+    }
+
+    private static function normalizeFilename(string $filepath): string
+    {
+        $filename = basename($filepath);
+        $filename = substr($filename, 0, (int)strpos($filename, ':'));
+
+        if (false === ($pos = strpos($filename, '.'))) {
+            return $filename;
+        }
+
+        return substr($filename, 0, $pos);
     }
 
     public function getCacheKey(string $resolvableType): string
@@ -58,28 +79,6 @@ final class ClassInfo
     public function getFullNamespace(): string
     {
         return $this->callerNamespace;
-    }
-
-    private function normalizeFilename(string $filepath): string
-    {
-        $filename = basename($filepath);
-        $filename = substr($filename, 0, (int)strpos($filename, ':'));
-
-        if (false === ($pos = strpos($filename, '.'))) {
-            return $filename;
-        }
-
-        return substr($filename, 0, $pos);
-    }
-
-    private function normalizeCallerNamespace(string ...$callerClassParts): string
-    {
-        return implode('\\', array_slice($callerClassParts, 0, count($callerClassParts) - 1));
-    }
-
-    private function normalizeCallerModuleName(string ...$callerClassParts): string
-    {
-        return $callerClassParts[count($callerClassParts) - 2] ?? '';
     }
 
     public function toString(): string

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace Gacela\Framework\ClassResolver;
 
 use function array_slice;
+use function basename;
 use function count;
+use function end;
+use function explode;
 use function get_class;
+use function implode;
 use function is_string;
+use function ltrim;
+use function sprintf;
+use function strpos;
+use function substr;
 
 final class ClassInfo
 {

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -6,7 +6,6 @@ namespace Gacela\Framework\ClassResolver\ClassNameFinder;
 
 use Gacela\Framework\ClassResolver\ClassInfo;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
-use function implode;
 
 final class ClassNameFinder implements ClassNameFinderInterface
 {
@@ -42,7 +41,8 @@ final class ClassNameFinder implements ClassNameFinderInterface
      */
     public function findClassName(ClassInfo $classInfo, array $resolvableTypes): ?string
     {
-        $cacheKey = $this->generateUniqueKey($classInfo, $resolvableTypes);
+        $cacheKey = $classInfo->getCacheKey();
+
         if (isset(self::$cachedClassNames[$cacheKey])) {
             return self::$cachedClassNames[$cacheKey];
         }
@@ -58,13 +58,5 @@ final class ClassNameFinder implements ClassNameFinderInterface
         }
 
         return null;
-    }
-
-    /**
-     * @param list<string> $resolvableTypes
-     */
-    private function generateUniqueKey(ClassInfo $classInfo, array $resolvableTypes): string
-    {
-        return $classInfo->toString() . implode('-', $resolvableTypes);
     }
 }

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinderInterface.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinderInterface.php
@@ -8,5 +8,8 @@ use Gacela\Framework\ClassResolver\ClassInfo;
 
 interface ClassNameFinderInterface
 {
-    public function findClassName(ClassInfo $classInfo, string $resolvableType): ?string;
+    /**
+     * @param list<string> $resolvableTypes
+     */
+    public function findClassName(ClassInfo $classInfo, array $resolvableTypes): ?string;
 }

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassValidator.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\ClassNameFinder;
+
+use function class_exists;
+
+final class ClassValidator implements ClassValidatorInterface
+{
+    public function isClassNameValid(string $className): bool
+    {
+        return class_exists($className);
+    }
+}

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassValidatorInterface.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\ClassNameFinder;
+
+interface ClassValidatorInterface
+{
+    public function isClassNameValid(string $className): bool;
+}

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -10,7 +10,7 @@ trait ClassResolverExceptionTrait
 {
     private function buildMessage(object $callerClass, string $resolvableType): string
     {
-        $callerClassInfo = new ClassInfo($callerClass);
+        $callerClassInfo = ClassInfo::fromObject($callerClass);
 
         $message = 'ClassResolver Exception' . PHP_EOL;
         $message .= sprintf(

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -10,7 +10,7 @@ trait ClassResolverExceptionTrait
 {
     private function buildMessage(object $callerClass, string $resolvableType): string
     {
-        $callerClassInfo = ClassInfo::fromObject($callerClass);
+        $callerClassInfo = ClassInfo::fromObject($callerClass, $resolvableType);
 
         $message = 'ClassResolver Exception' . PHP_EOL;
         $message .= sprintf(

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -6,6 +6,8 @@ namespace Gacela\Framework\ClassResolver;
 
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinderInterface;
+use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidator;
+use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithModulePrefix;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithoutModulePrefix;
@@ -15,8 +17,14 @@ final class ClassResolverFactory
     public function createClassNameFinder(): ClassNameFinderInterface
     {
         return new ClassNameFinder(
+            $this->createClassValidator(),
             $this->createFinderRules(),
         );
+    }
+
+    private function createClassValidator(): ClassValidatorInterface
+    {
+        return new ClassValidator();
     }
 
     /**

--- a/src/Framework/ClassResolver/ResolvableType.php
+++ b/src/Framework/ClassResolver/ResolvableType.php
@@ -25,10 +25,8 @@ final class ResolvableType
     {
         foreach (self::DEFAULT_ALLOWED_TYPES as $resolvableType) {
             if (false !== strpos($className, $resolvableType)) {
-                return new self(
-                    $resolvableType,
-                    substr($className, 0, strlen($className) - strlen($resolvableType))
-                );
+                $moduleName = substr($className, 0, strlen($className) - strlen($resolvableType));
+                return new self($resolvableType, $moduleName);
             }
         }
 

--- a/src/Framework/Config/GacelaConfigFileFactory.php
+++ b/src/Framework/Config/GacelaConfigFileFactory.php
@@ -68,7 +68,7 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
          * @var array{
          *     config?: list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string},
          *     mapping-interfaces?: array<class-string,class-string|callable>,
-         *     override-resolvable-types?: array{Factory?:string,Config?:string,DependencyProvider?:string}
+         *     override-resolvable-types?: array{Factory?:list<string>|string, Config?:list<string>|string, DependencyProvider?:list<string>|string}
          * } $configFromGlobalServices
          */
         $configFromGlobalServices = $this->globalServices;
@@ -82,7 +82,7 @@ final class GacelaConfigFileFactory implements GacelaConfigFileFactoryInterface
     /**
      * @param list<GacelaConfigItem> $configItems
      * @param array<class-string,class-string|callable> $mappingInterfaces
-     * @param array{Factory?:string,Config?:string,DependencyProvider?:string} $overrideResolvableTypes
+     * @param array{Factory?:list<string>|string, Config?:list<string>|string, DependencyProvider?:list<string>|string} $overrideResolvableTypes
      */
     private function createWithDefaultIfEmpty(
         array $configItems,

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -12,7 +12,13 @@ final class GacelaConfigFile
     /** @var array<class-string,class-string|callable> */
     private array $mappingInterfaces = [];
 
-    /** @var array{Factory?:string,Config?:string,DependencyProvider?:string} */
+    /**
+     * @var array{
+     *     Factory?:list<string>|string,
+     *     Config?:list<string>|string,
+     *     DependencyProvider?:list<string>|string,
+     * }
+     */
     private array $overrideResolvableTypes = [];
 
     public static function withDefaults(): self
@@ -61,7 +67,7 @@ final class GacelaConfigFile
     }
 
     /**
-     * @param array{Factory?:string,Config?:string,DependencyProvider?:string} $overrideResolvableTypes
+     * @param array{Factory?:list<string>|string, Config?:list<string>|string, DependencyProvider?:list<string>|string} $overrideResolvableTypes
      */
     public function setOverrideResolvableTypes(array $overrideResolvableTypes): self
     {
@@ -71,7 +77,7 @@ final class GacelaConfigFile
     }
 
     /**
-     * @return array{Factory?:string,Config?:string,DependencyProvider?:string}
+     * @return array{Factory?:list<string>|string, Config?:list<string>|string, DependencyProvider?:list<string>|string}
      */
     public function getOverrideResolvableTypes(): array
     {

--- a/src/Framework/Container/Exception/ContainerKeyNotFoundException.php
+++ b/src/Framework/Container/Exception/ContainerKeyNotFoundException.php
@@ -14,7 +14,7 @@ final class ContainerKeyNotFoundException extends RuntimeException
      */
     public function __construct($callerClass, string $key)
     {
-        $classInfo = new ClassInfo($callerClass);
+        $classInfo = ClassInfo::fromObject($callerClass);
 
         parent::__construct($this->buildMessage($classInfo, $key));
     }

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/FeatureTest.php
@@ -8,7 +8,7 @@ use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Within the same gacela bootstrap, it recognizes different suffixes for it gacela files.
+ * Within the same gacela bootstrap, it recognizes different suffixes for its gacela files.
  */
 final class FeatureTest extends TestCase
 {
@@ -33,6 +33,19 @@ final class FeatureTest extends TestCase
     public function test_load_module_b(): void
     {
         $facade = new ModuleB\FacadeModuleB();
+
+        self::assertSame(
+            [
+                'config-key' => 'config-value',
+                'provided-dependency' => 'dependency-value',
+            ],
+            $facade->doSomething()
+        );
+    }
+
+    public function test_load_module_c(): void
+    {
+        $facade = new ModuleC\Facade();
 
         self::assertSame(
             [

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/FeatureTest.php
@@ -7,6 +7,9 @@ namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Within the same gacela bootstrap, it recognizes different suffixes for it gacela files.
+ */
 final class FeatureTest extends TestCase
 {
     public function setUp(): void
@@ -14,9 +17,22 @@ final class FeatureTest extends TestCase
         Gacela::bootstrap(__DIR__);
     }
 
-    public function test_load_multiple_config_files(): void
+    public function test_load_module_a(): void
     {
-        $facade = new LocalConfig\FacaCustom();
+        $facade = new ModuleA\FacadeModuleA();
+
+        self::assertSame(
+            [
+                'config-key' => 'config-value',
+                'provided-dependency' => 'dependency-value',
+            ],
+            $facade->doSomething()
+        );
+    }
+
+    public function test_load_module_b(): void
+    {
+        $facade = new ModuleB\FacadeModuleB();
 
         self::assertSame(
             [

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/ConfModuleA.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/ConfModuleA.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleA;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ConfModuleA extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/DepProModuleA.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/DepProModuleA.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\LocalConfig;
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleA;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 
-final class DepProvCustom extends AbstractDependencyProvider
+final class DepProModuleA extends AbstractDependencyProvider
 {
     public function provideModuleDependencies(Container $container): void
     {

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/FacadeModuleA.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/FacadeModuleA.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleA;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FactoryModuleA getFactory()
+ */
+final class FacadeModuleA extends AbstractFacade
+{
+    public function doSomething(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/FactoryModuleA.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleA/FactoryModuleA.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\LocalConfig;
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleA;
 
 use Gacela\Framework\AbstractFactory;
 
 /**
- * @method ConfCustom getConfig()
+ * @method ConfModuleA getConfig()
  */
-final class FactCustom extends AbstractFactory
+final class FactoryModuleA extends AbstractFactory
 {
     public function getArrayConfigAndProvidedDependency(): array
     {

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/ConfModuleB.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/ConfModuleB.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\LocalConfig;
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleB;
 
 use Gacela\Framework\AbstractConfig;
 
-final class ConfCustom extends AbstractConfig
+final class ConfModuleB extends AbstractConfig
 {
     public function getConfigValue(): string
     {

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/DepProModuleB.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/DepProModuleB.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleB;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DepProModuleB extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/FacadeModuleB.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/FacadeModuleB.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\LocalConfig;
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleB;
 
 use Gacela\Framework\AbstractFacade;
 
 /**
- * @method FactCustom getFactory()
+ * @method FactoryModuleB getFactory()
  */
-final class FacaCustom extends AbstractFacade
+final class FacadeModuleB extends AbstractFacade
 {
     public function doSomething(): array
     {

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/FactoryModuleB.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleB/FactoryModuleB.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleB;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method ConfModuleB getConfig()
+ */
+final class FactoryModuleB extends AbstractFactory
+{
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/Config.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/Config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleC;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/DependencyProvider.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/DependencyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleC;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DependencyProvider extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/Facade.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleC;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function doSomething(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/Factory.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/ModuleC/Factory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes\ModuleC;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method Config getConfig()
+ */
+final class Factory extends AbstractFactory
+{
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/gacela.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/gacela.php
@@ -10,9 +10,9 @@ return static fn () => new class () extends AbstractConfigGacela {
     public function overrideResolvableTypes(): array
     {
         return [
-            'Factory' => 'FactCustom',
-            'Config' => 'ConfCustom',
-            'DependencyProvider' => 'DepProvCustom',
+            'Factory' => ['FactoryModuleA', 'FactoryModuleB'],
+            'Config' => ['ConfModuleA', 'ConfModuleB'],
+            'DependencyProvider' => ['DepProModuleA', 'DepProModuleB'],
         ];
     }
 };

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/gacela.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/gacela.php
@@ -10,9 +10,9 @@ return static fn () => new class () extends AbstractConfigGacela {
     public function overrideResolvableTypes(): array
     {
         return [
-            'Factory' => ['FactoryModuleA', 'FactoryModuleB'],
-            'Config' => ['ConfModuleA', 'ConfModuleB'],
-            'DependencyProvider' => ['DepProModuleA', 'DepProModuleB'],
+            'Factory' => ['FactoryModuleA', 'FactoryModuleB', 'Factory'],
+            'Config' => ['ConfModuleA', 'ConfModuleB', 'Config'],
+            'DependencyProvider' => ['DepProModuleA', 'DepProModuleB', 'DependencyProvider'],
         ];
     }
 };

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -24,7 +24,7 @@ final class ClassNameFinderTest extends TestCase
             []
         );
 
-        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];
         $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
 
@@ -43,7 +43,7 @@ final class ClassNameFinderTest extends TestCase
 
         $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
 
-        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = [];
         $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
 
@@ -62,7 +62,7 @@ final class ClassNameFinderTest extends TestCase
 
         $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
 
-        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];
         $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
 
@@ -81,7 +81,7 @@ final class ClassNameFinderTest extends TestCase
 
         $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
 
-        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];
         $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
 
@@ -100,7 +100,7 @@ final class ClassNameFinderTest extends TestCase
 
         $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
 
-        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];
         $classNameFinder->findClassName($classInfo, $resolvableTypes);
         $classNameFinder->findClassName($classInfo, $resolvableTypes);

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver;
+
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
+use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
+use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ClassNameFinderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ClassNameFinder::resetCachedClassNames();
+    }
+
+    public function test_no_rules(): void
+    {
+        $classNameFinder = new ClassNameFinder(
+            $this->createMock(ClassValidatorInterface::class),
+            []
+        );
+
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $resolvableTypes = ['A', 'B'];
+        $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
+
+        self::assertNull($actual);
+    }
+
+    public function test_rule_but_no_resolvable_types(): void
+    {
+        $classValidator = $this->createMock(ClassValidatorInterface::class);
+        $classValidator->method('isClassNameValid')
+            ->with('\valid\class\name')
+            ->willReturn(true);
+
+        $finderRule = $this->createStub(FinderRuleInterface::class);
+        $finderRule->method('buildClassCandidate')->willReturn('\valid\class\name');
+
+        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $resolvableTypes = [];
+        $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
+
+        self::assertNull($actual);
+    }
+
+    public function test_rule_returns_invalid_class_name(): void
+    {
+        $classValidator = $this->createMock(ClassValidatorInterface::class);
+        $classValidator->method('isClassNameValid')
+            ->with('\valid\class\name')
+            ->willReturn(false);
+
+        $finderRule = $this->createStub(FinderRuleInterface::class);
+        $finderRule->method('buildClassCandidate')->willReturn('\valid\class\name');
+
+        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $resolvableTypes = ['A', 'B'];
+        $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
+
+        self::assertNull($actual);
+    }
+
+    public function test_rule_returns_valid_class_name(): void
+    {
+        $classValidator = $this->createMock(ClassValidatorInterface::class);
+        $classValidator->method('isClassNameValid')
+            ->with('\valid\class\name')
+            ->willReturn(true);
+
+        $finderRule = $this->createStub(FinderRuleInterface::class);
+        $finderRule->method('buildClassCandidate')->willReturn('\valid\class\name');
+
+        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $resolvableTypes = ['A', 'B'];
+        $actual = $classNameFinder->findClassName($classInfo, $resolvableTypes);
+
+        self::assertSame('\valid\class\name', $actual);
+    }
+
+    public function test_caching_valid_class_name(): void
+    {
+        $classValidator = $this->createMock(ClassValidatorInterface::class);
+        $classValidator->method('isClassNameValid')->willReturn(true);
+
+        $finderRule = $this->createMock(FinderRuleInterface::class);
+        $finderRule->expects(self::once())
+            ->method('buildClassCandidate')
+            ->willReturn('\valid\class\name');
+
+        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+
+        $classInfo = new ClassInfo('callerNamespace', 'callerModuleName');
+        $resolvableTypes = ['A', 'B'];
+        $classNameFinder->findClassName($classInfo, $resolvableTypes);
+        $classNameFinder->findClassName($classInfo, $resolvableTypes);
+        $classNameFinder->findClassName($classInfo, $resolvableTypes);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Related to the issue: https://github.com/gacela-project/gacela/issues/105 although, it might not be exactly the "requested feature itself", I think this is an easier implementation that can help us get there if needed.

This allows you to define not just one replacement for the resolvable types keywords (Factory, Config, DependencyProvider) but now you can define multiple keywords for the same resolvable type.

### For example
You can have modules with different suffixes for Factories, Config, and DependencyProvider gacela classes, like:
```php
[
    'Factory' => ['FactoryModuleA', 'FactoryModuleB', '...'],
    'Config' => ['ConfModuleA', 'ConfModuleB'],
    'DependencyProvider' => ['DepProModuleA', 'DepProModuleB'],
]
```

You could even define the default values in the begging and having as fallback other especial suffixes for certain modules:
```php
[
    'Factory' => ['Factory', 'FactoryModuleA', 'FactoryModuleB', '...'],
    'Config' => ['Config', 'ConfModuleA', 'ConfModuleB', '...'],
    'DependencyProvider' => ['DependencyProvider', 'DepProModuleA', 'DepProModuleB', '...'],
]
```

## 💡  Goal

Allow the developer to define different resolvable types, so they can have different naming/suffix on different modules.

## 🔖 Changes

- In the gacela.php the `overrideResolvableTypes()` allows a `list<string>|string`.
- Refactor `ClassInfo`. Added a named-constructor  `::fromObject`.