### PR TITLE
Separate the anonymous logic from the AbstractClassResolver

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ClassResolver\DependencyResolver\DependencyResolver;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use function class_exists;
 use function is_string;
 
 abstract class AbstractClassResolver

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\ClassResolver;
 
 use Gacela\Framework\Exception\Backtrace;
+use function sprintf;
 
 trait ClassResolverExceptionTrait
 {

--- a/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
+++ b/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\GlobalInstance;
+
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\ClassResolver\GlobalKey;
+use Gacela\Framework\ClassResolver\ResolvableType;
+use RuntimeException;
+
+final class AnonymousGlobal
+{
+    private const ALLOWED_TYPES_FOR_ANONYMOUS_GLOBAL = ['Config', 'Factory', 'DependencyProvider'];
+
+    /** @var array<string,object> */
+    private static array $cachedGlobalInstances = [];
+
+    /**
+     * @template T
+     *
+     * @param class-string<T> $className
+     *
+     * @return ?T
+     *
+     * @internal so the Locator can access to the global instances before creating a new instance
+     */
+    public static function getByClassName(string $className)
+    {
+        $key = self::getGlobalKeyFromClassName($className);
+
+        /** @var ?T $instance */
+        $instance = self::getByKey($key)
+            ?? self::getByKey('\\' . $key)
+            ?? null;
+
+        return $instance;
+    }
+
+    /**
+     * @return ?object
+     */
+    public static function getByKey(string $key)
+    {
+        return self::$cachedGlobalInstances[$key] ?? null;
+    }
+
+    /**
+     * Add an anonymous class as 'Config', 'Factory' or 'DependencyProvider' as a global resource
+     * bound to the context that it's pass as first argument. It can be the string-key
+     * (from a non-class/file context) or the class/object itself.
+     *
+     * @param object|string $context
+     */
+    public static function addGlobal($context, object $resolvedClass): void
+    {
+        $contextName = self::extractContextNameFromContext($context);
+        $parentClass = get_parent_class($resolvedClass);
+
+        $type = is_string($parentClass)
+            ? ResolvableType::fromClassName($parentClass)->resolvableType()
+            : $contextName;
+
+        self::validateTypeForAnonymousGlobalRegistration($type);
+
+        $key = sprintf('\%s\%s\%s', ClassInfo::MODULE_NAME_ANONYMOUS, $contextName, $type);
+        self::addCachedGlobalInstance($key, $resolvedClass);
+    }
+
+    public static function overrideExistingResolvedClass(string $className, object $resolvedClass): void
+    {
+        $key = self::getGlobalKeyFromClassName($className);
+
+        self::addCachedGlobalInstance($key, $resolvedClass);
+    }
+
+    /**
+     * @param object|string $context
+     */
+    private static function extractContextNameFromContext($context): string
+    {
+        if (is_string($context)) {
+            return $context;
+        }
+
+        $callerClass = get_class($context);
+        /** @var list<string> $callerClassParts */
+        $callerClassParts = explode('\\', ltrim($callerClass, '\\'));
+
+        $lastCallerClassParts = end($callerClassParts);
+
+        return is_string($lastCallerClassParts) ? $lastCallerClassParts : '';
+    }
+
+    private static function validateTypeForAnonymousGlobalRegistration(string $type): void
+    {
+        if (!in_array($type, self::ALLOWED_TYPES_FOR_ANONYMOUS_GLOBAL)) {
+            throw new RuntimeException(
+                "Type '$type' not allowed. Valid types: " . implode(', ', self::ALLOWED_TYPES_FOR_ANONYMOUS_GLOBAL)
+            );
+        }
+    }
+
+    private static function addCachedGlobalInstance(string $key, object $resolvedClass): void
+    {
+        self::$cachedGlobalInstances[$key] = $resolvedClass;
+    }
+
+    private static function getGlobalKeyFromClassName(string $className): string
+    {
+        return GlobalKey::fromClassName($className);
+    }
+}

--- a/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
+++ b/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
@@ -8,6 +8,15 @@ use Gacela\Framework\ClassResolver\ClassInfo;
 use Gacela\Framework\ClassResolver\GlobalKey;
 use Gacela\Framework\ClassResolver\ResolvableType;
 use RuntimeException;
+use function end;
+use function explode;
+use function get_class;
+use function get_parent_class;
+use function implode;
+use function in_array;
+use function is_string;
+use function ltrim;
+use function sprintf;
 
 final class AnonymousGlobal
 {

--- a/src/Framework/ClassResolver/ResolvableType.php
+++ b/src/Framework/ClassResolver/ResolvableType.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
+use function str_replace;
 use function strlen;
+use function strpos;
+use function strrpos;
+use function substr;
 
 final class ResolvableType
 {

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Container;
 
-use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 
 final class Locator
 {
@@ -59,7 +59,7 @@ final class Locator
             return $instance;
         }
 
-        $locatedInstance = AbstractClassResolver::getCachedGlobalInstance($concreteClass)
+        $locatedInstance = AnonymousGlobal::getByClassName($concreteClass)
             ?? $this->newInstance($concreteClass);
 
         /** @psalm-suppress MixedAssignment */

--- a/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
@@ -8,8 +8,10 @@ use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\AbstractFactory;
-use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Container\Container;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
 /**
  * @BeforeMethods("setUp")
@@ -22,7 +24,7 @@ final class AnonymousGlobalsBench
 
     public function setUp(): void
     {
-        AbstractClassResolver::addAnonymousGlobal(
+        AnonymousGlobal::addGlobal(
             $this,
             new class () extends AbstractConfig {
                 public function getValues(): array
@@ -32,7 +34,7 @@ final class AnonymousGlobalsBench
             }
         );
 
-        AbstractClassResolver::addAnonymousGlobal(
+        AnonymousGlobal::addGlobal(
             $this,
             new class () extends AbstractDependencyProvider {
                 public function provideModuleDependencies(Container $container): void
@@ -42,7 +44,7 @@ final class AnonymousGlobalsBench
             }
         );
 
-        AbstractClassResolver::addAnonymousGlobal(
+        AnonymousGlobal::addGlobal(
             $this,
             new class () extends AbstractFactory {
                 public function createDomainClass(): object

--- a/tests/Integration/Framework/GlobalServices/AnonymousClassesTest.php
+++ b/tests/Integration/Framework/GlobalServices/AnonymousClassesTest.php
@@ -8,7 +8,7 @@ use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\AbstractFactory;
-use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Container\Container;
 use PHPUnit\Framework\TestCase;
 
@@ -45,7 +45,7 @@ final class AnonymousClassesTest extends TestCase
      */
     private function registerConfig(): void
     {
-        AbstractClassResolver::addAnonymousGlobal(
+        AnonymousGlobal::addGlobal(
             $this,
             new class () extends AbstractConfig {
                 /**
@@ -64,7 +64,7 @@ final class AnonymousClassesTest extends TestCase
      */
     private function registerFactory(): void
     {
-        AbstractClassResolver::addAnonymousGlobal(
+        AnonymousGlobal::addGlobal(
             'AnonymousClassesTest',
             new class () extends AbstractFactory {
                 public function createDomainClass(): object
@@ -105,7 +105,7 @@ final class AnonymousClassesTest extends TestCase
 
     private function registerDependencyProvider(): void
     {
-        AbstractClassResolver::addAnonymousGlobal(
+        AnonymousGlobal::addGlobal(
             $this,
             new class () extends AbstractDependencyProvider {
                 public function provideModuleDependencies(Container $container): void

--- a/tests/Unit/Framework/ClassResolver/GlobalInstance/AnonymousGlobalTest.php
+++ b/tests/Unit/Framework/ClassResolver/GlobalInstance/AnonymousGlobalTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Unit\Framework\ClassResolver;
+namespace GacelaTest\Unit\Framework\ClassResolver\GlobalInstance;
 
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\AbstractFactory;
-use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Container\Container;
 use PHPUnit\Framework\TestCase;
 
-final class AbstractClassResolverTest extends TestCase
+final class AnonymousGlobalTest extends TestCase
 {
     /**
      * The anonymous class is not extending from Abstract[Factory,Config,DependencyProvider]
@@ -20,15 +20,15 @@ final class AbstractClassResolverTest extends TestCase
      */
     public function test_error_when_non_allowed_anon_global_type(): void
     {
-        $this->expectErrorMessage("Type 'AbstractClassResolverTest' not allowed");
+        $this->expectErrorMessage("Type 'AnonymousGlobalTest' not allowed");
 
-        AbstractClassResolver::addAnonymousGlobal($this, new class () {
+        AnonymousGlobal::addGlobal($this, new class () {
         });
     }
 
     public function test_allowed_factory_anon_global(): void
     {
-        AbstractClassResolver::addAnonymousGlobal($this, new class () extends AbstractFactory {
+        AnonymousGlobal::addGlobal($this, new class () extends AbstractFactory {
         });
 
         self::assertTrue(true); # Assert non error is thrown
@@ -36,7 +36,7 @@ final class AbstractClassResolverTest extends TestCase
 
     public function test_allowed_config_anon_global(): void
     {
-        AbstractClassResolver::addAnonymousGlobal($this, new class () extends AbstractConfig {
+        AnonymousGlobal::addGlobal($this, new class () extends AbstractConfig {
         });
 
         self::assertTrue(true); # Assert non error is thrown
@@ -44,7 +44,7 @@ final class AbstractClassResolverTest extends TestCase
 
     public function test_allowed_dependency_provider_anon_global(): void
     {
-        AbstractClassResolver::addAnonymousGlobal($this, new class () extends AbstractDependencyProvider {
+        AnonymousGlobal::addGlobal($this, new class () extends AbstractDependencyProvider {
             public function provideModuleDependencies(Container $container): void
             {
             }
@@ -60,9 +60,9 @@ final class AbstractClassResolverTest extends TestCase
     {
         $resolvedClass = new class () {
         };
-        AbstractClassResolver::overrideExistingResolvedClass($className, $resolvedClass);
+        AnonymousGlobal::overrideExistingResolvedClass($className, $resolvedClass);
 
-        self::assertSame($resolvedClass, AbstractClassResolver::getCachedGlobalInstance($className));
+        self::assertSame($resolvedClass, AnonymousGlobal::getByClassName($className));
     }
 
     public function providerOverrideExistingResolvedClass(): iterable


### PR DESCRIPTION
## 📚 Description

The class `AbstractClassResolver` has too many things inside. It clearly has one responsibility that can be extracted away: the responsibility of the anonymous globals.

## 🔖 Changes

-   Move to a separate class the "anonymous globals logic" from `AbstractClassResolver`.