### PR TITLE
Increase Code Coverage excluding some files

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -34,5 +34,9 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+        <exclude>
+            <directory prefix="CodeGenerator">src/CodeGenerator</directory>
+            <directory suffix=".php">src/CodeGenerator/Infrastructure</directory>
+        </exclude>
     </coverage>
 </phpunit>


### PR DESCRIPTION
## 📚 Description

Increase Code Coverage from 87% to 94% excluding some files from `src/CodeCoverage` module.

We already have [excellent `feature` tests for the module](https://github.com/gacela-project/gacela/tree/master/tests/Feature/CodeGenerator), so, those classes are being "tested" indirectly through PHP `exec()` command. Still, unfortunately, they are not included in the PHPUnit coverage, and because of that, the code coverage drops 7 points.

I think the best alternative is just ignore them 😄
