### PR TITLE
Group gacela cache files inside a cache directory

### DIFF
--- a/src/Framework/ClassResolver/AbstractFileCache.php
+++ b/src/Framework/ClassResolver/AbstractFileCache.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
+use RuntimeException;
+
 abstract class AbstractFileCache implements ClassNameCacheInterface
 {
     /** @var array<string,string> */
@@ -68,6 +70,12 @@ abstract class AbstractFileCache implements ClassNameCacheInterface
 
     private function getAbsoluteCacheFilename(): string
     {
-        return $this->cacheDir . $this->getCacheFilename();
+        if (!is_dir($this->cacheDir)
+            && !mkdir($concurrentDirectory = $this->cacheDir)
+            && !is_dir($concurrentDirectory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        }
+
+        return $this->cacheDir . '/' . $this->getCacheFilename();
     }
 }

--- a/src/Framework/ClassResolver/Cache/GacelaCache.php
+++ b/src/Framework/ClassResolver/Cache/GacelaCache.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver\Cache;
+
+final class GacelaCache
+{
+    public const ENABLED = 'gacela-cache-enabled';
+    public const DEFAULT_VALUE = true;
+}

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -27,7 +27,7 @@ final class ClassResolverFactory
     public function createClassNameCache(): ClassNameCacheInterface
     {
         return new ClassNameCache(
-            $this->getCachedClassNamesDir(),
+            Config::getInstance()->getCacheDir(),
         );
     }
 
@@ -45,10 +45,5 @@ final class ClassResolverFactory
             new FinderRuleWithModulePrefix(),
             new FinderRuleWithoutModulePrefix(),
         ];
-    }
-
-    private function getCachedClassNamesDir(): string
-    {
-        return Config::getInstance()->getAppRootDir() . '/';
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -28,7 +28,7 @@ final class ClassResolverFactory
     public function createClassNameCache(): ClassNameCacheInterface
     {
         if (!$this->isCacheEnabled()) {
-            return new InMemoryFileCache(ClassNameCache::class);
+            return new InMemoryCache(ClassNameCache::class);
         }
 
         return new ClassNameCache(

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinderInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidator;
@@ -26,6 +27,10 @@ final class ClassResolverFactory
 
     public function createClassNameCache(): ClassNameCacheInterface
     {
+        if (!$this->isCacheEnabled()) {
+            return new InMemoryFileCache(ClassNameCache::class);
+        }
+
         return new ClassNameCache(
             Config::getInstance()->getCacheDir(),
         );
@@ -45,5 +50,11 @@ final class ClassResolverFactory
             new FinderRuleWithModulePrefix(),
             new FinderRuleWithoutModulePrefix(),
         ];
+    }
+
+    private function isCacheEnabled(): bool
+    {
+        return (bool)Config::getInstance()
+            ->get(GacelaCache::ENABLED, GacelaCache::DEFAULT_VALUE);
     }
 }

--- a/src/Framework/ClassResolver/InMemoryCache.php
+++ b/src/Framework/ClassResolver/InMemoryCache.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
-final class InMemoryFileCache implements ClassNameCacheInterface
+final class InMemoryCache implements ClassNameCacheInterface
 {
     /** @var array<string,array<string,string>> */
     private static array $cache = [];

--- a/src/Framework/ClassResolver/InMemoryFileCache.php
+++ b/src/Framework/ClassResolver/InMemoryFileCache.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+final class InMemoryFileCache implements ClassNameCacheInterface
+{
+    /** @var array<string,array<string,string>> */
+    private static array $cache = [];
+
+    private string $key;
+
+    public function __construct(string $key)
+    {
+        $this->key = $key;
+    }
+
+    /**
+     * @internal
+     */
+    public static function getAll(string $key): array
+    {
+        return self::$cache[$key] ?? [];
+    }
+
+    /**
+     * @internal
+     */
+    public static function resetCache(): void
+    {
+        self::$cache = [];
+    }
+
+    public function has(string $cacheKey): bool
+    {
+        return isset(self::$cache[$this->key][$cacheKey]);
+    }
+
+    public function get(string $cacheKey): string
+    {
+        return self::$cache[$this->key][$cacheKey];
+    }
+
+    public function put(string $cacheKey, string $className): void
+    {
+        self::$cache[$this->key][$cacheKey] = $className;
+    }
+}

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -95,6 +95,11 @@ final class Config
         return $this->appRootDir ?? getcwd() ?: '';
     }
 
+    public function getCacheDir(): string
+    {
+        return $this->getAppRootDir() . '/cache/';
+    }
+
     public function setSetup(SetupGacelaInterface $setup): self
     {
         $this->setup = $setup;

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -8,6 +8,8 @@ use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Exception\ConfigException;
 
+use function array_key_exists;
+
 final class Config
 {
     public const DEFAULT_CONFIG_VALUE = 'Gacela\Framework\Config::DEFAULT_CONFIG_VALUE';
@@ -124,7 +126,7 @@ final class Config
 
     private function hasValue(string $key): bool
     {
-        return isset($this->config[$key]);
+        return array_key_exists($key, $this->config);
     }
 
     /**

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -11,7 +11,7 @@ use Gacela\Framework\ClassResolver\DocBlockService\DocBlockParser;
 use Gacela\Framework\ClassResolver\DocBlockService\DocBlockServiceResolver;
 use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
 use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
-use Gacela\Framework\ClassResolver\InMemoryFileCache;
+use Gacela\Framework\ClassResolver\InMemoryCache;
 use Gacela\Framework\Config\Config;
 use ReflectionClass;
 
@@ -132,7 +132,7 @@ trait DocBlockResolverAwareTrait
     private function createCustomServicesCache(): ClassNameCacheInterface
     {
         if (!$this->isCacheEnabled()) {
-            return new InMemoryFileCache(CustomServicesCache::class);
+            return new InMemoryCache(CustomServicesCache::class);
         }
 
         return new CustomServicesCache(

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -127,11 +127,8 @@ trait DocBlockResolverAwareTrait
 
     private function createCustomServicesCache(): CustomServicesCache
     {
-        return new CustomServicesCache($this->getCachedClassNamesDir());
-    }
-
-    private function getCachedClassNamesDir(): string
-    {
-        return Config::getInstance()->getAppRootDir() . '/';
+        return new CustomServicesCache(
+            Config::getInstance()->getCacheDir()
+        );
     }
 }

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
-final class DocBlockResolverAwareTest extends TestCase
+final class DocBlockResolverCustomServicesAwareTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -17,7 +18,9 @@ final class DocBlockResolverAwareTest extends TestCase
 
     protected function setUp(): void
     {
-        Gacela::bootstrap(__DIR__);
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/custom-services/*.php');
+        });
     }
 
     public function test_existing_service(): void
@@ -25,6 +28,7 @@ final class DocBlockResolverAwareTest extends TestCase
         $dummy = new DummyDocBlockResolverAware();
         $actual = $dummy->getRepository()->findName();
 
+        self::assertCount(1, CustomServicesCache::getAll());
         self::assertSame('name', $actual);
     }
 

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
@@ -6,7 +6,7 @@ namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
-use Gacela\Framework\ClassResolver\InMemoryFileCache;
+use Gacela\Framework\ClassResolver\InMemoryCache;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +14,7 @@ final class DocBlockResolverInMemoryAwareTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        InMemoryFileCache::resetCache();
+        InMemoryCache::resetCache();
     }
 
     protected function setUp(): void
@@ -29,7 +29,7 @@ final class DocBlockResolverInMemoryAwareTest extends TestCase
         $dummy = new DummyDocBlockResolverAware();
         $actual = $dummy->getRepository()->findName();
 
-        self::assertCount(1, InMemoryFileCache::getAll(CustomServicesCache::class));
+        self::assertCount(1, InMemoryCache::getAll(CustomServicesCache::class));
         self::assertSame('name', $actual);
     }
 
@@ -38,13 +38,13 @@ final class DocBlockResolverInMemoryAwareTest extends TestCase
      */
     public function test_existing_service_cached(): void
     {
-        self::assertCount(1, InMemoryFileCache::getAll(CustomServicesCache::class));
+        self::assertCount(1, InMemoryCache::getAll(CustomServicesCache::class));
 
         $dummy = new DummyDocBlockResolverAware();
         $dummy->getRepository()->findName();
         $dummy->getRepository()->findName();
 
-        self::assertCount(1, InMemoryFileCache::getAll(CustomServicesCache::class));
+        self::assertCount(1, InMemoryCache::getAll(CustomServicesCache::class));
     }
 
     public function test_non_existing_service(): void

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
+use Gacela\Framework\ClassResolver\InMemoryFileCache;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class DocBlockResolverInMemoryAwareTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        InMemoryFileCache::resetCache();
+    }
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/in-memory/*.php');
+        });
+    }
+
+    public function test_existing_service(): void
+    {
+        $dummy = new DummyDocBlockResolverAware();
+        $actual = $dummy->getRepository()->findName();
+
+        self::assertCount(1, InMemoryFileCache::getAll(CustomServicesCache::class));
+        self::assertSame('name', $actual);
+    }
+
+    /**
+     * @depends test_existing_service
+     */
+    public function test_existing_service_cached(): void
+    {
+        self::assertCount(1, InMemoryFileCache::getAll(CustomServicesCache::class));
+
+        $dummy = new DummyDocBlockResolverAware();
+        $dummy->getRepository()->findName();
+        $dummy->getRepository()->findName();
+
+        self::assertCount(1, InMemoryFileCache::getAll(CustomServicesCache::class));
+    }
+
+    public function test_non_existing_service(): void
+    {
+        $this->expectExceptionMessage('Missing the concrete return type for the method `getRepository()`');
+
+        $dummy = new BadDummyDocBlockResolverAware();
+        $dummy->getRepository();
+    }
+}

--- a/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+
 return [
-    'cache-enabled' => true,
+    GacelaCache::ENABLED  => true,
 ];

--- a/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'cache-enabled' => true,
+];

--- a/tests/Integration/Framework/DocBlockResolverAware/config/in-memory/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/in-memory/default.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+
+return [
+    GacelaCache::ENABLED => false,
+];

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -10,6 +10,7 @@ use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinder;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidatorInterface;
 use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleInterface;
+use Gacela\Framework\ClassResolver\InMemoryCache;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -119,7 +120,7 @@ final class ClassNameFinderTest extends TestCase
         $classNameFinder = new ClassNameFinder(
             $classValidator,
             [$finderRule],
-            new InMemoryClassNameCache()
+            new InMemoryCache(ClassInfo::class)
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');


### PR DESCRIPTION
## 📚 Description

Currently the gacela cache files are created under the root project dir.

## 🔖 Changes

- Create a directory "cache" on the fly in case it does not exists.
- Store inside the "cache" directory the cache files.
- Allow enable/disable the cache from the config files directly.