### PR TITLE
Remove dead code from DocBlockResolverAwareTrait

### DIFF
--- a/src/Framework/DocBlockResolverAwareTrait.php
+++ b/src/Framework/DocBlockResolverAwareTrait.php
@@ -27,21 +27,7 @@ trait DocBlockResolverAwareTrait
         $docBlockResolver = DocBlockResolver::fromCaller($this);
         $resolvable = $docBlockResolver->getDocBlockResolvable($method);
 
-        $resolved = (new DocBlockServiceResolver($resolvable->resolvableType()))
+        return (new DocBlockServiceResolver($resolvable->resolvableType()))
             ->resolve($resolvable->className());
-
-        if ($resolved !== null) {
-            return $resolved;
-        }
-
-        if ($docBlockResolver->hasParentCallMethod()) {
-            /** @psalm-suppress ParentNotFound, MixedAssignment, UndefinedMethod */
-            $parentReturn = parent::__call($method, $parameters); // @phpstan-ignore-line
-            $this->customServices[$method] = $parentReturn;
-
-            return $parentReturn;
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
## 📚 Description

I remember we faced some errors when in Laravel a `Controller` class, a userland use the `DocBlockResolverAwareTrait`.
This error was happening because both (the trait and the controller) implemented the magic `__call()` method. In some scenarios, when the trait was implemented, it was overriding the `__call()` from the controller facing some undesirable effects.

It seems that this error is not happening anymore in Laravel (I could not reproduce this scenario), so, I decided to remove this _dead_ code from now.
