### PR TITLE
Load both gacela.php and gacela-xxx.php files

### DIFF
--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
@@ -23,6 +23,7 @@ final class FeatureTest extends TestCase
 
         self::assertSame(
             [
+                'default_key' => 'from:default',
                 'key' => 'from:default',
             ],
             $facade->doSomething()
@@ -39,6 +40,7 @@ final class FeatureTest extends TestCase
 
         self::assertSame(
             [
+                'default_key' => 'from:default',
                 'key' => 'from:dev',
             ],
             $facade->doSomething()
@@ -55,6 +57,7 @@ final class FeatureTest extends TestCase
 
         self::assertSame(
             [
+                'default_key' => 'from:default',
                 'key' => 'from:prod',
             ],
             $facade->doSomething()
@@ -71,6 +74,7 @@ final class FeatureTest extends TestCase
 
         self::assertSame(
             [
+                'default_key' => 'from:default',
                 'key' => 'from:default',
             ],
             $facade->doSomething()

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Config.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/LocalConfig/Config.php
@@ -11,6 +11,7 @@ final class Config extends AbstractConfig
     public function getArrayConfig(): array
     {
         return [
+            'default_key' => (string)$this->get('default_key'),
             'key' => (string)$this->get('key'),
         ];
     }

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/default.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/config/default.php
@@ -3,5 +3,6 @@
 declare(strict_types=1);
 
 return [
+    'default_key' => 'from:default',
     'key' => 'from:default',
 ];


### PR DESCRIPTION
## 📚 Description

Having a `gacela.php` and a `gacela-prod.php` file.

If we define the `APP_ENV` as `dev`
1. `gacela.php` should be loaded

When we define the `APP_ENV` as `prod`
1. `gacela.php` should be loaded
2. `gacela-prod.php` should be loaded right after (overriding the keys if repeated)