### PR TITLE
Add PhpDoc to $parentReturn var

### DIFF
--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -54,7 +54,7 @@ trait DocBlockResolverAwareTrait
         }
 
         if ($this->hasParentClass()) {
-            /** @psalm-suppress ParentNotFound */
+            /** @var class-string $parentReturn */
             $parentReturn = parent::__call($method, $parameters);
             $this->customServices[$method] = $parentReturn;
 


### PR DESCRIPTION
## 📚 Description

The old tag `@psalm-suppress ParentNotFound` was not necessary anymore because in the previous `if`, we check if the current class has already some parent class.

In another way, from time to time the Psalm complain because the `$parentReturn` is not a `string-class` but a simple string, with this PhpDoc Psalm is not complaining anymore.

