### PR TITLE
Fix PHPStan error should return class-string but returns string

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,5 +6,6 @@ parameters:
     checkMissingIterableValueType: false
 
     ignoreErrors:
+        - '#Method Gacela\\.*::.* should return class-string.*but returns string#'
         - '#Method Gacela\\.*::.* should return array<.*> but returns array#'
         - '#Method Gacela\\.*::.* should return array{.*} but returns array#'

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -48,7 +48,7 @@ final class ClassNameFinder implements ClassNameFinderInterface
         $cacheKey = $classInfo->getCacheKey();
 
         if ($this->classNameCache->has($cacheKey)) {
-            return $this->classNameCache->get($cacheKey); //@phpstan-ignore-line
+            return $this->classNameCache->get($cacheKey);
         }
 
         $projectNamespaces = $this->projectNamespaces;
@@ -62,7 +62,7 @@ final class ClassNameFinder implements ClassNameFinderInterface
                     if ($this->classValidator->isClassNameValid($className)) {
                         $this->classNameCache->put($cacheKey, $className);
 
-                        return $className; //@phpstan-ignore-line
+                        return $className;
                     }
                 }
             }


### PR DESCRIPTION
## 📚 Description

Add to `phpstan.neon` the rule to ignore when a `class-string` should be returned but returns a `string` and clean a little the code 😄 