### PR TITLE
Process configFn from appRootDir if exists, and it wasn't defined on bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed deprecated `SetupGacelaInterface` from `gacela.php`.
 - Allow using abstracts Factory and Config by default.
 - Create `gacela cache:clear` command.
+- Process configFn from appRootDir if exists, and it wasn't defined on bootstrap.
 
 ### 0.24.0
 #### 2022-07-23

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ClassResolver\Cache\GacelaCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use RuntimeException;
 
 final class SetupGacela extends AbstractSetupGacela
 {
@@ -48,6 +49,18 @@ final class SetupGacela extends AbstractSetupGacela
         };
         $this->suffixTypesFn = static function (): void {
         };
+    }
+
+    public static function fromFile(string $gacelaFilePath): self
+    {
+        if (!is_file($gacelaFilePath)) {
+            throw new RuntimeException("Invalid file path: '{$gacelaFilePath}'");
+        }
+
+        /** @var Closure(GacelaConfig):void $setupGacelaFileFn */
+        $setupGacelaFileFn = include $gacelaFilePath;
+
+        return self::fromCallable($setupGacelaFileFn);
     }
 
     /**

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework;
 use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\ClassNameCache;
 use Gacela\Framework\Config\Config;
@@ -20,9 +21,7 @@ final class Gacela
      */
     public static function bootstrap(string $appRootDir, Closure $configFn = null): void
     {
-        $setup = $configFn !== null
-            ? SetupGacela::fromCallable($configFn)
-            : new SetupGacela();
+        $setup = self::processConfigFnIntoSetup($appRootDir, $configFn);
 
         if (!$setup->isCacheEnabled()) {
             ClassNameCache::resetCache();
@@ -34,5 +33,23 @@ final class Gacela
             ->setAppRootDir($appRootDir)
             ->setSetup($setup)
             ->init();
+    }
+
+    /**
+     * @param null|Closure(GacelaConfig):void $configFn
+     */
+    private static function processConfigFnIntoSetup(string $appRootDir, Closure $configFn = null): SetupGacelaInterface
+    {
+        if ($configFn !== null) {
+            return SetupGacela::fromCallable($configFn);
+        }
+
+        $gacelaFilePath = $appRootDir . '/gacela.php';
+
+        if (is_file($gacelaFilePath)) {
+            return SetupGacela::fromFile($gacelaFilePath);
+        }
+
+        return new SetupGacela();
     }
 }


### PR DESCRIPTION
## 📚  Description
Currently, `Gacela::bootstrap()` load only the configFn that it's passed as 2nd arg or uses default values. There is no way to let Gacela know to use your custom gacela.php file to take the configFn setup from there.

## 🔖 Changes

Added a new condition on `Gacela::bootstrap()` in order to fetch the `configFn` that will initialize the "SetupGacela" values.