### PR TITLE
Move reader as last argument in ConfigBuilder->add() method

### DIFF
--- a/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
@@ -22,13 +22,8 @@ final class ConfigBuilder
      */
     public function add(string $path, string $pathLocal = '', $reader = null): self
     {
-        $readerInstance = new PhpConfigReader();
-
-        if (is_string($reader)) {
-            /** @psalm-suppress MixedMethodCall */
-            $readerInstance = new $reader();
-            assert($readerInstance instanceof ConfigReaderInterface);
-        }
+        $readerInstance = is_string($reader) ? new $reader() : new PhpConfigReader();
+        assert($readerInstance instanceof ConfigReaderInterface);
 
         $this->configItems[] = new GacelaConfigItem($path, $pathLocal, $readerInstance);
 

--- a/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
@@ -20,11 +20,8 @@ final class ConfigBuilder
      * @param string $pathLocal define the path where Gacela will read the local config file
      * @param class-string<ConfigReaderInterface>|ConfigReaderInterface|null $reader Define the reader class which will read and parse the config files
      */
-    public function add(
-        string $path = GacelaConfigItem::DEFAULT_PATH,
-        string $pathLocal = GacelaConfigItem::DEFAULT_PATH_LOCAL,
-        $reader = null
-    ): self {
+    public function add(string $path, string $pathLocal = '', $reader = null): self
+    {
         $readerInstance = new PhpConfigReader();
 
         if (is_string($reader)) {

--- a/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
@@ -7,7 +7,6 @@ namespace Gacela\Framework\Config\GacelaConfigBuilder;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
-use function assert;
 use function is_string;
 
 final class ConfigBuilder
@@ -22,8 +21,13 @@ final class ConfigBuilder
      */
     public function add(string $path, string $pathLocal = '', $reader = null): self
     {
-        $readerInstance = is_string($reader) ? new $reader() : new PhpConfigReader();
-        assert($readerInstance instanceof ConfigReaderInterface);
+        if ($reader instanceof ConfigReaderInterface) {
+            $readerInstance = $reader;
+        } elseif (is_string($reader)) {
+            $readerInstance = new $reader();
+        } else {
+            $readerInstance = new PhpConfigReader();
+        }
 
         $this->configItems[] = new GacelaConfigItem($path, $pathLocal, $readerInstance);
 

--- a/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
@@ -21,13 +21,7 @@ final class ConfigBuilder
      */
     public function add(string $path, string $pathLocal = '', $reader = null): self
     {
-        if ($reader instanceof ConfigReaderInterface) {
-            $readerInstance = $reader;
-        } elseif (is_string($reader)) {
-            $readerInstance = new $reader();
-        } else {
-            $readerInstance = new PhpConfigReader();
-        }
+        $readerInstance = $this->normalizeReader($reader);
 
         $this->configItems[] = new GacelaConfigItem($path, $pathLocal, $readerInstance);
 
@@ -44,5 +38,21 @@ final class ConfigBuilder
         }
 
         return $this->configItems;
+    }
+
+    /**
+     * @param class-string<ConfigReaderInterface>|ConfigReaderInterface|null $reader
+     */
+    private function normalizeReader($reader): ConfigReaderInterface
+    {
+        if ($reader instanceof ConfigReaderInterface) {
+            return $reader;
+        }
+
+        if (is_string($reader)) {
+            return new $reader();
+        }
+
+        return new PhpConfigReader();
     }
 }

--- a/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
@@ -16,14 +16,14 @@ final class ConfigBuilder
     private array $configItems = [];
 
     /**
-     * @param class-string<ConfigReaderInterface>|ConfigReaderInterface $reader Define the reader class which will read and parse the config files
      * @param string $path define the path where Gacela will read all the config files
      * @param string $pathLocal define the path where Gacela will read the local config file
+     * @param class-string<ConfigReaderInterface>|ConfigReaderInterface|null $reader Define the reader class which will read and parse the config files
      */
     public function add(
-        $reader,
         string $path = GacelaConfigItem::DEFAULT_PATH,
-        string $pathLocal = GacelaConfigItem::DEFAULT_PATH_LOCAL
+        string $pathLocal = GacelaConfigItem::DEFAULT_PATH_LOCAL,
+        $reader = null
     ): self {
         $readerInstance = new PhpConfigReader();
 
@@ -44,7 +44,7 @@ final class ConfigBuilder
     public function build(): array
     {
         if (empty($this->configItems)) {
-            return [GacelaConfigItem::withDefaults()];
+            return [new GacelaConfigItem()];
         }
 
         return $this->configItems;

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -32,7 +32,7 @@ final class GacelaConfigFile
     public static function withDefaults(): self
     {
         return (new self())
-            ->setConfigItems([GacelaConfigItem::withDefaults()])
+            ->setConfigItems([new GacelaConfigItem()])
             ->setSuffixTypes(SuffixTypesBuilder::DEFAULT_SUFFIX_TYPES);
     }
 

--- a/tests/Feature/Framework/UsingConfigTypePhp/gacela.php
+++ b/tests/Feature/Framework/UsingConfigTypePhp/gacela.php
@@ -3,12 +3,11 @@
 declare(strict_types=1);
 
 use Gacela\Framework\AbstractConfigGacela;
-use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 
 return static fn () => new class() extends AbstractConfigGacela {
     public function config(ConfigBuilder $configBuilder): void
     {
-        $configBuilder->add(PhpConfigReader::class, 'config/*.php', 'config/local.php');
+        $configBuilder->add('config/*.php', 'config/local.php');
     }
 };

--- a/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
@@ -13,7 +13,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, [
-            'config' => function (ConfigBuilder $configBuilder): void {
+            'config' => static function (ConfigBuilder $configBuilder): void {
                 $configBuilder->add('custom-config.php', 'custom-config_local.php');
             },
         ]);

--- a/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingConfigWithBootstrapSetup;
 
-use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
@@ -14,8 +13,8 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, [
-            'config' => static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add(PhpConfigReader::class, 'custom-config.php', 'custom-config_local.php');
+            'config' => function (ConfigBuilder $configBuilder): void {
+                $configBuilder->add('custom-config.php', 'custom-config_local.php');
             },
         ]);
     }

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingMultipleConfig;
 
-use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\SimpleEnvConfigReader;
@@ -16,8 +15,8 @@ final class FeatureTest extends TestCase
     {
         $globalServices = [
             'config' => static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add(SimpleEnvConfigReader::class, 'config/.env*');
-                $configBuilder->add(new PhpConfigReader(), 'config/*.php');
+                $configBuilder->add('config/.env*', '', SimpleEnvConfigReader::class);
+                $configBuilder->add('config/*.php');
             },
         ];
 

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -7,7 +7,7 @@ namespace GacelaTest\Feature\Framework\UsingMultipleConfig;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Gacela;
-use GacelaTest\Feature\Framework\UsingMultipleConfig\LocalConfig\Domain\SimpleEnvConfigReader;
+use GacelaTest\Fixtures\SimpleEnvConfigReader;
 use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase

--- a/tests/Fixtures/SimpleEnvConfigReader.php
+++ b/tests/Fixtures/SimpleEnvConfigReader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\UsingMultipleConfig\LocalConfig\Domain;
+namespace GacelaTest\Fixtures;
 
 use Gacela\Framework\Config\ConfigReaderInterface;
 

--- a/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
@@ -43,7 +43,7 @@ final class ConfigBuilderTest extends TestCase
 
     public function test_custom_reader(): void
     {
-        $reader = new class () implements ConfigReaderInterface {
+        $reader = new class() implements ConfigReaderInterface {
             public function read(string $absolutePath): array
             {
                 return ['key' => 'value'];

--- a/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\GacelaConfigBuilder;
+
+use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use GacelaTest\Fixtures\SimpleEnvConfigReader;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigBuilderTest extends TestCase
+{
+    public function test_empty_then_default(): void
+    {
+        $builder = new ConfigBuilder();
+
+        self::assertEquals([new GacelaConfigItem()], $builder->build());
+    }
+
+    public function test_custom_path(): void
+    {
+        $builder = new ConfigBuilder();
+        $builder->add('custom/*.php');
+
+        self::assertEquals(
+            [new GacelaConfigItem('custom/*.php', '')],
+            $builder->build()
+        );
+    }
+
+    public function test_custom_path_local(): void
+    {
+        $builder = new ConfigBuilder();
+        $builder->add('', 'custom/local.php');
+
+        self::assertEquals(
+            [new GacelaConfigItem('', 'custom/local.php')],
+            $builder->build()
+        );
+    }
+
+    public function test_custom_reader(): void
+    {
+        $reader = new class () implements ConfigReaderInterface {
+            public function read(string $absolutePath): array
+            {
+                return ['key' => 'value'];
+            }
+        };
+
+        $builder = new ConfigBuilder();
+        $builder->add('custom/*.php', 'custom/local.php', $reader);
+
+        self::assertEquals(
+            [new GacelaConfigItem('custom/*.php', 'custom/local.php', $reader)],
+            $builder->build()
+        );
+    }
+
+    public function test_custom_reader_by_class_name(): void
+    {
+        $builder = new ConfigBuilder();
+        $builder->add('custom/*.php', 'custom/local.php', SimpleEnvConfigReader::class);
+
+        self::assertEquals(
+            [new GacelaConfigItem('custom/*.php', 'custom/local.php', new SimpleEnvConfigReader())],
+            $builder->build()
+        );
+    }
+}

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -37,7 +37,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     {
         $factory = new GacelaConfigFromBootstrapFactory([
             'config' => static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add(PhpConfigReader::class, 'custom-path.php', 'custom-path_local.php');
+                $configBuilder->add('custom-path.php', 'custom-path_local.php');
             },
         ]);
 

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -72,7 +72,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo->method('include')->willReturn(static fn () => new class() extends AbstractConfigGacela {
             public function config(ConfigBuilder $configBuilder): void
             {
-                $configBuilder->add(PhpConfigReader::class, 'custom-path.php', 'custom-path_local.php');
+                $configBuilder->add('custom-path.php', 'custom-path_local.php');
             }
         });
 


### PR DESCRIPTION
## 📚 Description

The PhpConfigReader is the default config reader for gacela. I think it would be better to keep it as last optional argument when adding a new config reader.

## 🔖 Changes

Chnage the method signature for `ConfigBuilder->add()`:

```diff
-public function add(
-    $reader
-    string $path = GacelaConfigItem::DEFAULT_PATH,
-    string $pathLocal = GacelaConfigItem::DEFAULT_PATH_LOCAL,
-): self {

+public function add(
+    string $path,
+    string $pathLocal = '',
+    $reader = null
+): self {
```
