### PR TITLE
Add gacela-cli script back to gacela

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,11 @@
         "friendsofphp/php-cs-fixer": "^3.8",
         "phpbench/phpbench": "^1.2",
         "phpmetrics/phpmetrics": "^2.8",
+        "symfony/console": "^5.4",
         "symfony/var-dumper": "^5.4"
     },
     "suggest": {
-        "gacela-project/gacela-cli": "Gacela cli util",
+        "symfony/console": "Allows to use vendor/bin/gacela script",
         "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
         "gacela-project/gacela-yaml-config-reader": "Allows to read yml/yaml config files"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4b31d5169f3d2167f422d7537fbb432",
+    "content-hash": "4f070ba936d54f885c32a38491292a11",
     "packages": [],
     "packages-dev": [
         {
@@ -1778,16 +1778,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.14",
+            "version": "1.7.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e6f145f196a59c7ca91ea926c87ef3d936c4305f"
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e6f145f196a59c7ca91ea926c87ef3d936c4305f",
-                "reference": "e6f145f196a59c7ca91ea926c87ef3d936c4305f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
                 "shasum": ""
             },
             "require": {
@@ -1813,7 +1813,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.14"
+                "source": "https://github.com/phpstan/phpstan/tree/1.7.15"
             },
             "funding": [
                 {
@@ -1833,7 +1833,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-14T13:09:35+00:00"
+            "time": "2022-06-20T08:29:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2155,16 +2155,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -2198,7 +2198,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -2242,7 +2241,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -2254,7 +2253,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "psr/cache",

--- a/gacela
+++ b/gacela
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\CodeGenerator\Infrastructure\Command\MakeFileCommand;
+use Gacela\CodeGenerator\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Framework\Gacela;
+use Symfony\Component\Console\Application;
+
+$cwd = getcwd();
+if (!file_exists($autoloadPath = $cwd . '/vendor/autoload.php')) {
+    exit("Cannot load composer's autoload file: " . $autoloadPath);
+}
+
+require $autoloadPath;
+
+Gacela::bootstrap($cwd);
+
+$codeGeneratorFacade = new CodeGeneratorFacade();
+
+$application = new Application();
+$application->add(new MakeFileCommand());
+$application->add(new MakeModuleCommand());
+$application->run();
+

--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator;
+
+use Gacela\Framework\AbstractConfig;
+use JsonException;
+use LogicException;
+
+final class CodeGeneratorConfig extends AbstractConfig
+{
+    public function getFacadeMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('facade-maker.txt');
+    }
+
+    public function getFactoryMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('factory-maker.txt');
+    }
+
+    public function getConfigMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('config-maker.txt');
+    }
+
+    public function getDependencyProviderMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('dependency-provider-maker.txt');
+    }
+
+    /**
+     * @throws JsonException
+     *
+     * @return array{autoload: array{psr-4: array<string,string>}}
+     */
+    public function getComposerJsonContentAsArray(): array
+    {
+        $filename = $this->getAppRootDir() . '/composer.json';
+        if (!file_exists($filename)) {
+            throw new LogicException('composer.json file not found but it is required');
+        }
+
+        /** @var array{autoload: array{psr-4: array<string,string>}} $json */
+        $json = (array)json_decode((string)file_get_contents($filename), true, 512, JSON_THROW_ON_ERROR);
+
+        return $json;
+    }
+
+    private function getCommandTemplateContent(string $filename): string
+    {
+        return (string)file_get_contents(__DIR__ . '/Infrastructure/Template/Command/' . $filename);
+    }
+}

--- a/src/CodeGenerator/CodeGeneratorDependencyProvider.php
+++ b/src/CodeGenerator/CodeGeneratorDependencyProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator;
+
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizer;
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * @method CodeGeneratorConfig getConfig()
+ */
+final class CodeGeneratorDependencyProvider extends AbstractDependencyProvider
+{
+    public const TEMPLATE_BY_FILENAME_MAP = 'TEMPLATE_FILENAME_MAP';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $this->addTemplateByFilenameMap($container);
+    }
+
+    private function addTemplateByFilenameMap(Container $container): void
+    {
+        $codeTemplate = $this->getConfig();
+
+        $container->set(self::TEMPLATE_BY_FILENAME_MAP, static fn () => [
+            FilenameSanitizer::FACADE => $codeTemplate->getFacadeMakerTemplate(),
+            FilenameSanitizer::FACTORY => $codeTemplate->getFactoryMakerTemplate(),
+            FilenameSanitizer::CONFIG => $codeTemplate->getConfigMakerTemplate(),
+            FilenameSanitizer::DEPENDENCY_PROVIDER => $codeTemplate->getDependencyProviderMakerTemplate(),
+        ]);
+    }
+}

--- a/src/CodeGenerator/CodeGeneratorFacade.php
+++ b/src/CodeGenerator/CodeGeneratorFacade.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator;
+
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArguments;
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method CodeGeneratorFactory getFactory()
+ */
+final class CodeGeneratorFacade extends AbstractFacade
+{
+    public function sanitizeFilename(string $filename): string
+    {
+        return $this->getFactory()
+            ->createFilenameSanitizer()
+            ->sanitize($filename);
+    }
+
+    public function parseArguments(string $desiredNamespace): CommandArguments
+    {
+        return $this->getFactory()
+            ->createCommandArgumentsParser()
+            ->parse($desiredNamespace);
+    }
+
+    public function generateFileContent(
+        CommandArguments $commandArguments,
+        string $filename,
+        bool $withShortName = false
+    ): string {
+        return $this->getFactory()
+            ->createFileContentGenerator()
+            ->generate($commandArguments, $filename, $withShortName);
+    }
+}

--- a/src/CodeGenerator/CodeGeneratorFactory.php
+++ b/src/CodeGenerator/CodeGeneratorFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator;
+
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArgumentsParser;
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArgumentsParserInterface;
+use Gacela\CodeGenerator\Domain\FileContent\FileContentGenerator;
+use Gacela\CodeGenerator\Domain\FileContent\FileContentGeneratorInterface;
+use Gacela\CodeGenerator\Domain\FileContent\FileContentIoInterface;
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizer;
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizerInterface;
+use Gacela\CodeGenerator\Infrastructure\FileContentIo;
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method CodeGeneratorConfig getConfig()
+ */
+final class CodeGeneratorFactory extends AbstractFactory
+{
+    public function createCommandArgumentsParser(): CommandArgumentsParserInterface
+    {
+        return new CommandArgumentsParser(
+            $this->getConfig()->getComposerJsonContentAsArray()
+        );
+    }
+
+    public function createFilenameSanitizer(): FilenameSanitizerInterface
+    {
+        return new FilenameSanitizer();
+    }
+
+    public function createFileContentGenerator(): FileContentGeneratorInterface
+    {
+        return new FileContentGenerator(
+            $this->createFileContentIo(),
+            $this->getTemplateByFilenameMap()
+        );
+    }
+
+    private function createFileContentIo(): FileContentIoInterface
+    {
+        return new FileContentIo();
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function getTemplateByFilenameMap(): array
+    {
+        /** @var array<string,string> $map */
+        $map = $this->getProvidedDependency(CodeGeneratorDependencyProvider::TEMPLATE_BY_FILENAME_MAP);
+        return $map;
+    }
+}

--- a/src/CodeGenerator/Domain/CommandArguments/CommandArguments.php
+++ b/src/CodeGenerator/Domain/CommandArguments/CommandArguments.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\CommandArguments;
+
+final class CommandArguments
+{
+    private string $namespace;
+    private string $directory;
+
+    public function __construct(string $namespace, string $directory)
+    {
+        $this->namespace = $namespace;
+        $this->directory = $directory;
+    }
+
+    public function namespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function directory(): string
+    {
+        return $this->directory;
+    }
+
+    public function basename(): string
+    {
+        return basename($this->directory);
+    }
+}

--- a/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsException.php
+++ b/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\CommandArguments;
+
+use RuntimeException;
+
+final class CommandArgumentsException extends RuntimeException
+{
+    public static function noAutoloadFound(): self
+    {
+        return new self('No autoload found in your composer.json');
+    }
+
+    public static function noAutoloadPsr4Found(): self
+    {
+        return new self('No autoload psr-4 match found in your composer.json');
+    }
+
+    /**
+     * @param list<string> $knownPsr4
+     */
+    public static function noAutoloadPsr4MatchFound(string $desiredNamespace, array $knownPsr4 = []): self
+    {
+        $parsedKnownPsr4 = array_map(static fn (string $p) => str_replace('\\', '', $p), $knownPsr4);
+
+        return new self(
+            sprintf(
+                'No autoload psr-4 match found for %s. Known PSR-4: %s',
+                $desiredNamespace,
+                implode(', ', $parsedKnownPsr4)
+            )
+        );
+    }
+}

--- a/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsParser.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\CommandArguments;
+
+use InvalidArgumentException;
+use function count;
+
+final class CommandArgumentsParser implements CommandArgumentsParserInterface
+{
+    /** @var array{autoload: array{psr-4?:array<string,string>}} */
+    private array $composerJson;
+
+    /**
+     * @param array{autoload: array{psr-4?:array<string,string>}} $composerJson
+     */
+    public function __construct(array $composerJson)
+    {
+        $this->composerJson = $composerJson;
+    }
+
+    /**
+     * @param string $desiredNamespace The location of the new module. For example: App/TestModule
+     *
+     * @throws InvalidArgumentException
+     */
+    public function parse(string $desiredNamespace): CommandArguments
+    {
+        if (!isset($this->composerJson['autoload'])) {
+            throw CommandArgumentsException::noAutoloadFound();
+        }
+
+        if (!isset($this->composerJson['autoload']['psr-4'])) {
+            throw CommandArgumentsException::noAutoloadPsr4Found();
+        }
+
+        $psr4 = $this->composerJson['autoload']['psr-4'];
+        $allPsr4Combinations = $this->allPossiblePsr4Combinations($desiredNamespace);
+
+        foreach ($allPsr4Combinations as $psr4Combination) {
+            $psr4Key = $psr4Combination . '\\';
+
+            if (isset($psr4[$psr4Key])) {
+                return $this->foundPsr4($psr4Key, $psr4[$psr4Key], $desiredNamespace);
+            }
+        }
+
+        throw CommandArgumentsException::noAutoloadPsr4MatchFound($desiredNamespace, array_keys($psr4));
+    }
+
+    /**
+     * Combine all possible psr-4 combinations and return them ordered by longer to shorter.
+     * This way we'll be able to find the longer match first.
+     * For example: App/TestModule/TestSubModule will produce an array such as:
+     * [
+     *   'App/TestModule/TestSubModule',
+     *   'App/TestModule',
+     *   'App',
+     * ]
+     *
+     * @return list<string>
+     */
+    private function allPossiblePsr4Combinations(string $desiredNamespace): array
+    {
+        $result = [];
+
+        foreach (explode('/', $desiredNamespace) as $explodedArg) {
+            if (empty($result)) {
+                $result[] = $explodedArg;
+            } else {
+                $prevValue = $result[count($result) - 1];
+                $result[] = $prevValue . '\\' . $explodedArg;
+            }
+        }
+
+        return array_reverse($result);
+    }
+
+    private function foundPsr4(string $psr4Key, string $psr4Value, string $desiredNamespace): CommandArguments
+    {
+        $rootDir = mb_substr($psr4Value, 0, -1);
+        $rootNamespace = mb_substr($psr4Key, 0, -1);
+        $targetDirectory = str_replace(['/', $rootNamespace, '\\'], ['\\', $rootDir, '/'], $desiredNamespace);
+        $namespace = str_replace([$rootDir, '/'], [$rootNamespace, '\\'], $targetDirectory);
+
+        return new CommandArguments($namespace, $targetDirectory);
+    }
+}

--- a/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsParserInterface.php
+++ b/src/CodeGenerator/Domain/CommandArguments/CommandArgumentsParserInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\CommandArguments;
+
+interface CommandArgumentsParserInterface
+{
+    /**
+     * @param string $desiredNamespace The location of the new module. For example: App/TestModule
+     */
+    public function parse(string $desiredNamespace): CommandArguments;
+}

--- a/src/CodeGenerator/Domain/FileContent/FileContentGenerator.php
+++ b/src/CodeGenerator/Domain/FileContent/FileContentGenerator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\FileContent;
+
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArguments;
+use RuntimeException;
+
+final class FileContentGenerator implements FileContentGeneratorInterface
+{
+    private FileContentIoInterface $fileContentIo;
+
+    /** @var array<string,string> */
+    private array $templateByFilenameMap;
+
+    /**
+     * @param array<string,string> $templateByFilenameMap
+     */
+    public function __construct(
+        FileContentIoInterface $fileContentIo,
+        array $templateByFilenameMap
+    ) {
+        $this->fileContentIo = $fileContentIo;
+        $this->templateByFilenameMap = $templateByFilenameMap;
+    }
+
+    /**
+     * @return string path result where the file was generated
+     */
+    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false): string
+    {
+        $this->fileContentIo->mkdir($commandArguments->directory());
+
+        $moduleName = $withShortName ? '' : $commandArguments->basename();
+        $className = $moduleName . $filename;
+
+        $path = sprintf('%s/%s.php', $commandArguments->directory(), $className);
+        $search = ['$NAMESPACE$', '$MODULE_NAME$', '$CLASS_NAME$'];
+        $replace = [$commandArguments->namespace(), $moduleName, $className];
+
+        $template = $this->templateByFilenameMap[$filename] ?? '';
+        if (empty($template)) {
+            throw new RuntimeException("Unknown template for '{$filename}'?");
+        }
+
+        $fileContent = str_replace($search, $replace, $template);
+
+        $this->fileContentIo->filePutContents($path, $fileContent);
+
+        return $path;
+    }
+}

--- a/src/CodeGenerator/Domain/FileContent/FileContentGeneratorInterface.php
+++ b/src/CodeGenerator/Domain/FileContent/FileContentGeneratorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\FileContent;
+
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArguments;
+
+interface FileContentGeneratorInterface
+{
+    /**
+     * @return string path result where the file was generated
+     */
+    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false): string;
+}

--- a/src/CodeGenerator/Domain/FileContent/FileContentIoInterface.php
+++ b/src/CodeGenerator/Domain/FileContent/FileContentIoInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\FileContent;
+
+interface FileContentIoInterface
+{
+    public function mkdir(string $directory): void;
+
+    public function filePutContents(string $path, string $fileContent): void;
+}

--- a/src/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizer.php
+++ b/src/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\FilenameSanitizer;
+
+use RuntimeException;
+use function count;
+
+final class FilenameSanitizer implements FilenameSanitizerInterface
+{
+    public const FACADE = 'Facade';
+    public const FACTORY = 'Factory';
+    public const CONFIG = 'Config';
+    public const DEPENDENCY_PROVIDER = 'DependencyProvider';
+
+    public const EXPECTED_FILENAMES = [
+        self::FACADE,
+        self::FACTORY,
+        self::CONFIG,
+        self::DEPENDENCY_PROVIDER,
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public function getExpectedFilenames(): array
+    {
+        return self::EXPECTED_FILENAMES;
+    }
+
+    public function sanitize(string $filename): string
+    {
+        $percents = [];
+
+        foreach (self::EXPECTED_FILENAMES as $expected) {
+            $percents[$expected] = similar_text($expected, $filename, $percent);
+        }
+
+        $maxVal = max($percents);
+        $maxValKeys = array_keys($percents, $maxVal, true);
+
+        if (count($maxValKeys) > 1) {
+            throw new RuntimeException(sprintf(
+                'When using "%s", which filename do you mean [%s]?',
+                $filename,
+                implode(' or ', $maxValKeys)
+            ));
+        }
+
+        return reset($maxValKeys);
+    }
+}

--- a/src/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizerInterface.php
+++ b/src/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Domain\FilenameSanitizer;
+
+interface FilenameSanitizerInterface
+{
+    /**
+     * @return list<string>
+     */
+    public function getExpectedFilenames(): array;
+
+    public function sanitize(string $filename): string;
+}

--- a/src/CodeGenerator/Infrastructure/Command/MakeFileCommand.php
+++ b/src/CodeGenerator/Infrastructure/Command/MakeFileCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Infrastructure\Command;
+
+use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizer;
+use Gacela\Framework\DocBlockResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @method CodeGeneratorFacade getFacade()
+ */
+final class MakeFileCommand extends Command
+{
+    use DocBlockResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('make:file')
+            ->setDescription('Generate a ' . $this->getExpectedFilenames())
+            ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
+            ->addArgument('filenames', InputArgument::REQUIRED | InputArgument::IS_ARRAY, $this->getExpectedFilenames())
+            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var list<string> $inputFileNames */
+        $inputFileNames = $input->getArgument('filenames');
+
+        $filenames = array_map(
+            fn (string $raw): string => $this->getFacade()->sanitizeFilename($raw),
+            $inputFileNames
+        );
+
+        /** @var string $path */
+        $path = $input->getArgument('path');
+        $commandArguments = $this->getFacade()->parseArguments($path);
+        $shortName = (bool)$input->getOption('short-name');
+
+        foreach ($filenames as $filename) {
+            $absolutePath = $this->getFacade()->generateFileContent(
+                $commandArguments,
+                $filename,
+                $shortName
+            );
+            $output->writeln("> Path '{$absolutePath}' created successfully");
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function getExpectedFilenames(): string
+    {
+        return implode(', ', FilenameSanitizer::EXPECTED_FILENAMES);
+    }
+}

--- a/src/CodeGenerator/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/CodeGenerator/Infrastructure/Command/MakeModuleCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Infrastructure\Command;
+
+use Gacela\CodeGenerator\CodeGeneratorFacade;
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizer;
+use Gacela\Framework\DocBlockResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @method CodeGeneratorFacade getFacade()
+ */
+final class MakeModuleCommand extends Command
+{
+    use DocBlockResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('make:module')
+            ->setDescription('Generate a basic module with an empty ' . $this->getExpectedFilenames())
+            ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
+            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $path */
+        $path = $input->getArgument('path');
+        $commandArguments = $this->getFacade()->parseArguments($path);
+        $shortName = (bool)$input->getOption('short-name');
+
+        foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
+            $fullPath = $this->getFacade()->generateFileContent(
+                $commandArguments,
+                $filename,
+                $shortName
+            );
+            $output->writeln("> Path '{$fullPath}' created successfully");
+        }
+
+        $pieces = explode('/', $commandArguments->directory());
+        $moduleName = end($pieces);
+        $output->writeln("Module '{$moduleName}' created successfully");
+
+        return self::SUCCESS;
+    }
+
+    private function getExpectedFilenames(): string
+    {
+        return implode(', ', FilenameSanitizer::EXPECTED_FILENAMES);
+    }
+}

--- a/src/CodeGenerator/Infrastructure/FileContentIo.php
+++ b/src/CodeGenerator/Infrastructure/FileContentIo.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\CodeGenerator\Infrastructure;
+
+use Gacela\CodeGenerator\Domain\FileContent\FileContentIoInterface;
+use RuntimeException;
+
+/**
+ * @codeCoverageIgnore
+ */
+final class FileContentIo implements FileContentIoInterface
+{
+    public function mkdir(string $directory): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+        if (!mkdir($directory) && !is_dir($directory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $directory));
+        }
+    }
+
+    public function filePutContents(string $path, string $fileContent): void
+    {
+        file_put_contents($path, $fileContent);
+    }
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/config-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/config-maker.txt
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractConfig;
+
+final class $CLASS_NAME$ extends AbstractConfig
+{
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/dependency-provider-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/dependency-provider-maker.txt
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class $CLASS_NAME$ extends AbstractDependencyProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/facade-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/facade-maker.txt
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method $MODULE_NAME$Factory getFactory()
+ */
+final class $CLASS_NAME$ extends AbstractFacade
+{
+}

--- a/src/CodeGenerator/Infrastructure/Template/Command/factory-maker.txt
+++ b/src/CodeGenerator/Infrastructure/Template/Command/factory-maker.txt
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method $MODULE_NAME$Config getConfig()
+ */
+final class $CLASS_NAME$ extends AbstractFactory
+{
+}

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -47,6 +47,7 @@ trait DocBlockResolverAwareTrait
         }
 
         /** @psalm-suppress ArgumentTypeCoercion */
+        /** @var class-string $className */
         $className = $cache->get($cacheKey);
         $resolvableType = $this->normalizeResolvableType($className);
 
@@ -58,8 +59,8 @@ trait DocBlockResolverAwareTrait
         }
 
         if ($this->hasParentClass()) {
-            /** @psalm-suppress ParentNotFound */
-            $parentReturn = parent::__call($method, $parameters);
+            /** @psalm-suppress ParentNotFound, MixedAssignment, UndefinedMethod */
+            $parentReturn = parent::__call($method, $parameters); // @phpstan-ignore-line
             $this->customServices[$method] = $parentReturn;
 
             return $parentReturn;
@@ -104,9 +105,9 @@ trait DocBlockResolverAwareTrait
      */
     private function searchClassOverUseStatements(ReflectionClass $reflectionClass, string $className): string
     {
-        $fileName = $reflectionClass->getFileName();
+        $fileName = (string) $reflectionClass->getFileName();
         if (!isset(static::$fileContentCache[$fileName])) {
-            static::$fileContentCache[$fileName] = file_get_contents($fileName);
+            static::$fileContentCache[$fileName] = (string) file_get_contents($fileName);
         }
         $phpFile = static::$fileContentCache[$fileName];
 

--- a/tests/Feature/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeFileCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\CodeGenerator;
+
+use GacelaTest\Feature\CodeGenerator\Util\DirectoryUtil;
+use PHPUnit\Framework\TestCase;
+
+final class MakeFileCommandTest extends TestCase
+{
+    private const ENTRY_POINT = __DIR__ . '/../../../';
+
+    public static function tearDownAfterClass(): void
+    {
+        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+    }
+
+    public function setUp(): void
+    {
+        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+    }
+
+    /**
+     * @dataProvider createFilesProvider
+     */
+    public function test_make_file(string $action, string $fileName, string $shortName): void
+    {
+        $command = sprintf('%sgacela make:file %s Gacela/TestModule %s', self::ENTRY_POINT, $shortName, $action);
+        exec($command, $output);
+
+        self::assertSame("> Path 'src/TestModule/{$fileName}.php' created successfully", $output[0]);
+        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}.php");
+    }
+
+    public function createFilesProvider(): iterable
+    {
+        yield 'facade' => ['facade', 'TestModuleFacade', ''];
+        yield 'factory' => ['factory', 'TestModuleFactory', ''];
+        yield 'config' => ['config', 'TestModuleConfig', ''];
+        yield 'dependency provider' => ['dependency-provider', 'TestModuleDependencyProvider', ''];
+
+        // Sort name flag
+        yield 'facade -s' => ['facade', 'Facade', '-s'];
+        yield 'factory -s' => ['factory', 'Factory', '-s'];
+        yield 'config -s' => ['config', 'Config', '-s'];
+        yield 'dependency provider -s' => ['dependency-provider', 'DependencyProvider', '-s'];
+    }
+}

--- a/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\CodeGenerator;
+
+use GacelaTest\Feature\CodeGenerator\Util\DirectoryUtil;
+use PHPUnit\Framework\TestCase;
+
+final class MakeModuleCommandTest extends TestCase
+{
+    private const ENTRY_POINT = __DIR__ . '/../../../';
+
+    public static function tearDownAfterClass(): void
+    {
+        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+    }
+
+    public function setUp(): void
+    {
+        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+    }
+
+    /**
+     * @dataProvider createModulesProvider
+     */
+    public function test_make_module(string $fileName, string $shortName): void
+    {
+        $command = sprintf('%sgacela make:module %s Gacela/TestModule', self::ENTRY_POINT, $shortName);
+        exec($command, $output);
+
+        self::assertSame("> Path 'src/TestModule/{$fileName}Facade.php' created successfully", $output[0]);
+        self::assertSame("> Path 'src/TestModule/{$fileName}Factory.php' created successfully", $output[1]);
+        self::assertSame("> Path 'src/TestModule/{$fileName}Config.php' created successfully", $output[2]);
+        self::assertSame("> Path 'src/TestModule/{$fileName}DependencyProvider.php' created successfully", $output[3]);
+        self::assertSame("Module 'TestModule' created successfully", $output[4]);
+
+        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Facade.php");
+        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Factory.php");
+        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Config.php");
+        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}DependencyProvider.php");
+    }
+
+    public function createModulesProvider(): iterable
+    {
+        yield 'module' => ['TestModule', ''];
+        yield 'module -s' => ['', '-s'];
+    }
+}

--- a/tests/Feature/CodeGenerator/Util/DirectoryUtil.php
+++ b/tests/Feature/CodeGenerator/Util/DirectoryUtil.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\CodeGenerator\Util;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class DirectoryUtil
+{
+    public static function removeDir(string $target): void
+    {
+        if (!is_dir($target)) {
+            return;
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($target, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            if (is_dir($file->getPathname())) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($target);
+    }
+}

--- a/tests/Unit/CodeGenerator/Domain/CommandArguments/CommandArgumentsParserTest.php
+++ b/tests/Unit/CodeGenerator/Domain/CommandArguments/CommandArgumentsParserTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\CodeGenerator\Domain\CommandArguments;
+
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArgumentsException;
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArgumentsParser;
+use PHPUnit\Framework\TestCase;
+
+final class CommandArgumentsParserTest extends TestCase
+{
+    public function test_exception_when_no_autoload_found(): void
+    {
+        $this->expectExceptionObject(CommandArgumentsException::noAutoloadFound());
+        $parser = new CommandArgumentsParser([]);
+        $parser->parse('');
+    }
+
+    public function test_exception_when_no_psr4_found(): void
+    {
+        $this->expectExceptionObject(CommandArgumentsException::noAutoloadPsr4Found());
+        $parser = new CommandArgumentsParser(['autoload' => []]);
+        $parser->parse('');
+    }
+
+    public function test_parse_one_level_from_root_namespace(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse('App/TestModule');
+
+        self::assertSame('App\TestModule', $args->namespace());
+    }
+
+    public function test_parse_multi_level_from_root_namespace(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse('App/TestModule/TestSubModule');
+
+        self::assertSame('App\TestModule\TestSubModule', $args->namespace());
+    }
+
+    public function test_parse_one_level_from_target_directory(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse('App/TestModule');
+
+        self::assertSame('src/TestModule', $args->directory());
+    }
+
+    public function test_parse_multi_level_from_target_directory(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse('App/TestModule/TestSubModule');
+
+        self::assertSame('src/TestModule/TestSubModule', $args->directory());
+    }
+
+    public function test_parse_multilevel_root_namespace(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleMultiLevelComposerJson());
+        $args = $parser->parse('App/TestModule/TestSubModule');
+
+        self::assertSame('App\TestModule\TestSubModule', $args->namespace());
+    }
+
+    public function test_parse_multilevel_target_directory(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleMultiLevelComposerJson());
+        $args = $parser->parse('App/TestModule/TestSubModule');
+
+        self::assertSame('src/TestSubModule', $args->directory());
+    }
+
+    public function test_no_autoload_psr4_match_found(): void
+    {
+        $this->expectExceptionObject(
+            CommandArgumentsException::noAutoloadPsr4MatchFound('Unknown/Module', ['App'])
+        );
+
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $parser->parse('Unknown/Module');
+    }
+
+    private function exampleOneLevelComposerJson(): array
+    {
+        $composerJson = <<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+JSON;
+        return json_decode($composerJson, true);
+    }
+
+    /**
+     * @return array{autoload: array{psr-4: array<string,string>}}
+     */
+    private function exampleMultiLevelComposerJson(): array
+    {
+        $composerJson = <<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\TestModule\\": "src/"
+        }
+    }
+}
+JSON;
+        return json_decode($composerJson, true);
+    }
+}

--- a/tests/Unit/CodeGenerator/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/CodeGenerator/Domain/FileContent/FileContentGeneratorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\CodeGenerator\Domain\FileContent;
+
+use Gacela\CodeGenerator\Domain\CommandArguments\CommandArguments;
+use Gacela\CodeGenerator\Domain\FileContent\FileContentGenerator;
+use Gacela\CodeGenerator\Domain\FileContent\FileContentIoInterface;
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class FileContentGeneratorTest extends TestCase
+{
+    public function test_error_when_unknown_template(): void
+    {
+        $fileContentIo = $this->createStub(FileContentIoInterface::class);
+        $generator = new FileContentGenerator($fileContentIo, []);
+
+        $this->expectExceptionMessage("Unknown template for 'unknown_template'?");
+        $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            'unknown_template'
+        );
+    }
+
+    public function test_facade_maker_template(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/DirFacade.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'Facade' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::FACADE
+        );
+
+        self::assertSame('Dir/DirFacade.php', $actualPath);
+    }
+
+    public function test_factory_maker_template(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/DirFactory.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'Factory' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::FACTORY
+        );
+
+        self::assertSame('Dir/DirFactory.php', $actualPath);
+    }
+
+    public function test_config_maker_template(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/DirConfig.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'Config' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::CONFIG
+        );
+
+        self::assertSame('Dir/DirConfig.php', $actualPath);
+    }
+
+    public function test_dependency_provider_maker_template(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/DirDependencyProvider.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'DependencyProvider' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::DEPENDENCY_PROVIDER
+        );
+
+        self::assertSame('Dir/DirDependencyProvider.php', $actualPath);
+    }
+}

--- a/tests/Unit/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizerTest.php
+++ b/tests/Unit/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\CodeGenerator\Domain\FilenameSanitizer;
+
+use Gacela\CodeGenerator\Domain\FilenameSanitizer\FilenameSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class FilenameSanitizerTest extends TestCase
+{
+    private FilenameSanitizer $filenameSanitizer;
+
+    public function setUp(): void
+    {
+        $this->filenameSanitizer = new FilenameSanitizer();
+    }
+
+    public function test_expected_filenames(): void
+    {
+        $actual = implode(', ', $this->filenameSanitizer->getExpectedFilenames());
+
+        self::assertSame('Facade, Factory, Config, DependencyProvider', $actual);
+    }
+
+    public function test_facade_or_factory_problem(): void
+    {
+        $this->expectExceptionMessage('When using "fac", which filename do you mean [Facade or Factory]?');
+        $this->filenameSanitizer->sanitize('fac');
+    }
+
+    /**
+     * @dataProvider providerFacade
+     */
+    public function test_facade(string $filename): void
+    {
+        self::assertSame(
+            FilenameSanitizer::FACADE,
+            $this->filenameSanitizer->sanitize($filename)
+        );
+    }
+
+    public function providerFacade(): iterable
+    {
+        yield ['faca'];
+        yield ['facad'];
+        yield ['facade'];
+        yield ['Facade'];
+        yield ['cade'];
+    }
+
+    /**
+     * @dataProvider providerFactory
+     */
+    public function test_factory(string $filename): void
+    {
+        self::assertSame(
+            FilenameSanitizer::FACTORY,
+            $this->filenameSanitizer->sanitize($filename)
+        );
+    }
+
+    public function providerFactory(): iterable
+    {
+        yield ['fact'];
+        yield ['facto'];
+        yield ['factor'];
+        yield ['factory'];
+        yield ['Factory'];
+        yield ['tory'];
+    }
+
+    /**
+     * @dataProvider providerConfig
+     */
+    public function test_config(string $filename): void
+    {
+        self::assertSame(
+            FilenameSanitizer::CONFIG,
+            $this->filenameSanitizer->sanitize($filename)
+        );
+    }
+
+    public function providerConfig(): iterable
+    {
+        yield ['conf'];
+        yield ['confi'];
+        yield ['config'];
+        yield ['Config'];
+        yield ['fig'];
+    }
+
+    /**
+     * @dataProvider providerDependencyProvider
+     */
+    public function test_dependency_provider(string $filename): void
+    {
+        self::assertSame(
+            FilenameSanitizer::DEPENDENCY_PROVIDER,
+            $this->filenameSanitizer->sanitize($filename)
+        );
+    }
+
+    public function providerDependencyProvider(): iterable
+    {
+        yield ['depe'];
+        yield ['dependency'];
+        yield ['pro'];
+        yield ['provider'];
+        yield ['de-pr'];
+        yield ['dependencyprovider'];
+        yield ['dependency-provider'];
+    }
+}


### PR DESCRIPTION
## 📚 Description

I do not think it is necessary splitting the gacela script in another project (gacela-cli), but rather keep it in this repo.
In case someone wants to use it, they have to require `symfony/console` dependency. Otherwise, there is no need for such dependency in the main required dependencies for gacela.

## 🔖 Changes

Move the logic from https://github.com/gacela-project/gacela-cli into this repository.
