### PR TITLE
Create SetupGacela to replace AbstractConfigGacela

### DIFF
--- a/src/Framework/AbstractConfigGacela.php
+++ b/src/Framework/AbstractConfigGacela.php
@@ -4,29 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Setup\AbstractSetupGacela;
 
-abstract class AbstractConfigGacela
+/**
+ * @deprecated use AbstractSetupGacela instead
+ */
+abstract class AbstractConfigGacela extends AbstractSetupGacela
 {
-    public function config(ConfigBuilder $configBuilder): void
-    {
-    }
-
-    /**
-     * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
-     *
-     * @param array<string,mixed> $globalServices
-     */
-    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
-    {
-    }
-
-    /**
-     * Allow overriding gacela resolvable types.
-     */
-    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void
-    {
-    }
 }

--- a/src/Framework/Config.php
+++ b/src/Framework/Config.php
@@ -6,6 +6,8 @@ namespace Gacela\Framework;
 
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Exception\ConfigException;
+use Gacela\Framework\Setup\SetupGacela;
+use Gacela\Framework\Setup\SetupGacelaInterface;
 
 final class Config
 {
@@ -18,8 +20,7 @@ final class Config
     /** @var array<string,mixed> */
     private array $config = [];
 
-    /** @var array<string,mixed> */
-    private array $setup = [];
+    private ?SetupGacelaInterface $setup = null;
 
     private ?ConfigFactory $configFactory = null;
 
@@ -95,10 +96,7 @@ final class Config
         return $this->appRootDir ?? getcwd() ?: '';
     }
 
-    /**
-     * @param array<string,mixed> $setup
-     */
-    public function setSetup(array $setup): self
+    public function setSetup(SetupGacelaInterface $setup): self
     {
         $this->setup = $setup;
 
@@ -113,7 +111,7 @@ final class Config
         if (null === $this->configFactory) {
             $this->configFactory = new ConfigFactory(
                 $this->getAppRootDir(),
-                $this->setup
+                $this->setup ?? new SetupGacela()
             );
         }
 

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigUsingGacelaPhpF
 use Gacela\Framework\Config\PathNormalizer\AbsolutePathNormalizer;
 use Gacela\Framework\Config\PathNormalizer\WithoutSuffixAbsolutePathStrategy;
 use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
+use Gacela\Framework\Setup\SetupGacelaInterface;
 
 final class ConfigFactory extends AbstractFactory
 {
@@ -17,13 +18,9 @@ final class ConfigFactory extends AbstractFactory
 
     private string $appRootDir;
 
-    /** @var array<string,mixed> */
-    private array $setup;
+    private SetupGacelaInterface $setup;
 
-    /**
-     * @param array<string,mixed> $setup
-     */
-    public function __construct(string $appRootDir, array $setup)
+    public function __construct(string $appRootDir, SetupGacelaInterface $setup)
     {
         $this->appRootDir = $appRootDir;
         $this->setup = $setup;

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -10,17 +10,13 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
-use Gacela\Framework\Gacela;
+use Gacela\Framework\Setup\SetupGacelaInterface;
 
 final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryInterface
 {
-    /** @var array<string,mixed> */
-    private array $setup;
+    private SetupGacelaInterface $setup;
 
-    /**
-     * @param array<string,mixed> $setup
-     */
-    public function __construct(array $setup)
+    public function __construct(SetupGacelaInterface $setup)
     {
         $this->setup = $setup;
     }
@@ -36,43 +32,24 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
 
     private function createConfigBuilder(): ConfigBuilder
     {
-        /** @var array{config?: callable} $setup */
-        $setup = $this->setup;
-
         $configBuilder = new ConfigBuilder();
-        $configFromSetupFn = $setup[Gacela::CONFIG] ?? null;
-        if (null !== $configFromSetupFn) {
-            $configFromSetupFn($configBuilder);
-        }
+        $this->setup->config($configBuilder);
 
         return $configBuilder;
     }
 
     private function createMappingInterfacesBuilder(): MappingInterfacesBuilder
     {
-        /** @var array{mapping-interfaces?: callable, global-services?: array<string,mixed>} $setup */
-        $setup = $this->setup;
-
         $mappingInterfacesBuilder = new MappingInterfacesBuilder();
-        $mappingInterfacesFn = $setup[Gacela::MAPPING_INTERFACES] ?? null;
-        if (null !== $mappingInterfacesFn) {
-            $globalServicesFallback = $setup; // @deprecated, the fallback will be an empty array in the next version
-            # $globalServicesFallback = []; // Replacement for the deprecated version
-            $mappingInterfacesFn($mappingInterfacesBuilder, $setup[Gacela::GLOBAL_SERVICES] ?? $globalServicesFallback);
-        }
+        $this->setup->mappingInterfaces($mappingInterfacesBuilder, []);
 
         return $mappingInterfacesBuilder;
     }
 
     private function createSuffixTypesBuilder(): SuffixTypesBuilder
     {
-        /** @var array{suffix-types?: callable} $setup */
-        $setup = $this->setup;
         $suffixTypesBuilder = new SuffixTypesBuilder();
-        $suffixTypesFn = $setup[Gacela::SUFFIX_TYPES] ?? null;
-        if (null !== $suffixTypesFn) {
-            $suffixTypesFn($suffixTypesBuilder);
-        }
+        $this->setup->suffixTypes($suffixTypesBuilder);
 
         return $suffixTypesBuilder;
     }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -27,7 +27,10 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
         $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder();
         $suffixTypesBuilder = $this->createSuffixTypesBuilder();
 
-        return GacelaConfigFile::usingBuilders($configBuilder, $mappingInterfacesBuilder, $suffixTypesBuilder);
+        return (new GacelaConfigFile())
+            ->setConfigItems($configBuilder->build())
+            ->setMappingInterfaces($mappingInterfacesBuilder->build())
+            ->setSuffixTypes($suffixTypesBuilder->build());
     }
 
     private function createConfigBuilder(): ConfigBuilder

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig\Factory;
 
-use Gacela\Framework\AbstractConfigGacela;
 use Gacela\Framework\Config\FileIoInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
@@ -12,7 +11,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
-use Gacela\Framework\Gacela;
+use Gacela\Framework\Setup\SetupGacelaInterface;
 use RuntimeException;
 use function is_callable;
 
@@ -20,17 +19,13 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 {
     private string $gacelaPhpPath;
 
-    /** @var array<string,mixed> */
-    private array $setup;
+    private SetupGacelaInterface $setup;
 
     private FileIoInterface $fileIo;
 
-    /**
-     * @param array<string,mixed> $setup
-     */
     public function __construct(
         string $gacelaPhpPath,
-        array $setup,
+        SetupGacelaInterface $setup,
         FileIoInterface $fileIo
     ) {
         $this->gacelaPhpPath = $gacelaPhpPath;
@@ -40,25 +35,25 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $configGacela = $this->fileIo->include($this->gacelaPhpPath);
-        if (!is_callable($configGacela)) {
-            throw new RuntimeException('Create a function that returns an anonymous class that extends AbstractConfigGacela');
+        $setupGacela = $this->fileIo->include($this->gacelaPhpPath);
+        if (!is_callable($setupGacela)) {
+            throw new RuntimeException('Create a function that returns an anonymous class that implements SetupGacelaInterface');
         }
 
-        /** @var object $configGacelaClass */
-        $configGacelaClass = $configGacela();
-        if (!is_subclass_of($configGacelaClass, AbstractConfigGacela::class)) {
-            throw new RuntimeException('Your anonymous class must extends AbstractConfigGacela');
+        /** @var object $setupGacelaClass */
+        $setupGacelaClass = $setupGacela();
+        if (!is_subclass_of($setupGacelaClass, SetupGacelaInterface::class)) {
+            throw new RuntimeException('Your anonymous class must implements SetupGacelaInterface');
         }
 
-        $configBuilder = $this->createConfigBuilder($configGacelaClass);
-        $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder($configGacelaClass);
-        $suffixTypesBuilder = $this->createSuffixTypesBuilder($configGacelaClass);
+        $configBuilder = $this->createConfigBuilder($setupGacelaClass);
+        $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder($setupGacelaClass);
+        $suffixTypesBuilder = $this->createSuffixTypesBuilder($setupGacelaClass);
 
         return GacelaConfigFile::usingBuilders($configBuilder, $mappingInterfacesBuilder, $suffixTypesBuilder);
     }
 
-    private function createConfigBuilder(AbstractConfigGacela $configGacelaClass): ConfigBuilder
+    private function createConfigBuilder(SetupGacelaInterface $configGacelaClass): ConfigBuilder
     {
         $configBuilder = new ConfigBuilder();
         $configGacelaClass->config($configBuilder);
@@ -66,20 +61,15 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         return $configBuilder;
     }
 
-    private function createMappingInterfacesBuilder(AbstractConfigGacela $configGacelaClass): MappingInterfacesBuilder
+    private function createMappingInterfacesBuilder(SetupGacelaInterface $setupGacela): MappingInterfacesBuilder
     {
-        /** @var array{global-services?: array<string,mixed>} $setup */
-        $setup = $this->setup;
-
         $mappingInterfacesBuilder = new MappingInterfacesBuilder();
-        $globalServicesFallback = $setup; // @deprecated, the fallback will be an empty array in the next version
-        # $globalServicesFallback = []; // Replacement for the deprecated version
-        $configGacelaClass->mappingInterfaces($mappingInterfacesBuilder, $setup[Gacela::GLOBAL_SERVICES] ?? $globalServicesFallback);
+        $setupGacela->mappingInterfaces($mappingInterfacesBuilder, $this->setup->globalServices());
 
         return $mappingInterfacesBuilder;
     }
 
-    private function createSuffixTypesBuilder(AbstractConfigGacela $configGacelaClass): SuffixTypesBuilder
+    private function createSuffixTypesBuilder(SetupGacelaInterface $configGacelaClass): SuffixTypesBuilder
     {
         $suffixTypesBuilder = new SuffixTypesBuilder();
         $configGacelaClass->suffixTypes($suffixTypesBuilder);

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig;
 
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
 final class GacelaConfigFile implements GacelaConfigFileInterface
@@ -25,26 +23,11 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
      */
     private array $suffixTypes = [];
 
-    private function __construct()
-    {
-    }
-
     public static function withDefaults(): self
     {
         return (new self())
             ->setConfigItems([new GacelaConfigItem()])
             ->setSuffixTypes(SuffixTypesBuilder::DEFAULT_SUFFIX_TYPES);
-    }
-
-    public static function usingBuilders(
-        ConfigBuilder $configBuilder,
-        MappingInterfacesBuilder $mappingInterfacesBuilder,
-        SuffixTypesBuilder $suffixTypesBuilder
-    ): self {
-        return (new self())
-            ->setConfigItems($configBuilder->build())
-            ->setMappingInterfaces($mappingInterfacesBuilder->build())
-            ->setSuffixTypes($suffixTypesBuilder->build());
     }
 
     /**

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -19,8 +19,6 @@ final class Gacela
     /**
      * Define the entry point of Gacela.
      *
-     * @psalm-suppress ArgumentTypeCoercion
-     *
      * @param array|SetupGacelaInterface|null $setup array to allow BC. Use SetupGacelaInterface instead.
      */
     public static function bootstrap(string $appRootDir, $setup = null): void
@@ -42,8 +40,6 @@ final class Gacela
             trigger_deprecation('Gacela', '0.14', 'Use SetupGacelaInterface instead');
 
             /**
-             * @psalm-suppress InvalidArgument
-             *
              * @var array{
              *     config?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder):void,
              *     mapping-interfaces?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder, array<string,mixed>):void,

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -19,15 +19,14 @@ final class Gacela
     /**
      * Define the entry point of Gacela.
      *
-     * @param array|SetupGacelaInterface|null $setup array to allow BC. Use SetupGacelaInterface instead.
+     * @param array|SetupGacelaInterface|null $setup Use SetupGacelaInterface.
+     *      Array is deprecated and will be removed in the next version.
      */
     public static function bootstrap(string $appRootDir, $setup = null): void
     {
-        $setup = self::normalizeSetup($setup);
-
         Config::getInstance()
             ->setAppRootDir($appRootDir)
-            ->setSetup($setup)
+            ->setSetup(self::normalizeSetup($setup))
             ->init();
     }
 
@@ -37,7 +36,7 @@ final class Gacela
     private static function normalizeSetup($setup = null): SetupGacelaInterface
     {
         if (is_array($setup)) {
-            trigger_deprecation('Gacela', '0.14', 'Use SetupGacelaInterface instead');
+            trigger_deprecation('Gacela', '0.14', 'Use SetupGacelaInterface instead.');
 
             /**
              * @var array{

--- a/src/Framework/Setup/AbstractSetupGacela.php
+++ b/src/Framework/Setup/AbstractSetupGacela.php
@@ -10,6 +10,9 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
 abstract class AbstractSetupGacela implements SetupGacelaInterface
 {
+    /**
+     * Define different config sources.
+     */
     public function config(ConfigBuilder $configBuilder): void
     {
     }
@@ -24,17 +27,17 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     }
 
     /**
+     * Allow overriding gacela resolvable types.
+     */
+    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void
+    {
+    }
+
+    /**
      * @return array<string,mixed>
      */
     public function globalServices(): array
     {
         return [];
-    }
-
-    /**
-     * Allow overriding gacela resolvable types.
-     */
-    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void
-    {
     }
 }

--- a/src/Framework/Setup/AbstractSetupGacela.php
+++ b/src/Framework/Setup/AbstractSetupGacela.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Setup;
+
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+
+abstract class AbstractSetupGacela implements SetupGacelaInterface
+{
+    public function config(ConfigBuilder $configBuilder): void
+    {
+    }
+
+    /**
+     * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
+     *
+     * @param array<string,mixed> $globalServices
+     */
+    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
+    {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function globalServices(): array
+    {
+        return [];
+    }
+
+    /**
+     * Allow overriding gacela resolvable types.
+     */
+    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void
+    {
+    }
+}

--- a/src/Framework/Setup/SetupGacela.php
+++ b/src/Framework/Setup/SetupGacela.php
@@ -61,8 +61,6 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @psalm-suppress MixedPropertyTypeCoercion
-     *
      * @param callable(SuffixTypesBuilder):void $callable
      */
     public function setSuffixTypes(callable $callable): self

--- a/src/Framework/Setup/SetupGacela.php
+++ b/src/Framework/Setup/SetupGacela.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Setup;
+
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+
+final class SetupGacela extends AbstractSetupGacela
+{
+    /** @var ?callable(ConfigBuilder):void */
+    private $configFn = null;
+
+    /** @var ?callable(MappingInterfacesBuilder,array<string,mixed>):void */
+    private $mappingInterfacesFn = null;
+
+    /** @var ?callable(SuffixTypesBuilder):void */
+    private $suffixTypesFn = null;
+
+    /** @var array<string,mixed> */
+    private array $globalServices = [];
+
+    /**
+     * @param callable(ConfigBuilder):void $callable
+     */
+    public function setConfig(callable $callable): self
+    {
+        $this->configFn = $callable;
+
+        return $this;
+    }
+
+    public function config(ConfigBuilder $configBuilder): void
+    {
+        $this->configFn && ($this->configFn)($configBuilder);
+    }
+
+    /**
+     * @param callable(MappingInterfacesBuilder,array<string,mixed>):void $callable
+     */
+    public function setMappingInterfaces(callable $callable): self
+    {
+        $this->mappingInterfacesFn = $callable;
+
+        return $this;
+    }
+
+    /**
+     * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
+     *
+     * @param array<string,mixed> $globalServices
+     */
+    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
+    {
+        $this->mappingInterfacesFn && ($this->mappingInterfacesFn)(
+            $mappingInterfacesBuilder,
+            array_merge($this->globalServices, $globalServices)
+        );
+    }
+
+    /**
+     * @psalm-suppress MixedPropertyTypeCoercion
+     *
+     * @param callable(SuffixTypesBuilder):void $callable
+     */
+    public function setSuffixTypes(callable $callable): self
+    {
+        $this->suffixTypesFn = $callable;
+
+        return $this;
+    }
+
+    /**
+     * Allow overriding gacela resolvable types.
+     */
+    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void
+    {
+        $this->suffixTypesFn && ($this->suffixTypesFn)($suffixTypesBuilder);
+    }
+
+    /**
+     * @param array<string,mixed> $array
+     */
+    public function setGlobalServices(array $array): self
+    {
+        $this->globalServices = $array;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function globalServices(): array
+    {
+        return $this->globalServices;
+    }
+}

--- a/src/Framework/Setup/SetupGacelaFactory.php
+++ b/src/Framework/Setup/SetupGacelaFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Setup;
+
+use Gacela\Framework\Gacela;
+
+final class SetupGacelaFactory
+{
+    /**
+     * @param array{
+     *     config?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder):void,
+     *     mapping-interfaces?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder, array<string,mixed>):void,
+     *     suffix-types?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder):void,
+     *     global-services?: array<string,mixed>,
+     * } $globalServices
+     */
+    public static function fromArray(array $globalServices): SetupGacelaInterface
+    {
+        $setup = new SetupGacela();
+        if (isset($globalServices[Gacela::CONFIG])) {
+            $setup->setConfig($globalServices[Gacela::CONFIG]);
+        }
+        if (isset($globalServices[Gacela::MAPPING_INTERFACES])) {
+            $setup->setMappingInterfaces($globalServices[Gacela::MAPPING_INTERFACES]);
+        }
+        if (isset($globalServices[Gacela::SUFFIX_TYPES])) {
+            $setup->setSuffixTypes($globalServices[Gacela::SUFFIX_TYPES]);
+        }
+        if (isset($globalServices[Gacela::GLOBAL_SERVICES])) {
+            $setup->setGlobalServices($globalServices[Gacela::GLOBAL_SERVICES]);
+        }
+
+        return $setup;
+    }
+}

--- a/src/Framework/Setup/SetupGacelaInterface.php
+++ b/src/Framework/Setup/SetupGacelaInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Setup;
+
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+
+interface SetupGacelaInterface
+{
+    public function config(ConfigBuilder $configBuilder): void;
+
+    /**
+     * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
+     *
+     * @param array<string,mixed> $globalServices
+     */
+    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void;
+
+    /**
+     * Define global services that can be accessible via the mapping interfaces.
+     *
+     * @return array<string,mixed>
+     */
+    public function globalServices(): array;
+
+    /**
+     * Allow overriding gacela resolvable types.
+     */
+    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void;
+}

--- a/src/Framework/Setup/SetupGacelaInterface.php
+++ b/src/Framework/Setup/SetupGacelaInterface.php
@@ -10,6 +10,9 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
 interface SetupGacelaInterface
 {
+    /**
+     * Define different config sources.
+     */
     public function config(ConfigBuilder $configBuilder): void;
 
     /**
@@ -20,14 +23,14 @@ interface SetupGacelaInterface
     public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void;
 
     /**
+     * Allow overriding gacela resolvable types.
+     */
+    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void;
+
+    /**
      * Define global services that can be accessible via the mapping interfaces.
      *
      * @return array<string,mixed>
      */
     public function globalServices(): array;
-
-    /**
-     * Allow overriding gacela resolvable types.
-     */
-    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void;
 }

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Gacela\Framework\AbstractConfigGacela;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
+use Gacela\Framework\Setup\SetupGacela;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractClass;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractFromAnonymousClass;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractFromCallable;
@@ -11,59 +11,53 @@ use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\InterfaceFromCallable;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Infrastructure\ConcreteClass;
 
-return static fn () => new class() extends AbstractConfigGacela {
-    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
-    {
+return static fn () => (new SetupGacela())->setMappingInterfaces(
+    static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void {
         // Resolve an abstract class from a concrete instance of a class
         $mappingInterfacesBuilder->bind(AbstractClass::class, new ConcreteClass(true, 'string', 1, 1.2, ['array']));
 
         // Resolve anonymous-classes/callables from abstract classes and interfaces
-        $mappingInterfacesBuilder->bind(AbstractFromAnonymousClass::class, $this->usingAbstractFromAnonymousClass());
-        $mappingInterfacesBuilder->bind(AbstractFromCallable::class, $this->usingAbstractFromCallable());
-        $mappingInterfacesBuilder->bind(InterfaceFromAnonymousClass::class, $this->usingInterfaceFromAnonymousClass());
-        $mappingInterfacesBuilder->bind(InterfaceFromCallable::class, $this->usingInterfaceFromCallable());
+        $mappingInterfacesBuilder->bind(
+            AbstractFromAnonymousClass::class,
+            new class() extends AbstractFromAnonymousClass {
+                public function getClassName(): string
+                {
+                    return AbstractFromAnonymousClass::class;
+                }
+            }
+        );
+
+        $mappingInterfacesBuilder->bind(
+            AbstractFromCallable::class,
+            static fn () => new class() extends AbstractFromCallable {
+                public function getClassName(): string
+                {
+                    return AbstractFromCallable::class;
+                }
+            }
+        );
+
+        $mappingInterfacesBuilder->bind(
+            InterfaceFromAnonymousClass::class,
+            new class() implements InterfaceFromAnonymousClass {
+                public function getClassName(): string
+                {
+                    return InterfaceFromAnonymousClass::class;
+                }
+            }
+        );
+
+        $mappingInterfacesBuilder->bind(
+            InterfaceFromCallable::class,
+            static fn () => new class() implements InterfaceFromCallable {
+                public function getClassName(): string
+                {
+                    return InterfaceFromCallable::class;
+                }
+            }
+        );
         // Is it also possible to bind classes like => AbstractClass::class => SpecificClass::class
         // Check the test _BindingInterfacesWithDependenciesAndGlobalServices_ BUT
         // be aware this way is not possible if the class has dependencies that cannot be resolved automatically!
     }
-
-    private function usingAbstractFromAnonymousClass(): AbstractFromAnonymousClass
-    {
-        return new class() extends AbstractFromAnonymousClass {
-            public function getClassName(): string
-            {
-                return AbstractFromAnonymousClass::class;
-            }
-        };
-    }
-
-    private function usingAbstractFromCallable(): callable
-    {
-        return static fn () => new class() extends AbstractFromCallable {
-            public function getClassName(): string
-            {
-                return AbstractFromCallable::class;
-            }
-        };
-    }
-
-    private function usingInterfaceFromAnonymousClass(): InterfaceFromAnonymousClass
-    {
-        return new class() implements InterfaceFromAnonymousClass {
-            public function getClassName(): string
-            {
-                return InterfaceFromAnonymousClass::class;
-            }
-        };
-    }
-
-    private function usingInterfaceFromCallable(): callable
-    {
-        return static fn () => new class() implements InterfaceFromCallable {
-            public function getClassName(): string
-            {
-                return InterfaceFromCallable::class;
-            }
-        };
-    }
-};
+);

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Gacela\Framework\AbstractConfigGacela;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
+use Gacela\Framework\Setup\SetupGacela;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\CorrectCompanyGenerator;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\IncorrectCompanyGenerator;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\GreeterGeneratorInterface;
@@ -16,13 +16,14 @@ use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalCon
  * - 2: Let Gacela resolve in the factory the mapping from `GreeterGeneratorInterface` to `CorrectCompanyGenerator`
  *      AND auto-resolve the class `CustomNameGenerator` from the `CorrectCompanyGenerator` constructor.
  */
-return static fn () => new class() extends AbstractConfigGacela {
-    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
-    {
+return static fn () => (new SetupGacela())
+    ->setMappingInterfaces(static function (
+        MappingInterfacesBuilder $mappingInterfacesBuilder,
+        array $globalServices
+    ): void {
         $mappingInterfacesBuilder->bind(GreeterGeneratorInterface::class, IncorrectCompanyGenerator::class);
 
         if ('yes!' === $globalServices['isWorking?']) {
             $mappingInterfacesBuilder->bind(GreeterGeneratorInterface::class, CorrectCompanyGenerator::class);
         }
-    }
-};
+    });

--- a/tests/Feature/Framework/UsingConfigTypePhp/gacela.php
+++ b/tests/Feature/Framework/UsingConfigTypePhp/gacela.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-use Gacela\Framework\AbstractConfigGacela;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Setup\SetupGacela;
 
-return static fn () => new class() extends AbstractConfigGacela {
-    public function config(ConfigBuilder $configBuilder): void
-    {
+return static fn () => (new SetupGacela())->setConfig(
+    static function (ConfigBuilder $configBuilder): void {
         $configBuilder->add('config/*.php', 'config/local.php');
     }
-};
+);

--- a/tests/Feature/Framework/UsingConfigTypePhp/gacela.php
+++ b/tests/Feature/Framework/UsingConfigTypePhp/gacela.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Setup\SetupGacela;
 
-return static fn () => (new SetupGacela())->setConfig(
-    static function (ConfigBuilder $configBuilder): void {
-        $configBuilder->add('config/*.php', 'config/local.php');
-    }
-);
+return static fn () => (new SetupGacela())
+    ->setConfig(
+        static function (ConfigBuilder $configBuilder): void {
+            $configBuilder->add('config/*.php', 'config/local.php');
+        }
+    );

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/gacela.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/gacela.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes;
 
-use Gacela\Framework\AbstractConfigGacela;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Setup\SetupGacela;
 
-return static fn () => new class() extends AbstractConfigGacela {
-    public function suffixTypes(SuffixTypesBuilder $suffixTypesBuilder): void
-    {
-        $suffixTypesBuilder
-            ->addFactory('FactoryModuleA')
-            ->addFactory('FactoryModuleB')
-            ->addConfig('ConfModuleA')
-            ->addConfig('ConfModuleB')
-            ->addDependencyProvider('DepProModuleA')
-            ->addDependencyProvider('DepProModuleB');
-    }
-};
+return static fn () => (new SetupGacela())
+    ->setSuffixTypes(
+        static function (SuffixTypesBuilder $suffixTypesBuilder): void {
+            $suffixTypesBuilder
+                ->addFactory('FactoryModuleA')
+                ->addFactory('FactoryModuleB')
+                ->addConfig('ConfModuleA')
+                ->addConfig('ConfModuleB')
+                ->addDependencyProvider('DepProModuleA')
+                ->addDependencyProvider('DepProModuleB');
+        }
+    );

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/FeatureTest.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/FeatureTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingDeprecatedAbstractConfigGacela;
+
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__);
+    }
+
+    public function test_config_php_files(): void
+    {
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'config' => 1,
+                'override' => 2,
+                'local' => 3,
+                'override_from_local' => 4,
+            ],
+            $facade->doSomething()
+        );
+    }
+}

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/LocalConfig/Config.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/LocalConfig/Config.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingDeprecatedAbstractConfigGacela\LocalConfig;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+    public function getArrayConfig(): array
+    {
+        return [
+            'config' => (int) $this->get('config_key'),
+            'override' => (int) $this->get('override_key'),
+            'local' => (int) $this->get('local_key'),
+            'override_from_local' => (int) $this->get('override_key_from_local'),
+        ];
+    }
+}

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/LocalConfig/Facade.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/LocalConfig/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingDeprecatedAbstractConfigGacela\LocalConfig;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function doSomething(): array
+    {
+        return $this->getFactory()->getArrayConfig();
+    }
+}

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/LocalConfig/Factory.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/LocalConfig/Factory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingDeprecatedAbstractConfigGacela\LocalConfig;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method Config getConfig()
+ */
+final class Factory extends AbstractFactory
+{
+    public function getArrayConfig(): array
+    {
+        return $this->getConfig()->getArrayConfig();
+    }
+}

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/.env.omit
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/.env.omit
@@ -1,0 +1,3 @@
+# I am not a PHP file. I will be omitted.
+config=88888
+override=99999

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/default.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/default.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config_key' => 1,
+    'override_key' => 1,
+    'local_key' => 1,
+];

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/local.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/local.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+return new class() implements JsonSerializable {
+    public function jsonSerialize(): array
+    {
+        return [
+            'local_key' => 3,
+            'override_key_from_local' => 4,
+        ];
+    }
+};

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/omit.yml
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/omit.yml
@@ -1,0 +1,3 @@
+# I am not a PHP file. I will be omitted.
+config: 88888
+override: 99999

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/override.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/config/override.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'override_key' => 2,
+    'override_key_from_local' => 2,
+];

--- a/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/gacela.php
+++ b/tests/Feature/Framework/UsingDeprecatedAbstractConfigGacela/gacela.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\AbstractConfigGacela;
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+
+return static fn () => new class() extends AbstractConfigGacela {
+    public function config(ConfigBuilder $configBuilder): void
+    {
+        $configBuilder->add('config/*.php', 'config/local.php');
+    }
+};

--- a/tests/Unit/Framework/Setup/SetupGacelaFactoryTest.php
+++ b/tests/Unit/Framework/Setup/SetupGacelaFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Setup;
+
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Setup\SetupGacela;
+use Gacela\Framework\Setup\SetupGacelaFactory;
+use GacelaTest\Fixtures\CustomClass;
+use GacelaTest\Fixtures\CustomInterface;
+use PHPUnit\Framework\TestCase;
+
+final class SetupGacelaFactoryTest extends TestCase
+{
+    public function test_empty_array(): void
+    {
+        $actual = SetupGacelaFactory::fromArray([]);
+        $expected = new SetupGacela();
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_config(): void
+    {
+        $callable = static function (ConfigBuilder $builder): void {
+            $builder->add('path', 'pathLocal');
+        };
+
+        $actual = SetupGacelaFactory::fromArray([
+            Gacela::CONFIG => $callable,
+        ]);
+
+        $expected = (new SetupGacela())->setConfig($callable);
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_mapping_interfaces(): void
+    {
+        $callable = static function (MappingInterfacesBuilder $builder): void {
+            $builder->bind(CustomInterface::class, CustomClass::class);
+        };
+
+        $actual = SetupGacelaFactory::fromArray([
+            Gacela::MAPPING_INTERFACES => $callable,
+        ]);
+
+        $expected = (new SetupGacela())->setMappingInterfaces($callable);
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_suffix_types(): void
+    {
+        $callable = static function (SuffixTypesBuilder $builder): void {
+            $builder->addFactory('F')->addConfig('C')->addDependencyProvider('DP');
+        };
+
+        $actual = SetupGacelaFactory::fromArray([
+            Gacela::SUFFIX_TYPES => $callable,
+        ]);
+
+        $expected = (new SetupGacela())->setSuffixTypes($callable);
+
+        self::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
## 📚  Description

The current logic that it's used by `Gacela::bootstrap()` and `gacela.php` it's similar but different... The goal is to normalise these two places in order to facilitate its usage and experience.

## 🔖 Changes

- Deprecate `AbstractConfigGacela`, in favor of `SetupGacela`

#### Current gacela.php style

```php
return static fn () => new class() extends AbstractConfigGacela {
    public function config(ConfigBuilder $configBuilder): void
    {
        $configBuilder->add('config/*.php', 'config/local.php');
    }
};
```

#### New style
```php
return static fn () => (new SetupGacela())
    ->setConfig(
        static function (ConfigBuilder $configBuilder): void {
            $configBuilder->add('config/*.php', 'config/local.php');
        }
    );

```