### PR TITLE
Reset cache from class resolver when bootstrapping

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -20,6 +20,8 @@ final class GacelaConfig
     /** @var array<string,class-string|object|callable> */
     private array $externalServices;
 
+    private bool $classResolverCached = true;
+
     /**
      * @param array<string,class-string|object|callable> $externalServices
      */
@@ -110,12 +112,20 @@ final class GacelaConfig
         return $this;
     }
 
+    public function setClassResolverCached(bool $flag): self
+    {
+        $this->classResolverCached = $flag;
+
+        return $this;
+    }
+
     /**
      * @return array{
      *     external-services:array<string,class-string|object|callable>,
      *     config-builder:ConfigBuilder,
      *     suffix-types-builder:SuffixTypesBuilder,
      *     mapping-interfaces-builder:MappingInterfacesBuilder,
+     *     class-resolver-cached:bool,
      * }
      *
      * @internal
@@ -127,6 +137,7 @@ final class GacelaConfig
             'config-builder' => $this->configBuilder,
             'suffix-types-builder' => $this->suffixTypesBuilder,
             'mapping-interfaces-builder' => $this->mappingInterfacesBuilder,
+            'class-resolver-cached' => $this->classResolverCached,
         ];
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -28,6 +28,8 @@ class SetupGacela extends AbstractSetupGacela
 
     private ?MappingInterfacesBuilder $mappingInterfacesBuilder = null;
 
+    private bool $classResolverCached = true;
+
     /**
      * @param callable(GacelaConfig):void $setupGacelaFileFn
      */
@@ -47,7 +49,8 @@ class SetupGacela extends AbstractSetupGacela
             ->setConfigBuilder($build['config-builder'])
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
             ->setMappingInterfacesBuilder($build['mapping-interfaces-builder'])
-            ->setExternalServices($build['external-services']);
+            ->setExternalServices($build['external-services'])
+            ->setClassResolverCached($build['class-resolver-cached']);
     }
 
     public function setMappingInterfacesBuilder(MappingInterfacesBuilder $builder): self
@@ -163,5 +166,17 @@ class SetupGacela extends AbstractSetupGacela
     public function externalServices(): array
     {
         return $this->externalServices;
+    }
+
+    public function setClassResolverCached(bool $flag): self
+    {
+        $this->classResolverCached = $flag;
+
+        return $this;
+    }
+
+    public function isClassResolverCached(): bool
+    {
+        return $this->classResolverCached;
     }
 }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -33,4 +33,6 @@ interface SetupGacelaInterface
      * @return array<string,class-string|object|callable>
      */
     public function externalServices(): array;
+
+    public function isClassResolverCached(): bool;
 }

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -25,7 +25,7 @@ abstract class AbstractClassResolver
     private ?InstanceCreator $instanceCreator = null;
 
     /**
-     * @internal just for testing purposes
+     * @internal remove all cached instances: facade, factory, config, dependency-provider
      */
     public static function resetCache(): void
     {

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -31,7 +31,9 @@ final class Gacela
 
         $setup = self::normalizeSetup($configFn);
 
-        AbstractClassResolver::resetCache();
+        if (!$setup->isClassResolverCached()) {
+            AbstractClassResolver::resetCache();
+        }
 
         Config::getInstance()
             ->setAppRootDir($appRootDir)

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\Config\Config;
 
 use function is_callable;
@@ -29,6 +30,8 @@ final class Gacela
         }
 
         $setup = self::normalizeSetup($configFn);
+
+        AbstractClassResolver::resetCache();
 
         Config::getInstance()
             ->setAppRootDir($appRootDir)


### PR DESCRIPTION
## 📚 Description

Allow disabling the cache for gacela resolved classes (facade, factory, config, dependency-provider). 

It's enable by default (keeping the backward compatibility), but you can disable from the config like:
```php
public function setUp(): void
{
    $configFn = static function (GacelaConfig $config): void {
        $config->addAppConfig('config/*.php', 'config/local.php');
        $config->setClassResolverCached(false); # <---- THIS IS THE NEW THING :)
    };
    Gacela::bootstrap(__DIR__, $configFn);
}
```

## 🔖 Changes

- Add `AbstractClassResolver::resetCache()` inside `Gacela::bootstrap()` when the cache is disabled for class resolver.
