### PR TITLE
Doc block resolver aware with no parent

### DIFF
--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -28,22 +28,25 @@ trait DocBlockResolverAwareTrait
      */
     public function __call($method, $parameters = [])
     {
-        if (!isset($this->customServices[$method])) {
-            $className = $this->getClassFromDoc($method);
-            $resolvableType = $this->normalizeResolvableType($className);
-
-            $this->customServices[$method] = (new DocBlockServiceResolver($resolvableType))
-                ->resolve($className);
+        if (isset($this->customServices[$method])) {
+            return $this->customServices[$method];
         }
 
-        $object = $this->customServices[$method];
+        $className = $this->getClassFromDoc($method);
+        $resolvableType = $this->normalizeResolvableType($className);
 
-        if (isset($object)) {
-            return $object;
+        $resolved = (new DocBlockServiceResolver($resolvableType))
+            ->resolve($className);
+
+        if (isset($resolved)) {
+            return $resolved;
         }
 
         if (method_exists(parent::class, '__call')) {
-            return parent::__call($method, $parameters);
+            $parentReturn = parent::__call($method, $parameters);
+            $this->customServices[$method] = $parentReturn;
+
+            return $parentReturn;
         }
 
         return null;

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -38,11 +38,12 @@ trait DocBlockResolverAwareTrait
         $resolved = (new DocBlockServiceResolver($resolvableType))
             ->resolve($className);
 
-        if (isset($resolved)) {
+        if ($resolved !== null) {
             return $resolved;
         }
 
-        if (method_exists(parent::class, '__call')) {
+        /** @psalm-suppress ParentNotFound,MixedArgument */
+        if (class_parents($this) && method_exists(parent::class, '__call')) {
             $parentReturn = parent::__call($method, $parameters);
             $this->customServices[$method] = $parentReturn;
 

--- a/tests/Integration/Framework/DocBlockResolverAware/BadDummyDocBlockResolverAware.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/BadDummyDocBlockResolverAware.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
+
+use Gacela\Framework\DocBlockResolverAwareTrait;
+
+/**
+ * @method NonExistingResolverAware getRepository()
+ */
+final class BadDummyDocBlockResolverAware
+{
+    use DocBlockResolverAwareTrait;
+}

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverAwareTest.php
@@ -8,12 +8,19 @@ use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverAwareTest extends TestCase
 {
-    public function test_qualified_class_name(): void
+    public function test_existing_service(): void
     {
-        $docBlockResolverAware = new DummyDocBlockResolverAware();
-
-        $actual = $docBlockResolverAware->getRepository()->findName();
+        $dummy = new DummyDocBlockResolverAware();
+        $actual = $dummy->getRepository()->findName();
 
         self::assertSame('name', $actual);
+    }
+
+    public function test_non_existing_service(): void
+    {
+        $this->expectExceptionMessage('Missing the concrete return type for the method `getRepository()`');
+
+        $dummy = new BadDummyDocBlockResolverAware();
+        $dummy->getRepository();
     }
 }


### PR DESCRIPTION
## 📚 Description

When `DocBlockResolverAwareTrait` uses `parent::class` without checking if there is or not a parent class then you might face this  ```Error: Cannot use "parent" when current class scope has no parent```.

## 🔖 Changes

- Check if the current class has a parent before accessing the `parent::class` .
