### PR TITLE
Remove deprecated SetupGacelaInterface from gacela.php

### DIFF
--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -48,11 +48,6 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         $configFn($gacelaConfig);
         $setupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
 
-        /** @var object $setupGacela */
-        if (!is_subclass_of($setupGacela, SetupGacelaInterface::class)) {
-            throw new RuntimeException('`gacela.php` file should return a `callable(GacelaConfig)`');
-        }
-
         $configBuilder = $this->createConfigBuilder($setupGacela);
         $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder($setupGacela);
         $suffixTypesBuilder = $this->createSuffixTypesBuilder($setupGacela);

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -38,22 +38,15 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        /** @var SetupGacelaInterface|callable(GacelaConfig) $configFn */
+        /** @var callable(GacelaConfig):void $configFn */
         $configFn = $this->fileIo->include($this->gacelaPhpPath);
-
-        if (is_callable($configFn)) {
-            $gacelaConfig = new GacelaConfig($this->setup->externalServices());
-            $configFn($gacelaConfig);
-            $setupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
-        } else {
-            trigger_deprecation(
-                'gacela-project/gacela',
-                '0.18',
-                '`SetupGacelaInterface` is deprecated. Use `callable(GacelaConfig)` instead.'
-            );
-
-            $setupGacela = $configFn;
+        if (!is_callable($configFn)) {
+            throw new RuntimeException('`gacela.php` file should return a `callable(GacelaConfig)`');
         }
+
+        $gacelaConfig = new GacelaConfig($this->setup->externalServices());
+        $configFn($gacelaConfig);
+        $setupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
 
         /** @var object $setupGacela */
         if (!is_subclass_of($setupGacela, SetupGacelaInterface::class)) {

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/gacela.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/gacela.php
@@ -4,21 +4,18 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingCustomSuffixTypes;
 
-use Gacela\Framework\Bootstrap\SetupGacela;
-use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 
-return (new SetupGacela())
-    ->setSuffixTypesFn(
-        static function (SuffixTypesBuilder $suffixTypesBuilder): void {
-            $suffixTypesBuilder
-                ->addFacade('FacaModuleA')
-                ->addFactory('FactModuleA')
-                ->addConfig('ConfModuleA')
-                ->addDependencyProvider('DepProModuleA')
-
-                ->addFacade('FacadeModuleB')
-                ->addFactory('FactoryModuleB')
-                ->addConfig('ConfigModuleB')
-                ->addDependencyProvider('DependencyProviderModuleB');
-        }
-    );
+return static function (GacelaConfig $config): void {
+    $config
+        // ModuleA
+        ->addSuffixTypeFacade('FacaModuleA')
+        ->addSuffixTypeFactory('FactModuleA')
+        ->addSuffixTypeConfig('ConfModuleA')
+        ->addSuffixTypeDependencyProvider('DepProModuleA')
+        // ModuleB
+        ->addSuffixTypeFacade('FacadeModuleB')
+        ->addSuffixTypeFactory('FactoryModuleB')
+        ->addSuffixTypeConfig('ConfigModuleB')
+        ->addSuffixTypeDependencyProvider('DependencyProviderModuleB');
+};

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -48,7 +48,8 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
             $fileIo
         );
 
-        self::assertEquals(new GacelaConfigFile(), $factory->createGacelaFileConfig());
+        $this->expectErrorMessage('`gacela.php` file should return a `callable(GacelaConfig)`');
+        $factory->createGacelaFileConfig();
     }
 
     public function test_gacela_file_using_callable_does_not_override_anything_then_use_defaults(): void

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Config\GacelaFileConfig\Factory;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Config\FileIoInterface;
@@ -18,29 +17,10 @@ use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
 {
-    public function test_exception_when_the_class_does_not_implements_setup_gacela_interface(): void
+    public function test_exception_when_the_class_does_not_return_a_callable(): void
     {
         $fileIo = $this->createStub(FileIoInterface::class);
-        $fileIo->method('include')->willReturn(
-            new class() {
-            }
-        );
-
-        $factory = new GacelaConfigUsingGacelaPhpFileFactory(
-            'gacelaPhpPath',
-            $this->createStub(SetupGacelaInterface::class),
-            $fileIo
-        );
-
-        $this->expectErrorMessage('`gacela.php` file should return a `callable(GacelaConfig)`');
-        $factory->createGacelaFileConfig();
-    }
-
-    public function test_gacela_file_using_setup_class_does_not_override_anything_then_use_defaults(): void
-    {
-        $fileIo = $this->createStub(FileIoInterface::class);
-        $fileIo->method('existsFile')->willReturn(true);
-        $fileIo->method('include')->willReturn(new SetupGacela());
+        $fileIo->method('include')->willReturn(new class() {});
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',


### PR DESCRIPTION
## 🔖 Changes

- Remove the deprecated possibility of returning a `SetupGacelaInterface` from `gacdela.php`
  - Use `callable(GacelaConfig)` instead.
