### PR TITLE
Split in methods the AnonymousGlobalsBench class

### DIFF
--- a/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
@@ -20,10 +20,10 @@ final class AnonymousGlobalsBench
 
     public function setUp(): void
     {
-        $this->abstractConfig();
-        $this->abstractDependencyProvider();
-        $this->abstractFactory();
-        $this->abstractFacade();
+        $this->setupAbstractConfig();
+        $this->setupAbstractDependencyProvider();
+        $this->setupAbstractFactory();
+        $this->setupAbstractFacade();
     }
 
     public function bench_class_resolving(): void
@@ -32,7 +32,7 @@ final class AnonymousGlobalsBench
         $this->facade->getValueFromDependencyProvider();
     }
 
-    private function abstractConfig(): void
+    private function setupAbstractConfig(): void
     {
         AnonymousGlobal::addGlobal(
             $this,
@@ -45,7 +45,7 @@ final class AnonymousGlobalsBench
         );
     }
 
-    private function abstractDependencyProvider(): void
+    private function setupAbstractDependencyProvider(): void
     {
         AnonymousGlobal::addGlobal(
             $this,
@@ -58,7 +58,7 @@ final class AnonymousGlobalsBench
         );
     }
 
-    private function abstractFactory(): void
+    private function setupAbstractFactory(): void
     {
         AnonymousGlobal::addGlobal(
             $this,
@@ -98,7 +98,7 @@ final class AnonymousGlobalsBench
         );
     }
 
-    private function abstractFacade(): void
+    private function setupAbstractFacade(): void
     {
         $this->facade = new class() extends AbstractFacade {
             public function getConfigValues(): array

--- a/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
@@ -20,6 +20,20 @@ final class AnonymousGlobalsBench
 
     public function setUp(): void
     {
+        $this->abstractConfig();
+        $this->abstractDependencyProvider();
+        $this->abstractFactory();
+        $this->abstractFacade();
+    }
+
+    public function bench_class_resolving(): void
+    {
+        $this->facade->getConfigValues();
+        $this->facade->getValueFromDependencyProvider();
+    }
+
+    private function abstractConfig(): void
+    {
         AnonymousGlobal::addGlobal(
             $this,
             new class() extends AbstractConfig {
@@ -29,7 +43,10 @@ final class AnonymousGlobalsBench
                 }
             }
         );
+    }
 
+    private function abstractDependencyProvider(): void
+    {
         AnonymousGlobal::addGlobal(
             $this,
             new class() extends AbstractDependencyProvider {
@@ -39,7 +56,10 @@ final class AnonymousGlobalsBench
                 }
             }
         );
+    }
 
+    private function abstractFactory(): void
+    {
         AnonymousGlobal::addGlobal(
             $this,
             new class() extends AbstractFactory {
@@ -76,7 +96,10 @@ final class AnonymousGlobalsBench
                 }
             }
         );
+    }
 
+    private function abstractFacade(): void
+    {
         $this->facade = new class() extends AbstractFacade {
             public function getConfigValues(): array
             {
@@ -92,11 +115,5 @@ final class AnonymousGlobalsBench
                     ->getValueFromDependencyProvider();
             }
         };
-    }
-
-    public function bench_class_resolving(): void
-    {
-        $this->facade->getConfigValues();
-        $this->facade->getValueFromDependencyProvider();
     }
 }


### PR DESCRIPTION
## 📚 Description

Split the `AnonymousGlobalsBench` class, doing that, we should achieve a better score in Scrutinizer (currently this class' score is a **B**)

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/6381924/160844987-e399568d-04c0-4649-b954-d05672921b30.png">

https://scrutinizer-ci.com/g/gacela-project/gacela/code-structure/master/operation/anonymous//tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php%244::setUp
