### PR TITLE
Fix setCacheDirectory() with nested dir levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.23.1
+#### 2022-06-25
+
+- Fix `setCacheDirectory()` with nested dir levels.
+
 ### 0.23.0
 #### 2022-06-24
 

--- a/src/Framework/ClassResolver/AbstractFileCache.php
+++ b/src/Framework/ClassResolver/AbstractFileCache.php
@@ -71,7 +71,7 @@ abstract class AbstractFileCache implements ClassNameCacheInterface
     private function getAbsoluteCacheFilename(): string
     {
         if (!is_dir($this->cacheDir)
-            && !mkdir($concurrentDirectory = $this->cacheDir)
+            && !mkdir($concurrentDirectory = $this->cacheDir, 0777, true)
             && !is_dir($concurrentDirectory)) {
             throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }

--- a/tests/Feature/Framework/CustomCacheDirectory/FeatureTest.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/FeatureTest.php
@@ -17,13 +17,13 @@ final class FeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->addAppConfig('config/*.php');
-            $config->setCacheDirectory('custom-caching-dir');
+            $config->setCacheDirectory('custom/caching-dir');
         });
     }
 
     public function tearDown(): void
     {
-        DirectoryUtil::removeDir(__DIR__ . '/custom-caching-dir');
+        DirectoryUtil::removeDir(__DIR__ . '/custom/caching-dir');
     }
 
     public function test_custom_caching_dir(): void
@@ -31,7 +31,7 @@ final class FeatureTest extends TestCase
         $facade = new Module\Facade();
         self::assertSame('name', $facade->getName());
 
-        self::assertFileExists(__DIR__ . '/custom-caching-dir/' . ClassNameCache::CACHE_FILENAME);
-        self::assertFileExists(__DIR__ . '/custom-caching-dir/' . CustomServicesCache::CACHE_FILENAME);
+        self::assertFileExists(__DIR__ . '/custom/caching-dir/' . ClassNameCache::CACHE_FILENAME);
+        self::assertFileExists(__DIR__ . '/custom/caching-dir/' . CustomServicesCache::CACHE_FILENAME);
     }
 }


### PR DESCRIPTION
## 📚 Description

Currently, `$config->setCacheDirectory('custom-caching-dir');` doesn't work if you points to a non existing directory with multiple nested level; for example `'custom/caching-dir'`.

## 🔖 Changes

- Fix nested directly levels for the cache directory.
