### PR TITLE
Gacela configuration for different environments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Unreleased
 
-- Added `GacelaConfig->setProjectNamespaces(array)` to be able to resolve different project namespaces.
+- Added project namespaces.
+  - `GacelaConfig->setProjectNamespaces(array)` to be able to resolve gacela classes with priorities.
+- Added gacela configuration for different environments.
 
 ### 0.23.1
 #### 2022-06-25

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -56,7 +56,7 @@ final class ConfigFactory extends AbstractFactory
 
         return array_reduce(
             $gacelaConfigFiles,
-            static fn (GacelaConfigFileInterface $carry, GacelaConfigFileInterface $item): GacelaConfigFileInterface => $carry->combine($item),
+            static fn (GacelaConfigFileInterface $carry, GacelaConfigFileInterface $item) => $carry->combine($item),
             (new GacelaConfigFromBootstrapFactory($this->setup))->createGacelaFileConfig()
         );
     }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -57,11 +57,6 @@ final class ConfigFactory extends AbstractFactory
         return $gacelaSetupFromBootstrap;
     }
 
-    private function createFileIo(): FileIoInterface
-    {
-        return new FileIo();
-    }
-
     private function createPathFinder(): PathFinderInterface
     {
         return new PathFinder();
@@ -75,34 +70,18 @@ final class ConfigFactory extends AbstractFactory
         ]);
     }
 
-    private function env(): string
-    {
-        return getenv('APP_ENV') ?: '';
-    }
-
     private function getGacelaPhpPath(): string
     {
+        if ($this->env() === '') {
+            return $this->getGacelaPhpDefaultPath();
+        }
+
         $gacelaPhpPathFromEnv = $this->getGacelaPhpPathFromEnv();
         if ($this->createFileIo()->existsFile($gacelaPhpPathFromEnv)) {
             return $gacelaPhpPathFromEnv;
         }
 
         return $this->getGacelaPhpDefaultPath();
-    }
-
-    private function getGacelaPhpPathFromEnv(): string
-    {
-        if ($this->env() === '') {
-            return $this->getGacelaPhpDefaultPath();
-        }
-
-        return sprintf(
-            '%s/%s-%s%s',
-            $this->appRootDir,
-            self::GACELA_PHP_CONFIG_FILENAME,
-            $this->env(),
-            self::GACELA_PHP_CONFIG_EXTENSION
-        );
     }
 
     private function getGacelaPhpDefaultPath(): string
@@ -113,5 +92,26 @@ final class ConfigFactory extends AbstractFactory
             self::GACELA_PHP_CONFIG_FILENAME,
             self::GACELA_PHP_CONFIG_EXTENSION
         );
+    }
+
+    private function getGacelaPhpPathFromEnv(): string
+    {
+        return sprintf(
+            '%s/%s-%s%s',
+            $this->appRootDir,
+            self::GACELA_PHP_CONFIG_FILENAME,
+            $this->env(),
+            self::GACELA_PHP_CONFIG_EXTENSION
+        );
+    }
+
+    private function env(): string
+    {
+        return getenv('APP_ENV') ?: '';
+    }
+
+    private function createFileIo(): FileIoInterface
+    {
+        return new FileIo();
     }
 }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -15,7 +15,8 @@ use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
 
 final class ConfigFactory extends AbstractFactory
 {
-    private const GACELA_PHP_CONFIG_FILENAME = 'gacela.php';
+    private const GACELA_PHP_CONFIG_FILENAME = 'gacela';
+    private const GACELA_PHP_CONFIG_EXTENSION = '.php';
 
     private string $appRootDir;
 
@@ -38,7 +39,7 @@ final class ConfigFactory extends AbstractFactory
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $gacelaPhpPath = $this->appRootDir . '/' . self::GACELA_PHP_CONFIG_FILENAME;
+        $gacelaPhpPath = $this->getGacelaPhpPath();
         $fileIo = $this->createFileIo();
 
         if ($fileIo->existsFile($gacelaPhpPath)) {
@@ -77,5 +78,25 @@ final class ConfigFactory extends AbstractFactory
     private function env(): string
     {
         return getenv('APP_ENV') ?: '';
+    }
+
+    private function getGacelaPhpPath(): string
+    {
+        if ($this->env() === '') {
+            return sprintf(
+                '%s/%s%s',
+                $this->appRootDir,
+                self::GACELA_PHP_CONFIG_FILENAME,
+                self::GACELA_PHP_CONFIG_EXTENSION
+            );
+        }
+
+        return sprintf(
+            '%s/%s-%s%s',
+            $this->appRootDir,
+            self::GACELA_PHP_CONFIG_FILENAME,
+            $this->env(),
+            self::GACELA_PHP_CONFIG_EXTENSION
+        );
     }
 }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -39,23 +39,23 @@ final class ConfigFactory extends AbstractFactory
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $gacelaSetups = [];
+        $gacelaConfigFiles = [];
         $fileIo = $this->createFileIo();
 
         $gacelaPhpDefaultPath = $this->getGacelaPhpDefaultPath();
         if ($fileIo->existsFile($gacelaPhpDefaultPath)) {
             $factoryFromGacelaPhp = new GacelaConfigUsingGacelaPhpFileFactory($gacelaPhpDefaultPath, $this->setup, $fileIo);
-            $gacelaSetups[] = $factoryFromGacelaPhp->createGacelaFileConfig();
+            $gacelaConfigFiles[] = $factoryFromGacelaPhp->createGacelaFileConfig();
         }
 
         $gacelaPhpPath = $this->getGacelaPhpPathFromEnv();
         if ($fileIo->existsFile($gacelaPhpPath)) {
             $factoryFromGacelaPhp = new GacelaConfigUsingGacelaPhpFileFactory($gacelaPhpPath, $this->setup, $fileIo);
-            $gacelaSetups[] = $factoryFromGacelaPhp->createGacelaFileConfig();
+            $gacelaConfigFiles[] = $factoryFromGacelaPhp->createGacelaFileConfig();
         }
 
         return array_reduce(
-            $gacelaSetups,
+            $gacelaConfigFiles,
             static fn (GacelaConfigFileInterface $carry, GacelaConfigFileInterface $item): GacelaConfigFileInterface => $carry->combine($item),
             (new GacelaConfigFromBootstrapFactory($this->setup))->createGacelaFileConfig()
         );

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -82,13 +82,18 @@ final class ConfigFactory extends AbstractFactory
 
     private function getGacelaPhpPath(): string
     {
+        $gacelaPhpPathFromEnv = $this->getGacelaPhpPathFromEnv();
+        if ($this->createFileIo()->existsFile($gacelaPhpPathFromEnv)) {
+            return $gacelaPhpPathFromEnv;
+        }
+
+        return $this->getGacelaPhpDefaultPath();
+    }
+
+    private function getGacelaPhpPathFromEnv(): string
+    {
         if ($this->env() === '') {
-            return sprintf(
-                '%s/%s%s',
-                $this->appRootDir,
-                self::GACELA_PHP_CONFIG_FILENAME,
-                self::GACELA_PHP_CONFIG_EXTENSION
-            );
+            return $this->getGacelaPhpDefaultPath();
         }
 
         return sprintf(
@@ -96,6 +101,16 @@ final class ConfigFactory extends AbstractFactory
             $this->appRootDir,
             self::GACELA_PHP_CONFIG_FILENAME,
             $this->env(),
+            self::GACELA_PHP_CONFIG_EXTENSION
+        );
+    }
+
+    private function getGacelaPhpDefaultPath(): string
+    {
+        return sprintf(
+            '%s/%s%s',
+            $this->appRootDir,
+            self::GACELA_PHP_CONFIG_FILENAME,
             self::GACELA_PHP_CONFIG_EXTENSION
         );
     }

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingGacelaFileFromCustomEnv;
+
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        # Remove the APP_ENV
+        putenv('APP_ENV');
+    }
+
+    public function test_load_config_from_custom_env_default(): void
+    {
+        Gacela::bootstrap(__DIR__);
+
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'key' => 'from:default',
+            ],
+            $facade->doSomething()
+        );
+    }
+
+    public function test_load_config_from_custom_env_dev(): void
+    {
+        self::markTestSkipped('TODO');
+        putenv('APP_ENV=dev');
+
+        Gacela::bootstrap(__DIR__);
+
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'key' => 'from:dev',
+            ],
+            $facade->doSomething()
+        );
+    }
+
+    public function test_load_config_from_custom_env_prod(): void
+    {
+        self::markTestSkipped('TODO');
+        putenv('APP_ENV=prod');
+
+        Gacela::bootstrap(__DIR__);
+
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'key' => 'from:prod',
+            ],
+            $facade->doSomething()
+        );
+    }
+}

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
@@ -60,4 +60,20 @@ final class FeatureTest extends TestCase
             $facade->doSomething()
         );
     }
+
+    public function test_load_gacela_default_file_if_custom_does_not_exists(): void
+    {
+        putenv('APP_ENV=custom');
+
+        Gacela::bootstrap(__DIR__);
+
+        $facade = new LocalConfig\Facade();
+
+        self::assertSame(
+            [
+                'key' => 'from:default',
+            ],
+            $facade->doSomething()
+        );
+    }
 }

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
@@ -15,7 +15,7 @@ final class FeatureTest extends TestCase
         putenv('APP_ENV');
     }
 
-    public function test_load_config_from_custom_env_default(): void
+    public function test_load_gacela_default_file(): void
     {
         Gacela::bootstrap(__DIR__);
 
@@ -29,9 +29,8 @@ final class FeatureTest extends TestCase
         );
     }
 
-    public function test_load_config_from_custom_env_dev(): void
+    public function test_load_gacela_dev_file(): void
     {
-        self::markTestSkipped('TODO');
         putenv('APP_ENV=dev');
 
         Gacela::bootstrap(__DIR__);
@@ -46,9 +45,8 @@ final class FeatureTest extends TestCase
         );
     }
 
-    public function test_load_config_from_custom_env_prod(): void
+    public function test_load_gacela_prod_file(): void
     {
-        self::markTestSkipped('TODO');
         putenv('APP_ENV=prod');
 
         Gacela::bootstrap(__DIR__);

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Config.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingGacelaFileFromCustomEnv\LocalConfig;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+    public function getArrayConfig(): array
+    {
+        return [
+            'key' => (string)$this->get('key'),
+        ];
+    }
+}

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Facade.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingGacelaFileFromCustomEnv\LocalConfig;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function doSomething(): array
+    {
+        return $this->getFactory()->getArrayConfig();
+    }
+}

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Factory.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Factory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\UsingGacelaFileFromCustomEnv\LocalConfig;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method Config getConfig()
+ */
+final class Factory extends AbstractFactory
+{
+    public function getArrayConfig(): array
+    {
+        return $this->getConfig()->getArrayConfig();
+    }
+}

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/default.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/default.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'key' => 'from:default',
+];

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/dev.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/dev.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'key' => 'from:dev',
+];

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/prod.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/prod.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'key' => 'from:prod',
+];

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/gacela-dev.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/gacela-dev.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->addAppConfig('config/dev.php');
+};

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/gacela-prod.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/gacela-prod.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->addAppConfig('config/prod.php');
+};

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/gacela.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/gacela.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->addAppConfig('config/default.php');
+};


### PR DESCRIPTION
## 📚 Description

Issue: #95

Load a custom `gacela-*.php` file depending on the `APP_ENV` environment variable.

Currently, we have something similar for application config key-values, for example: 
- `config/file.php` # putenv('APP_ENV'); // empty
- `config/file-test.php` # putenv('APP_ENV=test');
- `config/file-prod.php` # putenv('APP_ENV=prod');

The idea is to have something like this:
- `gacela.php` # putenv('APP_ENV'); // empty
- `gacela-test.php` # putenv('APP_ENV=test');
- `gacela-prod.php` # putenv('APP_ENV=prod');

> **Note**: Depending on the `APP_ENV` it will load a different file.

## 🔖 Changes

- Check the `APP_ENV` in the `ConfigFactory` when reading the gacela file
