### PR TITLE
Make GacelaConfigFileFactory testable

### DIFF
--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -41,7 +41,8 @@ final class ConfigFactory
             $this->appRootDir,
             self::GACELA_PHP_CONFIG_FILENAME,
             $this->globalServices,
-            $this->createConfigGacelaMapper()
+            $this->createConfigGacelaMapper(),
+            $this->createFileIo(),
         );
     }
 
@@ -50,9 +51,14 @@ final class ConfigFactory
         return new PathFinder();
     }
 
-    private function createConfigGacelaMapper(): ConfigGacelaMapper
+    private function createConfigGacelaMapper(): ConfigGacelaMapperInterface
     {
         return new ConfigGacelaMapper();
+    }
+
+    private function createFileIo(): FileIoInterface
+    {
+        return new FileIo();
     }
 
     private function createPathNormalizer(): PathNormalizerInterface

--- a/src/Framework/Config/ConfigGacelaMapper.php
+++ b/src/Framework/Config/ConfigGacelaMapper.php
@@ -6,7 +6,7 @@ namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 
-final class ConfigGacelaMapper
+final class ConfigGacelaMapper implements ConfigGacelaMapperInterface
 {
     /**
      * @param list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string} $config

--- a/src/Framework/Config/ConfigGacelaMapperInterface.php
+++ b/src/Framework/Config/ConfigGacelaMapperInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+
+interface ConfigGacelaMapperInterface
+{
+    /**
+     * @param list<array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string}>|array{path?:string, path_local?:string, reader?:ConfigReaderInterface|class-string} $config
+     *
+     * @return list<GacelaConfigItem>
+     */
+    public function mapConfigItems(array $config): array;
+}

--- a/src/Framework/Config/FileIo.php
+++ b/src/Framework/Config/FileIo.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+final class FileIo implements FileIoInterface
+{
+    public function existsFile(string $filePath): bool
+    {
+        return file_exists($filePath);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function include(string $filePath)
+    {
+        /** @psalm-suppress UnresolvableInclude */
+        return include $filePath;
+    }
+}

--- a/src/Framework/Config/FileIoInterface.php
+++ b/src/Framework/Config/FileIoInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+interface FileIoInterface
+{
+    public function existsFile(string $filePath): bool;
+
+    /**
+     * @return mixed
+     */
+    public function include(string $filePath);
+}

--- a/tests/Unit/Framework/Config/GacelaConfigFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigFileFactoryTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\AbstractConfigGacela;
+use Gacela\Framework\Config\ConfigGacelaMapperInterface;
+use Gacela\Framework\Config\FileIoInterface;
+use Gacela\Framework\Config\GacelaConfigFileFactory;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use PHPUnit\Framework\TestCase;
+
+final class GacelaConfigFileFactoryTest extends TestCase
+{
+    public function test_gacela_file_does_not_exists_then_use_defaults(): void
+    {
+        $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
+        $fileIo = $this->createStub(FileIoInterface::class);
+        $fileIo->method('existsFile')->willReturn(false);
+
+        $factory = new GacelaConfigFileFactory(
+            'appRootDir',
+            'gacelaPhpConfigFilename',
+            ['globalServiceKey' => 'globalServiceValue'],
+            $configGacelaMapper,
+            $fileIo
+        );
+
+        self::assertEquals(GacelaConfigFile::withDefaults(), $factory->createGacelaFileConfig());
+    }
+
+    public function test_gacela_file_does_not_exists_but_global_services(): void
+    {
+        $mappingInterfaces = ['interface' => 'concrete'];
+        $overrideResolvableTypes = ['DependencyProvider' => 'Binding'];
+
+        $gacelaConfigFile = (new GacelaConfigFile())
+            ->setConfigItems([new GacelaConfigItem('path.php', 'path_local.php')])
+            ->setMappingInterfaces($mappingInterfaces)
+            ->setOverrideResolvableTypes($overrideResolvableTypes);
+
+        $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
+        $configGacelaMapper->method('mapConfigItems')->willReturn([$gacelaConfigFile]);
+
+        $fileIo = $this->createStub(FileIoInterface::class);
+        $fileIo->method('existsFile')->willReturn(false);
+
+        $factory = new GacelaConfigFileFactory(
+            'appRootDir',
+            'gacelaPhpConfigFilename',
+            [
+                'config' => ['anything'],
+                'mapping-interfaces' => $mappingInterfaces,
+                'override-resolvable-types' => $overrideResolvableTypes,
+            ],
+            $configGacelaMapper,
+            $fileIo
+        );
+
+        $expected = (new GacelaConfigFile())
+            ->setConfigItems([$gacelaConfigFile])
+            ->setMappingInterfaces($mappingInterfaces)
+            ->setOverrideResolvableTypes($overrideResolvableTypes);
+
+        self::assertEquals($expected, $factory->createGacelaFileConfig());
+    }
+
+    public function test_exception_when_include_gacela_file_is_not_callable(): void
+    {
+        $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
+        $fileIo = $this->createStub(FileIoInterface::class);
+        $fileIo->method('existsFile')->willReturn(true);
+        $fileIo->method('include')->willReturn('anything-but-not-callable');
+
+        $factory = new GacelaConfigFileFactory(
+            'appRootDir',
+            'gacelaPhpConfigFilename',
+            ['globalServiceKey' => 'globalServiceValue'],
+            $configGacelaMapper,
+            $fileIo
+        );
+
+        $this->expectErrorMessage('Create a function that returns an anonymous class that extends AbstractConfigGacela');
+        $factory->createGacelaFileConfig();
+    }
+
+    public function test_exception_when_gacela_file_is_callable_but_does_not_extends_abstract_config_gacela(): void
+    {
+        $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
+        $fileIo = $this->createStub(FileIoInterface::class);
+        $fileIo->method('existsFile')->willReturn(true);
+        $fileIo->method('include')->willReturn(fn () => new class () {
+        });
+
+        $factory = new GacelaConfigFileFactory(
+            'appRootDir',
+            'gacelaPhpConfigFilename',
+            ['globalServiceKey' => 'globalServiceValue'],
+            $configGacelaMapper,
+            $fileIo
+        );
+
+        $this->expectErrorMessage('Your anonymous class must extends AbstractConfigGacela');
+        $factory->createGacelaFileConfig();
+    }
+
+    public function test_gacela_file_does_not_override_anything_then_use_defaults(): void
+    {
+        $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
+        $fileIo = $this->createStub(FileIoInterface::class);
+        $fileIo->method('existsFile')->willReturn(true);
+        $fileIo->method('include')->willReturn(fn () => new class () extends AbstractConfigGacela {
+        });
+
+        $factory = new GacelaConfigFileFactory(
+            'appRootDir',
+            'gacelaPhpConfigFilename',
+            ['globalServiceKey' => 'globalServiceValue'],
+            $configGacelaMapper,
+            $fileIo
+        );
+
+        self::assertEquals(GacelaConfigFile::withDefaults(), $factory->createGacelaFileConfig());
+    }
+
+    public function test_gacela_file_overrides_config_items(): void
+    {
+        $gacelaConfigFile = (new GacelaConfigFile())
+            ->setConfigItems([new GacelaConfigItem('path.php', 'path_local.php')])
+            ->setMappingInterfaces(['interface' => 'concrete'])
+            ->setOverrideResolvableTypes(['DependencyProvider' => 'Binding']);
+
+        $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
+        $configGacelaMapper->method('mapConfigItems')->willReturn([$gacelaConfigFile]);
+
+        $fileIo = $this->createStub(FileIoInterface::class);
+        $fileIo->method('existsFile')->willReturn(true);
+        $fileIo->method('include')->willReturn(fn () => new class () extends AbstractConfigGacela {
+            public function config(): array
+            {
+                return ['anything'];
+            }
+
+            public function mappingInterfaces(array $globalServices): array
+            {
+                return ['interface' => 'concrete'];
+            }
+
+            public function overrideResolvableTypes(): array
+            {
+                return ['DependencyProvider' => 'Binding'];
+            }
+        });
+
+        $factory = new GacelaConfigFileFactory(
+            'appRootDir',
+            'gacelaPhpConfigFilename',
+            ['globalServiceKey' => 'globalServiceValue'],
+            $configGacelaMapper,
+            $fileIo
+        );
+
+        $expected = (new GacelaConfigFile())
+            ->setConfigItems([$gacelaConfigFile])
+            ->setMappingInterfaces(['interface' => 'concrete'])
+            ->setOverrideResolvableTypes(['DependencyProvider' => 'Binding']);
+
+        self::assertEquals($expected, $factory->createGacelaFileConfig());
+    }
+}


### PR DESCRIPTION
## 📚 Description

This is pointing to `feature/allow-multiple-resolvable-type-names` because otherwise we will face unnecessary conflicts (due to changes on the same files). **We can merge this PR (into master) once the other one gets merged first.**

## 🔖 Changes

- Create a `FileIoInterface` so we can create unit tests for `GacelaConfigFileFactory`.
