### PR TITLE
Change cache default directory to .gacela/cache

### DIFF
--- a/src/Framework/ClassResolver/Cache/GacelaCache.php
+++ b/src/Framework/ClassResolver/Cache/GacelaCache.php
@@ -8,5 +8,5 @@ final class GacelaCache
 {
     public const KEY_ENABLED = 'gacela-cache-enabled';
     public const DEFAULT_ENABLED_VALUE = true;
-    public const DEFAULT_DIRECTORY_VALUE = 'data/cache';
+    public const DEFAULT_DIRECTORY_VALUE = '.gacela/cache';
 }


### PR DESCRIPTION
## 📚 Description

The gacela cache directly name is still customisable when bootstrapping gacela. But, by default, I think it's better to group the generated files under a directory named `.gacela/`.

## 🔖 Changes

- Change `DEFAULT_DIRECTORY_VALUE` to `.gacela/cache`
