### PR TITLE
Add addFacade to SuffixTypesBuilder class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added DocBlockResolverAwareTrait.
 - Deprecated FacadeResolverAwareTrait in favor of DocBlockResolverAwareTrait.
 - Removed deprecated setup as array in Gacela::bootstrap()
+- Allow overriding Gacela resolvable Facade type.
 
 ### 0.16.0
 #### 2022-04-14

--- a/src/Framework/Config/GacelaConfigBuilder/SuffixTypesBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/SuffixTypesBuilder.php
@@ -7,14 +7,19 @@ namespace Gacela\Framework\Config\GacelaConfigBuilder;
 final class SuffixTypesBuilder
 {
     public const DEFAULT_SUFFIX_TYPES = [
+        'Facade' => self::DEFAULT_FACADES,
         'Factory' => self::DEFAULT_FACTORIES,
         'Config' => self::DEFAULT_CONFIGS,
         'DependencyProvider' => self::DEFAULT_DEPENDENCY_PROVIDERS,
     ];
 
+    private const DEFAULT_FACADES = ['Facade'];
     private const DEFAULT_FACTORIES = ['Factory'];
     private const DEFAULT_CONFIGS = ['Config'];
     private const DEFAULT_DEPENDENCY_PROVIDERS = ['DependencyProvider'];
+
+    /** @var list<string> */
+    private array $facades = self::DEFAULT_FACADES;
 
     /** @var list<string> */
     private array $factories = self::DEFAULT_FACTORIES;
@@ -24,6 +29,13 @@ final class SuffixTypesBuilder
 
     /** @var list<string> */
     private array $dependencyProviders = self::DEFAULT_DEPENDENCY_PROVIDERS;
+
+    public function addFacade(string $suffix): self
+    {
+        $this->facades[] = $suffix;
+
+        return $this;
+    }
 
     public function addFactory(string $suffix): self
     {
@@ -48,6 +60,7 @@ final class SuffixTypesBuilder
 
     /**
      * @return array{
+     *     Facade:list<string>,
      *     Factory:list<string>,
      *     Config:list<string>,
      *     DependencyProvider:list<string>,
@@ -56,6 +69,7 @@ final class SuffixTypesBuilder
     public function build(): array
     {
         return [
+            'Facade' => array_values(array_unique($this->facades)),
             'Factory' => array_values(array_unique($this->factories)),
             'Config' => array_values(array_unique($this->configs)),
             'DependencyProvider' => array_values(array_unique($this->dependencyProviders)),

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -16,6 +16,7 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
 
     /**
      * @var array{
+     *     Facade:list<string>,
      *     Factory:list<string>,
      *     Config:list<string>,
      *     DependencyProvider:list<string>,
@@ -70,9 +71,10 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
 
     /**
      * @param array{
+     *     Facade:list<string>,
      *     Factory:list<string>,
      *     Config:list<string>,
-     *     DependencyProvider:list<string>
+     *     DependencyProvider:list<string>,
      * } $suffixTypes
      */
     public function setSuffixTypes(array $suffixTypes): self
@@ -84,6 +86,7 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
 
     /**
      * @return array{
+     *     Facade:list<string>,
      *     Factory:list<string>,
      *     Config:list<string>,
      *     DependencyProvider:list<string>,
@@ -100,6 +103,7 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
         $new->configItems = array_merge($this->configItems, $other->getConfigItems());
         $new->mappingInterfaces = array_merge($this->mappingInterfaces, $other->getMappingInterfaces());
         $new->suffixTypes = [
+            'Facade' => $this->filterList($other, 'Facade'),
             'Factory' => $this->filterList($other, 'Factory'),
             'Config' => $this->filterList($other, 'Config'),
             'DependencyProvider' => $this->filterList($other, 'DependencyProvider'),

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
@@ -19,40 +19,40 @@ final class FeatureTest extends TestCase
 
     public function test_load_module_a(): void
     {
-        $facade = new ModuleA\FacadeModuleA();
+        $commandA = new ModuleA\CommandModuleA();
 
         self::assertSame(
             [
                 'config-key' => 'config-value',
                 'provided-dependency' => 'dependency-value',
             ],
-            $facade->doSomething()
+            $commandA->execute()
         );
     }
 
     public function test_load_module_b(): void
     {
-        $facade = new ModuleB\FacadeModuleB();
+        $commandB = new ModuleB\CommandModuleB();
 
         self::assertSame(
             [
                 'config-key' => 'config-value',
                 'provided-dependency' => 'dependency-value',
             ],
-            $facade->doSomething()
+            $commandB->execute()
         );
     }
 
     public function test_load_module_c(): void
     {
-        $facade = new ModuleC\Facade();
+        $commandC = new ModuleC\CommandModuleC();
 
         self::assertSame(
             [
                 'config-key' => 'config-value',
                 'provided-dependency' => 'dependency-value',
             ],
-            $facade->doSomething()
+            $commandC->execute()
         );
     }
 }

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleA/CommandModuleA.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleA/CommandModuleA.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleA;
+
+use Gacela\Framework\DocBlockResolverAwareTrait;
+
+/**
+ * @method FaçModuleA getFacade()
+ */
+final class CommandModuleA
+{
+    use DocBlockResolverAwareTrait;
+
+    public function execute(): array
+    {
+        return $this->getFacade()->doSomething();
+    }
+}

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleA/FactModuleA.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleA/FactModuleA.php
@@ -9,7 +9,7 @@ use Gacela\Framework\AbstractFactory;
 /**
  * @method ConfModuleA getConfig()
  */
-final class FactoryModuleA extends AbstractFactory
+final class FactModuleA extends AbstractFactory
 {
     public function getArrayConfigAndProvidedDependency(): array
     {

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleA/FaçModuleA.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleA/FaçModuleA.php
@@ -7,9 +7,9 @@ namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleA;
 use Gacela\Framework\AbstractFacade;
 
 /**
- * @method FactoryModuleA getFactory()
+ * @method FactModuleA getFactory()
  */
-final class FacadeModuleA extends AbstractFacade
+final class FaçModuleA extends AbstractFacade
 {
     public function doSomething(): array
     {

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/CommandModuleB.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/CommandModuleB.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleB;
+
+use Gacela\Framework\DocBlockResolverAwareTrait;
+
+/**
+ * @method FacadeModuleB getFacade()
+ */
+final class CommandModuleB
+{
+    use DocBlockResolverAwareTrait;
+
+    public function execute(): array
+    {
+        return $this->getFacade()->doSomething();
+    }
+}

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/ConfigModuleB.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/ConfigModuleB.php
@@ -6,7 +6,7 @@ namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleB;
 
 use Gacela\Framework\AbstractConfig;
 
-final class ConfModuleB extends AbstractConfig
+final class ConfigModuleB extends AbstractConfig
 {
     public function getConfigValue(): string
     {

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/DependencyProviderModuleB.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/DependencyProviderModuleB.php
@@ -7,7 +7,7 @@ namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleB;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 
-final class DepProModuleB extends AbstractDependencyProvider
+final class DependencyProviderModuleB extends AbstractDependencyProvider
 {
     public function provideModuleDependencies(Container $container): void
     {

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/FactoryModuleB.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleB/FactoryModuleB.php
@@ -7,7 +7,7 @@ namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleB;
 use Gacela\Framework\AbstractFactory;
 
 /**
- * @method ConfModuleB getConfig()
+ * @method ConfigModuleB getConfig()
  */
 final class FactoryModuleB extends AbstractFactory
 {

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleC/CommandModuleC.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/ModuleC/CommandModuleC.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes\ModuleC;
+
+use Gacela\Framework\DocBlockResolverAwareTrait;
+
+/**
+ * @method Facade getFacade()
+ */
+final class CommandModuleC
+{
+    use DocBlockResolverAwareTrait;
+
+    public function execute(): array
+    {
+        return $this->getFacade()->doSomething();
+    }
+}

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/gacela.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/gacela.php
@@ -11,11 +11,14 @@ return static fn () => (new SetupGacela())
     ->setSuffixTypes(
         static function (SuffixTypesBuilder $suffixTypesBuilder): void {
             $suffixTypesBuilder
-                ->addFactory('FactoryModuleA')
-                ->addFactory('FactoryModuleB')
+                ->addFacade('FaçModuleA')
+                ->addFactory('FactModuleA')
                 ->addConfig('ConfModuleA')
-                ->addConfig('ConfModuleB')
                 ->addDependencyProvider('DepProModuleA')
-                ->addDependencyProvider('DepProModuleB');
+
+                ->addFacade('FacadeModuleB')
+                ->addFactory('FactoryModuleB')
+                ->addConfig('ConfigModuleB')
+                ->addDependencyProvider('DependencyProviderModuleB');
         }
     );

--- a/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
@@ -46,6 +46,7 @@ final class ConfigFactoryTest extends TestCase
                 CustomInterface::class => CustomClass::class,
             ])
             ->setSuffixTypes([
+                'Facade' => ['Facade', 'FacadeFromGacelaFile'],
                 'Factory' => ['Factory', 'FactoryFromGacelaFile'],
                 'Config' => ['Config', 'ConfigFromGacelaFile'],
                 'DependencyProvider' => ['DependencyProvider', 'DependencyProviderFromGacelaFile'],
@@ -71,6 +72,7 @@ final class ConfigFactoryTest extends TestCase
             )
             ->setSuffixTypes(static function (SuffixTypesBuilder $suffixTypesBuilder): void {
                 $suffixTypesBuilder
+                    ->addFacade('FacadeFromBootstrap')
                     ->addFactory('FactoryFromBootstrap')
                     ->addConfig('ConfigFromBootstrap')
                     ->addDependencyProvider('DependencyProviderFromBootstrap');
@@ -87,6 +89,7 @@ final class ConfigFactoryTest extends TestCase
                 CustomInterface::class => CustomClass::class,
             ])
             ->setSuffixTypes([
+                'Facade' => ['Facade', 'FacadeFromBootstrap'],
                 'Factory' => ['Factory', 'FactoryFromBootstrap'],
                 'Config' => ['Config', 'ConfigFromBootstrap'],
                 'DependencyProvider' => ['DependencyProvider', 'DependencyProviderFromBootstrap'],
@@ -109,6 +112,7 @@ final class ConfigFactoryTest extends TestCase
             )
             ->setSuffixTypes(static function (SuffixTypesBuilder $suffixTypesBuilder): void {
                 $suffixTypesBuilder
+                    ->addFacade('FacadeFromBootstrap')
                     ->addFactory('FactoryFromBootstrap')
                     ->addConfig('ConfigFromBootstrap')
                     ->addDependencyProvider('DependencyProviderFromBootstrap');
@@ -127,6 +131,11 @@ final class ConfigFactoryTest extends TestCase
                 AbstractCustom::class => CustomClass::class,
             ])
             ->setSuffixTypes([
+                'Facade' => [
+                    'Facade',
+                    'FacadeFromBootstrap',
+                    'FacadeFromGacelaFile',
+                ],
                 'Factory' => [
                     'Factory',
                     'FactoryFromBootstrap',

--- a/tests/Integration/Framework/Config/ConfigFactory/WithGacelaFile/gacela.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/WithGacelaFile/gacela.php
@@ -21,6 +21,7 @@ return static fn () => (new SetupGacela())
     )
     ->setSuffixTypes(static function (SuffixTypesBuilder $suffixTypesBuilder): void {
         $suffixTypesBuilder
+            ->addFacade('FacadeFromGacelaFile')
             ->addFactory('FactoryFromGacelaFile')
             ->addConfig('ConfigFromGacelaFile')
             ->addDependencyProvider('DependencyProviderFromGacelaFile');

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -90,6 +90,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
                 'DependencyProvider' => ['DependencyProvider', 'DPCustom'],
                 'Factory' => ['Factory'],
                 'Config' => ['Config'],
+                'Facade' => ['Facade'],
             ]);
 
         self::assertEquals($expected, $factory->createGacelaFileConfig());

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -139,6 +139,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
                 'Factory' => ['Factory'],
                 'Config' => ['Config'],
                 'DependencyProvider' => ['DependencyProvider', 'Binding'],
+                'Facade' => ['Facade'],
             ]);
 
         self::assertEquals($expected, $factory->createGacelaFileConfig());

--- a/tests/Unit/Framework/Config/GacelaFileConfig/GacelaConfigFileTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/GacelaConfigFileTest.php
@@ -93,12 +93,14 @@ final class GacelaConfigFileTest extends TestCase
     {
         $configFile1 = (new GacelaConfigFile())
             ->setSuffixTypes([
+                'Facade' => ['FA'],
                 'Factory' => ['F'],
                 'Config' => ['C'],
                 'DependencyProvider' => ['DP'],
             ]);
         $configFile2 = (new GacelaConfigFile())
             ->setSuffixTypes([
+                'Facade' => ['FA'],
                 'Factory' => ['F'],
                 'Config' => ['C'],
                 'DependencyProvider' => ['DP'],
@@ -108,6 +110,7 @@ final class GacelaConfigFileTest extends TestCase
 
         $expected = (new GacelaConfigFile())
             ->setSuffixTypes([
+                'Facade' => ['FA'],
                 'Factory' => ['F'],
                 'Config' => ['C'],
                 'DependencyProvider' => ['DP'],
@@ -120,12 +123,14 @@ final class GacelaConfigFileTest extends TestCase
     {
         $configFile1 = (new GacelaConfigFile())
             ->setSuffixTypes([
+                'Facade' => ['FA1'],
                 'Factory' => ['F1'],
                 'Config' => ['C1'],
                 'DependencyProvider' => ['DP1'],
             ]);
         $configFile2 = (new GacelaConfigFile())
             ->setSuffixTypes([
+                'Facade' => ['FA2'],
                 'Factory' => ['F2'],
                 'Config' => ['C2'],
                 'DependencyProvider' => ['DP2'],
@@ -135,6 +140,7 @@ final class GacelaConfigFileTest extends TestCase
 
         $expected = (new GacelaConfigFile())
             ->setSuffixTypes([
+                'Facade' => ['FA1', 'FA2'],
                 'Factory' => ['F1', 'F2'],
                 'Config' => ['C1', 'C2'],
                 'DependencyProvider' => ['DP1', 'DP2'],


### PR DESCRIPTION
## 📚 Description

:octocat: Github Issue: https://github.com/gacela-project/gacela/issues/138

This PR enables to define the `addFacade()` method to the `SuffixTypesBuilder` as follows:

```php
->setSuffixTypes(static function (SuffixTypesBuilder $suffixTypesBuilder): void {
        $suffixTypesBuilder
            ->addFacade('FacadeFileName')
            ->addFactory('...')
            ->addConfig('...')
            ->addDependencyProvider('...');
    });
```

By doing this, the user is able to decouple from the `Gacela` predetermined naming convention, and with annotations, execute from any entry point (command, controller...) the logic from his domain through the facade 🎉 