### PR TITLE
Small code improvements

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap;
 
+use Closure;
 use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
@@ -34,7 +35,7 @@ final class GacelaConfig
     }
 
     /**
-     * @return callable(GacelaConfig):void
+     * @return Closure(GacelaConfig):void
      */
     public static function withPhpConfigDefault(): callable
     {

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -9,7 +9,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
-class SetupGacela extends AbstractSetupGacela
+final class SetupGacela extends AbstractSetupGacela
 {
     /** @var ?callable(ConfigBuilder):void */
     private $configFn = null;

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class FeatureTest extends TestCase
 {
-    protected function setUp(): void
+    public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
     }

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
 {
-    protected function setUp(): void
+    public function setUp(): void
     {
         Config::resetInstance();
     }

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ClassNameFinderTest extends TestCase
 {
-    protected function setUp(): void
+    public function setUp(): void
     {
         ClassNameFinder::resetCachedClassNames();
     }

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockParserTest.php
@@ -11,7 +11,7 @@ final class DocBlockParserTest extends TestCase
 {
     private DocBlockParser $parser;
 
-    protected function setUp(): void
+    public function setUp(): void
     {
         $this->parser = new DocBlockParser();
     }

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
@@ -11,7 +11,7 @@ final class UseBlockParserTest extends TestCase
 {
     private UseBlockParser $parser;
 
-    protected function setUp(): void
+    public function setUp(): void
     {
         $this->parser = new UseBlockParser();
     }

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -89,8 +89,8 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo = $this->createStub(FileIoInterface::class);
         $fileIo->method('include')->willReturn(
             static function (GacelaConfig $config): void {
-                $config->addExternalService('externalServiceKey', 'externalServiceValue');
-                self::assertSame('externalServiceValue', $config->getExternalService('externalServiceKey'));
+                $config->addExternalService('externalServiceKey', static fn () => 'externalServiceValue');
+                self::assertSame('externalServiceValue', $config->getExternalService('externalServiceKey')->__invoke());
                 $config->addMappingInterface(CustomInterface::class, new CustomClass());
                 $config->addMappingInterface(CustomInterface::class, CustomClass::class);
             }


### PR DESCRIPTION
## 📚 Description

- Change `callable` to `Closure` in PhpDoc for `GacelaConfig::withPhpConfigDefault()`
- Mark some classes as `final`
- Define `setUp()` from tests as `public`
- Check the `$config->addExternalService()`, the 2nd parameter is a closure
