### PR TITLE
Make the Facade accesible from module-internal subfolders

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -24,16 +24,16 @@ abstract class AbstractClassResolver
     private ?InstanceCreator $instanceCreator = null;
 
     /**
-     * @param object|class-string $callerClass
+     * @param object|class-string $caller
      */
-    abstract public function resolve($callerClass): ?object;
+    abstract public function resolve($caller): ?object;
 
     /**
-     * @param object|class-string $callerClass
+     * @param object|class-string $caller
      */
-    public function doResolve($callerClass): ?object
+    public function doResolve($caller): ?object
     {
-        $classInfo = ClassInfo::from($callerClass, $this->getResolvableType());
+        $classInfo = ClassInfo::from($caller, $this->getResolvableType());
 
         $cacheKey = $classInfo->getCacheKey();
 

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\ClassResolver\InstanceCreator\InstanceCreator;
 use Gacela\Framework\Config;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+
 use function is_array;
 
 abstract class AbstractClassResolver
@@ -22,11 +23,18 @@ abstract class AbstractClassResolver
 
     private ?InstanceCreator $instanceCreator = null;
 
-    abstract public function resolve(object $callerClass): ?object;
+    /**
+     * @param object|class-string $callerClass
+     */
+    abstract public function resolve($callerClass): ?object;
 
-    public function doResolve(object $callerClass): ?object
+    /**
+     * @param object|class-string $callerClass
+     */
+    public function doResolve($callerClass): ?object
     {
-        $classInfo = ClassInfo::fromObject($callerClass, $this->getResolvableType());
+        $classInfo = ClassInfo::from($callerClass, $this->getResolvableType());
+
         $cacheKey = $classInfo->getCacheKey();
 
         $resolvedClass = $this->resolveCached($cacheKey);

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -68,14 +68,14 @@ final class ClassInfo
         );
     }
 
-    private static function fromObject(object $callerObject, string $resolvableType = ''): self
+    private static function fromObject(object $callerObject, string $resolvableType): self
     {
         $callerClass = get_class($callerObject);
 
         return self::fromString($callerClass, $resolvableType);
     }
 
-    private static function fromString(string $callerClass, string $resolvableType = ''): self
+    private static function fromString(string $callerClass, string $resolvableType): self
     {
         if (isset(self::$callerClassCache[$callerClass][$resolvableType])) {
             return self::$callerClassCache[$callerClass][$resolvableType];

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework\ClassResolver;
 use function array_slice;
 use function count;
 use function get_class;
+use function is_object;
 use function is_string;
 
 final class ClassInfo
@@ -30,38 +31,16 @@ final class ClassInfo
         $this->cacheKey = $cacheKey;
     }
 
-    public static function fromObject(object $callerObject, string $resolvableType = ''): self
+    /**
+     * @param object|class-string $caller
+     */
+    public static function from($caller, string $resolvableType = ''): self
     {
-        $callerClass = get_class($callerObject);
-
-        if (isset(self::$callerClassCache[$callerClass][$resolvableType])) {
-            return self::$callerClassCache[$callerClass][$resolvableType];
-        }
-        /** @var string[] $callerClassParts */
-        $callerClassParts = explode('\\', ltrim($callerClass, '\\'));
-        $lastCallerClassPart = end($callerClassParts);
-        $filepath = is_string($lastCallerClassPart) ? $lastCallerClassPart : '';
-        $filename = self::normalizeFilename($filepath);
-
-        if (strpos($filepath, 'anonymous') !== false) {
-            $callerClassParts = [
-                self::MODULE_NAME_ANONYMOUS . '\\' . $filename,
-                $filepath,
-            ];
+        if (is_object($caller)) {
+            return self::fromObject($caller, $resolvableType);
         }
 
-        $callerNamespace = implode('\\', array_slice($callerClassParts, 0, count($callerClassParts) - 1));
-        $callerModuleName = $callerClassParts[count($callerClassParts) - 2] ?? '';
-        $cacheKey = GlobalKey::fromClassName(sprintf(
-            '\\%s\\%s',
-            $callerNamespace,
-            $resolvableType
-        ));
-
-        $self = new self($callerNamespace, $callerModuleName, $cacheKey);
-        self::$callerClassCache[$callerClass][$resolvableType] = $self;
-
-        return $self;
+        return self::fromString($caller, $resolvableType);
     }
 
     public function getCacheKey(): string
@@ -87,6 +66,43 @@ final class ClassInfo
             $this->callerModuleName,
             $this->callerNamespace,
         );
+    }
+
+    private static function fromObject(object $callerObject, string $resolvableType = ''): self
+    {
+        $callerClass = get_class($callerObject);
+
+        return self::fromString($callerClass, $resolvableType);
+    }
+
+    private static function fromString(string $callerClass, string $resolvableType = ''): self
+    {
+        if (isset(self::$callerClassCache[$callerClass][$resolvableType])) {
+            return self::$callerClassCache[$callerClass][$resolvableType];
+        }
+        /** @var string[] $callerClassParts */
+        $callerClassParts = explode('\\', ltrim($callerClass, '\\'));
+        $lastCallerClassPart = end($callerClassParts);
+        $filepath = is_string($lastCallerClassPart) ? $lastCallerClassPart : '';
+        $filename = self::normalizeFilename($filepath);
+
+        if (strpos($filepath, 'anonymous') !== false) {
+            $callerClassParts = [
+                self::MODULE_NAME_ANONYMOUS . '\\' . $filename,
+                $filepath,
+            ];
+        }
+
+        $callerNamespace = implode('\\', array_slice($callerClassParts, 0, count($callerClassParts) - 1));
+        $callerModuleName = $callerClassParts[count($callerClassParts) - 2] ?? '';
+        $cacheKey = GlobalKey::fromClassName(
+            sprintf('\\%s\\%s', $callerNamespace, $resolvableType)
+        );
+
+        $self = new self($callerNamespace, $callerModuleName, $cacheKey);
+        self::$callerClassCache[$callerClass][$resolvableType] = $self;
+
+        return $self;
     }
 
     private static function normalizeFilename(string $filepath): string

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -8,9 +8,12 @@ use Gacela\Framework\Exception\Backtrace;
 
 trait ClassResolverExceptionTrait
 {
-    private function buildMessage(object $callerClass, string $resolvableType): string
+    /**
+     * @param object|class-string $caller
+     */
+    private function buildMessage($caller, string $resolvableType): string
     {
-        $callerClassInfo = ClassInfo::fromObject($callerClass, $resolvableType);
+        $callerClassInfo = ClassInfo::from($caller, $resolvableType);
 
         $message = 'ClassResolver Exception' . PHP_EOL;
         $message .= sprintf(

--- a/src/Framework/ClassResolver/Config/ConfigNotFoundException.php
+++ b/src/Framework/ClassResolver/Config/ConfigNotFoundException.php
@@ -11,8 +11,11 @@ final class ConfigNotFoundException extends Exception
 {
     use ClassResolverExceptionTrait;
 
-    public function __construct(object $callerClass)
+    /**
+     * @param object|class-string $caller
+     */
+    public function __construct($caller)
     {
-        parent::__construct($this->buildMessage($callerClass, 'Config'));
+        parent::__construct($this->buildMessage($caller, 'Config'));
     }
 }

--- a/src/Framework/ClassResolver/Config/ConfigResolver.php
+++ b/src/Framework/ClassResolver/Config/ConfigResolver.php
@@ -10,17 +10,17 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class ConfigResolver extends AbstractClassResolver
 {
     /**
-     * @param object|class-string $callerClass
+     * @param object|class-string $caller
      *
      * @throws ConfigNotFoundException
      */
-    public function resolve($callerClass): AbstractConfig
+    public function resolve($caller): AbstractConfig
     {
         /** @var ?AbstractConfig $resolved */
-        $resolved = $this->doResolve($callerClass);
+        $resolved = $this->doResolve($caller);
 
         if ($resolved === null) {
-            throw new ConfigNotFoundException($callerClass);
+            throw new ConfigNotFoundException($caller);
         }
 
         return $resolved;

--- a/src/Framework/ClassResolver/Config/ConfigResolver.php
+++ b/src/Framework/ClassResolver/Config/ConfigResolver.php
@@ -10,9 +10,11 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class ConfigResolver extends AbstractClassResolver
 {
     /**
+     * @param object|class-string $callerClass
+     *
      * @throws ConfigNotFoundException
      */
-    public function resolve(object $callerClass): AbstractConfig
+    public function resolve($callerClass): AbstractConfig
     {
         /** @var ?AbstractConfig $resolved */
         $resolved = $this->doResolve($callerClass);

--- a/src/Framework/ClassResolver/DependencyProvider/DependencyProviderNotFoundException.php
+++ b/src/Framework/ClassResolver/DependencyProvider/DependencyProviderNotFoundException.php
@@ -11,8 +11,11 @@ final class DependencyProviderNotFoundException extends Exception
 {
     use ClassResolverExceptionTrait;
 
-    public function __construct(object $callerClass)
+    /**
+     * @param object|class-string $caller
+     */
+    public function __construct($caller)
     {
-        parent::__construct($this->buildMessage($callerClass, 'DependencyProvider'));
+        parent::__construct($this->buildMessage($caller, 'DependencyProvider'));
     }
 }

--- a/src/Framework/ClassResolver/DependencyProvider/DependencyProviderResolver.php
+++ b/src/Framework/ClassResolver/DependencyProvider/DependencyProviderResolver.php
@@ -10,9 +10,11 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class DependencyProviderResolver extends AbstractClassResolver
 {
     /**
+     * @param object|class-string $callerClass
+     *
      * @throws DependencyProviderNotFoundException
      */
-    public function resolve(object $callerClass): AbstractDependencyProvider
+    public function resolve($callerClass): AbstractDependencyProvider
     {
         /** @var ?AbstractDependencyProvider $resolved */
         $resolved = $this->doResolve($callerClass);

--- a/src/Framework/ClassResolver/DependencyProvider/DependencyProviderResolver.php
+++ b/src/Framework/ClassResolver/DependencyProvider/DependencyProviderResolver.php
@@ -10,17 +10,17 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class DependencyProviderResolver extends AbstractClassResolver
 {
     /**
-     * @param object|class-string $callerClass
+     * @param object|class-string $caller
      *
      * @throws DependencyProviderNotFoundException
      */
-    public function resolve($callerClass): AbstractDependencyProvider
+    public function resolve($caller): AbstractDependencyProvider
     {
         /** @var ?AbstractDependencyProvider $resolved */
-        $resolved = $this->doResolve($callerClass);
+        $resolved = $this->doResolve($caller);
 
         if ($resolved === null) {
-            throw new DependencyProviderNotFoundException($callerClass);
+            throw new DependencyProviderNotFoundException($caller);
         }
 
         return $resolved;

--- a/src/Framework/ClassResolver/Facade/FacadeNotFoundException.php
+++ b/src/Framework/ClassResolver/Facade/FacadeNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\Facade;
+
+use Exception;
+use Gacela\Framework\ClassResolver\ClassResolverExceptionTrait;
+
+final class FacadeNotFoundException extends Exception
+{
+    use ClassResolverExceptionTrait;
+
+    public function __construct(object $callerClass)
+    {
+        parent::__construct($this->buildMessage($callerClass, 'Facade'));
+    }
+}

--- a/src/Framework/ClassResolver/Facade/FacadeNotFoundException.php
+++ b/src/Framework/ClassResolver/Facade/FacadeNotFoundException.php
@@ -11,8 +11,11 @@ final class FacadeNotFoundException extends Exception
 {
     use ClassResolverExceptionTrait;
 
-    public function __construct(object $callerClass)
+    /**
+     * @param object|class-string $caller
+     */
+    public function __construct($caller)
     {
-        parent::__construct($this->buildMessage($callerClass, 'Facade'));
+        parent::__construct($this->buildMessage($caller, 'Facade'));
     }
 }

--- a/src/Framework/ClassResolver/Facade/FacadeResolver.php
+++ b/src/Framework/ClassResolver/Facade/FacadeResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\Facade;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ClassResolver\AbstractClassResolver;
+
+final class FacadeResolver extends AbstractClassResolver
+{
+    /**
+     * @throws FacadeNotFoundException
+     */
+    public function resolve(object $callerClass): AbstractFacade
+    {
+        /** @var ?AbstractFacade $resolved */
+        $resolved = $this->doResolve($callerClass);
+
+        if ($resolved === null) {
+            throw new FacadeNotFoundException($callerClass);
+        }
+
+        return $resolved;
+    }
+
+    protected function getResolvableType(): string
+    {
+        return 'Facade';
+    }
+}

--- a/src/Framework/ClassResolver/Facade/FacadeResolver.php
+++ b/src/Framework/ClassResolver/Facade/FacadeResolver.php
@@ -10,9 +10,11 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class FacadeResolver extends AbstractClassResolver
 {
     /**
+     * @param object|class-string $callerClass
+     *
      * @throws FacadeNotFoundException
      */
-    public function resolve(object $callerClass): AbstractFacade
+    public function resolve($callerClass): AbstractFacade
     {
         /** @var ?AbstractFacade $resolved */
         $resolved = $this->doResolve($callerClass);

--- a/src/Framework/ClassResolver/Facade/FacadeResolver.php
+++ b/src/Framework/ClassResolver/Facade/FacadeResolver.php
@@ -10,17 +10,17 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class FacadeResolver extends AbstractClassResolver
 {
     /**
-     * @param object|class-string $callerClass
+     * @param object|class-string $caller
      *
      * @throws FacadeNotFoundException
      */
-    public function resolve($callerClass): AbstractFacade
+    public function resolve($caller): AbstractFacade
     {
         /** @var ?AbstractFacade $resolved */
-        $resolved = $this->doResolve($callerClass);
+        $resolved = $this->doResolve($caller);
 
         if ($resolved === null) {
-            throw new FacadeNotFoundException($callerClass);
+            throw new FacadeNotFoundException($caller);
         }
 
         return $resolved;

--- a/src/Framework/ClassResolver/Factory/FactoryNotFoundException.php
+++ b/src/Framework/ClassResolver/Factory/FactoryNotFoundException.php
@@ -11,8 +11,11 @@ final class FactoryNotFoundException extends Exception
 {
     use ClassResolverExceptionTrait;
 
-    public function __construct(object $callerClass)
+    /**
+     * @param object|class-string $caller
+     */
+    public function __construct($caller)
     {
-        parent::__construct($this->buildMessage($callerClass, 'Factory'));
+        parent::__construct($this->buildMessage($caller, 'Factory'));
     }
 }

--- a/src/Framework/ClassResolver/Factory/FactoryResolver.php
+++ b/src/Framework/ClassResolver/Factory/FactoryResolver.php
@@ -10,9 +10,11 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class FactoryResolver extends AbstractClassResolver
 {
     /**
+     * @param object|class-string $callerClass
+     *
      * @throws FactoryNotFoundException
      */
-    public function resolve(object $callerClass): AbstractFactory
+    public function resolve($callerClass): AbstractFactory
     {
         /** @var ?AbstractFactory $resolved */
         $resolved = $this->doResolve($callerClass);

--- a/src/Framework/ClassResolver/Factory/FactoryResolver.php
+++ b/src/Framework/ClassResolver/Factory/FactoryResolver.php
@@ -10,17 +10,17 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 final class FactoryResolver extends AbstractClassResolver
 {
     /**
-     * @param object|class-string $callerClass
+     * @param object|class-string $caller
      *
      * @throws FactoryNotFoundException
      */
-    public function resolve($callerClass): AbstractFactory
+    public function resolve($caller): AbstractFactory
     {
         /** @var ?AbstractFactory $resolved */
-        $resolved = $this->doResolve($callerClass);
+        $resolved = $this->doResolve($caller);
 
         if ($resolved === null) {
-            throw new FactoryNotFoundException($callerClass);
+            throw new FactoryNotFoundException($caller);
         }
 
         return $resolved;

--- a/src/Framework/Container/Exception/ContainerKeyNotFoundException.php
+++ b/src/Framework/Container/Exception/ContainerKeyNotFoundException.php
@@ -10,11 +10,11 @@ use RuntimeException;
 final class ContainerKeyNotFoundException extends RuntimeException
 {
     /**
-     * @param object $callerClass
+     * @param object $caller
      */
-    public function __construct($callerClass, string $key)
+    public function __construct($caller, string $key)
     {
-        $classInfo = ClassInfo::fromObject($callerClass);
+        $classInfo = ClassInfo::from($caller);
 
         parent::__construct($this->buildMessage($classInfo, $key));
     }

--- a/src/Framework/FacadeResolverAwareTrait.php
+++ b/src/Framework/FacadeResolverAwareTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Gacela\Framework\ClassResolver\Facade\FacadeResolver;
-use function get_class;
 
 trait FacadeResolverAwareTrait
 {
@@ -14,8 +13,7 @@ trait FacadeResolverAwareTrait
     protected function getFacade(): AbstractFacade
     {
         if ($this->facade === null) {
-            $this->facade = (new FacadeResolver())
-                ->resolve($this->classLevelUpNamespace());
+            $this->facade = (new FacadeResolver())->resolve($this->facadeClass());
         }
 
         return $this->facade;
@@ -24,10 +22,5 @@ trait FacadeResolverAwareTrait
     /**
      * @return class-string
      */
-    private function classLevelUpNamespace(): string
-    {
-        $thisClass = get_class($this);
-
-        return substr($thisClass, 0, (int)strrpos($thisClass, '\\'));
-    }
+    abstract protected function facadeClass(): string;
 }

--- a/src/Framework/FacadeResolverAwareTrait.php
+++ b/src/Framework/FacadeResolverAwareTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework;
+
+use Gacela\Framework\ClassResolver\Facade\FacadeResolver;
+
+trait FacadeResolverAwareTrait
+{
+    private ?AbstractFacade $facade = null;
+
+    protected function getFacade(): AbstractFacade
+    {
+        if ($this->facade === null) {
+            $this->facade = (new FacadeResolver())->resolve($this);
+        }
+
+        return $this->facade;
+    }
+}

--- a/src/Framework/FacadeResolverAwareTrait.php
+++ b/src/Framework/FacadeResolverAwareTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Gacela\Framework\ClassResolver\Facade\FacadeResolver;
+use function get_class;
 
 trait FacadeResolverAwareTrait
 {
@@ -13,7 +14,10 @@ trait FacadeResolverAwareTrait
     protected function getFacade(): AbstractFacade
     {
         if ($this->facade === null) {
-            $this->facade = (new FacadeResolver())->resolve($this);
+            $thisClass = get_class($this);
+            /** @var class-string $classLevelUpNamespace */
+            $classLevelUpNamespace = substr($thisClass, 0, (int)strrpos($thisClass, '\\'));
+            $this->facade = (new FacadeResolver())->resolve($classLevelUpNamespace);
         }
 
         return $this->facade;

--- a/src/Framework/FacadeResolverAwareTrait.php
+++ b/src/Framework/FacadeResolverAwareTrait.php
@@ -14,12 +14,20 @@ trait FacadeResolverAwareTrait
     protected function getFacade(): AbstractFacade
     {
         if ($this->facade === null) {
-            $thisClass = get_class($this);
-            /** @var class-string $classLevelUpNamespace */
-            $classLevelUpNamespace = substr($thisClass, 0, (int)strrpos($thisClass, '\\'));
-            $this->facade = (new FacadeResolver())->resolve($classLevelUpNamespace);
+            $this->facade = (new FacadeResolver())
+                ->resolve($this->classLevelUpNamespace());
         }
 
         return $this->facade;
+    }
+
+    /**
+     * @return class-string
+     */
+    private function classLevelUpNamespace(): string
+    {
+        $thisClass = get_class($this);
+
+        return substr($thisClass, 0, (int)strrpos($thisClass, '\\'));
     }
 }

--- a/tests/Benchmark/Framework/ClassResolver/ClassInfo/ClassInfoBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassInfo/ClassInfoBench.php
@@ -14,12 +14,12 @@ final class ClassInfoBench
     {
         $facade = new class() extends AbstractFacade {
         };
-        ClassInfo::fromObject($facade, 'Factory');
+        ClassInfo::from($facade, 'Factory');
     }
 
     public function bench_real_class(): void
     {
         $facade = new ClassInfoTestingFacade();
-        ClassInfo::fromObject($facade, 'Factory');
+        ClassInfo::from($facade, 'Factory');
     }
 }

--- a/tests/Feature/Framework/FacadeAware/FeatureTest.php
+++ b/tests/Feature/Framework/FacadeAware/FeatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\FacadeAware;
 
 use Gacela\Framework\Gacela;
-use GacelaTest\Feature\Framework\FacadeAware\Module\Command\TestHiCommand;
+use GacelaTest\Feature\Framework\FacadeAware\Module\UserInput\Command\TestHiCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;

--- a/tests/Feature/Framework/FacadeAware/FeatureTest.php
+++ b/tests/Feature/Framework/FacadeAware/FeatureTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\FacadeAware;
+
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\FacadeAware\Module\Command\TestHiCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class FeatureTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__);
+    }
+
+    public function test_facade_aware(): void
+    {
+        $output = new BufferedOutput();
+
+        $hiCommand = new TestHiCommand();
+
+        $hiCommand->run(
+            $this->createStub(InputInterface::class),
+            $output
+        );
+
+        self::assertSame('Hi', $output->fetch());
+    }
+}

--- a/tests/Feature/Framework/FacadeAware/Module/Command/TestHiCommand.php
+++ b/tests/Feature/Framework/FacadeAware/Module/Command/TestHiCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\FacadeAware\Module\Command;
+
+use Gacela\Framework\FacadeResolverAwareTrait;
+use GacelaTest\Feature\Framework\FacadeAware\Module\Facade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @method Facade getFacade()
+ */
+final class TestHiCommand extends Command
+{
+    use FacadeResolverAwareTrait;
+
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $output->write($this->getFacade()->sayHi());
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/Framework/FacadeAware/Module/Facade.php
+++ b/tests/Feature/Framework/FacadeAware/Module/Facade.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\FacadeAware\Module;
+
+use Gacela\Framework\AbstractFacade;
+
+final class Facade extends AbstractFacade
+{
+    public function sayHi(): string
+    {
+        return 'Hi';
+    }
+}

--- a/tests/Feature/Framework/FacadeAware/Module/UserInput/Command/TestHiCommand.php
+++ b/tests/Feature/Framework/FacadeAware/Module/UserInput/Command/TestHiCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\FacadeAware\Module\Command;
+namespace GacelaTest\Feature\Framework\FacadeAware\Module\UserInput\Command;
 
 use Gacela\Framework\FacadeResolverAwareTrait;
 use GacelaTest\Feature\Framework\FacadeAware\Module\Facade;
@@ -22,5 +22,10 @@ final class TestHiCommand extends Command
         $output->write($this->getFacade()->sayHi());
 
         return self::SUCCESS;
+    }
+
+    protected function facadeClass(): string
+    {
+        return Facade::class;
     }
 }

--- a/tests/Feature/Framework/FacadeAware/config/default.php
+++ b/tests/Feature/Framework/FacadeAware/config/default.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config_key' => 1,
+    'override_key' => 1,
+    'local_key' => 1,
+];

--- a/tests/Unit/Framework/ClassResolver/ClassInfoTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassInfoTest.php
@@ -15,17 +15,26 @@ final class ClassInfoTest extends TestCase
     {
         $facade = new class() extends AbstractFacade {
         };
-        $actual = ClassInfo::fromObject($facade, 'Factory');
+        $actual = ClassInfo::from($facade, 'Factory');
 
         self::assertSame('module-name@anonymous\ClassInfoTest', $actual->getModule());
         self::assertSame('module-name@anonymous\ClassInfoTest', $actual->getFullNamespace());
         self::assertSame('\module-name@anonymous\ClassInfoTest\Factory', $actual->getCacheKey());
     }
 
-    public function test_real_class(): void
+    public function test_object_real_class(): void
     {
         $facade = new ClassInfoTestingFacade();
-        $actual = ClassInfo::fromObject($facade, 'Factory');
+        $actual = ClassInfo::from($facade, 'Factory');
+
+        self::assertSame('Fixtures', $actual->getModule());
+        self::assertSame('GacelaTest\Fixtures', $actual->getFullNamespace());
+        self::assertSame('\GacelaTest\Fixtures\Factory', $actual->getCacheKey());
+    }
+
+    public function test_string_real_class(): void
+    {
+        $actual = ClassInfo::from(ClassInfoTestingFacade::class, 'Factory');
 
         self::assertSame('Fixtures', $actual->getModule());
         self::assertSame('GacelaTest\Fixtures', $actual->getFullNamespace());


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/gacela-project/gacela/issues/136

In the context of a module, allow the auto-wiring of the `Facade` of the module on a specific/custom folder.

Consider the following example. Given these two classes:
```php
App\MyModule\MyModuleFacade;
App\MyModule\Command\HelloCommand;
```

The class `HelloCommand` should have access to the `MyModuleFacade` using `getFacade()`.

Until now, we construct these classes in the Factory, where we inject the Facade on it, but this is a bit odd. And it doesn't feel right. The reason is that the Command belongs to the infrastructure layer, therefore I should be able to talk to the Facade directly using Gacela's auto-wiring.

## 💡 Goal

Allow accessing the `Facade` of the module from a subfolder of 1 level.

## 🔖 Changes

- Prepare failing test related to FacadeAware
- Change signature `ClassInfo::fromObject(object)` to `ClassInfo::from(object|class-string)`
- Change signature `AbstractClassResolver::doResolve(object|class-string $caller): ?object`
  - Before allowed only an `object`, now it allows also a raw `class-string`

> Some ideas about the current status: this wont be easy (or even possible 🤔) because the ClassResolver find the classes on the same namespace (as siblings classes) on the classes which are calling them. Therefore, using `getFacade()` it looks on the same level and there is no Facade there. We need to find a way to locate the Facade in upper levels.


### 💭 Extra

This will bring a lot of potential improvements for the Phel commands design 😄  CC: @jenshaase 