### PR TITLE
Add cache to ClassInfo

### DIFF
--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -13,6 +13,9 @@ final class ClassInfo
 {
     public const MODULE_NAME_ANONYMOUS = 'module-name@anonymous';
 
+    /** @var array<string,array<string,self>> */
+    private static array $callerClassCache;
+
     private string $callerModuleName;
     private string $callerNamespace;
     private string $cacheKey;
@@ -31,6 +34,9 @@ final class ClassInfo
     {
         $callerClass = get_class($callerObject);
 
+        if (isset(self::$callerClassCache[$callerClass][$resolvableType])) {
+            return self::$callerClassCache[$callerClass][$resolvableType];
+        }
         /** @var string[] $callerClassParts */
         $callerClassParts = explode('\\', ltrim($callerClass, '\\'));
         $lastCallerClassPart = end($callerClassParts);
@@ -52,7 +58,10 @@ final class ClassInfo
             $resolvableType
         ));
 
-        return new self($callerNamespace, $callerModuleName, $cacheKey);
+        $self = new self($callerNamespace, $callerModuleName, $cacheKey);
+        self::$callerClassCache[$callerClass][$resolvableType] = $self;
+
+        return $self;
     }
 
     public function getCacheKey(): string

--- a/tests/Benchmark/Framework/ClassResolver/ClassInfo/ClassInfoBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassInfo/ClassInfoBench.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassInfo;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ClassResolver\ClassInfo;
+use GacelaTest\Fixtures\ClassInfoTestingFacade;
+
+/**
+ * @Iterations(5)
+ * @Revs(1000)
+ */
+final class ClassInfoBench
+{
+    public function bench_anonymous_class(): void
+    {
+        $facade = new class() extends AbstractFacade {
+        };
+        ClassInfo::fromObject($facade, 'Factory');
+    }
+
+    public function bench_real_class(): void
+    {
+        $facade = new ClassInfoTestingFacade();
+        ClassInfo::fromObject($facade, 'Factory');
+    }
+}

--- a/tests/Fixtures/ClassInfoTestingFacade.php
+++ b/tests/Fixtures/ClassInfoTestingFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Fixtures;
+
+use Gacela\Framework\AbstractFacade;
+
+final class ClassInfoTestingFacade extends AbstractFacade
+{
+}

--- a/tests/Unit/Framework/ClassResolver/ClassInfoTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassInfoTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ClassResolver\ClassInfo;
+use GacelaTest\Fixtures\ClassInfoTestingFacade;
+use PHPUnit\Framework\TestCase;
+
+final class ClassInfoTest extends TestCase
+{
+    public function test_anonymous_class(): void
+    {
+        $facade = new class() extends AbstractFacade {
+        };
+        $actual = ClassInfo::fromObject($facade, 'Factory');
+
+        self::assertSame('module-name@anonymous\ClassInfoTest', $actual->getModule());
+        self::assertSame('module-name@anonymous\ClassInfoTest', $actual->getFullNamespace());
+        self::assertSame('\module-name@anonymous\ClassInfoTest\Factory', $actual->getCacheKey());
+    }
+
+    public function test_real_class(): void
+    {
+        $facade = new ClassInfoTestingFacade();
+        $actual = ClassInfo::fromObject($facade, 'Factory');
+
+        self::assertSame('Fixtures', $actual->getModule());
+        self::assertSame('GacelaTest\Fixtures', $actual->getFullNamespace());
+        self::assertSame('\GacelaTest\Fixtures\Factory', $actual->getCacheKey());
+    }
+}


### PR DESCRIPTION
## 📚 Description

I was profiling Gacela (using [blackfire](https://blackfire.io/)) in order to find the slowest parts, and I found that `ClassInfo::fromObject()` is currently one of the most expensive places. So, I think adding a cache here make total sense.

## 🔖 Changes

- Added in memory cache to the result of `ClassInfo::fromObject()`, so it doesn't compute the same every time, instead it return the cached value (which is indeed a value object).

## 🖼️ Screenshots

**LEFT**: Before (current master) -> `ClassInfo::fromObject()` is the first item (most expensive one).
**RIGHT**: After (current branch) -> `ClassInfo::fromObject()` is more efficient.
<img width="1263" alt="Screenshot 2022-03-23 at 11 25 47" src="https://user-images.githubusercontent.com/5256287/159678698-972b6b37-5e39-46e5-94a8-9e4833398681.png">

How did I performed this test? I created a test app with 16 modules (each of them with the basic Gacela files) and I load all of them a few hundreds of time. This is the code:
<img width="1043" alt="Screenshot 2022-03-23 at 11 33 59" src="https://user-images.githubusercontent.com/5256287/159680186-98bd0b7f-0101-409d-9880-802b7149fa5e.png">

```php
<?php

declare(strict_types = 1);

namespace GacelaData\Cache;

use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
use Gacela\Framework\Gacela;
use GacelaTest\Fixtures\StringValue;
use GacelaTest\Fixtures\StringValueInterface;

require getcwd() . '/vendor/autoload.php';

const ITERATIONS = 20;
const REVOLUTIONS = 500;
[$filename, $withCacheStr] = $argv;
$withCache = ('true' === $withCacheStr) ? true : false;

function gacelaBootstrapWithCache(bool $cacheEnabled): void
{
    Gacela::bootstrap(__DIR__, [
        'resolvable-names-cache-enabled' => $cacheEnabled,
        'mapping-interfaces' => static function (MappingInterfacesBuilder $interfacesBuilder): void {
            $interfacesBuilder->bind(StringValueInterface::class, new StringValue('testing-string'));
        },
        'suffix-types' => static function (SuffixTypesBuilder $suffixTypesBuilder): void {
            $suffixTypesBuilder
                ->addFactory('FactoryA')
                ->addFactory('FactoryB')
                ->addConfig('ConfigA')
                ->addConfig('ConfigB')
                ->addDependencyProvider('DepProvA')
                ->addDependencyProvider('DepProvB');
        },
    ]);
}

gacelaBootstrapWithCache($withCache);

for ($i = 0; $i < ITERATIONS; $i++) {
    echo sprintf("Iteration %d. Revs (%d)\n", $i, REVOLUTIONS);
    for ($j = 0; $j < REVOLUTIONS; $j++) {
        (new ModuleA\Facade())->loadGacelaCacheFile();
        (new ModuleB\Facade())->loadGacelaCacheFile();
        (new ModuleC\Facade())->loadGacelaCacheFile();
        (new ModuleD\Facade())->loadGacelaCacheFile();
        (new ModuleE\Facade())->loadGacelaCacheFile();
        (new ModuleF\Facade())->loadGacelaCacheFile();
        (new ModuleG\Facade())->loadGacelaCacheFile();
        (new ModuleH\Facade())->loadGacelaCacheFile();
        (new ModuleI\Facade())->loadGacelaCacheFile();
        (new ModuleJ\Facade())->loadGacelaCacheFile();
        (new ModuleK\Facade())->loadGacelaCacheFile();
        (new ModuleL\Facade())->loadGacelaCacheFile();
        (new ModuleM\Facade())->loadGacelaCacheFile();
        (new ModuleN\Facade())->loadGacelaCacheFile();
        (new ModuleO\Facade())->loadGacelaCacheFile();
        (new ModuleP\Facade())->loadGacelaCacheFile();
    }
    gacelaBootstrapWithCache($withCache);
}
```
