### PR TITLE
Define local pattern php config default 

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -37,7 +37,7 @@ final class GacelaConfig
     public static function withPhpConfigDefault(): callable
     {
         return static function (self $config): void {
-            $config->addAppConfig('config/*.php');
+            $config->addAppConfig('config/*.php', 'config/local.php');
         };
     }
 
@@ -111,14 +111,14 @@ final class GacelaConfig
     }
 
     /**
-     * @internal
-     *
      * @return array{
      *     external-services:array<string,class-string|object|callable>,
      *     config-builder:ConfigBuilder,
      *     suffix-types-builder:SuffixTypesBuilder,
      *     mapping-interfaces-builder:MappingInterfacesBuilder,
      * }
+     *
+     * @internal
      */
     public function build(): array
     {

--- a/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingConfigFromCustomEnv;
 
-use Gacela\Framework\Bootstrap\SetupGacela;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
 {
-    private SetupGacela $setup;
-
-    protected function setUp(): void
-    {
-        $this->setup = (new SetupGacela())
-            ->setConfigFn(static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add('config/*.php', 'config/local.php');
-            });
-    }
-
     public function tearDown(): void
     {
         # Remove the APP_ENV
@@ -29,7 +18,8 @@ final class FeatureTest extends TestCase
 
     public function test_load_config_from_custom_env_default(): void
     {
-        Gacela::bootstrap(__DIR__, $this->setup);
+        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+
         $facade = new LocalConfig\Facade();
 
         self::assertSame(
@@ -45,7 +35,9 @@ final class FeatureTest extends TestCase
     public function test_load_config_from_custom_env_dev(): void
     {
         putenv('APP_ENV=dev');
-        Gacela::bootstrap(__DIR__, $this->setup);
+
+        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+
         $facade = new LocalConfig\Facade();
 
         self::assertSame(
@@ -61,7 +53,9 @@ final class FeatureTest extends TestCase
     public function test_load_config_from_custom_env_prod(): void
     {
         putenv('APP_ENV=prod');
-        Gacela::bootstrap(__DIR__, $this->setup);
+
+        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+
         $facade = new LocalConfig\Facade();
 
         self::assertSame(

--- a/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingConfigWithBootstrapSetup;
 
-use Gacela\Framework\Bootstrap\SetupGacela;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -13,12 +12,11 @@ final class FeatureTest extends TestCase
 {
     public function setUp(): void
     {
-        $setup = (new SetupGacela())
-            ->setConfigFn(static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add('custom-config.php', 'custom-config_local.php');
-            });
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('custom-config.php', 'custom-config_local.php');
+        };
 
-        Gacela::bootstrap(__DIR__, $setup);
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     public function test_load_default_config(): void

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes;
 
-use Gacela\Framework\Bootstrap\SetupGacela;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -16,12 +15,7 @@ final class FeatureTest extends TestCase
 {
     protected function setUp(): void
     {
-        $setup = (new SetupGacela())
-            ->setConfigFn(static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add('config/*.php', 'config/local.php');
-            });
-
-        Gacela::bootstrap(__DIR__, $setup);
+        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
     }
 
     public function test_load_module_a(): void


### PR DESCRIPTION
## 🔖 Changes

- Define `config/local.php` in `GacelaConfig::withPhpConfigDefault()`
- Use `GacelaConfig::withPhpConfigDefault()` in tests
