### PR TITLE
Extract class refactoring in DocBlockResolverAwareTrait

### DIFF
--- a/src/Framework/DocBlockResolver/DocBlockResolvable.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolvable.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\DocBlockResolver;
+
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
+use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
+use Gacela\Framework\ClassResolver\DocBlockService\DocBlockParser;
+use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
+use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
+use Gacela\Framework\ClassResolver\InMemoryCache;
+use Gacela\Framework\Config\Config;
+use ReflectionClass;
+
+use function get_class;
+use function is_string;
+
+final class DocBlockResolvable
+{
+    /** @var array<string,string> [fileName => fileContent] cached */
+    private static array $fileContentCache = [];
+
+    /** @var class-string */
+    private string $callerClass;
+
+    /** @var class-string|string */
+    private string $callerParentClass;
+
+    /**
+     * @param class-string $callerClass
+     * @param class-string|string $callerParentClass
+     */
+    private function __construct(string $callerClass, string $callerParentClass)
+    {
+        $this->callerClass = $callerClass;
+        $this->callerParentClass = $callerParentClass;
+    }
+
+    public static function fromCaller(object $caller): self
+    {
+        return new self(
+            get_class($caller),
+            get_parent_class($caller) ?: ''
+        );
+    }
+
+    public function getClassName(string $method): string
+    {
+        $cacheKey = $this->generateCacheKey($method);
+        $cache = $this->createCustomServicesCache();
+
+        if (!$cache->has($cacheKey)) {
+            $className = $this->getClassFromDoc($method);
+            $cache->put($cacheKey, $className);
+        }
+
+        /** @psalm-suppress ArgumentTypeCoercion */
+        return $cache->get($cacheKey);
+    }
+
+
+    public function hasParentClass(): bool
+    {
+        /** @psalm-suppress ArgumentTypeCoercion */
+        return $this->callerParentClass !== ''
+            && method_exists($this->callerParentClass, '__call');
+    }
+
+    public function normalizeResolvableType(string $resolvableType): string
+    {
+        /** @var list<string> $resolvableTypeParts */
+        $resolvableTypeParts = explode('\\', ltrim($resolvableType, '\\'));
+        $normalizedResolvableType = end($resolvableTypeParts);
+
+        return is_string($normalizedResolvableType)
+            ? $normalizedResolvableType
+            : $resolvableType;
+    }
+
+    public function createCustomServicesCache(): ClassNameCacheInterface
+    {
+        if (!$this->isProjectCacheEnabled()) {
+            return new InMemoryCache(CustomServicesCache::class);
+        }
+
+        return new CustomServicesCache(
+            Config::getInstance()->getCacheDir()
+        );
+    }
+
+    /**
+     * @return class-string
+     */
+    private function getClassFromDoc(string $method): string
+    {
+        $reflectionClass = new ReflectionClass($this->callerClass);
+        $className = $this->searchClassOverDocBlock($reflectionClass, $method);
+        if (class_exists($className)) {
+            return $className;
+        }
+        $className = $this->searchClassOverUseStatements($reflectionClass, $className);
+        if (class_exists($className)) {
+            return $className;
+        }
+        throw MissingClassDefinitionException::missingDefinition($this->callerClass, $method, $className);
+    }
+
+    private function searchClassOverDocBlock(ReflectionClass $reflectionClass, string $method): string
+    {
+        $docBlock = (string)$reflectionClass->getDocComment();
+
+        return (new DocBlockParser())->getClassFromMethod($docBlock, $method);
+    }
+
+    /**
+     * Look the uses, to find the fully-qualified class name for the className.
+     */
+    private function searchClassOverUseStatements(ReflectionClass $reflectionClass, string $className): string
+    {
+        $fileName = (string)$reflectionClass->getFileName();
+        if (!isset(self::$fileContentCache[$fileName])) {
+            self::$fileContentCache[$fileName] = (string)file_get_contents($fileName);
+        }
+        $phpFile = self::$fileContentCache[$fileName];
+
+        return (new UseBlockParser())->getUseStatement($className, $phpFile);
+    }
+
+    private function generateCacheKey(string $method): string
+    {
+        return $this->callerClass . '::' . $method;
+    }
+
+    private function isProjectCacheEnabled(): bool
+    {
+        return (new GacelaCache(Config::getInstance()))
+            ->isProjectCacheEnabled();
+    }
+}

--- a/src/Framework/DocBlockResolver/DocBlockResolvable.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolvable.php
@@ -4,136 +4,32 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\DocBlockResolver;
 
-use Gacela\Framework\ClassResolver\Cache\GacelaCache;
-use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
-use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
-use Gacela\Framework\ClassResolver\DocBlockService\DocBlockParser;
-use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
-use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
-use Gacela\Framework\ClassResolver\InMemoryCache;
-use Gacela\Framework\Config\Config;
-use ReflectionClass;
-
-use function get_class;
-use function is_string;
-
 final class DocBlockResolvable
 {
-    /** @var array<string,string> [fileName => fileContent] cached */
-    private static array $fileContentCache = [];
-
     /** @var class-string */
-    private string $callerClass;
+    private string $className;
 
-    /** @var class-string|string */
-    private string $callerParentClass;
+    private string $resolvableType;
 
     /**
-     * @param class-string $callerClass
-     * @param class-string|string $callerParentClass
+     * @param class-string $className
      */
-    private function __construct(string $callerClass, string $callerParentClass)
+    public function __construct(string $className, string $resolvableType)
     {
-        $this->callerClass = $callerClass;
-        $this->callerParentClass = $callerParentClass;
-    }
-
-    public static function fromCaller(object $caller): self
-    {
-        return new self(
-            get_class($caller),
-            get_parent_class($caller) ?: ''
-        );
-    }
-
-    public function getClassName(string $method): string
-    {
-        $cacheKey = $this->generateCacheKey($method);
-        $cache = $this->createClassNameCache();
-
-        if (!$cache->has($cacheKey)) {
-            $className = $this->getClassFromDoc($method);
-            $cache->put($cacheKey, $className);
-        }
-
-        return $cache->get($cacheKey);
-    }
-
-    public function normalizeResolvableType(string $resolvableType): string
-    {
-        /** @var list<string> $resolvableTypeParts */
-        $resolvableTypeParts = explode('\\', ltrim($resolvableType, '\\'));
-        $normalizedResolvableType = end($resolvableTypeParts);
-
-        return is_string($normalizedResolvableType)
-            ? $normalizedResolvableType
-            : $resolvableType;
-    }
-
-    public function hasParentClass(): bool
-    {
-        /** @psalm-suppress ArgumentTypeCoercion */
-        return $this->callerParentClass !== ''
-            && method_exists($this->callerParentClass, '__call');
-    }
-
-    private function generateCacheKey(string $method): string
-    {
-        return $this->callerClass . '::' . $method;
-    }
-
-    private function createClassNameCache(): ClassNameCacheInterface
-    {
-        if (!$this->isProjectCacheEnabled()) {
-            return new InMemoryCache(CustomServicesCache::class);
-        }
-
-        return new CustomServicesCache(
-            Config::getInstance()->getCacheDir()
-        );
-    }
-
-    private function isProjectCacheEnabled(): bool
-    {
-        return (new GacelaCache(Config::getInstance()))
-            ->isProjectCacheEnabled();
+        $this->resolvableType = $resolvableType;
+        $this->className = $className;
     }
 
     /**
      * @return class-string
      */
-    private function getClassFromDoc(string $method): string
+    public function className(): string
     {
-        $reflectionClass = new ReflectionClass($this->callerClass);
-        $className = $this->searchClassOverDocBlock($reflectionClass, $method);
-        if (class_exists($className)) {
-            return $className;
-        }
-        $className = $this->searchClassOverUseStatements($reflectionClass, $className);
-        if (class_exists($className)) {
-            return $className;
-        }
-        throw MissingClassDefinitionException::missingDefinition($this->callerClass, $method, $className);
+        return $this->className;
     }
 
-    private function searchClassOverDocBlock(ReflectionClass $reflectionClass, string $method): string
+    public function resolvableType(): string
     {
-        $docBlock = (string)$reflectionClass->getDocComment();
-
-        return (new DocBlockParser())->getClassFromMethod($docBlock, $method);
-    }
-
-    /**
-     * Look the uses, to find the fully-qualified class name for the className.
-     */
-    private function searchClassOverUseStatements(ReflectionClass $reflectionClass, string $className): string
-    {
-        $fileName = (string)$reflectionClass->getFileName();
-        if (!isset(self::$fileContentCache[$fileName])) {
-            self::$fileContentCache[$fileName] = (string)file_get_contents($fileName);
-        }
-        $phpFile = self::$fileContentCache[$fileName];
-
-        return (new UseBlockParser())->getUseStatement($className, $phpFile);
+        return $this->resolvableType;
     }
 }

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\DocBlockResolver;
+
+use Gacela\Framework\ClassResolver\Cache\GacelaCache;
+use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
+use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
+use Gacela\Framework\ClassResolver\DocBlockService\DocBlockParser;
+use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
+use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
+use Gacela\Framework\ClassResolver\InMemoryCache;
+use Gacela\Framework\Config\Config;
+use ReflectionClass;
+
+use function get_class;
+use function is_string;
+
+final class DocBlockResolver
+{
+    /** @var array<string,string> [fileName => fileContent] */
+    private static array $fileContentCache = [];
+
+    /** @var class-string */
+    private string $callerClass;
+
+    /** @var class-string|string */
+    private string $callerParentClass;
+
+    /**
+     * @param class-string $callerClass
+     * @param class-string|string $callerParentClass
+     */
+    private function __construct(string $callerClass, string $callerParentClass)
+    {
+        $this->callerClass = $callerClass;
+        $this->callerParentClass = $callerParentClass;
+    }
+
+    public static function fromCaller(object $caller): self
+    {
+        return new self(
+            get_class($caller),
+            get_parent_class($caller) ?: ''
+        );
+    }
+
+    public function hasParentCallMethod(): bool
+    {
+        /** @psalm-suppress ArgumentTypeCoercion */
+        return $this->callerParentClass !== ''
+            && method_exists($this->callerParentClass, '__call');
+    }
+
+    public function getDocBlockResolvable(string $method): DocBlockResolvable
+    {
+        $className = $this->getClassName($method);
+        $resolvableType = $this->normalizeResolvableType($className);
+
+        return new DocBlockResolvable($className, $resolvableType);
+    }
+
+    /**
+     * @return class-string
+     */
+    private function getClassName(string $method): string
+    {
+        $cacheKey = $this->generateCacheKey($method);
+        $cache = $this->createClassNameCache();
+
+        if (!$cache->has($cacheKey)) {
+            $className = $this->getClassFromDoc($method);
+            $cache->put($cacheKey, $className);
+        }
+
+        /** @psalm-suppress ArgumentTypeCoercion */
+        /** @var class-string $className */
+        $className = $cache->get($cacheKey);
+
+        return $className;
+    }
+
+    private function normalizeResolvableType(string $resolvableType): string
+    {
+        /** @var list<string> $resolvableTypeParts */
+        $resolvableTypeParts = explode('\\', ltrim($resolvableType, '\\'));
+        $normalizedResolvableType = end($resolvableTypeParts);
+
+        return is_string($normalizedResolvableType)
+            ? $normalizedResolvableType
+            : $resolvableType;
+    }
+
+    private function generateCacheKey(string $method): string
+    {
+        return $this->callerClass . '::' . $method;
+    }
+
+    private function createClassNameCache(): ClassNameCacheInterface
+    {
+        if (!$this->isProjectCacheEnabled()) {
+            return new InMemoryCache(CustomServicesCache::class);
+        }
+
+        return new CustomServicesCache(
+            Config::getInstance()->getCacheDir()
+        );
+    }
+
+    private function isProjectCacheEnabled(): bool
+    {
+        return (new GacelaCache(Config::getInstance()))
+            ->isProjectCacheEnabled();
+    }
+
+    /**
+     * @return class-string
+     */
+    private function getClassFromDoc(string $method): string
+    {
+        $reflectionClass = new ReflectionClass($this->callerClass);
+        $className = $this->searchClassOverDocBlock($reflectionClass, $method);
+        if (class_exists($className)) {
+            return $className;
+        }
+        $className = $this->searchClassOverUseStatements($reflectionClass, $className);
+        if (class_exists($className)) {
+            return $className;
+        }
+        throw MissingClassDefinitionException::missingDefinition($this->callerClass, $method, $className);
+    }
+
+    private function searchClassOverDocBlock(ReflectionClass $reflectionClass, string $method): string
+    {
+        $docBlock = (string)$reflectionClass->getDocComment();
+
+        return (new DocBlockParser())->getClassFromMethod($docBlock, $method);
+    }
+
+    /**
+     * Look the uses, to find the fully-qualified class name for the className.
+     */
+    private function searchClassOverUseStatements(ReflectionClass $reflectionClass, string $className): string
+    {
+        $fileName = (string)$reflectionClass->getFileName();
+        if (!isset(self::$fileContentCache[$fileName])) {
+            self::$fileContentCache[$fileName] = (string)file_get_contents($fileName);
+        }
+        $phpFile = self::$fileContentCache[$fileName];
+
+        return (new UseBlockParser())->getUseStatement($className, $phpFile);
+    }
+}

--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -4,24 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
-use Gacela\Framework\ClassResolver\Cache\GacelaCache;
-use Gacela\Framework\ClassResolver\ClassNameCacheInterface;
-use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesCache;
-use Gacela\Framework\ClassResolver\DocBlockService\DocBlockParser;
 use Gacela\Framework\ClassResolver\DocBlockService\DocBlockServiceResolver;
-use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
-use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
-use Gacela\Framework\ClassResolver\InMemoryCache;
-use Gacela\Framework\Config\Config;
-use ReflectionClass;
-
-use function is_string;
+use Gacela\Framework\DocBlockResolver\DocBlockResolvable;
 
 trait DocBlockResolverAwareTrait
 {
-    /** @var array<string,string> */
-    protected static array $fileContentCache = [];
-
     /** @var array<string,?mixed> */
     private array $customServices = [];
 
@@ -37,18 +24,11 @@ trait DocBlockResolverAwareTrait
             return $this->customServices[$method];
         }
 
-        $cacheKey = $this->generateCacheKey($method);
-        $cache = $this->createCustomServicesCache();
+        $docBlockResolvable = DocBlockResolvable::fromCaller($this);
 
-        if (!$cache->has($cacheKey)) {
-            $className = $this->getClassFromDoc($method);
-            $cache->put($cacheKey, $className);
-        }
-
-        /** @psalm-suppress ArgumentTypeCoercion */
         /** @var class-string $className */
-        $className = $cache->get($cacheKey);
-        $resolvableType = $this->normalizeResolvableType($className);
+        $className = $docBlockResolvable->getClassName($method);
+        $resolvableType = $docBlockResolvable->normalizeResolvableType($className);
 
         $resolved = (new DocBlockServiceResolver($resolvableType))
             ->resolve($className);
@@ -57,7 +37,7 @@ trait DocBlockResolverAwareTrait
             return $resolved;
         }
 
-        if ($this->hasParentClass()) {
+        if ($docBlockResolvable->hasParentClass()) {
             /** @psalm-suppress ParentNotFound, MixedAssignment, UndefinedMethod */
             $parentReturn = parent::__call($method, $parameters); // @phpstan-ignore-line
             $this->customServices[$method] = $parentReturn;
@@ -66,83 +46,5 @@ trait DocBlockResolverAwareTrait
         }
 
         return null;
-    }
-
-    private function hasParentClass(): bool
-    {
-        /** @psalm-suppress ParentNotFound,MixedArgument */
-        return class_parents($this)
-            && method_exists(parent::class, '__call');
-    }
-
-    /**
-     * @return class-string
-     */
-    private function getClassFromDoc(string $method): string
-    {
-        $reflectionClass = new ReflectionClass(static::class);
-        $className = $this->searchClassOverDocBlock($reflectionClass, $method);
-        if (class_exists($className)) {
-            return $className;
-        }
-        $className = $this->searchClassOverUseStatements($reflectionClass, $className);
-        if (class_exists($className)) {
-            return $className;
-        }
-        throw MissingClassDefinitionException::missingDefinition(static::class, $method, $className);
-    }
-
-    private function searchClassOverDocBlock(ReflectionClass $reflectionClass, string $method): string
-    {
-        $docBlock = (string)$reflectionClass->getDocComment();
-
-        return (new DocBlockParser())->getClassFromMethod($docBlock, $method);
-    }
-
-    /**
-     * Look the uses, to find the fully-qualified class name for the className.
-     */
-    private function searchClassOverUseStatements(ReflectionClass $reflectionClass, string $className): string
-    {
-        $fileName = (string)$reflectionClass->getFileName();
-        if (!isset(static::$fileContentCache[$fileName])) {
-            static::$fileContentCache[$fileName] = (string)file_get_contents($fileName);
-        }
-        $phpFile = static::$fileContentCache[$fileName];
-
-        return (new UseBlockParser())->getUseStatement($className, $phpFile);
-    }
-
-    private function normalizeResolvableType(string $resolvableType): string
-    {
-        /** @var list<string> $resolvableTypeParts */
-        $resolvableTypeParts = explode('\\', ltrim($resolvableType, '\\'));
-        $normalizedResolvableType = end($resolvableTypeParts);
-
-        return is_string($normalizedResolvableType)
-            ? $normalizedResolvableType
-            : $resolvableType;
-    }
-
-    private function generateCacheKey(string $method): string
-    {
-        return self::class . '::' . $method;
-    }
-
-    private function createCustomServicesCache(): ClassNameCacheInterface
-    {
-        if (!$this->isProjectCacheEnabled()) {
-            return new InMemoryCache(CustomServicesCache::class);
-        }
-
-        return new CustomServicesCache(
-            Config::getInstance()->getCacheDir()
-        );
-    }
-
-    private function isProjectCacheEnabled(): bool
-    {
-        return (new GacelaCache(Config::getInstance()))
-            ->isProjectCacheEnabled();
     }
 }


### PR DESCRIPTION
## 📚 Description

The current `DocBlockResolverAwareTrait` has too much logic, and it's really hard to follow what's going on. Especially, considering that this trait is something that the user will use on their end.

## 🔖 Changes

- Apply "extract class refactoring" on `DocBlockResolverAwareTrait` to improve the readability of the trait logic itself.

> **Note**: We have a full test coverage on this area under `GacelaTest\Integration\Framework\DocBlockResolverAware`.