### PR TITLE
Rename the concept of GlobalServices to ExternalServices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Unreleased
+
+- Rename the concept of `GlobalServices` by `ExternalServices`.
+  - Deprecated the `SetupGacelaInterface::setGlobalServices()` method.
+
 ### 0.15.0
 #### 2022-03-26
 

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -67,7 +67,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
     private function createMappingInterfacesBuilder(SetupGacelaInterface $setupGacela): MappingInterfacesBuilder
     {
         $mappingInterfacesBuilder = new MappingInterfacesBuilder();
-        $setupGacela->mappingInterfaces($mappingInterfacesBuilder, $this->setup->globalServices());
+        $setupGacela->mappingInterfaces($mappingInterfacesBuilder, $this->setup->externalServices());
 
         return $mappingInterfacesBuilder;
     }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -14,7 +14,7 @@ final class Gacela
     public const CONFIG = 'config';
     public const MAPPING_INTERFACES = 'mapping-interfaces';
     public const SUFFIX_TYPES = 'suffix-types';
-    public const GLOBAL_SERVICES = 'global-services';
+    public const EXTERNAL_SERVICES = 'external-services';
 
     /**
      * Define the entry point of Gacela.
@@ -43,7 +43,7 @@ final class Gacela
              *     config?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder):void,
              *     mapping-interfaces?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder, array<string,mixed>):void,
              *     suffix-types?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder):void,
-             *     global-services?: array<string,mixed>,
+             *     external-services?: array<string,mixed>,
              * } $setup
              */
             return SetupGacelaFactory::fromArray($setup);

--- a/src/Framework/Setup/AbstractSetupGacela.php
+++ b/src/Framework/Setup/AbstractSetupGacela.php
@@ -42,7 +42,7 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     }
 
     /**
-     * @deprecated
+     * @deprecated in favor of `externalServices()`
      *
      * @return array<string,mixed>
      */

--- a/src/Framework/Setup/AbstractSetupGacela.php
+++ b/src/Framework/Setup/AbstractSetupGacela.php
@@ -20,9 +20,9 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
-     * @param array<string,mixed> $globalServices
+     * @param array<string,mixed> $externalServices
      */
-    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
+    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void
     {
     }
 
@@ -36,8 +36,18 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     /**
      * @return array<string,mixed>
      */
-    public function globalServices(): array
+    public function externalServices(): array
     {
         return [];
+    }
+
+    /**
+     * @deprecated
+     *
+     * @return array<string,mixed>
+     */
+    public function globalServices(): array
+    {
+        return $this->externalServices();
     }
 }

--- a/src/Framework/Setup/SetupGacela.php
+++ b/src/Framework/Setup/SetupGacela.php
@@ -89,7 +89,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @deprecated Use `externalServices()` instead
+     * @deprecated in favor of `externalServices()`
      *
      * @return array<string,mixed>
      */

--- a/src/Framework/Setup/SetupGacela.php
+++ b/src/Framework/Setup/SetupGacela.php
@@ -20,7 +20,7 @@ final class SetupGacela extends AbstractSetupGacela
     private $suffixTypesFn = null;
 
     /** @var array<string,mixed> */
-    private array $globalServices = [];
+    private array $externalServices = [];
 
     /**
      * @param callable(ConfigBuilder):void $callable
@@ -50,13 +50,13 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
-     * @param array<string,mixed> $globalServices
+     * @param array<string,mixed> $externalServices
      */
-    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void
+    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void
     {
         $this->mappingInterfacesFn && ($this->mappingInterfacesFn)(
             $mappingInterfacesBuilder,
-            array_merge($this->globalServices, $globalServices)
+            array_merge($this->externalServices, $externalServices)
         );
     }
 
@@ -81,18 +81,28 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param array<string,mixed> $array
      */
-    public function setGlobalServices(array $array): self
+    public function setExternalServices(array $array): self
     {
-        $this->globalServices = $array;
+        $this->externalServices = $array;
 
         return $this;
     }
 
     /**
+     * @deprecated Use `externalServices()` instead
+     *
      * @return array<string,mixed>
      */
     public function globalServices(): array
     {
-        return $this->globalServices;
+        return $this->externalServices();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function externalServices(): array
+    {
+        return $this->externalServices;
     }
 }

--- a/src/Framework/Setup/SetupGacelaFactory.php
+++ b/src/Framework/Setup/SetupGacelaFactory.php
@@ -13,23 +13,23 @@ final class SetupGacelaFactory
      *     config?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder):void,
      *     mapping-interfaces?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder, array<string,mixed>):void,
      *     suffix-types?: callable(\Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder):void,
-     *     global-services?: array<string,mixed>,
-     * } $globalServices
+     *     external-services?: array<string,mixed>,
+     * } $externalServices
      */
-    public static function fromArray(array $globalServices): SetupGacelaInterface
+    public static function fromArray(array $externalServices): SetupGacelaInterface
     {
         $setup = new SetupGacela();
-        if (isset($globalServices[Gacela::CONFIG])) {
-            $setup->setConfig($globalServices[Gacela::CONFIG]);
+        if (isset($externalServices[Gacela::CONFIG])) {
+            $setup->setConfig($externalServices[Gacela::CONFIG]);
         }
-        if (isset($globalServices[Gacela::MAPPING_INTERFACES])) {
-            $setup->setMappingInterfaces($globalServices[Gacela::MAPPING_INTERFACES]);
+        if (isset($externalServices[Gacela::MAPPING_INTERFACES])) {
+            $setup->setMappingInterfaces($externalServices[Gacela::MAPPING_INTERFACES]);
         }
-        if (isset($globalServices[Gacela::SUFFIX_TYPES])) {
-            $setup->setSuffixTypes($globalServices[Gacela::SUFFIX_TYPES]);
+        if (isset($externalServices[Gacela::SUFFIX_TYPES])) {
+            $setup->setSuffixTypes($externalServices[Gacela::SUFFIX_TYPES]);
         }
-        if (isset($globalServices[Gacela::GLOBAL_SERVICES])) {
-            $setup->setGlobalServices($globalServices[Gacela::GLOBAL_SERVICES]);
+        if (isset($externalServices[Gacela::EXTERNAL_SERVICES])) {
+            $setup->setExternalServices($externalServices[Gacela::EXTERNAL_SERVICES]);
         }
 
         return $setup;

--- a/src/Framework/Setup/SetupGacelaInterface.php
+++ b/src/Framework/Setup/SetupGacelaInterface.php
@@ -18,9 +18,9 @@ interface SetupGacelaInterface
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
-     * @param array<string,mixed> $globalServices
+     * @param array<string,mixed> $externalServices
      */
-    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void;
+    public function mappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void;
 
     /**
      * Allow overriding gacela resolvable types.
@@ -29,6 +29,13 @@ interface SetupGacelaInterface
 
     /**
      * Define global services that can be accessible via the mapping interfaces.
+     *
+     * @return array<string,mixed>
+     */
+    public function externalServices(): array;
+
+    /**
+     * @deprecated Use `externalServices()` instead
      *
      * @return array<string,mixed>
      */

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
@@ -12,7 +12,7 @@ use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Infrastructure\ConcreteClass;
 
 return static fn () => (new SetupGacela())->setMappingInterfaces(
-    static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void {
+    static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
         // Resolve an abstract class from a concrete instance of a class
         $mappingInterfacesBuilder->bind(AbstractClass::class, new ConcreteClass(true, 'string', 1, 1.2, ['array']));
 
@@ -57,7 +57,7 @@ return static fn () => (new SetupGacela())->setMappingInterfaces(
             }
         );
         // Is it also possible to bind classes like => AbstractClass::class => SpecificClass::class
-        // Check the test _BindingInterfacesWithDependenciesAndGlobalServices_ BUT
-        // be aware this way is not possible if the class has dependencies that cannot be resolved automatically!
+        // Check the test _BindingInterfacesWithInnerDependencies_ BUT be aware this way is not possible
+        // if the class has dependencies that cannot be resolved automatically!
     }
 );

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
@@ -12,7 +12,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, [
-            Gacela::GLOBAL_SERVICES => ['isWorking?' => 'yes!'],
+            Gacela::EXTERNAL_SERVICES => ['isWorking?' => 'yes!'],
         ]);
     }
 

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
@@ -11,7 +11,7 @@ use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalCon
 /**
  * This Feature-test does two things:
  *
- * - 1: Check the "globalService" variable was properly defined in the 'Gacela::bootstrap()' with the key `isWorking?`.
+ * - 1: Check the "externalService" variable was properly defined in the 'Gacela::bootstrap()' with the key `isWorking?`.
  *
  * - 2: Let Gacela resolve in the factory the mapping from `GreeterGeneratorInterface` to `CorrectCompanyGenerator`
  *      AND auto-resolve the class `CustomNameGenerator` from the `CorrectCompanyGenerator` constructor.
@@ -19,11 +19,11 @@ use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalCon
 return static fn () => (new SetupGacela())
     ->setMappingInterfaces(static function (
         MappingInterfacesBuilder $mappingInterfacesBuilder,
-        array $globalServices
+        array $externalServices
     ): void {
         $mappingInterfacesBuilder->bind(GreeterGeneratorInterface::class, IncorrectCompanyGenerator::class);
 
-        if ($globalServices['isWorking?'] === 'yes!') {
+        if ($externalServices['isWorking?'] === 'yes!') {
             $mappingInterfacesBuilder->bind(GreeterGeneratorInterface::class, CorrectCompanyGenerator::class);
         }
     });

--- a/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
@@ -60,12 +60,12 @@ final class ConfigFactoryTest extends TestCase
             ->setConfig(static function (ConfigBuilder $builder): void {
                 $builder->add('config/from-bootstrap.php');
             })
-            ->setGlobalServices(['CustomClassFromBootstrap' => CustomClass::class])
+            ->setExternalServices(['CustomClassFromBootstrap' => CustomClass::class])
             ->setMappingInterfaces(
-                static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void {
+                static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
                     $mappingInterfacesBuilder->bind(
                         CustomInterface::class,
-                        $globalServices['CustomClassFromBootstrap']
+                        $externalServices['CustomClassFromBootstrap']
                     );
                 },
             )
@@ -101,10 +101,10 @@ final class ConfigFactoryTest extends TestCase
             ->setConfig(static function (ConfigBuilder $builder): void {
                 $builder->add('config/from-bootstrap.php');
             })
-            ->setGlobalServices(['CustomClassFromBootstrap' => CustomClass::class])
+            ->setExternalServices(['CustomClassFromBootstrap' => CustomClass::class])
             ->setMappingInterfaces(
-                static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void {
-                    $mappingInterfacesBuilder->bind(AbstractCustom::class, $globalServices['CustomClassFromBootstrap']);
+                static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
+                    $mappingInterfacesBuilder->bind(AbstractCustom::class, $externalServices['CustomClassFromBootstrap']);
                 },
             )
             ->setSuffixTypes(static function (SuffixTypesBuilder $suffixTypesBuilder): void {

--- a/tests/Integration/Framework/Config/ConfigFactory/WithGacelaFile/gacela.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/WithGacelaFile/gacela.php
@@ -13,10 +13,10 @@ return static fn () => (new SetupGacela())
     ->setConfig(static function (ConfigBuilder $builder): void {
         $builder->add('config/from-gacela-file.php');
     })
-    ->setGlobalServices(['CustomClassFromGacelaFile' => CustomClass::class])
+    ->setExternalServices(['CustomClassFromGacelaFile' => CustomClass::class])
     ->setMappingInterfaces(
-        static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void {
-            $mappingInterfacesBuilder->bind(CustomInterface::class, $globalServices['CustomClassFromGacelaFile']);
+        static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
+            $mappingInterfacesBuilder->bind(CustomInterface::class, $externalServices['CustomClassFromGacelaFile']);
         },
     )
     ->setSuffixTypes(static function (SuffixTypesBuilder $suffixTypesBuilder): void {

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -33,7 +33,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     public function test_no_special_global_services_then_default(): void
     {
         $setupGacela = $this->createStub(SetupGacelaInterface::class);
-        $setupGacela->method('globalServices')->willReturn([
+        $setupGacela->method('externalServices')->willReturn([
             'randomKey' => 'randomValue',
         ]);
 
@@ -61,14 +61,14 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
         $factory = new GacelaConfigFromBootstrapFactory(
             SetupGacelaFactory::fromArray(
                 [
-                    Gacela::GLOBAL_SERVICES => [
-                        'globalServiceKey' => 'globalServiceValue',
+                    Gacela::EXTERNAL_SERVICES => [
+                        'externalServiceKey' => 'externalServiceValue',
                     ],
                     Gacela::MAPPING_INTERFACES => static function (
                         MappingInterfacesBuilder $interfacesBuilder,
-                        array $globalServices
+                        array $externalServices
                     ): void {
-                        self::assertSame($globalServices['globalServiceKey'], 'globalServiceValue');
+                        self::assertSame($externalServices['externalServiceKey'], 'externalServiceValue');
                         $interfacesBuilder->bind(CustomInterface::class, CustomClass::class);
                     },
                 ]

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -94,10 +94,10 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo = $this->createStub(FileIoInterface::class);
         $fileIo->method('include')->willReturn(
             static fn () => (new SetupGacela())
-                ->setGlobalServices(['globalServiceKey' => 'globalServiceValue'])
+                ->setExternalServices(['externalServiceKey' => 'externalServiceValue'])
                 ->setMappingInterfaces(
-                    static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $globalServices): void {
-                        self::assertSame('globalServiceValue', $globalServices['globalServiceKey']);
+                    static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
+                        self::assertSame('externalServiceValue', $externalServices['externalServiceKey']);
                         $mappingInterfacesBuilder->bind(CustomInterface::class, new CustomClass());
                         $mappingInterfacesBuilder->bind(CustomInterface::class, CustomClass::class);
                     },


### PR DESCRIPTION
## 📚 Description

[Issue link](https://github.com/gacela-project/gacela/issues/131)

The origin of the `globalService` concept started as a "bag" where we define all `Gacela` framework configuration, over the time, we move this configuration/setup to specific callables, but the name was still there and losing meaning.

At this point, the `globalService` key in the setup was only for link external services from the exterior to the Gacela framework, in this scenario, the idea of `externalService` makes much more sense.

## 🔖 Changes

- Rename the `globalService` method/properties to `externalService`
- Deprecate the original `globalService` method from the setup
