### PR TITLE
Create MappingInterfacesResolver

### DIFF
--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaConfigArgs\MappingInterfacesResolver;
 use Gacela\Framework\Config\GacelaConfigArgs\ResolvableTypesConfig;
 
 abstract class AbstractConfigGacela
@@ -44,26 +45,12 @@ abstract class AbstractConfigGacela
     }
 
     /**
-     * e.g:
-     * <code>
-     * return [
-     *     // It instantiates the specific class on runtime
-     *     AbstractClass::class => SpecificClass::class,
-     *
-     *     // It resolves the callable on runtime
-     *     InterfaceClass::class => fn() => new SpecificClass($dependencies),
-     * ];
-     * </code>
-     *
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
      * @param array<string,mixed> $globalServices
-     *
-     * @return array<class-string,class-string|callable>
      */
-    public function mappingInterfaces(array $globalServices): array
+    public function mappingInterfaces(MappingInterfacesResolver $interfacesResolver, array $globalServices): void
     {
-        return [];
     }
 
     /**

--- a/src/Framework/Config/GacelaConfigArgs/MappingInterfacesResolver.php
+++ b/src/Framework/Config/GacelaConfigArgs/MappingInterfacesResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\GacelaConfigArgs;
+
+final class MappingInterfacesResolver
+{
+    /** @var array<class-string,class-string|object|callable> */
+    private array $mapping = [];
+
+    /**
+     * @param class-string $key
+     * @param class-string|object|callable $value
+     */
+    public function bind(string $key, $value): self
+    {
+        $this->mapping[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<class-string,class-string|object|callable>
+     */
+    public function resolve(): array
+    {
+        return $this->mapping;
+    }
+}

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -11,7 +11,7 @@ final class GacelaConfigFile
     /** @var list<GacelaConfigItem> */
     private array $configItems = [];
 
-    /** @var array<class-string,class-string|callable> */
+    /** @var array<class-string,class-string|callable|object> */
     private array $mappingInterfaces = [];
 
     /**
@@ -53,7 +53,7 @@ final class GacelaConfigFile
     }
 
     /**
-     * @param array<class-string,class-string|callable> $mappingInterfaces
+     * @param array<class-string,class-string|callable|object> $mappingInterfaces
      */
     public function setMappingInterfaces(array $mappingInterfaces): self
     {

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Gacela\Framework\AbstractConfigGacela;
+use Gacela\Framework\Config\GacelaConfigArgs\MappingInterfacesResolver;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractClass;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractFromAnonymousClass;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractFromCallable;
@@ -11,25 +12,24 @@ use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Infrastructure\ConcreteClass;
 
 return static fn () => new class () extends AbstractConfigGacela {
-    public function mappingInterfaces(array $globalServices): array
-    {
-        return [
-            // Resolve an abstract class from a concrete instance of a class
-            AbstractClass::class => new ConcreteClass(true, 'string', 1, 1.2, ['array']),
+    public function mappingInterfaces(
+        MappingInterfacesResolver $interfacesResolver,
+        array $globalServices = []
+    ): void {
+        // Resolve an abstract class from a concrete instance of a class
+        $interfacesResolver->bind(AbstractClass::class, new ConcreteClass(true, 'string', 1, 1.2, ['array']));
 
-            // Resolve anonymous-classes/callables from abstract classes and interfaces
-            AbstractFromAnonymousClass::class => $this->resolveAbstractFromAnonymousClass(),
-            AbstractFromCallable::class => $this->resolveAbstractFromCallable(),
-            InterfaceFromAnonymousClass::class => $this->resolveInterfaceFromAnonymousClass(),
-            InterfaceFromCallable::class => $this->resolveInterfaceFromCallable(),
-
-            // Is it also possible to bind classes like => AbstractClass::class => SpecificClass::class
-            // Check the test _BindingInterfacesWithDependenciesAndGlobalServices_ BUT
-            // be aware this way is not possible if the class has dependencies that cannot be resolved automatically!
-        ];
+        // Resolve anonymous-classes/callables from abstract classes and interfaces
+        $interfacesResolver->bind(AbstractFromAnonymousClass::class, $this->usingAbstractFromAnonymousClass());
+        $interfacesResolver->bind(AbstractFromCallable::class, $this->usingAbstractFromCallable());
+        $interfacesResolver->bind(InterfaceFromAnonymousClass::class, $this->usingInterfaceFromAnonymousClass());
+        $interfacesResolver->bind(InterfaceFromCallable::class, $this->usingInterfaceFromCallable());
+        // Is it also possible to bind classes like => AbstractClass::class => SpecificClass::class
+        // Check the test _BindingInterfacesWithDependenciesAndGlobalServices_ BUT
+        // be aware this way is not possible if the class has dependencies that cannot be resolved automatically!
     }
 
-    private function resolveAbstractFromAnonymousClass(): AbstractFromAnonymousClass
+    private function usingAbstractFromAnonymousClass(): AbstractFromAnonymousClass
     {
         return new class () extends AbstractFromAnonymousClass {
             public function getClassName(): string
@@ -39,7 +39,7 @@ return static fn () => new class () extends AbstractConfigGacela {
         };
     }
 
-    private function resolveAbstractFromCallable(): callable
+    private function usingAbstractFromCallable(): callable
     {
         return static fn () => new class () extends AbstractFromCallable {
             public function getClassName(): string
@@ -49,7 +49,7 @@ return static fn () => new class () extends AbstractConfigGacela {
         };
     }
 
-    private function resolveInterfaceFromAnonymousClass(): InterfaceFromAnonymousClass
+    private function usingInterfaceFromAnonymousClass(): InterfaceFromAnonymousClass
     {
         return new class () implements InterfaceFromAnonymousClass {
             public function getClassName(): string
@@ -59,7 +59,7 @@ return static fn () => new class () extends AbstractConfigGacela {
         };
     }
 
-    private function resolveInterfaceFromCallable(): callable
+    private function usingInterfaceFromCallable(): callable
     {
         return static fn () => new class () implements InterfaceFromCallable {
             public function getClassName(): string

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Gacela\Framework\AbstractConfigGacela;
+use Gacela\Framework\Config\GacelaConfigArgs\MappingInterfacesResolver;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\CorrectCompanyGenerator;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\IncorrectCompanyGenerator;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\GreeterGeneratorInterface;
@@ -16,14 +17,12 @@ use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalCon
  *      AND auto-resolve the class `CustomNameGenerator` from the `CorrectCompanyGenerator` constructor.
  */
 return static fn () => new class () extends AbstractConfigGacela {
-    public function mappingInterfaces(array $globalServices): array
+    public function mappingInterfaces(MappingInterfacesResolver $interfacesResolver, array $globalServices): void
     {
-        $interfaces = [GreeterGeneratorInterface::class => IncorrectCompanyGenerator::class];
+        $interfacesResolver->bind(GreeterGeneratorInterface::class, IncorrectCompanyGenerator::class);
 
         if ('yes!' === $globalServices['isWorking?']) {
-            $interfaces[GreeterGeneratorInterface::class] = CorrectCompanyGenerator::class;
+            $interfacesResolver->bind(GreeterGeneratorInterface::class, CorrectCompanyGenerator::class);
         }
-
-        return $interfaces;
     }
 };

--- a/tests/Unit/Framework/Config/GacelaConfigFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigFileFactoryTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\Unit\Framework\Config;
 use Gacela\Framework\AbstractConfigGacela;
 use Gacela\Framework\Config\ConfigGacelaMapperInterface;
 use Gacela\Framework\Config\FileIoInterface;
+use Gacela\Framework\Config\GacelaConfigArgs\MappingInterfacesResolver;
 use Gacela\Framework\Config\GacelaConfigArgs\ResolvableTypesConfig;
 use Gacela\Framework\Config\GacelaConfigFileFactory;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
@@ -34,14 +35,13 @@ final class GacelaConfigFileFactoryTest extends TestCase
 
     public function test_gacela_file_does_not_exists_but_global_services(): void
     {
-        $mappingInterfaces = ['interface' => 'concrete'];
         $overrideResolvableTypes = [
             'DependencyProvider' => ['DPCustom'],
         ];
 
         $gacelaConfigFile = (new GacelaConfigFile())
             ->setConfigItems([new GacelaConfigItem('path.php', 'path_local.php')])
-            ->setMappingInterfaces($mappingInterfaces)
+            ->setMappingInterfaces(['interface' => 'concrete'])
             ->setOverrideResolvableTypes($overrideResolvableTypes);
 
         $configGacelaMapper = $this->createStub(ConfigGacelaMapperInterface::class);
@@ -55,7 +55,9 @@ final class GacelaConfigFileFactoryTest extends TestCase
             'gacelaPhpConfigFilename',
             [
                 'config' => ['anything'],
-                'mapping-interfaces' => $mappingInterfaces,
+                'mapping-interfaces' => function (MappingInterfacesResolver $interfacesResolver): void {
+                    $interfacesResolver->bind('interface', 'concrete');
+                },
                 'override-resolvable-types' => function (ResolvableTypesConfig $resolvableTypesConfig): void {
                     $resolvableTypesConfig->addDependencyProvider('DPCustom');
                 },
@@ -66,7 +68,7 @@ final class GacelaConfigFileFactoryTest extends TestCase
 
         $expected = (new GacelaConfigFile())
             ->setConfigItems([$gacelaConfigFile])
-            ->setMappingInterfaces($mappingInterfaces)
+            ->setMappingInterfaces(['interface' => 'concrete'])
             ->setOverrideResolvableTypes([
                 'DependencyProvider' => ['DependencyProvider', 'DPCustom'],
                 'Factory' => ['Factory'],
@@ -152,9 +154,9 @@ final class GacelaConfigFileFactoryTest extends TestCase
                 return ['anything'];
             }
 
-            public function mappingInterfaces(array $globalServices): array
+            public function mappingInterfaces(MappingInterfacesResolver $interfacesResolver, array $globalServices): void
             {
-                return ['interface' => 'concrete'];
+                $interfacesResolver->bind('interface', 'concrete');
             }
 
             public function overrideResolvableTypes(ResolvableTypesConfig $resolvableTypesConfig): void


### PR DESCRIPTION
## 📚 Description

Instead of defining the mapping interfaces as a raw array, we created a class to wrap the usage of that behaviour making it easier to use for the end-user with the parameter `MappingInterfacesResolver`

## 🔖 Changes

- Create a new class `MappingInterfacesResolver`, which will be the first argument received from the `mappingInterface()`
