### PR TITLE
Allow to return an instance of SetupGacela on gacela.php

### DIFF
--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -38,7 +38,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         /** @var SetupGacelaInterface|callable $setupGacelaFile */
         $setupGacelaFile = $this->fileIo->include($this->gacelaPhpPath);
         if (is_callable($setupGacelaFile)) {
-            trigger_deprecation('Gacela', '0.15', 'Return a SetupGacela object directly');
+            trigger_deprecation('Gacela', '0.15', 'Return a SetupGacelaInterface instance directly. The callable option will be removed in the next version.');
         }
 
         /** @var object $setupGacela */

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -35,15 +35,17 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $setupGacelaFn = $this->fileIo->include($this->gacelaPhpPath);
-        if (!is_callable($setupGacelaFn)) {
-            throw new RuntimeException('Create a function that returns an anonymous class that implements SetupGacelaInterface');
+        /** @var SetupGacelaInterface|callable $setupGacelaFile */
+        $setupGacelaFile = $this->fileIo->include($this->gacelaPhpPath);
+        if (is_callable($setupGacelaFile)) {
+            trigger_deprecation('Gacela', '0.15', 'Return a SetupGacela object directly');
         }
 
         /** @var object $setupGacela */
-        $setupGacela = $setupGacelaFn();
+        $setupGacela = is_callable($setupGacelaFile) ? $setupGacelaFile() : $setupGacelaFile;
+
         if (!is_subclass_of($setupGacela, SetupGacelaInterface::class)) {
-            throw new RuntimeException('Your anonymous class must implements SetupGacelaInterface');
+            throw new RuntimeException('The gacela.php file should return an instance of SetupGacela');
         }
 
         $configBuilder = $this->createConfigBuilder($setupGacela);

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -20,10 +20,10 @@ use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
 {
-    public function test_exception_when_include_gacela_file_is_not_callable(): void
+    public function test_exception_when_the_class_does_not_implements_setup_gacela_interface(): void
     {
         $fileIo = $this->createStub(FileIoInterface::class);
-        $fileIo->method('include')->willReturn('anything-but-not-callable');
+        $fileIo->method('include')->willReturn(new class() {});
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',
@@ -31,7 +31,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
             $fileIo
         );
 
-        $this->expectErrorMessage('Create a function that returns an anonymous class that implements SetupGacelaInterface');
+        $this->expectErrorMessage('The gacela.php file should return an instance of SetupGacela');
         $factory->createGacelaFileConfig();
     }
 
@@ -47,7 +47,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
             $fileIo
         );
 
-        $this->expectErrorMessage('Your anonymous class must implements SetupGacelaInterface');
+        $this->expectErrorMessage('The gacela.php file should return an instance of SetupGacela');
         $factory->createGacelaFileConfig();
     }
 
@@ -93,7 +93,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
     {
         $fileIo = $this->createStub(FileIoInterface::class);
         $fileIo->method('include')->willReturn(
-            static fn () => (new SetupGacela())
+            (new SetupGacela())
                 ->setExternalServices(['externalServiceKey' => 'externalServiceValue'])
                 ->setMappingInterfaces(
                     static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
@@ -119,12 +119,14 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
     public function test_gacela_file_set_suffix_types(): void
     {
         $fileIo = $this->createStub(FileIoInterface::class);
-        $fileIo->method('include')->willReturn(static fn () => (new SetupGacela())
-            ->setSuffixTypes(
-                static function (SuffixTypesBuilder $suffixTypesBuilder): void {
-                    $suffixTypesBuilder->addDependencyProvider('Binding');
-                }
-            ));
+        $fileIo->method('include')->willReturn(
+            (new SetupGacela())
+                ->setSuffixTypes(
+                    static function (SuffixTypesBuilder $suffixTypesBuilder): void {
+                        $suffixTypesBuilder->addDependencyProvider('Binding');
+                    }
+                )
+        );
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',


### PR DESCRIPTION
## 📚 Description

Related issue: #101 

This PR allows returning a `SetupGacela` instance instead of a callable directly from the `gacela.php` file.