### PR TITLE
Create addAppConfigKeyValues() from GacelaConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ### Unreleased
 
+- Change cache default directory to `.gacela/cache`.
 - Added project namespaces.
   - `GacelaConfig->setProjectNamespaces(array)` to be able to resolve gacela classes with priorities.
 - Added gacela configuration for different environments.
+- Allow adding config key-values from GacelaConfig.
+  - `GacelaConfig->addAppConfigKeyValue(string, mixed)`
+  - `GacelaConfig->addAppConfigKeyValues( array<string, mixed> )`
 
 ### 0.23.1
 #### 2022-06-25

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "^4.23",
-        "phpstan/phpstan": "^1.7",
-        "friendsofphp/php-cs-fixer": "^3.8",
+        "vimeo/psalm": "^4.24",
+        "phpstan/phpstan": "^1.8",
+        "friendsofphp/php-cs-fixer": "^3.9",
         "phpbench/phpbench": "^1.2",
         "phpmetrics/phpmetrics": "^2.8",
         "symfony/console": "^5.4",

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -157,6 +157,16 @@ final class GacelaConfig
     }
 
     /**
+     * @param array<string, mixed> $config
+     */
+    public function addAppConfigKeyValues(array $config): self
+    {
+        $this->configKeyValues = array_merge($this->configKeyValues, $config);
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     external-services:array<string,class-string|object|callable>,
      *     config-builder:ConfigBuilder,

--- a/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/FeatureTest.php
+++ b/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/FeatureTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module\Facade;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValues([
+                GacelaCache::KEY_ENABLED => true,
+                'some_key' => 'some value',
+                'another_key' => 'another value',
+            ]);
+            $config->addAppConfigKeyValue(GacelaCache::KEY_ENABLED, false); // it overrides previous 'GacelaCache::KEY_ENABLED' key
+        });
+    }
+
+    public function test_override_factory_from_highest_prio_namespace(): void
+    {
+        $facade = new Facade();
+
+        self::assertSame([
+            GacelaCache::KEY_ENABLED => false,
+            'some_key' => 'some value',
+            'another_key' => 'another value',
+        ], $facade->getConfigData());
+    }
+}

--- a/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/FeatureTest.php
+++ b/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/FeatureTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module\Facade;
 use PHPUnit\Framework\TestCase;
@@ -15,12 +14,15 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('first_key', 'individual config key-value');
+
             $config->addAppConfigKeyValues([
-                GacelaCache::KEY_ENABLED => true,
                 'some_key' => 'some value',
                 'another_key' => 'another value',
+                'override_key' => 'i am going to be overrided',
             ]);
-            $config->addAppConfigKeyValue(GacelaCache::KEY_ENABLED, false); // it overrides previous 'GacelaCache::KEY_ENABLED' key
+
+            $config->addAppConfigKeyValue('override_key', 'truly override'); // it overrides previous 'override_key' key
         });
     }
 
@@ -29,9 +31,10 @@ final class FeatureTest extends TestCase
         $facade = new Facade();
 
         self::assertSame([
-            GacelaCache::KEY_ENABLED => false,
+            'first_key' => 'individual config key-value',
             'some_key' => 'some value',
             'another_key' => 'another value',
+            'override_key' => 'truly override',
         ], $facade->getConfigData());
     }
 }

--- a/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Config.php
+++ b/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Config.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
 
 use Gacela\Framework\AbstractConfig;
-use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 
 final class Config extends AbstractConfig
 {
     public function getData(): array
     {
         return [
-            GacelaCache::KEY_ENABLED => $this->get(GacelaCache::KEY_ENABLED),
+            'first_key' => $this->get('first_key'),
+            'some_key' => $this->get('some_key'),
+            'another_key' => $this->get('another_key'),
+            'override_key' => $this->get('override_key'),
         ];
     }
 }

--- a/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Config.php
+++ b/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
+
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+
+final class Config extends AbstractConfig
+{
+    public function getData(): array
+    {
+        return [
+            GacelaCache::KEY_ENABLED => $this->get(GacelaCache::KEY_ENABLED),
+        ];
+    }
+}

--- a/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Facade.php
+++ b/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Facade.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function getConfigData(): array
+    {
+        return $this->getFactory()
+            ->getConfigData();
+    }
+}

--- a/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Factory.php
+++ b/tests/Feature/Framework/AddAppConfigKeyValuesInGacelaBootstrap/Module/Factory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method Config getConfig
+ */
+final class Factory extends AbstractFactory
+{
+    public function getConfigData(): array
+    {
+        return $this->getConfig()
+            ->getData();
+    }
+}


### PR DESCRIPTION
📚 Description

Issue: https://github.com/gacela-project/gacela/issues/178 - _part 2_

Continuation of https://github.com/gacela-project/gacela/pull/183#discussion_r921013044 🤠 

🔖 Changes

Add method: `GacelaConfig->addAppConfigKeyValues( array<string, mixed> )`