### PR TITLE
Create ResolvableTypesConfig

### DIFF
--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaConfigArgs\ResolvableTypesConfig;
 
 abstract class AbstractConfigGacela
 {
@@ -66,31 +67,9 @@ abstract class AbstractConfigGacela
     }
 
     /**
-     * e.g:
-     * <code>
-     * return [
-     *     'Factory' => 'Creator',
-     *     'Config' => 'Conf',
-     *     'DependencyProvider' => 'Binding',
-     * ];
-     * // OR
-     * return [
-     *     'Factory' => ['Creator', '...'],
-     *     'Config' => ['Conf', '...'],
-     *     'DependencyProvider' => ['Binding', '...'],
-     * ];
-     * </code>
-     *
      * Allow overriding gacela resolvable types.
-     *
-     * @return array{
-     *     Factory?:list<string>|string,
-     *     Config?:list<string>|string,
-     *     DependencyProvider?:list<string>|string
-     * }
      */
-    public function overrideResolvableTypes(): array
+    public function overrideResolvableTypes(ResolvableTypesConfig $resolvableTypesConfig): void
     {
-        return [];
     }
 }

--- a/src/Framework/Config/GacelaConfigArgs/ResolvableTypesConfig.php
+++ b/src/Framework/Config/GacelaConfigArgs/ResolvableTypesConfig.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\GacelaConfigArgs;
+
+final class ResolvableTypesConfig
+{
+    private array $factories = ['Factory'];
+    private array $configs = ['Config'];
+    private array $dependencyProviders = ['DependencyProvider'];
+
+    public function addFactory(string $suffix): self
+    {
+        $this->factories[] = $suffix;
+
+        return $this;
+    }
+
+    public function addConfig(string $suffix): self
+    {
+        $this->configs[] = $suffix;
+
+        return $this;
+    }
+
+    public function addDependencyProvider(string $suffix): self
+    {
+        $this->dependencyProviders[] = $suffix;
+
+        return $this;
+    }
+
+    /**
+     * @return array{
+     *     Factory:list<string>,
+     *     Config:list<string>,
+     *     DependencyProvider:list<string>,
+     * }
+     */
+    public function resolve(): array
+    {
+        return [
+            'Factory' => array_unique($this->factories),
+            'Config' => array_unique($this->configs),
+            'DependencyProvider' => array_unique($this->dependencyProviders),
+        ];
+    }
+}

--- a/src/Framework/Config/GacelaConfigArgs/ResolvableTypesConfig.php
+++ b/src/Framework/Config/GacelaConfigArgs/ResolvableTypesConfig.php
@@ -6,8 +6,13 @@ namespace Gacela\Framework\Config\GacelaConfigArgs;
 
 final class ResolvableTypesConfig
 {
+    /** @var list<string> */
     private array $factories = ['Factory'];
+
+    /** @var list<string> */
     private array $configs = ['Config'];
+
+    /** @var list<string> */
     private array $dependencyProviders = ['DependencyProvider'];
 
     public function addFactory(string $suffix): self
@@ -41,9 +46,9 @@ final class ResolvableTypesConfig
     public function resolve(): array
     {
         return [
-            'Factory' => array_unique($this->factories),
-            'Config' => array_unique($this->configs),
-            'DependencyProvider' => array_unique($this->dependencyProviders),
+            'Factory' => array_values(array_unique($this->factories)),
+            'Config' => array_values(array_unique($this->configs)),
+            'DependencyProvider' => array_values(array_unique($this->dependencyProviders)),
         ];
     }
 }

--- a/src/Framework/Config/GacelaConfigArgs/ResolvableTypesConfig.php
+++ b/src/Framework/Config/GacelaConfigArgs/ResolvableTypesConfig.php
@@ -6,14 +6,18 @@ namespace Gacela\Framework\Config\GacelaConfigArgs;
 
 final class ResolvableTypesConfig
 {
-    /** @var list<string> */
-    private array $factories = ['Factory'];
+    public const DEFAULT_FACTORIES = ['Factory'];
+    public const DEFAULT_CONFIG = ['Config'];
+    public const DEFAULT_DEPENDENCY_PROVIDERS = ['DependencyProvider'];
 
     /** @var list<string> */
-    private array $configs = ['Config'];
+    private array $factories = self::DEFAULT_FACTORIES;
 
     /** @var list<string> */
-    private array $dependencyProviders = ['DependencyProvider'];
+    private array $configs = self::DEFAULT_CONFIG;
+
+    /** @var list<string> */
+    private array $dependencyProviders = self::DEFAULT_DEPENDENCY_PROVIDERS;
 
     public function addFactory(string $suffix): self
     {

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -24,7 +24,12 @@ final class GacelaConfigFile
     public static function withDefaults(): self
     {
         return (new self())
-            ->setConfigItems([GacelaConfigItem::withDefaults()]);
+            ->setConfigItems([GacelaConfigItem::withDefaults()])
+            ->setOverrideResolvableTypes([
+                'Factory' => ['Factory'],
+                'Config' => ['Config'],
+                'DependencyProvider' => ['DependencyProvider'],
+            ]);
     }
 
     /**

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -14,9 +14,9 @@ final class GacelaConfigFile
 
     /**
      * @var array{
-     *     Factory?:list<string>|string,
-     *     Config?:list<string>|string,
-     *     DependencyProvider?:list<string>|string,
+     *     Factory?:list<string>,
+     *     Config?:list<string>,
+     *     DependencyProvider?:list<string>,
      * }
      */
     private array $overrideResolvableTypes = [];
@@ -72,7 +72,7 @@ final class GacelaConfigFile
     }
 
     /**
-     * @param array{Factory?:list<string>|string, Config?:list<string>|string, DependencyProvider?:list<string>|string} $overrideResolvableTypes
+     * @param array{Factory?:list<string>, Config?:list<string>, DependencyProvider?:list<string>} $overrideResolvableTypes
      */
     public function setOverrideResolvableTypes(array $overrideResolvableTypes): self
     {
@@ -82,7 +82,7 @@ final class GacelaConfigFile
     }
 
     /**
-     * @return array{Factory?:list<string>|string, Config?:list<string>|string, DependencyProvider?:list<string>|string}
+     * @return array{Factory?:list<string>, Config?:list<string>, DependencyProvider?:list<string>}
      */
     public function getOverrideResolvableTypes(): array
     {

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig;
 
+use Gacela\Framework\Config\GacelaConfigArgs\ResolvableTypesConfig;
+
 final class GacelaConfigFile
 {
     /** @var list<GacelaConfigItem> */
@@ -26,9 +28,9 @@ final class GacelaConfigFile
         return (new self())
             ->setConfigItems([GacelaConfigItem::withDefaults()])
             ->setOverrideResolvableTypes([
-                'Factory' => ['Factory'],
-                'Config' => ['Config'],
-                'DependencyProvider' => ['DependencyProvider'],
+                'Factory' => ResolvableTypesConfig::DEFAULT_FACTORIES,
+                'Config' => ResolvableTypesConfig::DEFAULT_CONFIG,
+                'DependencyProvider' => ResolvableTypesConfig::DEFAULT_DEPENDENCY_PROVIDERS,
             ]);
     }
 

--- a/tests/Feature/Framework/UsingCustomResolvableTypes/gacela.php
+++ b/tests/Feature/Framework/UsingCustomResolvableTypes/gacela.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\UsingCustomResolvableTypes;
 
 use Gacela\Framework\AbstractConfigGacela;
+use Gacela\Framework\Config\GacelaConfigArgs\ResolvableTypesConfig;
 
 return static fn () => new class () extends AbstractConfigGacela {
-    public function overrideResolvableTypes(): array
+    public function overrideResolvableTypes(ResolvableTypesConfig $resolvableTypesConfig): void
     {
-        return [
-            'Factory' => ['FactoryModuleA', 'FactoryModuleB', 'Factory'],
-            'Config' => ['ConfModuleA', 'ConfModuleB', 'Config'],
-            'DependencyProvider' => ['DepProModuleA', 'DepProModuleB', 'DependencyProvider'],
-        ];
+        $resolvableTypesConfig
+            ->addFactory('FactoryModuleA')
+            ->addFactory('FactoryModuleB')
+            ->addConfig('ConfModuleA')
+            ->addConfig('ConfModuleB')
+            ->addDependencyProvider('DepProModuleA')
+            ->addDependencyProvider('DepProModuleB');
     }
 };


### PR DESCRIPTION
## 📚 Description

Instead of returning an array, we were thinking (see the idea: https://github.com/gacela-project/gacela/discussions/100) about creating a class to encapsulate the interesting fields for each "gacela.php" method. The idea is to follow a similar approach for the other two methods: `config()` & `mappingInterfaces()`.

## 🔖 Changes

- Create `ResolvableTypesConfig` as argument for `overrideResolvableTypes()`.
