### PR TITLE
Rename $config->resetCache() to $config->setCacheEnabled()

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -21,7 +21,7 @@ final class GacelaConfig
     /** @var array<string,class-string|object|callable> */
     private array $externalServices;
 
-    private bool $resetCache = false;
+    private bool $cacheEnabled = true;
 
     /**
      * @param array<string,class-string|object|callable> $externalServices
@@ -113,9 +113,9 @@ final class GacelaConfig
         return $this;
     }
 
-    public function setResetCache(bool $flag): self
+    public function setCacheEnabled(bool $flag): self
     {
-        $this->resetCache = $flag;
+        $this->cacheEnabled = $flag;
 
         return $this;
     }
@@ -126,7 +126,7 @@ final class GacelaConfig
      *     config-builder:ConfigBuilder,
      *     suffix-types-builder:SuffixTypesBuilder,
      *     mapping-interfaces-builder:MappingInterfacesBuilder,
-     *     reset-cache:bool,
+     *     cache-enabled:bool,
      * }
      *
      * @internal
@@ -138,7 +138,7 @@ final class GacelaConfig
             'config-builder' => $this->configBuilder,
             'suffix-types-builder' => $this->suffixTypesBuilder,
             'mapping-interfaces-builder' => $this->mappingInterfacesBuilder,
-            'reset-cache' => $this->resetCache,
+            'cache-enabled' => $this->cacheEnabled,
         ];
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -29,7 +29,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     private ?MappingInterfacesBuilder $mappingInterfacesBuilder = null;
 
-    private bool $resetCache = false;
+    private bool $cacheEnabled = true;
 
     /**
      * @param Closure(GacelaConfig):void $setupGacelaFileFn
@@ -51,7 +51,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
             ->setMappingInterfacesBuilder($build['mapping-interfaces-builder'])
             ->setExternalServices($build['external-services'])
-            ->setResetCache($build['reset-cache']);
+            ->setCacheEnabled($build['cache-enabled']);
     }
 
     public function setMappingInterfacesBuilder(MappingInterfacesBuilder $builder): self
@@ -169,15 +169,15 @@ final class SetupGacela extends AbstractSetupGacela
         return $this->externalServices;
     }
 
-    public function setResetCache(bool $flag): self
+    public function setCacheEnabled(bool $flag): self
     {
-        $this->resetCache = $flag;
+        $this->cacheEnabled = $flag;
 
         return $this;
     }
 
-    public function isResetCache(): bool
+    public function isCacheEnabled(): bool
     {
-        return $this->resetCache;
+        return $this->cacheEnabled;
     }
 }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -34,5 +34,5 @@ interface SetupGacelaInterface
      */
     public function externalServices(): array;
 
-    public function isResetCache(): bool;
+    public function isCacheEnabled(): bool;
 }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -24,7 +24,7 @@ final class Gacela
             ? SetupGacela::fromCallable($configFn)
             : new SetupGacela();
 
-        if ($setup->isCacheEnabled()) {
+        if (!$setup->isCacheEnabled()) {
             ClassNameCache::resetCachedClassNames();
             AbstractClassResolver::resetCache();
             Config::resetInstance();

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -24,7 +24,7 @@ final class Gacela
             ? SetupGacela::fromCallable($configFn)
             : new SetupGacela();
 
-        if ($setup->isResetCache()) {
+        if ($setup->isCacheEnabled()) {
             ClassNameCache::resetCachedClassNames();
             AbstractClassResolver::resetCache();
             Config::resetInstance();

--- a/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ClassNameCacheBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/ClassNameCache/ClassNameCacheBench.php
@@ -27,7 +27,7 @@ final class ClassNameCacheBench
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($withCache): void {
             $config->addAppConfig('config/*.php');
-            $config->setResetCache(!$withCache);
+            $config->setCacheEnabled($withCache);
 
             $config->addMappingInterface(StringValueInterface::class, new StringValue('testing-string'));
 

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -14,7 +14,7 @@ final class ConfigTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->setResetCache(true);
+            $config->setCacheEnabled(false);
         });
     }
 

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -18,7 +18,7 @@ final class ClassNameFinderTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->setResetCache(true);
+            $config->setCacheEnabled(false);
         });
     }
 


### PR DESCRIPTION
## 📚 Description

Rename the GacelaConfig method from `$config->resetCache(bool)` to `$config->setCacheEnabled(bool)`.
The default value is now `true`.

## 🪱 Usage example

<img width="636" alt="image" src="https://user-images.githubusercontent.com/6381924/172417157-96dc27d9-e634-4b8c-af6c-fc69796d8990.png">
