### PR TITLE
Solve FatalError incompatible declaration in Laravel

### DIFF
--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -20,7 +20,13 @@ trait DocBlockResolverAwareTrait
     /** @var array<string,?object> */
     private array $customServices = [];
 
-    public function __call(string $method, array $arguments = []): ?object
+    /**
+     * @param string $method
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function __call($method, $parameters = [])
     {
         if (!isset($this->customServices[$method])) {
             $className = $this->getClassFromDoc($method);
@@ -30,7 +36,17 @@ trait DocBlockResolverAwareTrait
                 ->resolve($className);
         }
 
-        return $this->customServices[$method];
+        $object = $this->customServices[$method];
+
+        if (isset($object)) {
+            return $object;
+        }
+
+        if (method_exists(parent::class, '__call')) {
+            return parent::__call($method, $parameters);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

It was not possible to use the trait `DocBlockResolverAwareTrait` on Laravel's Controller, because the signature from `__call()` was different to the signature we had, so, we implement the signature from there to make it work 😄 
