### PR TITLE
Refactor gacela cache default values

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
@@ -23,7 +24,7 @@ final class GacelaConfig
 
     private bool $cacheEnabled = true;
 
-    private string $cacheDirectory = 'cache';
+    private string $cacheDirectory = GacelaCache::DEFAULT_DIRECTORY_VALUE;
 
     /**
      * @param array<string,class-string|object|callable> $externalServices

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
@@ -31,7 +32,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     private bool $cacheEnabled = true;
 
-    private string $cacheDirectory = 'cache';
+    private string $cacheDirectory = GacelaCache::DEFAULT_DIRECTORY_VALUE;
 
     public function __construct()
     {

--- a/src/Framework/ClassResolver/Cache/GacelaCache.php
+++ b/src/Framework/ClassResolver/Cache/GacelaCache.php
@@ -6,6 +6,7 @@ namespace Gacela\Framework\ClassResolver\Cache;
 
 final class GacelaCache
 {
-    public const ENABLED = 'gacela-cache-enabled';
-    public const DEFAULT_VALUE = true;
+    public const KEY_ENABLED = 'gacela-cache-enabled';
+    public const DEFAULT_ENABLED_VALUE = true;
+    public const DEFAULT_DIRECTORY_VALUE = 'data/cache';
 }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -55,6 +55,6 @@ final class ClassResolverFactory
     private function isProjectCacheEnabled(): bool
     {
         return (bool)Config::getInstance()
-            ->get(GacelaCache::ENABLED, GacelaCache::DEFAULT_VALUE);
+            ->get(GacelaCache::KEY_ENABLED, GacelaCache::DEFAULT_ENABLED_VALUE);
     }
 }

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -144,6 +144,6 @@ trait DocBlockResolverAwareTrait
     private function isProjectCacheEnabled(): bool
     {
         return (bool)Config::getInstance()
-            ->get(GacelaCache::ENABLED, GacelaCache::DEFAULT_VALUE);
+            ->get(GacelaCache::KEY_ENABLED, GacelaCache::DEFAULT_ENABLED_VALUE);
     }
 }

--- a/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
@@ -5,5 +5,5 @@ declare(strict_types=1);
 use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 
 return [
-    GacelaCache::ENABLED  => true,
+    GacelaCache::KEY_ENABLED  => true,
 ];

--- a/tests/Integration/Framework/DocBlockResolverAware/config/in-memory/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/in-memory/default.php
@@ -5,5 +5,5 @@ declare(strict_types=1);
 use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 
 return [
-    GacelaCache::ENABLED => false,
+    GacelaCache::KEY_ENABLED => false,
 ];


### PR DESCRIPTION
## 🔖 Changes

- Refactor the `GacelaCache` constant names
- Change the default cache-dir name from `cache` to `data/cache`