### PR TITLE
Refactor CodeGenerator tests to include them in the code coverage

### DIFF
--- a/src/Console/ConsoleConfig.php
+++ b/src/Console/ConsoleConfig.php
@@ -41,7 +41,7 @@ final class ConsoleConfig extends AbstractConfig
     {
         $filename = $this->getAppRootDir() . '/composer.json';
         if (!file_exists($filename)) {
-            throw new LogicException('composer.json file not found but it is required');
+            throw new LogicException("composer.json file not found but it is required. Not found in '{$filename}'");
         }
 
         return (array)json_decode((string)file_get_contents($filename), true, 512, JSON_THROW_ON_ERROR);

--- a/tests/Feature/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeFileCommandTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\CodeGenerator;
 
+use Gacela\Console\Infrastructure\Command\MakeFileCommand;
+use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MakeFileCommandTest extends TestCase
 {
@@ -18,6 +22,7 @@ final class MakeFileCommandTest extends TestCase
 
     public function setUp(): void
     {
+        Gacela::bootstrap(self::ENTRY_POINT);
         DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
     }
 
@@ -26,10 +31,13 @@ final class MakeFileCommandTest extends TestCase
      */
     public function test_make_file(string $action, string $fileName, string $shortName): void
     {
-        $command = sprintf('%sgacela make:file %s Gacela/TestModule %s', self::ENTRY_POINT, $shortName, $action);
-        exec($command, $output);
+        $input = new StringInput(sprintf('%s Gacela/TestModule %s', $shortName, $action));
+        $output = new BufferedOutput();
 
-        self::assertSame("> Path 'src/TestModule/{$fileName}.php' created successfully", $output[0]);
+        $command = new MakeFileCommand();
+        $command->run($input, $output);
+
+        self::assertSame("> Path 'src/TestModule/{$fileName}.php' created successfully", trim($output->fetch()));
         self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}.php");
     }
 

--- a/tests/Feature/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeFileCommandTest.php
@@ -13,17 +13,15 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MakeFileCommandTest extends TestCase
 {
-    private const ENTRY_POINT = __DIR__ . '/../../../';
-
     public static function tearDownAfterClass(): void
     {
-        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+        DirectoryUtil::removeDir('./src/TestModule');
     }
 
     public function setUp(): void
     {
-        Gacela::bootstrap(self::ENTRY_POINT);
-        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+        Gacela::bootstrap(__DIR__);
+        DirectoryUtil::removeDir('./src/TestModule');
     }
 
     /**
@@ -31,14 +29,14 @@ final class MakeFileCommandTest extends TestCase
      */
     public function test_make_file(string $action, string $fileName, string $shortName): void
     {
-        $input = new StringInput(sprintf('%s Gacela/TestModule %s', $shortName, $action));
+        $input = new StringInput(sprintf('%s Psr4CodeGenerator/TestModule %s', $shortName, $action));
         $output = new BufferedOutput();
 
         $command = new MakeFileCommand();
         $command->run($input, $output);
 
         self::assertSame("> Path 'src/TestModule/{$fileName}.php' created successfully", trim($output->fetch()));
-        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}.php");
+        self::assertFileExists("./src/TestModule/{$fileName}.php");
     }
 
     public function createFilesProvider(): iterable

--- a/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
@@ -13,17 +13,15 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MakeModuleCommandTest extends TestCase
 {
-    private const ENTRY_POINT = __DIR__ . '/../../../';
-
     public static function tearDownAfterClass(): void
     {
-        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+        DirectoryUtil::removeDir('./src/TestModule');
     }
 
     public function setUp(): void
     {
-        Gacela::bootstrap(self::ENTRY_POINT);
-        DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
+        Gacela::bootstrap(__DIR__);
+        DirectoryUtil::removeDir('./src/TestModule');
     }
 
     /**
@@ -31,7 +29,7 @@ final class MakeModuleCommandTest extends TestCase
      */
     public function test_make_module(string $fileName, string $shortName): void
     {
-        $input = new StringInput("Gacela/TestModule {$shortName}");
+        $input = new StringInput("Psr4CodeGenerator/TestModule {$shortName}");
         $output = new BufferedOutput();
 
         $command = new MakeModuleCommand();
@@ -44,13 +42,12 @@ final class MakeModuleCommandTest extends TestCase
 > Path 'src/TestModule/{$fileName}DependencyProvider.php' created successfully
 Module 'TestModule' created successfully
 OUT;
-
         self::assertSame($expectedOutput, trim($output->fetch()));
 
-        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Facade.php");
-        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Factory.php");
-        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Config.php");
-        self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}DependencyProvider.php");
+        self::assertFileExists("./src/TestModule/{$fileName}Facade.php");
+        self::assertFileExists("./src/TestModule/{$fileName}Factory.php");
+        self::assertFileExists("./src/TestModule/{$fileName}Config.php");
+        self::assertFileExists("./src/TestModule/{$fileName}DependencyProvider.php");
     }
 
     public function createModulesProvider(): iterable

--- a/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\CodeGenerator;
 
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MakeModuleCommandTest extends TestCase
 {
@@ -18,6 +22,7 @@ final class MakeModuleCommandTest extends TestCase
 
     public function setUp(): void
     {
+        Gacela::bootstrap(self::ENTRY_POINT);
         DirectoryUtil::removeDir(self::ENTRY_POINT . 'src/TestModule');
     }
 
@@ -26,14 +31,21 @@ final class MakeModuleCommandTest extends TestCase
      */
     public function test_make_module(string $fileName, string $shortName): void
     {
-        $command = sprintf('%sgacela make:module %s Gacela/TestModule', self::ENTRY_POINT, $shortName);
-        exec($command, $output);
+        $input = new StringInput("Gacela/TestModule {$shortName}");
+        $output = new BufferedOutput();
 
-        self::assertSame("> Path 'src/TestModule/{$fileName}Facade.php' created successfully", $output[0]);
-        self::assertSame("> Path 'src/TestModule/{$fileName}Factory.php' created successfully", $output[1]);
-        self::assertSame("> Path 'src/TestModule/{$fileName}Config.php' created successfully", $output[2]);
-        self::assertSame("> Path 'src/TestModule/{$fileName}DependencyProvider.php' created successfully", $output[3]);
-        self::assertSame("Module 'TestModule' created successfully", $output[4]);
+        $command = new MakeModuleCommand();
+        $command->run($input, $output);
+
+        $expectedOutput = <<<OUT
+> Path 'src/TestModule/{$fileName}Facade.php' created successfully
+> Path 'src/TestModule/{$fileName}Factory.php' created successfully
+> Path 'src/TestModule/{$fileName}Config.php' created successfully
+> Path 'src/TestModule/{$fileName}DependencyProvider.php' created successfully
+Module 'TestModule' created successfully
+OUT;
+
+        self::assertSame($expectedOutput, trim($output->fetch()));
 
         self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Facade.php");
         self::assertFileExists(self::ENTRY_POINT . "src/TestModule/{$fileName}Factory.php");

--- a/tests/Feature/CodeGenerator/composer.json
+++ b/tests/Feature/CodeGenerator/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Psr4CodeGenerator\\": "src/"
+        }
+    }
+}


### PR DESCRIPTION
## 🔖 Changes

There is no behaviour/logic change in this PR, just refactoring the existing tests for the CodeGenerator feature in order to count the code coverage for this feature as well.

Instead of using the `exec(...)` use the actual Command `new MakeFileCommand(...)` and run it in the test.


## 🖼️ Sreenshots

> Scrunitizer build: https://scrutinizer-ci.com/g/gacela-project/gacela/inspections/097747bd-d19e-4dba-8640-00fd22613b2a

<img width="346" alt="Screenshot 2022-09-29 at 10 25 48" src="https://user-images.githubusercontent.com/5256287/192980388-a8ab6af2-a6ae-4427-95dc-2f5495450131.png">

<img width="1179" alt="Screenshot 2022-09-29 at 10 25 38" src="https://user-images.githubusercontent.com/5256287/192980343-dce0c938-161e-4f10-86a8-9c60a809d166.png">
