### PR TITLE
Change PhpDoc from $externalServices

### DIFF
--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -21,7 +21,7 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
-     * @param array<string,mixed> $externalServices
+     * @param array<string,class-string|object|callable> $externalServices
      */
     public function buildMappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): MappingInterfacesBuilder
     {
@@ -37,7 +37,7 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     }
 
     /**
-     * @return array<string,mixed>
+     * @return array<string,class-string|object|callable>
      */
     public function externalServices(): array
     {

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -17,11 +17,11 @@ final class GacelaConfig
 
     private MappingInterfacesBuilder $mappingInterfacesBuilder;
 
-    /** @var array<string,mixed> */
+    /** @var array<string,class-string|object|callable> */
     private array $externalServices;
 
     /**
-     * @param array<string,mixed> $externalServices
+     * @param array<string,class-string|object|callable> $externalServices
      */
     public function __construct(array $externalServices = [])
     {
@@ -83,7 +83,7 @@ final class GacelaConfig
     }
 
     /**
-     * @return mixed
+     * @return class-string|object|callable
      */
     public function getExternalService(string $key)
     {
@@ -91,7 +91,7 @@ final class GacelaConfig
     }
 
     /**
-     * @param mixed $value
+     * @param class-string|object|callable $value
      */
     public function addExternalService(string $key, $value): self
     {
@@ -104,7 +104,7 @@ final class GacelaConfig
      * @internal
      *
      * @return array{
-     *     external-services:array<string,mixed>,
+     *     external-services:array<string,class-string|object|callable>,
      *     config-builder:ConfigBuilder,
      *     suffix-types-builder:SuffixTypesBuilder,
      *     mapping-interfaces-builder:MappingInterfacesBuilder,

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -19,7 +19,7 @@ class SetupGacela extends AbstractSetupGacela
     /** @var ?callable(SuffixTypesBuilder):void */
     private $suffixTypesFn = null;
 
-    /** @var array<string,mixed> */
+    /** @var array<string,class-string|object|callable> */
     private array $externalServices = [];
 
     private ?ConfigBuilder $configBuilder = null;
@@ -105,7 +105,7 @@ class SetupGacela extends AbstractSetupGacela
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
-     * @param array<string,mixed> $externalServices
+     * @param array<string,class-string|object|callable> $externalServices
      */
     public function buildMappingInterfaces(
         MappingInterfacesBuilder $mappingInterfacesBuilder,
@@ -148,7 +148,7 @@ class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,mixed> $array
+     * @param array<string,class-string|object|callable> $array
      */
     public function setExternalServices(array $array): self
     {
@@ -158,7 +158,7 @@ class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return array<string,mixed>
+     * @return array<string,class-string|object|callable>
      */
     public function externalServices(): array
     {

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -18,7 +18,7 @@ interface SetupGacelaInterface
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
-     * @param array<string,mixed> $externalServices
+     * @param array<string,class-string|object|callable> $externalServices
      */
     public function buildMappingInterfaces(MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): MappingInterfacesBuilder;
 
@@ -30,7 +30,7 @@ interface SetupGacelaInterface
     /**
      * Define global services that can be accessible via the mapping interfaces.
      *
-     * @return array<string,mixed>
+     * @return array<string,class-string|object|callable>
      */
     public function externalServices(): array;
 }

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\CorrectCompanyGenerator;
 use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
@@ -13,7 +14,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static fn (GacelaConfig $config) => $config
-            ->addExternalService('isWorking?', 'yes!'));
+            ->addExternalService('greeterGenerator', CorrectCompanyGenerator::class));
     }
 
     public function test_mapping_interfaces_from_config(): void

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/gacela.php
@@ -3,23 +3,13 @@
 declare(strict_types=1);
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
-use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\CorrectCompanyGenerator;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\Greeter\IncorrectCompanyGenerator;
 use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalConfig\Domain\GreeterGeneratorInterface;
-
-/**
- * This Feature-test does two things:
- *
- * - 1: Check the "externalService" variable was properly defined in the 'Gacela::bootstrap()' with the key `isWorking?`.
- *
- * - 2: Let Gacela resolve in the factory the mapping from `GreeterGeneratorInterface` to `CorrectCompanyGenerator`
- *      AND auto-resolve the class `CustomNameGenerator` from the `CorrectCompanyGenerator` constructor.
- */
 
 return static function (GacelaConfig $config): void {
     $config->addMappingInterface(GreeterGeneratorInterface::class, IncorrectCompanyGenerator::class);
 
-    if ($config->getExternalService('isWorking?') === 'yes!') {
-        $config->addMappingInterface(GreeterGeneratorInterface::class, CorrectCompanyGenerator::class);
-    }
+    // Overriding the `GreeterGeneratorInterface` with the proper external service.
+    // Check the FeatureTest class to see how the external service with key `greeterGenerator` is defined.
+    $config->addMappingInterface(GreeterGeneratorInterface::class, $config->getExternalService('greeterGenerator'));
 };


### PR DESCRIPTION
## 📚 Description

### 🛠️  _UNDER DISCUSSION_ 🛠️ 

In this PR, the PhpDoc from `externalServices` method was changed
- from `/** @var array<string,mixed> */`
- to `/** @var array<string,class-string|object|callable> */`

I think it doesn't make sense to add to `externalServices` any other kind rather than a callable, object or class-string, as the final purpose of this method is to pass external services (e.g: framework services) rather than booleans or any other type.

> I marked the PR as `under discussion` because we need to think a bit longer about this change, but I don't see any other scenario where a string or bool as an external service could have sense.