### PR TITLE
Add AbstractClassResolver::resetCache()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Add `resetCache()` to AbstractClassResolver
+
 ### 0.19.0
 #### 2022-05-19
 
@@ -18,8 +22,8 @@
 - Added allow gacela.php using a callable with GacelaConfig arg.
 - Moved namespace from Setup to Bootstrap (affecting SetupGacela).
   - Deprecated Setup namespace in favor of Bootstrap.
-- Remove deprecated globalServices() method.
-- Deprecate SetupGacelaInterface from gacela.php and Gacela::bootstrap(). Use callable(GacelaConfig) instead.
+- Remove deprecated `globalServices()` method.
+- Deprecate SetupGacelaInterface from gacela.php and `Gacela::bootstrap()`. Use callable(GacelaConfig) instead.
 
 ### 0.17.2
 #### 2022-05-02
@@ -36,7 +40,7 @@
 
 - Added DocBlockResolverAwareTrait.
 - Deprecated FacadeResolverAwareTrait in favor of DocBlockResolverAwareTrait.
-- Removed deprecated setup as array in Gacela::bootstrap()
+- Removed deprecated setup as array in `Gacela::bootstrap()`.
 - Allow overriding Gacela resolvable Facade type.
 
 ### 0.16.0

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -24,6 +24,9 @@ abstract class AbstractClassResolver
 
     private ?InstanceCreator $instanceCreator = null;
 
+    /**
+     * @internal just for testing purposes
+     */
     public static function resetCache(): void
     {
         self::$cachedInstances = [];

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -24,6 +24,11 @@ abstract class AbstractClassResolver
 
     private ?InstanceCreator $instanceCreator = null;
 
+    public static function resetCache(): void
+    {
+        self::$cachedInstances = [];
+    }
+
     /**
      * @param object|class-string $caller
      */


### PR DESCRIPTION
## 📚 Description

Create `AbstractClassResolver::resetCache()` method in order to remove the cache, this function is focus for tests when using `@dataproviders` for example.