### PR TITLE
Remove deprecated globalServices() from Setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added allow gacela.php using a callable with GacelaConfig arg.
 - Moved namespace from Setup to Bootstrap (affecting SetupGacela).
   - Deprecated Setup namespace in favor of Bootstrap.
+- Remove deprecated globalServices() method.
 
 ### 0.17.2
 #### 2022-05-02

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -43,14 +43,4 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     {
         return [];
     }
-
-    /**
-     * @deprecated in favor of `externalServices()`
-     *
-     * @return array<string,mixed>
-     */
-    public function globalServices(): array
-    {
-        return $this->externalServices();
-    }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -159,16 +159,6 @@ class SetupGacela extends AbstractSetupGacela
 
     /**
      * @return array<string,mixed>
-     *
-     * @deprecated in favor of `externalServices()`
-     */
-    public function globalServices(): array
-    {
-        return $this->externalServices();
-    }
-
-    /**
-     * @return array<string,mixed>
      */
     public function externalServices(): array
     {

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -33,11 +33,4 @@ interface SetupGacelaInterface
      * @return array<string,mixed>
      */
     public function externalServices(): array;
-
-    /**
-     * @deprecated Use `externalServices()` instead
-     *
-     * @return array<string,mixed>
-     */
-    public function globalServices(): array;
 }


### PR DESCRIPTION
## 📚 Description

The `globalServices` method was renamed to `externalServices` two versions ago, we decided to change the name but keep the original method for backward compatibility.
I think we gave enough time to this method, we can drop it in this PR.

As the PhpDoc mentioned, if you were using the `globalServices`, you only have to switch to the new `externalServicies`, everything should work as it was.