### PR TITLE
Allow defining custom cache directory name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Group gacela cache files inside a `cache/` directory.
 - Allow enabling/disabling cache files from the project config files. 
+- Added `setCacheDirectory()` to `GacelaConfig`.
 - Added `vendor/bin/gacela` script.
 - Add `.editorconfig` & `.gitattributes` files.
 - Ignore `composer.lock`.

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -23,6 +23,8 @@ final class GacelaConfig
 
     private bool $cacheEnabled = true;
 
+    private string $cacheDirectory = 'cache';
+
     /**
      * @param array<string,class-string|object|callable> $externalServices
      */
@@ -120,6 +122,13 @@ final class GacelaConfig
         return $this;
     }
 
+    public function setCacheDirectory(string $dir): self
+    {
+        $this->cacheDirectory = $dir;
+
+        return $this;
+    }
+
     /**
      * @return array{
      *     external-services:array<string,class-string|object|callable>,
@@ -127,6 +136,7 @@ final class GacelaConfig
      *     suffix-types-builder:SuffixTypesBuilder,
      *     mapping-interfaces-builder:MappingInterfacesBuilder,
      *     cache-enabled:bool,
+     *     cache-directory:string,
      * }
      *
      * @internal
@@ -139,6 +149,7 @@ final class GacelaConfig
             'suffix-types-builder' => $this->suffixTypesBuilder,
             'mapping-interfaces-builder' => $this->mappingInterfacesBuilder,
             'cache-enabled' => $this->cacheEnabled,
+            'cache-directory' => $this->cacheDirectory,
         ];
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -31,6 +31,8 @@ final class SetupGacela extends AbstractSetupGacela
 
     private bool $cacheEnabled = true;
 
+    private string $cacheDirectory = 'cache';
+
     public function __construct()
     {
         $this->configFn = static function (): void {
@@ -61,7 +63,8 @@ final class SetupGacela extends AbstractSetupGacela
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
             ->setMappingInterfacesBuilder($build['mapping-interfaces-builder'])
             ->setExternalServices($build['external-services'])
-            ->setCacheEnabled($build['cache-enabled']);
+            ->setCacheEnabled($build['cache-enabled'])
+            ->setCacheDirectory($build['cache-directory']);
     }
 
     public function setMappingInterfacesBuilder(MappingInterfacesBuilder $builder): self
@@ -189,5 +192,17 @@ final class SetupGacela extends AbstractSetupGacela
     public function isCacheEnabled(): bool
     {
         return $this->cacheEnabled;
+    }
+
+    public function setCacheDirectory(string $dir): self
+    {
+        $this->cacheDirectory = $dir;
+
+        return $this;
+    }
+
+    public function getCacheDirectory(): string
+    {
+        return $this->cacheDirectory;
     }
 }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -34,5 +34,7 @@ interface SetupGacelaInterface
      */
     public function externalServices(): array;
 
+    public function getCacheDirectory(): string;
+
     public function isCacheEnabled(): bool;
 }

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -99,7 +99,7 @@ final class Config
 
     public function getCacheDir(): string
     {
-        return $this->getAppRootDir() . '/cache/';
+        return $this->getAppRootDir() . '/' . $this->getSetupGacela()->getCacheDirectory();
     }
 
     public function setSetup(SetupGacelaInterface $setup): self
@@ -117,11 +117,16 @@ final class Config
         if ($this->configFactory === null) {
             $this->configFactory = new ConfigFactory(
                 $this->getAppRootDir(),
-                $this->setup ?? new SetupGacela()
+                $this->getSetupGacela()
             );
         }
 
         return $this->configFactory;
+    }
+
+    private function getSetupGacela(): SetupGacelaInterface
+    {
+        return $this->setup ?? new SetupGacela();
     }
 
     private function hasValue(string $key): bool

--- a/tests/Feature/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeFileCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\CodeGenerator;
 
-use GacelaTest\Feature\CodeGenerator\Util\DirectoryUtil;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class MakeFileCommandTest extends TestCase

--- a/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\CodeGenerator;
 
-use GacelaTest\Feature\CodeGenerator\Util\DirectoryUtil;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class MakeModuleCommandTest extends TestCase

--- a/tests/Feature/Framework/CustomCacheDirectory/FeatureTest.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/FeatureTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace GacelaTest\Feature\Framework\CustomCacheDirectory;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\ClassNameCache;
+use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        });
+    }
+
+    public function test_custom_caching_dir(): void
+    {
+        $facade = new Module\Facade();
+        self::assertSame('name', $facade->getName());
+
+        self::assertFileExists(__DIR__ . '/custom-caching-dir/' . ClassNameCache::CACHE_FILENAME);
+        self::assertFileExists(__DIR__ . '/custom-caching-dir/' . CustomServicesCache::CACHE_FILENAME);
+    }
+}

--- a/tests/Feature/Framework/CustomCacheDirectory/FeatureTest.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/FeatureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\CustomCacheDirectory;
 
@@ -8,6 +8,7 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\ClassNameCache;
 use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
@@ -16,7 +17,13 @@ final class FeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->addAppConfig('config/*.php');
+            $config->setCacheDirectory('custom-caching-dir');
         });
+    }
+
+    public function tearDown(): void
+    {
+        DirectoryUtil::removeDir(__DIR__ . '/custom-caching-dir');
     }
 
     public function test_custom_caching_dir(): void

--- a/tests/Feature/Framework/CustomCacheDirectory/Module/Facade.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/Module/Facade.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\CustomCacheDirectory\Module;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\DocBlockResolverAwareTrait;
+use GacelaTest\Feature\Framework\CustomCacheDirectory\Module\Persistence\FakeRepository;
+
+/**
+ * @method FakeRepository getRepository()
+ */
+final class Facade extends AbstractFacade
+{
+    use DocBlockResolverAwareTrait;
+
+    public function getName(): string
+    {
+        return $this->getRepository()->findName();
+    }
+}

--- a/tests/Feature/Framework/CustomCacheDirectory/Module/Persistence/FakeRepository.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/Module/Persistence/FakeRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\CustomCacheDirectory\Module\Persistence;
+
+final class FakeRepository
+{
+    public function findName(): string
+    {
+        return 'name';
+    }
+}

--- a/tests/Feature/Util/DirectoryUtil.php
+++ b/tests/Feature/Util/DirectoryUtil.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\CodeGenerator\Util;
+namespace GacelaTest\Feature\Util;
 
 use FilesystemIterator;
 use RecursiveDirectoryIterator;


### PR DESCRIPTION
## 📚 Description

Right now the cache directory name is fixed as `cache`.

## 🔖 Changes

- Added `setCacheDirectory()` to `GacelaConfig`
