### PR TITLE
Create a InstanceCreator class

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -20,6 +20,8 @@ abstract class AbstractClassResolver
 
     private ?GacelaConfigFileInterface $gacelaFileConfig = null;
 
+    private ?InstanceCreator $instanceCreator = null;
+
     abstract public function resolve(object $callerClass): ?object;
 
     public function doResolve(object $callerClass): ?object
@@ -85,8 +87,11 @@ abstract class AbstractClassResolver
 
     private function createInstance(string $resolvedClassName): ?object
     {
-        return (new InstanceCreator($this->getGacelaConfigFile()))
-            ->createInstance($resolvedClassName);
+        if (null === $this->instanceCreator) {
+            $this->instanceCreator = new InstanceCreator($this->getGacelaConfigFile());
+        }
+
+        return $this->instanceCreator->createByClassName($resolvedClassName);
     }
 
     private function getGacelaConfigFile(): GacelaConfigFileInterface

--- a/src/Framework/ClassResolver/DependencyResolver/DependencyResolver.php
+++ b/src/Framework/ClassResolver/DependencyResolver/DependencyResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver\DependencyResolver;
 
-use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -14,9 +14,9 @@ use function is_object;
 
 final class DependencyResolver
 {
-    private GacelaConfigFile $gacelaConfigFile;
+    private GacelaConfigFileInterface $gacelaConfigFile;
 
-    public function __construct(GacelaConfigFile $gacelaConfigFile)
+    public function __construct(GacelaConfigFileInterface $gacelaConfigFile)
     {
         $this->gacelaConfigFile = $gacelaConfigFile;
     }

--- a/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
+++ b/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\InstanceCreator;
+
+use Gacela\Framework\ClassResolver\DependencyResolver\DependencyResolver;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+
+final class InstanceCreator
+{
+    private GacelaConfigFileInterface $gacelaConfigFile;
+
+    private ?DependencyResolver $dependencyResolver = null;
+
+    public function __construct(GacelaConfigFileInterface $gacelaConfigFile)
+    {
+        $this->gacelaConfigFile = $gacelaConfigFile;
+    }
+
+    public function createInstance(string $resolvedClassName): ?object
+    {
+        if (class_exists($resolvedClassName)) {
+            $dependencies = $this->getDependencyResolver()
+                ->resolveDependencies($resolvedClassName);
+
+            /** @psalm-suppress MixedMethodCall */
+            return new $resolvedClassName(...$dependencies);
+        }
+
+        return null;
+    }
+
+    private function getDependencyResolver(): DependencyResolver
+    {
+        if (null === $this->dependencyResolver) {
+            $this->dependencyResolver = new DependencyResolver(
+                $this->gacelaConfigFile
+            );
+        }
+
+        return $this->dependencyResolver;
+    }
+}

--- a/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
+++ b/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
@@ -18,14 +18,15 @@ final class InstanceCreator
         $this->gacelaConfigFile = $gacelaConfigFile;
     }
 
-    public function createInstance(string $resolvedClassName): ?object
+    public function createByClassName(string $className): ?object
     {
-        if (class_exists($resolvedClassName)) {
+        if (class_exists($className)) {
+            // TODO: Consider caching the dependencies(?)
             $dependencies = $this->getDependencyResolver()
-                ->resolveDependencies($resolvedClassName);
+                ->resolveDependencies($className);
 
             /** @psalm-suppress MixedMethodCall */
-            return new $resolvedClassName(...$dependencies);
+            return new $className(...$dependencies);
         }
 
         return null;

--- a/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
+++ b/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
@@ -13,6 +13,9 @@ final class InstanceCreator
 
     private ?DependencyResolver $dependencyResolver = null;
 
+    /** @var array<class-string,list<mixed>> */
+    private array $cachedDependencies = [];
+
     public function __construct(GacelaConfigFileInterface $gacelaConfigFile)
     {
         $this->gacelaConfigFile = $gacelaConfigFile;
@@ -21,12 +24,14 @@ final class InstanceCreator
     public function createByClassName(string $className): ?object
     {
         if (class_exists($className)) {
-            // TODO: Consider caching the dependencies(?)
-            $dependencies = $this->getDependencyResolver()
-                ->resolveDependencies($className);
+            if (!isset($this->cachedDependencies[$className])) {
+                $this->cachedDependencies[$className] = $this
+                    ->getDependencyResolver()
+                    ->resolveDependencies($className);
+            }
 
             /** @psalm-suppress MixedMethodCall */
-            return new $className(...$dependencies);
+            return new $className(...$this->cachedDependencies[$className]);
         }
 
         return null;

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
-use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 
 final class ConfigLoader
@@ -59,7 +59,7 @@ final class ConfigLoader
     /**
      * @return array<string,mixed>
      */
-    private function readLocalConfigFile(GacelaConfigFile $gacelaConfigFile): array
+    private function readLocalConfigFile(GacelaConfigFileInterface $gacelaConfigFile): array
     {
         $result = [];
         $configItems = $gacelaConfigFile->getConfigItems();

--- a/src/Framework/Config/GacelaConfigFileFactoryInterface.php
+++ b/src/Framework/Config/GacelaConfigFileFactoryInterface.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
-use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 interface GacelaConfigFileFactoryInterface
 {
-    public function createGacelaFileConfig(): GacelaConfigFile;
+    public function createGacelaFileConfig(): GacelaConfigFileInterface;
 }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryInterface
 {
@@ -23,7 +24,7 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
         $this->globalServices = $globalServices;
     }
 
-    public function createGacelaFileConfig(): GacelaConfigFile
+    public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
         $configBuilder = $this->createConfigBuilder();
         $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder();

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use RuntimeException;
 use function is_callable;
 
@@ -36,7 +37,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         $this->fileIo = $fileIo;
     }
 
-    public function createGacelaFileConfig(): GacelaConfigFile
+    public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
         $configGacela = $this->fileIo->include($this->gacelaPhpPath);
         if (!is_callable($configGacela)) {

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -8,7 +8,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
-final class GacelaConfigFile
+final class GacelaConfigFile implements GacelaConfigFileInterface
 {
     /** @var list<GacelaConfigItem> */
     private array $configItems = [];

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFileInterface.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFileInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\GacelaFileConfig;
+
+interface GacelaConfigFileInterface
+{
+    /**
+     * @return list<GacelaConfigItem>
+     */
+    public function getConfigItems(): array;
+
+    /**
+     * Map interfaces to concrete classes or callable (which will be resolved on runtime).
+     * This is util to inject dependencies to Gacela services (such as Factories, for example) via their constructor.
+     *
+     * @return mixed
+     */
+    public function getMappingInterface(string $key);
+
+
+    /**
+     * @return array{
+     *     Factory?:list<string>,
+     *     Config?:list<string>,
+     *     DependencyProvider?:list<string>
+     * }
+     */
+    public function getSuffixTypes(): array;
+}

--- a/tests/Fixtures/CustomClass.php
+++ b/tests/Fixtures/CustomClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Fixtures;
+
+final class CustomClass implements CustomInterface
+{
+}

--- a/tests/Fixtures/CustomClassWithDependencies.php
+++ b/tests/Fixtures/CustomClassWithDependencies.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Fixtures;
+
+final class CustomClassWithDependencies implements CustomInterface
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getStringValue(): StringValueInterface
+    {
+        return $this->stringValue;
+    }
+}

--- a/tests/Fixtures/CustomInterface.php
+++ b/tests/Fixtures/CustomInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Unit\Framework\Fixtures;
+namespace GacelaTest\Fixtures;
 
 interface CustomInterface
 {

--- a/tests/Fixtures/StringValue.php
+++ b/tests/Fixtures/StringValue.php
@@ -6,7 +6,12 @@ namespace GacelaTest\Fixtures;
 
 final class StringValue implements StringValueInterface
 {
-    private string $value = '';
+    private string $value;
+
+    public function __construct(string $value = '')
+    {
+        $this->value = $value;
+    }
 
     public function setValue(string $value): void
     {

--- a/tests/Integration/Framework/ClassResolver/InstanceCreator/InstanceCreatorTest.php
+++ b/tests/Integration/Framework/ClassResolver/InstanceCreator/InstanceCreatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\InstanceCreator;
+
+use Gacela\Framework\ClassResolver\InstanceCreator\InstanceCreator;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use GacelaTest\Fixtures\CustomClass;
+use GacelaTest\Fixtures\CustomClassWithDependencies;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+use PHPUnit\Framework\TestCase;
+
+final class InstanceCreatorTest extends TestCase
+{
+    public function test_create_class_does_not_exists(): void
+    {
+        $gacelaConfigFile = $this->createStub(GacelaConfigFileInterface::class);
+        $instanceCreator = new InstanceCreator($gacelaConfigFile);
+
+        self::assertNull($instanceCreator->createByClassName('non-existing-class'));
+    }
+
+    public function test_create_class_without_dependencies(): void
+    {
+        $gacelaConfigFile = $this->createStub(GacelaConfigFileInterface::class);
+        $instanceCreator = new InstanceCreator($gacelaConfigFile);
+
+        self::assertEquals(
+            new CustomClass(),
+            $instanceCreator->createByClassName(CustomClass::class)
+        );
+    }
+
+    public function test_create_class_with_dependencies(): void
+    {
+        $gacelaConfigFile = $this->createMock(GacelaConfigFileInterface::class);
+        $gacelaConfigFile->method('getMappingInterface')->willReturnMap([
+            [StringValueInterface::class, new StringValue('custom-string')],
+        ]);
+
+        $instanceCreator = new InstanceCreator($gacelaConfigFile);
+
+        self::assertEquals(
+            new CustomClassWithDependencies(new StringValue('custom-string')),
+            $instanceCreator->createByClassName(CustomClassWithDependencies::class)
+        );
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/InstanceCreator/InstanceCreatorTest.php
+++ b/tests/Integration/Framework/ClassResolver/InstanceCreator/InstanceCreatorTest.php
@@ -35,7 +35,7 @@ final class InstanceCreatorTest extends TestCase
 
     public function test_create_class_with_dependencies(): void
     {
-        $gacelaConfigFile = $this->createMock(GacelaConfigFileInterface::class);
+        $gacelaConfigFile = $this->createStub(GacelaConfigFileInterface::class);
         $gacelaConfigFile->method('getMappingInterface')->willReturnMap([
             [StringValueInterface::class, new StringValue('custom-string')],
         ]);
@@ -46,5 +46,22 @@ final class InstanceCreatorTest extends TestCase
             new CustomClassWithDependencies(new StringValue('custom-string')),
             $instanceCreator->createByClassName(CustomClassWithDependencies::class)
         );
+    }
+
+    public function test_caching_dependencies(): void
+    {
+        $gacelaConfigFile = $this->createMock(GacelaConfigFileInterface::class);
+        $gacelaConfigFile
+            ->expects(self::once())
+            ->method('getMappingInterface')
+            ->with(StringValueInterface::class)
+            ->willReturn(new StringValue('custom-string'));
+
+        $instanceCreator = new InstanceCreator($gacelaConfigFile);
+        $actual1 = $instanceCreator->createByClassName(CustomClassWithDependencies::class);
+        $actual2 = $instanceCreator->createByClassName(CustomClassWithDependencies::class);
+
+        self::assertEquals($actual1, $actual2);
+        self::assertNotSame($actual1, $actual2);
     }
 }

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -11,8 +11,8 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigFromBootstrapFactory;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
-use GacelaTest\Unit\Framework\Fixtures\CustomClass;
-use GacelaTest\Unit\Framework\Fixtures\CustomInterface;
+use GacelaTest\Fixtures\CustomClass;
+use GacelaTest\Fixtures\CustomInterface;
 use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigFromBootstrapFactoryTest extends TestCase

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -13,8 +13,8 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigUsingGacelaPhpFileFactory;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
-use GacelaTest\Unit\Framework\Fixtures\CustomClass;
-use GacelaTest\Unit\Framework\Fixtures\CustomInterface;
+use GacelaTest\Fixtures\CustomClass;
+use GacelaTest\Fixtures\CustomInterface;
 use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase

--- a/tests/Unit/Framework/Fixtures/CustomClass.php
+++ b/tests/Unit/Framework/Fixtures/CustomClass.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace GacelaTest\Unit\Framework\Fixtures;
-
-final class CustomClass
-{
-}


### PR DESCRIPTION
## 📚 Description

Separate the logic to create new instances from the `AbstractClassResolver` class.
No existing logic should be altered.

## 🔖 Changes

- Apply "extract class refactoring" in `AbstractClassResolver` to extract the `createInstance()` logic to its own class.
