### PR TITLE
Create constants for Gacela::bootstrap() setup

### DIFF
--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Gacela;
 
 final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryInterface
 {
@@ -39,7 +40,7 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
         $setup = $this->setup;
 
         $configBuilder = new ConfigBuilder();
-        $configFromSetupFn = $setup['config'] ?? null;
+        $configFromSetupFn = $setup[Gacela::CONFIG] ?? null;
         if (null !== $configFromSetupFn) {
             $configFromSetupFn($configBuilder);
         }
@@ -53,11 +54,11 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
         $setup = $this->setup;
 
         $mappingInterfacesBuilder = new MappingInterfacesBuilder();
-        $mappingInterfacesFn = $setup['mapping-interfaces'] ?? null;
+        $mappingInterfacesFn = $setup[Gacela::MAPPING_INTERFACES] ?? null;
         if (null !== $mappingInterfacesFn) {
             $globalServicesFallback = $setup; // @deprecated, the fallback will be an empty array in the next version
             # $globalServicesFallback = []; // Replacement for the deprecated version
-            $mappingInterfacesFn($mappingInterfacesBuilder, $setup['global-services'] ?? $globalServicesFallback);
+            $mappingInterfacesFn($mappingInterfacesBuilder, $setup[Gacela::GLOBAL_SERVICES] ?? $globalServicesFallback);
         }
 
         return $mappingInterfacesBuilder;
@@ -68,7 +69,7 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
         /** @var array{suffix-types?: callable} $setup */
         $setup = $this->setup;
         $suffixTypesBuilder = new SuffixTypesBuilder();
-        $suffixTypesFn = $setup['suffix-types'] ?? null;
+        $suffixTypesFn = $setup[Gacela::SUFFIX_TYPES] ?? null;
         if (null !== $suffixTypesFn) {
             $suffixTypesFn($suffixTypesBuilder);
         }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -12,6 +12,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Gacela;
 use RuntimeException;
 use function is_callable;
 
@@ -73,7 +74,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         $mappingInterfacesBuilder = new MappingInterfacesBuilder();
         $globalServicesFallback = $setup; // @deprecated, the fallback will be an empty array in the next version
         # $globalServicesFallback = []; // Replacement for the deprecated version
-        $configGacelaClass->mappingInterfaces($mappingInterfacesBuilder, $setup['global-services'] ?? $globalServicesFallback);
+        $configGacelaClass->mappingInterfaces($mappingInterfacesBuilder, $setup[Gacela::GLOBAL_SERVICES] ?? $globalServicesFallback);
 
         return $mappingInterfacesBuilder;
     }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -6,6 +6,11 @@ namespace Gacela\Framework;
 
 final class Gacela
 {
+    public const CONFIG = 'config';
+    public const MAPPING_INTERFACES = 'mapping-interfaces';
+    public const SUFFIX_TYPES = 'suffix-types';
+    public const GLOBAL_SERVICES = 'global-services';
+
     /**
      * Define the entry point of Gacela.
      *

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
@@ -12,7 +12,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, [
-            'global-services' => ['isWorking?' => 'yes!'],
+            Gacela::GLOBAL_SERVICES => ['isWorking?' => 'yes!'],
         ]);
     }
 

--- a/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
@@ -13,7 +13,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, [
-            'config' => static function (ConfigBuilder $configBuilder): void {
+            Gacela::CONFIG => static function (ConfigBuilder $configBuilder): void {
                 $configBuilder->add('custom-config.php', 'custom-config_local.php');
             },
         ]);

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -14,7 +14,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         $setup = [
-            'config' => static function (ConfigBuilder $configBuilder): void {
+            Gacela::CONFIG => static function (ConfigBuilder $configBuilder): void {
                 $configBuilder->add('config/.env*', '', SimpleEnvConfigReader::class);
                 $configBuilder->add('config/*.php');
             },

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigFromBootstrapFactory;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\CustomClass;
 use GacelaTest\Fixtures\CustomInterface;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +37,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     public function test_global_service_config(): void
     {
         $factory = new GacelaConfigFromBootstrapFactory([
-            'config' => static function (ConfigBuilder $configBuilder): void {
+            Gacela::CONFIG => static function (ConfigBuilder $configBuilder): void {
                 $configBuilder->add('custom-path.php', 'custom-path_local.php');
             },
         ]);
@@ -50,10 +51,10 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     public function test_global_service_mapping_interfaces_with_global_services(): void
     {
         $factory = new GacelaConfigFromBootstrapFactory([
-            'global-services' => [
+            Gacela::GLOBAL_SERVICES => [
                 'globalServiceKey' => 'globalServiceValue',
             ],
-            'mapping-interfaces' => static function (
+            Gacela::MAPPING_INTERFACES => static function (
                 MappingInterfacesBuilder $interfacesBuilder,
                 array $globalServices
             ): void {
@@ -71,7 +72,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     public function test_global_service_suffix_types(): void
     {
         $factory = new GacelaConfigFromBootstrapFactory([
-            'suffix-types' => static function (SuffixTypesBuilder $suffixTypesBuilder): void {
+            Gacela::SUFFIX_TYPES => static function (SuffixTypesBuilder $suffixTypesBuilder): void {
                 $suffixTypesBuilder->addDependencyProvider('DPCustom');
             },
         ]);


### PR DESCRIPTION
## 📚 Description

[Issue #124](https://github.com/gacela-project/gacela/issues/124)

From now on, instead of bootstrapping like this:
```php
Gacela::bootstrap($appRootDir, [
    'global-services' => [],
    'config' => function (ConfigBuilder $configBuilder): void {
        // ...
    },
    'mapping-interfaces' => function (
        MappingInterfacesBuilder $interfacesBuilder,
        array $globalServices
    ): void {
        // ...
    },
    'suffix-types' => function (SuffixTypesBuilder $suffixTypesBuilder): void {
       // ...
    },
]);
```

we can use constants in the `Gacela` class, like:
```php
Gacela::bootstrap($appRootDir, [
    Gacela::GLOBAL_SERVICES => [],
    Gacela::CONFIG => function (ConfigBuilder $configBuilder): void {
        // ...
    },
    Gacela::MAPPING_INTERFACES => function (
        MappingInterfacesBuilder $interfacesBuilder,
        array $globalServices
    ): void {
        // ...
    },
    Gacela::SUFFIX_TYPES => function (SuffixTypesBuilder $suffixTypesBuilder): void {
       // ...
    },
]);
```

This change brings more facilities to the user in order to know the available possible keys for the setup 😄 