### PR TITLE
Cache class names and resolvable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Added a cache layer from class-names to their resolvable-type (in a file: `.gacela-class-names.cache`).
+
 ### 0.21.0
 #### 2022-05-29
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "GacelaData\\": "data",
             "GacelaTest\\": "tests"
         }
     },

--- a/src/Framework/ClassResolver/ClassNameCache.php
+++ b/src/Framework/ClassResolver/ClassNameCache.php
@@ -6,7 +6,7 @@ namespace Gacela\Framework\ClassResolver;
 
 final class ClassNameCache implements ClassNameCacheInterface
 {
-    private const CACHED_CLASS_NAMES_FILE = '.gacela-class-names.cache';
+    public const CACHED_CLASS_NAMES_FILE = '.gacela-class-names.cache';
 
     /** @var array<string,string> */
     private static array $cachedClassNames = [];

--- a/src/Framework/ClassResolver/ClassNameCache.php
+++ b/src/Framework/ClassResolver/ClassNameCache.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+final class ClassNameCache implements ClassNameCacheInterface
+{
+    /** @var array<string,string> */
+    private static array $cachedClassNames = [];
+
+    /**
+     * @param array<string,string> $cachedClassNames
+     */
+    public function __construct(array $cachedClassNames = [])
+    {
+        self::$cachedClassNames = $cachedClassNames;
+    }
+
+    /**
+     * @internal
+     */
+    public static function resetCachedClassNames(): void
+    {
+        self::$cachedClassNames = [];
+    }
+
+    public function has(string $cacheKey): bool
+    {
+        return isset(self::$cachedClassNames[$cacheKey]);
+    }
+
+    public function get(string $cacheKey): string
+    {
+        return self::$cachedClassNames[$cacheKey];
+    }
+
+    public function put(string $cacheKey, string $className): void
+    {
+        self::$cachedClassNames[$cacheKey] = $className;
+    }
+}

--- a/src/Framework/ClassResolver/ClassNameCache.php
+++ b/src/Framework/ClassResolver/ClassNameCache.php
@@ -6,7 +6,7 @@ namespace Gacela\Framework\ClassResolver;
 
 final class ClassNameCache implements ClassNameCacheInterface
 {
-    public const CACHED_CLASS_NAMES_FILE = '.gacela-class-names.cache';
+    private const CACHED_CLASS_NAMES_FILE = '.gacela-class-names.cache';
 
     /** @var array<string,string> */
     private static array $cachedClassNames = [];

--- a/src/Framework/ClassResolver/ClassNameCacheInterface.php
+++ b/src/Framework/ClassResolver/ClassNameCacheInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+interface ClassNameCacheInterface
+{
+    public function has(string $cacheKey): bool;
+
+    public function get(string $cacheKey): string;
+
+    public function put(string $cacheKey, string $className): void;
+}

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -5,38 +5,29 @@ declare(strict_types=1);
 namespace Gacela\Framework\ClassResolver\ClassNameFinder;
 
 use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
 
 final class ClassNameFinder implements ClassNameFinderInterface
 {
-    /** @var array<string,string> */
-    private static array $cachedClassNames = [];
-
     private ClassValidatorInterface $classValidator;
 
     /** @var list<FinderRuleInterface> */
     private array $finderRules;
 
+    private ClassNameCacheInterface $classNameCache;
+
     /**
      * @param list<FinderRuleInterface> $finderRules
-     * @param array<string,string> $cachedClassNames
      */
     public function __construct(
         ClassValidatorInterface $classValidator,
         array $finderRules,
-        array $cachedClassNames = []
+        ClassNameCacheInterface $classNameCache
     ) {
         $this->classValidator = $classValidator;
         $this->finderRules = $finderRules;
-        self::$cachedClassNames = $cachedClassNames;
-    }
-
-    /**
-     * @internal
-     */
-    public static function resetCachedClassNames(): void
-    {
-        self::$cachedClassNames = [];
+        $this->classNameCache = $classNameCache;
     }
 
     /**
@@ -46,15 +37,16 @@ final class ClassNameFinder implements ClassNameFinderInterface
     {
         $cacheKey = $classInfo->getCacheKey();
 
-        if (isset(self::$cachedClassNames[$cacheKey])) {
-            return self::$cachedClassNames[$cacheKey];
+        if ($this->classNameCache->has($cacheKey)) {
+            return $this->classNameCache->get($cacheKey);
         }
 
         foreach ($this->finderRules as $finderRule) {
             foreach ($resolvableTypes as $resolvableType) {
                 $className = $finderRule->buildClassCandidate($classInfo, $resolvableType);
                 if ($this->classValidator->isClassNameValid($className)) {
-                    self::$cachedClassNames[$cacheKey] = $className;
+                    $this->classNameCache->put($cacheKey, $className);
+
                     return $className;
                 }
             }

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -19,13 +19,16 @@ final class ClassNameFinder implements ClassNameFinderInterface
 
     /**
      * @param list<FinderRuleInterface> $finderRules
+     * @param array<string,string> $cachedClassNames
      */
     public function __construct(
         ClassValidatorInterface $classValidator,
-        array $finderRules
+        array $finderRules,
+        array $cachedClassNames = []
     ) {
         $this->classValidator = $classValidator;
         $this->finderRules = $finderRules;
+        self::$cachedClassNames = $cachedClassNames;
     }
 
     /**

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -17,22 +17,27 @@ trait ClassResolverExceptionTrait
 
         $message = 'ClassResolver Exception' . PHP_EOL;
         $message .= sprintf(
-            'Cannot resolve the "%s" for your module "%s"',
+            'Cannot resolve the `%s` for your module `%s`',
             $resolvableType,
             $callerClassInfo->getModule(),
         ) . PHP_EOL;
 
         $message .= sprintf(
-            'You can fix this by adding the missing "%s" to your module.',
+            'You can fix this by adding the missing `%s` to your module.',
             $resolvableType
         ) . PHP_EOL;
 
         $message .= sprintf(
-            'E.g. %s',
+            'E.g. `%s`',
             $this->findClassNameExample($callerClassInfo, $resolvableType)
         ) . PHP_EOL;
 
-        return $message . (new Backtrace())->get();
+        $message .= sprintf(
+            'If you got this ↑ already, then try removing the cache file: `%s`',
+            ClassNameCache::CACHED_CLASS_NAMES_FILE
+        ) . PHP_EOL;
+
+        return $message . PHP_EOL . (new Backtrace())->get();
     }
 
     private function findClassNameExample(ClassInfo $classInfo, string $resolvableType): string

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -26,9 +26,9 @@ final class ClassResolverFactory
         );
     }
 
-    public function createClassNameCache(): InMemoryClassNameCache
+    public function createClassNameCache(): ClassNameCacheInterface
     {
-        return new InMemoryClassNameCache(
+        return new ClassNameCache(
             $this->getCachedClassNames(),
         );
     }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -15,8 +15,6 @@ use Gacela\Framework\Config\Config;
 
 final class ClassResolverFactory
 {
-    public const CACHED_CLASS_NAMES_FILE = 'gacela-cached-class-names.cache';
-
     public function createClassNameFinder(): ClassNameFinderInterface
     {
         return new ClassNameFinder(
@@ -29,7 +27,7 @@ final class ClassResolverFactory
     public function createClassNameCache(): ClassNameCacheInterface
     {
         return new ClassNameCache(
-            $this->getCachedClassNames(),
+            $this->getCachedClassNamesDir(),
         );
     }
 
@@ -49,25 +47,8 @@ final class ClassResolverFactory
         ];
     }
 
-    /**
-     * @return array<string,string>
-     */
-    private function getCachedClassNames(): array
-    {
-        $filename = $this->getCachedClassNamesDir() . self::CACHED_CLASS_NAMES_FILE;
-
-        if (file_exists($filename)) {
-            /** @var array<string,string> $content */
-            $content = require $filename;
-
-            return $content;
-        }
-
-        return [];
-    }
-
     private function getCachedClassNamesDir(): string
     {
-        return Config::getInstance()->getAppRootDir() . '/data/';
+        return Config::getInstance()->getAppRootDir() . '/';
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -22,7 +22,14 @@ final class ClassResolverFactory
         return new ClassNameFinder(
             $this->createClassValidator(),
             $this->createFinderRules(),
-            $this->getCachedClassNames()
+            $this->createClassNameCache()
+        );
+    }
+
+    public function createClassNameCache(): InMemoryClassNameCache
+    {
+        return new InMemoryClassNameCache(
+            $this->getCachedClassNames(),
         );
     }
 
@@ -47,7 +54,7 @@ final class ClassResolverFactory
      */
     private function getCachedClassNames(): array
     {
-        $filename = Config::getInstance()->getAppRootDir() . '/data/' . self::CACHED_CLASS_NAMES_FILE;
+        $filename = $this->getCachedClassNamesDir() . self::CACHED_CLASS_NAMES_FILE;
 
         if (file_exists($filename)) {
             /** @var array<string,string> $content */
@@ -57,5 +64,10 @@ final class ClassResolverFactory
         }
 
         return [];
+    }
+
+    private function getCachedClassNamesDir(): string
+    {
+        return Config::getInstance()->getAppRootDir() . '/data/';
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -11,14 +11,18 @@ use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithModulePrefix;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithoutModulePrefix;
+use Gacela\Framework\Config\Config;
 
 final class ClassResolverFactory
 {
+    public const CACHED_CLASS_NAMES_FILE = 'gacela-cached-class-names.cache';
+
     public function createClassNameFinder(): ClassNameFinderInterface
     {
         return new ClassNameFinder(
             $this->createClassValidator(),
             $this->createFinderRules(),
+            $this->getCachedClassNames()
         );
     }
 
@@ -36,5 +40,22 @@ final class ClassResolverFactory
             new FinderRuleWithModulePrefix(),
             new FinderRuleWithoutModulePrefix(),
         ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function getCachedClassNames(): array
+    {
+        $filename = Config::getInstance()->getAppRootDir() . '/data/' . self::CACHED_CLASS_NAMES_FILE;
+
+        if (file_exists($filename)) {
+            /** @var array<string,string> $content */
+            $content = require $filename;
+
+            return $content;
+        }
+
+        return [];
     }
 }

--- a/src/Framework/ClassResolver/InMemoryClassNameCache.php
+++ b/src/Framework/ClassResolver/InMemoryClassNameCache.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+final class InMemoryClassNameCache implements ClassNameCacheInterface
+{
+    /** @var array<string,string> */
+    private static array $cachedClassNames = [];
+
+    /**
+     * @param array<string,string> $cachedClassNames
+     */
+    public function __construct(array $cachedClassNames = [])
+    {
+        self::$cachedClassNames = $cachedClassNames;
+    }
+
+    /**
+     * @internal
+     */
+    public static function resetCachedClassNames(): void
+    {
+        self::$cachedClassNames = [];
+    }
+
+    public function has(string $cacheKey): bool
+    {
+        return isset(self::$cachedClassNames[$cacheKey]);
+    }
+
+    public function get(string $cacheKey): string
+    {
+        return self::$cachedClassNames[$cacheKey];
+    }
+
+    public function put(string $cacheKey, string $className): void
+    {
+        self::$cachedClassNames[$cacheKey] = $className;
+    }
+}

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -8,7 +8,7 @@ use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
-use Gacela\Framework\ClassResolver\InMemoryClassNameCache;
+use Gacela\Framework\ClassResolver\ClassNameCache;
 use Gacela\Framework\Config\Config;
 
 final class Gacela
@@ -25,7 +25,7 @@ final class Gacela
             : new SetupGacela();
 
         if ($setup->isResetCache()) {
-            InMemoryClassNameCache::resetCachedClassNames();
+            ClassNameCache::resetCachedClassNames();
             AbstractClassResolver::resetCache();
             Config::resetInstance();
         }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -8,7 +8,7 @@ use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
-use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
+use Gacela\Framework\ClassResolver\InMemoryClassNameCache;
 use Gacela\Framework\Config\Config;
 
 final class Gacela
@@ -25,7 +25,7 @@ final class Gacela
             : new SetupGacela();
 
         if ($setup->isResetCache()) {
-            ClassNameFinder::resetCachedClassNames();
+            InMemoryClassNameCache::resetCachedClassNames();
             AbstractClassResolver::resetCache();
             Config::resetInstance();
         }

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ClassNameCacheBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ClassNameCacheBench.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+
+final class ClassNameCacheBench
+{
+    public function bench_with_cache(): void
+    {
+        $this->gacelaBootstrapWithCache(true);
+        $this->loadAllModules();
+    }
+
+    public function bench_without_cache(): void
+    {
+        $this->gacelaBootstrapWithCache(false);
+        $this->loadAllModules();
+    }
+
+    private function gacelaBootstrapWithCache(bool $withCache): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($withCache): void {
+            $config->addAppConfig('config/*.php');
+            $config->setResetCache(!$withCache);
+
+            $config->addMappingInterface(StringValueInterface::class, new StringValue('testing-string'));
+
+            $config->addSuffixTypeFactory('FactoryA');
+            $config->addSuffixTypeFactory('FactoryB');
+            $config->addSuffixTypeFactory('FactoryC');
+            $config->addSuffixTypeFactory('FactoryD');
+            $config->addSuffixTypeFactory('FactoryE');
+
+            $config->addSuffixTypeConfig('ConfigA');
+            $config->addSuffixTypeConfig('ConfigB');
+            $config->addSuffixTypeConfig('ConfigC');
+            $config->addSuffixTypeConfig('ConfigD');
+            $config->addSuffixTypeConfig('ConfigE');
+
+            $config->addSuffixTypeDependencyProvider('DepProvA');
+            $config->addSuffixTypeDependencyProvider('DepProvB');
+            $config->addSuffixTypeDependencyProvider('DepProvC');
+            $config->addSuffixTypeDependencyProvider('DepProvD');
+            $config->addSuffixTypeDependencyProvider('DepProvE');
+        });
+
+        $this->removeCacheFile($withCache);
+    }
+
+    private function removeCacheFile(bool $withCache): void
+    {
+        $cacheFilename = __DIR__ . '/' . '.gacela-class-names.cache';
+        if (!$withCache && file_exists($cacheFilename)) {
+            unlink($cacheFilename);
+        }
+    }
+
+    private function loadAllModules(): void
+    {
+        (new ModuleA\Facade())->loadGacelaCacheFile();
+        (new ModuleB\Facade())->loadGacelaCacheFile();
+        (new ModuleC\Facade())->loadGacelaCacheFile();
+        (new ModuleD\Facade())->loadGacelaCacheFile();
+        (new ModuleE\Facade())->loadGacelaCacheFile();
+        (new ModuleF\Facade())->loadGacelaCacheFile();
+        (new ModuleG\Facade())->loadGacelaCacheFile();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/ConfigA.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/ConfigA.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleA;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ConfigA extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/DepProvA.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/DepProvA.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleA;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DepProvA extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleA;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FactoryA getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/FactoryA.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleA/FactoryA.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleA;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method ConfigA getConfig()
+ */
+final class FactoryA extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/ConfigB.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/ConfigB.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleB;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ConfigB extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/DepProvB.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/DepProvB.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleB;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DepProvB extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleB;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FactoryB getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/FactoryB.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleB/FactoryB.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleB;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method ConfigB getConfig()
+ */
+final class FactoryB extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/ConfigC.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/ConfigC.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleC;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ConfigC extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/DepProvC.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/DepProvC.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleC;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DepProvC extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleC;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FactoryC getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/FactoryC.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleC/FactoryC.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleC;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method ConfigC getConfig()
+ */
+final class FactoryC extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/ConfigD.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/ConfigD.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleD;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ConfigD extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/DepProvD.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/DepProvD.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleD;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DepProvD extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleD;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FactoryD getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/FactoryD.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleD/FactoryD.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleD;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method ConfigD getConfig()
+ */
+final class FactoryD extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/ConfigE.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/ConfigE.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleE;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ConfigE extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/DepProvE.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/DepProvE.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleE;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DepProvE extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleE;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FactoryE getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/FactoryE.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleE/FactoryE.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleE;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method ConfigE getConfig()
+ */
+final class FactoryE extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/Config.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/Config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleF;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/DependencyProvider.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/DependencyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleF;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DependencyProvider extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleF;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/Factory.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleF/Factory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleF;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method Config getConfig()
+ */
+final class Factory extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/Config.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/Config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleG;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+    public function getConfigValue(): string
+    {
+        return $this->get('config-key');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/DependencyProvider.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/DependencyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleG;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DependencyProvider extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set('provided-dependency', 'dependency-value');
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/Facade.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleG;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function loadGacelaCacheFile(): array
+    {
+        return $this->getFactory()->getArrayConfigAndProvidedDependency();
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/Factory.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ModuleG/Factory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Framework\ClassResolver\ClassNameCache\ModuleG;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValueInterface;
+
+/**
+ * @method Config getConfig()
+ */
+final class Factory extends AbstractFactory
+{
+    private StringValueInterface $stringValue;
+
+    public function __construct(StringValueInterface $stringValue)
+    {
+        $this->stringValue = $stringValue;
+    }
+
+    public function getArrayConfigAndProvidedDependency(): array
+    {
+        return [
+            'config-key' => $this->getConfig()->getConfigValue(),
+            'string-value' => $this->stringValue->value(),
+            'provided-dependency' => $this->getProvidedDependency('provided-dependency'),
+        ];
+    }
+}

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/config/default.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/config/default.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config-key' => 'config-value',
+];

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -10,7 +10,6 @@ use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
-use Gacela\Framework\ClassResolver\InMemoryClassNameCache;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -6,9 +6,11 @@ namespace GacelaTest\Unit\Framework\ClassResolver;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
+use Gacela\Framework\ClassResolver\InMemoryClassNameCache;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +27,8 @@ final class ClassNameFinderTest extends TestCase
     {
         $classNameFinder = new ClassNameFinder(
             $this->createMock(ClassValidatorInterface::class),
-            []
+            [],
+            $this->createMock(ClassNameCacheInterface::class)
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
@@ -45,7 +48,11 @@ final class ClassNameFinderTest extends TestCase
         $finderRule = $this->createStub(FinderRuleInterface::class);
         $finderRule->method('buildClassCandidate')->willReturn('\valid\class\name');
 
-        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+        $classNameFinder = new ClassNameFinder(
+            $classValidator,
+            [$finderRule],
+            $this->createMock(ClassNameCacheInterface::class)
+        );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = [];
@@ -64,7 +71,11 @@ final class ClassNameFinderTest extends TestCase
         $finderRule = $this->createStub(FinderRuleInterface::class);
         $finderRule->method('buildClassCandidate')->willReturn('\valid\class\name');
 
-        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+        $classNameFinder = new ClassNameFinder(
+            $classValidator,
+            [$finderRule],
+            $this->createMock(ClassNameCacheInterface::class)
+        );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];
@@ -83,7 +94,11 @@ final class ClassNameFinderTest extends TestCase
         $finderRule = $this->createStub(FinderRuleInterface::class);
         $finderRule->method('buildClassCandidate')->willReturn('\valid\class\name');
 
-        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+        $classNameFinder = new ClassNameFinder(
+            $classValidator,
+            [$finderRule],
+            $this->createMock(ClassNameCacheInterface::class)
+        );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];
@@ -102,7 +117,11 @@ final class ClassNameFinderTest extends TestCase
             ->method('buildClassCandidate')
             ->willReturn('\valid\class\name');
 
-        $classNameFinder = new ClassNameFinder($classValidator, [$finderRule]);
+        $classNameFinder = new ClassNameFinder(
+            $classValidator,
+            [$finderRule],
+            new InMemoryClassNameCache()
+        );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
         $resolvableTypes = ['A', 'B'];

--- a/tests/Unit/Framework/ClassResolver/InMemoryClassNameCache.php
+++ b/tests/Unit/Framework/ClassResolver/InMemoryClassNameCache.php
@@ -2,28 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Gacela\Framework\ClassResolver;
+namespace GacelaTest\Unit\Framework\ClassResolver;
+
+use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
 
 final class InMemoryClassNameCache implements ClassNameCacheInterface
 {
     /** @var array<string,string> */
     private static array $cachedClassNames = [];
-
-    /**
-     * @param array<string,string> $cachedClassNames
-     */
-    public function __construct(array $cachedClassNames = [])
-    {
-        self::$cachedClassNames = $cachedClassNames;
-    }
-
-    /**
-     * @internal
-     */
-    public static function resetCachedClassNames(): void
-    {
-        self::$cachedClassNames = [];
-    }
 
     public function has(string $cacheKey): bool
     {


### PR DESCRIPTION
## 📚 Description

Create a `.cache` file with the "classInfo->cacheKey" and its "resolvable candidate" as a php array, so it can be `required` and used on the fly without losing performance.

## 🔖 Changes

- Extract the cached classes from `ClassNameFinder` and create its own separated class for it: `ClassNameCache`.
- The `ClassNameCache` will start with the content of the `'.gacela-class-names.cache'` and it will update the content of the cache file every-time it find and resolves a new classInfo.
- Added some benchmark tests to prove the speed improvement when using the cache vs without cache.

> Most of the added lines are the dummy modules for the benchmark tests.

## 🖼️ Screenshot

The same code executed without and with cache:

- Without cache:  3.9 ms
- With cache: 263.8 μs

> 1 ms = 1,000,000 μs

<img width="1534" alt="Screenshot 2022-06-04 at 21 23 19" src="https://user-images.githubusercontent.com/5256287/172022665-f34077dd-b0c7-4556-a495-fe29e7c6aaa9.png">

