### PR TITLE
Fixing setCacheEnable behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow adding config key-values from GacelaConfig.
   - `GacelaConfig->addAppConfigKeyValue(string, mixed)`
   - `GacelaConfig->addAppConfigKeyValues( array<string, mixed> )`
+- When cache is disabled on bootstrap, Gacela won't generate `*.cache` files
 
 ### 0.23.1
 #### 2022-06-25

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinderInterface;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\ClassResolver\InstanceCreator\InstanceCreator;
@@ -90,6 +91,7 @@ abstract class AbstractClassResolver
     {
         if ($this->classNameFinder === null) {
             $this->classNameFinder = (new ClassResolverFactory(
+                new GacelaCache(Config::getInstance()),
                 Config::getInstance()->getSetupGacela()
             ))->createClassNameFinder();
         }

--- a/src/Framework/ClassResolver/Cache/GacelaCache.php
+++ b/src/Framework/ClassResolver/Cache/GacelaCache.php
@@ -4,9 +4,27 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver\Cache;
 
+use Gacela\Framework\Config\ConfigInterface;
+
 final class GacelaCache
 {
     public const KEY_ENABLED = 'gacela-cache-enabled';
     public const DEFAULT_ENABLED_VALUE = true;
     public const DEFAULT_DIRECTORY_VALUE = '.gacela/cache';
+
+    private ConfigInterface $config;
+
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    public function isProjectCacheEnabled(): bool
+    {
+        if (!$this->config->getSetupGacela()->isCacheEnabled()) {
+            return false;
+        }
+
+        return (bool) $this->config->get(self::KEY_ENABLED, self::DEFAULT_ENABLED_VALUE);
+    }
 }

--- a/src/Framework/ClassResolver/Cache/GacelaCache.php
+++ b/src/Framework/ClassResolver/Cache/GacelaCache.php
@@ -21,10 +21,20 @@ final class GacelaCache
 
     public function isProjectCacheEnabled(): bool
     {
-        if (!$this->config->getSetupGacela()->isCacheEnabled()) {
+        if ($this->isCacheFromSetupGacelaDisabled()) {
             return false;
         }
 
+        return $this->isCacheFromApplicationConfigEnabled();
+    }
+
+    private function isCacheFromSetupGacelaDisabled(): bool
+    {
+        return !$this->config->getSetupGacela()->isCacheEnabled();
+    }
+
+    private function isCacheFromApplicationConfigEnabled(): bool
+    {
         return (bool) $this->config->get(self::KEY_ENABLED, self::DEFAULT_ENABLED_VALUE);
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -36,7 +36,7 @@ final class ClassResolverFactory
 
     public function createClassNameCache(): ClassNameCacheInterface
     {
-        if (!$this->isProjectCacheEnabled()) {
+        if (!$this->isProjectCacheEnabled() || !$this->setupGacela->isCacheEnabled()) {
             return new InMemoryCache(ClassNameCache::class);
         }
 

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -17,10 +17,12 @@ use Gacela\Framework\Config\Config;
 
 final class ClassResolverFactory
 {
+    private GacelaCache $gacelaCache;
     private SetupGacelaInterface $setupGacela;
 
-    public function __construct(SetupGacelaInterface $setupGacela)
+    public function __construct(GacelaCache $gacelaCache, SetupGacelaInterface $setupGacela)
     {
+        $this->gacelaCache = $gacelaCache;
         $this->setupGacela = $setupGacela;
     }
 
@@ -36,7 +38,7 @@ final class ClassResolverFactory
 
     public function createClassNameCache(): ClassNameCacheInterface
     {
-        if (!$this->isProjectCacheEnabled() || !$this->setupGacela->isCacheEnabled()) {
+        if (!$this->gacelaCache->isProjectCacheEnabled()) {
             return new InMemoryCache(ClassNameCache::class);
         }
 
@@ -59,12 +61,6 @@ final class ClassResolverFactory
             new FinderRuleWithModulePrefix(),
             new FinderRuleWithoutModulePrefix(),
         ];
-    }
-
-    private function isProjectCacheEnabled(): bool
-    {
-        return (bool)Config::getInstance()
-            ->get(GacelaCache::KEY_ENABLED, GacelaCache::DEFAULT_ENABLED_VALUE);
     }
 
     /**

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -10,10 +10,8 @@ use Gacela\Framework\Exception\ConfigException;
 
 use function array_key_exists;
 
-final class Config
+final class Config implements ConfigInterface
 {
-    public const DEFAULT_CONFIG_VALUE = 'Gacela\Framework\Config::DEFAULT_CONFIG_VALUE';
-
     private static ?self $instance = null;
 
     private ?string $appRootDir = null;

--- a/src/Framework/Config/ConfigInterface.php
+++ b/src/Framework/Config/ConfigInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Exception\ConfigException;
+
+interface ConfigInterface
+{
+    public const DEFAULT_CONFIG_VALUE = 'Gacela\Framework\Config::DEFAULT_CONFIG_VALUE';
+
+    /**
+     * @param null|mixed $default
+     *
+     * @throws ConfigException
+     *
+     * @return mixed
+     */
+    public function get(string $key, $default = self::DEFAULT_CONFIG_VALUE);
+
+    public function getSetupGacela(): SetupGacelaInterface;
+}

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -40,7 +40,6 @@ trait DocBlockResolverAwareTrait
         $cacheKey = $this->generateCacheKey($method);
         $cache = $this->createCustomServicesCache();
 
-
         if (!$cache->has($cacheKey)) {
             $className = $this->getClassFromDoc($method);
             $cache->put($cacheKey, $className);
@@ -105,9 +104,9 @@ trait DocBlockResolverAwareTrait
      */
     private function searchClassOverUseStatements(ReflectionClass $reflectionClass, string $className): string
     {
-        $fileName = (string) $reflectionClass->getFileName();
+        $fileName = (string)$reflectionClass->getFileName();
         if (!isset(static::$fileContentCache[$fileName])) {
-            static::$fileContentCache[$fileName] = (string) file_get_contents($fileName);
+            static::$fileContentCache[$fileName] = (string)file_get_contents($fileName);
         }
         $phpFile = static::$fileContentCache[$fileName];
 
@@ -132,7 +131,7 @@ trait DocBlockResolverAwareTrait
 
     private function createCustomServicesCache(): ClassNameCacheInterface
     {
-        if (!$this->isProjectCacheEnabled() || !Config::getInstance()->getSetupGacela()->isCacheEnabled()) {
+        if (!$this->isProjectCacheEnabled()) {
             return new InMemoryCache(CustomServicesCache::class);
         }
 
@@ -143,7 +142,7 @@ trait DocBlockResolverAwareTrait
 
     private function isProjectCacheEnabled(): bool
     {
-        return (bool)Config::getInstance()
-            ->get(GacelaCache::KEY_ENABLED, GacelaCache::DEFAULT_ENABLED_VALUE);
+        return (new GacelaCache(Config::getInstance()))
+            ->isProjectCacheEnabled();
     }
 }

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -132,7 +132,7 @@ trait DocBlockResolverAwareTrait
 
     private function createCustomServicesCache(): ClassNameCacheInterface
     {
-        if (!$this->isProjectCacheEnabled()) {
+        if (!$this->isProjectCacheEnabled() || !Config::getInstance()->getSetupGacela()->isCacheEnabled()) {
             return new InMemoryCache(CustomServicesCache::class);
         }
 

--- a/tests/Feature/Framework/CustomCacheDirectory/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/FileCacheFeatureTest.php
@@ -16,7 +16,7 @@ final class FileCacheFeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addAppConfig('config/*.php');
+            $config->setCacheEnabled(true);
             $config->setCacheDirectory('custom/caching-dir');
         });
     }

--- a/tests/Feature/Framework/CustomCacheDirectory/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/FileCacheFeatureTest.php
@@ -11,7 +11,7 @@ use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
-final class FeatureTest extends TestCase
+final class FileCacheFeatureTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/Feature/Framework/CustomCacheDirectory/NoFileCacheFeatureTest.php
+++ b/tests/Feature/Framework/CustomCacheDirectory/NoFileCacheFeatureTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\CustomCacheDirectory;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\ClassNameCache;
+use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class NoFileCacheFeatureTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+            $config->setCacheDirectory('custom/caching-dir');
+            $config->setCacheEnabled(false);
+        });
+    }
+
+    public function test_custom_caching_dir(): void
+    {
+        $facade = new Module\Facade();
+        self::assertSame('name', $facade->getName());
+
+        self::assertFileDoesNotExist(__DIR__ . '/custom/caching-dir/' . ClassNameCache::CACHE_FILENAME);
+        self::assertFileDoesNotExist(__DIR__ . '/custom/caching-dir/' . CustomServicesCache::CACHE_FILENAME);
+    }
+}

--- a/tests/Feature/Framework/CustomNoCacheDirectory/Module/Facade.php
+++ b/tests/Feature/Framework/CustomNoCacheDirectory/Module/Facade.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\CustomNoCacheDirectory\Module;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\DocBlockResolverAwareTrait;
+use GacelaTest\Feature\Framework\CustomNoCacheDirectory\Module\Persistence\FakeRepository;
+
+/**
+ * @method FakeRepository getRepository()
+ */
+final class Facade extends AbstractFacade
+{
+    use DocBlockResolverAwareTrait;
+
+    public function getName(): string
+    {
+        return $this->getRepository()->findName();
+    }
+}

--- a/tests/Feature/Framework/CustomNoCacheDirectory/Module/Persistence/FakeRepository.php
+++ b/tests/Feature/Framework/CustomNoCacheDirectory/Module/Persistence/FakeRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\CustomNoCacheDirectory\Module\Persistence;
+
+final class FakeRepository
+{
+    public function findName(): string
+    {
+        return 'name';
+    }
+}

--- a/tests/Feature/Framework/CustomNoCacheDirectory/NoFileCacheFeatureTest.php
+++ b/tests/Feature/Framework/CustomNoCacheDirectory/NoFileCacheFeatureTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\CustomCacheDirectory;
+namespace GacelaTest\Feature\Framework\CustomNoCacheDirectory;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\ClassNameCache;
@@ -15,18 +15,17 @@ final class NoFileCacheFeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addAppConfig('config/*.php');
-            $config->setCacheDirectory('custom/caching-dir');
             $config->setCacheEnabled(false);
+            $config->setCacheDirectory('custom/no-caching-dir');
         });
     }
 
-    public function test_custom_caching_dir(): void
+    public function test_custom_no_caching_dir(): void
     {
         $facade = new Module\Facade();
         self::assertSame('name', $facade->getName());
 
-        self::assertFileDoesNotExist(__DIR__ . '/custom/caching-dir/' . ClassNameCache::CACHE_FILENAME);
-        self::assertFileDoesNotExist(__DIR__ . '/custom/caching-dir/' . CustomServicesCache::CACHE_FILENAME);
+        self::assertFileDoesNotExist(__DIR__ . '/custom/no-caching-dir/' . ClassNameCache::CACHE_FILENAME);
+        self::assertFileDoesNotExist(__DIR__ . '/custom/no-caching-dir/' . CustomServicesCache::CACHE_FILENAME);
     }
 }

--- a/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/FeatureTest.php
+++ b/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/FeatureTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap;
+namespace GacelaTest\Feature\Framework\GacelaConfigAddAppConfigKeyValues;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
-use GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module\Facade;
+use GacelaTest\Feature\Framework\GacelaConfigAddAppConfigKeyValues\Module\Facade;
 use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
@@ -26,7 +26,7 @@ final class FeatureTest extends TestCase
         });
     }
 
-    public function test_override_factory_from_highest_prio_namespace(): void
+    public function test_application_config_are_added_from_gacela_config(): void
     {
         $facade = new Facade();
 

--- a/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Config.php
+++ b/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Config.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
+namespace GacelaTest\Feature\Framework\GacelaConfigAddAppConfigKeyValues\Module;
 
 use Gacela\Framework\AbstractConfig;
 

--- a/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Facade.php
+++ b/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Facade.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
+namespace GacelaTest\Feature\Framework\GacelaConfigAddAppConfigKeyValues\Module;
 
 use Gacela\Framework\AbstractFacade;
 

--- a/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Factory.php
+++ b/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Factory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Feature\Framework\AddAppConfigKeyValuesInGacelaBootstrap\Module;
+namespace GacelaTest\Feature\Framework\GacelaConfigAddAppConfigKeyValues\Module;
 
 use Gacela\Framework\AbstractFactory;
 

--- a/tests/Unit/Framework/ClassResolver/Cache/GacelaCacheTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/GacelaCacheTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\Cache;
+
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+use Gacela\Framework\Config\ConfigInterface;
+use PHPUnit\Framework\TestCase;
+
+final class GacelaCacheTest extends TestCase
+{
+    public function test_gacela_setup_is_disabled(): void
+    {
+        $setupGacela = $this->createMock(SetupGacelaInterface::class);
+        $setupGacela->method('isCacheEnabled')
+            ->willReturn(false);
+        $config = $this->createMock(ConfigInterface::class);
+        $config->method('getSetupGacela')
+            ->willReturn($setupGacela);
+
+        $gacelaCache = new GacelaCache($config);
+
+        self::assertFalse($gacelaCache->isProjectCacheEnabled());
+    }
+
+    public function test_application_config_key_is_disabled(): void
+    {
+        $setupGacela = $this->createMock(SetupGacelaInterface::class);
+        $setupGacela->method('isCacheEnabled')
+            ->willReturn(true);
+        $config = $this->createMock(ConfigInterface::class);
+        $config->method('getSetupGacela')
+            ->willReturn($setupGacela);
+        $config->method('get')
+            ->willReturn(false);
+
+        $gacelaCache = new GacelaCache($config);
+
+        self::assertFalse($gacelaCache->isProjectCacheEnabled());
+    }
+
+    public function test_cache_is_enabled(): void
+    {
+        $setupGacela = $this->createMock(SetupGacelaInterface::class);
+        $setupGacela->method('isCacheEnabled')
+            ->willReturn(true);
+        $config = $this->createMock(ConfigInterface::class);
+        $config->method('getSetupGacela')
+            ->willReturn($setupGacela);
+        $config->method('get')
+            ->willReturn(true);
+
+        $gacelaCache = new GacelaCache($config);
+
+        self::assertTrue($gacelaCache->isProjectCacheEnabled());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Issue https://github.com/gacela-project/gacela/issues/185

When the cache is disabled (from the application configs or the bootstrap), any `*.cache` file will be generated.

## 🏷️ Changes

- Extends `GacelaCache` file
- Introduce `ConfigInterface`