### PR TITLE
Rename config key from setClassResolverCached() to setResetCache()

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -20,7 +20,7 @@ final class GacelaConfig
     /** @var array<string,class-string|object|callable> */
     private array $externalServices;
 
-    private bool $classResolverCached = true;
+    private bool $resetCache = false;
 
     /**
      * @param array<string,class-string|object|callable> $externalServices
@@ -112,9 +112,9 @@ final class GacelaConfig
         return $this;
     }
 
-    public function setClassResolverCached(bool $flag): self
+    public function setResetCache(bool $flag): self
     {
-        $this->classResolverCached = $flag;
+        $this->resetCache = $flag;
 
         return $this;
     }
@@ -125,7 +125,7 @@ final class GacelaConfig
      *     config-builder:ConfigBuilder,
      *     suffix-types-builder:SuffixTypesBuilder,
      *     mapping-interfaces-builder:MappingInterfacesBuilder,
-     *     class-resolver-cached:bool,
+     *     reset-cache:bool,
      * }
      *
      * @internal
@@ -137,7 +137,7 @@ final class GacelaConfig
             'config-builder' => $this->configBuilder,
             'suffix-types-builder' => $this->suffixTypesBuilder,
             'mapping-interfaces-builder' => $this->mappingInterfacesBuilder,
-            'class-resolver-cached' => $this->classResolverCached,
+            'reset-cache' => $this->resetCache,
         ];
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -29,7 +29,7 @@ class SetupGacela extends AbstractSetupGacela
 
     private ?MappingInterfacesBuilder $mappingInterfacesBuilder = null;
 
-    private bool $classResolverCached = true;
+    private bool $resetCache = false;
 
     /**
      * @param Closure(GacelaConfig):void $setupGacelaFileFn
@@ -51,7 +51,7 @@ class SetupGacela extends AbstractSetupGacela
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
             ->setMappingInterfacesBuilder($build['mapping-interfaces-builder'])
             ->setExternalServices($build['external-services'])
-            ->setClassResolverCached($build['class-resolver-cached']);
+            ->setResetCache($build['reset-cache']);
     }
 
     public function setMappingInterfacesBuilder(MappingInterfacesBuilder $builder): self
@@ -169,15 +169,15 @@ class SetupGacela extends AbstractSetupGacela
         return $this->externalServices;
     }
 
-    public function setClassResolverCached(bool $flag): self
+    public function setResetCache(bool $flag): self
     {
-        $this->classResolverCached = $flag;
+        $this->resetCache = $flag;
 
         return $this;
     }
 
-    public function isClassResolverCached(): bool
+    public function isResetCache(): bool
     {
-        return $this->classResolverCached;
+        return $this->resetCache;
     }
 }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -34,5 +34,5 @@ interface SetupGacelaInterface
      */
     public function externalServices(): array;
 
-    public function isClassResolverCached(): bool;
+    public function isResetCache(): bool;
 }

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -29,7 +29,7 @@ final class ClassNameFinder implements ClassNameFinderInterface
     }
 
     /**
-     * @internal for testing purposes
+     * @internal
      */
     public static function resetCachedClassNames(): void
     {

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -37,7 +37,7 @@ final class Config
     }
 
     /**
-     * @internal for testing purposes
+     * @internal
      */
     public static function resetInstance(): void
     {

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -8,6 +8,7 @@ use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\Config\Config;
 
 final class Gacela
@@ -23,8 +24,10 @@ final class Gacela
             ? SetupGacela::fromCallable($configFn)
             : new SetupGacela();
 
-        if (!$setup->isClassResolverCached()) {
+        if ($setup->isResetCache()) {
+            ClassNameFinder::resetCachedClassNames();
             AbstractClassResolver::resetCache();
+            Config::resetInstance();
         }
 
         Config::getInstance()

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework\Config;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
 {
     protected function setUp(): void
     {
-        Config::resetInstance();
+        Gacela::bootstrap(__DIR__, static fn (GacelaConfig $config) => $config->setResetCache(true));
     }
 
     public function test_get_undefined_key(): void

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\ClassResolver;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\ClassInfo;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
+use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
 final class ClassNameFinderTest extends TestCase
 {
     protected function setUp(): void
     {
-        ClassNameFinder::resetCachedClassNames();
+        Gacela::bootstrap(__DIR__, static fn (GacelaConfig $config) => $config->setResetCache(true));
     }
 
     public function test_no_rules(): void


### PR DESCRIPTION
## 📚 Description

Rename flag `classResolverCached` to `resetCache` (the default value now is `false`).
Also, when you select you really want to reset the Gacela cache, you will reset all caches, including:
- ClassNameFinder::resetCachedClassNames()
- AbstractClassResolver::resetCache()
- Config::resetInstance()

So, we don't need to use the `@internal`s method anymore for an specific test, with the `$config->setResetCache(true)` is enough. 

## 🐞 Optional names

I was thinking and I have some alternatives to `resetCache`, e.g:
- resetCacheOnBootstrap
- resetGacelaCache
- classResolverCached (the old one, I think it's outdated...)
- you say! ...