### PR TITLE
Full code coverage on Gacela/Console module

### DIFF
--- a/src/Console/ConsoleConfig.php
+++ b/src/Console/ConsoleConfig.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Console;
 
+use Gacela\Console\Domain\ConsoleException;
 use Gacela\Framework\AbstractConfig;
 use JsonException;
-use LogicException;
 
 final class ConsoleConfig extends AbstractConfig
 {
@@ -33,7 +33,7 @@ final class ConsoleConfig extends AbstractConfig
     /**
      * @psalm-suppress MixedReturnTypeCoercion
      *
-     * @throws JsonException
+     * @throws ConsoleException|JsonException
      *
      * @return array{autoload: array{psr-4: array<string,string>}}
      */
@@ -41,7 +41,7 @@ final class ConsoleConfig extends AbstractConfig
     {
         $filename = $this->getAppRootDir() . '/composer.json';
         if (!file_exists($filename)) {
-            throw new LogicException("composer.json file not found but it is required. Not found in '{$filename}'");
+            throw ConsoleException::composerJsonNotFound();
         }
 
         return (array)json_decode((string)file_get_contents($filename), true, 512, JSON_THROW_ON_ERROR);

--- a/src/Console/Domain/ConsoleException.php
+++ b/src/Console/Domain/ConsoleException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain;
+
+use LogicException;
+
+final class ConsoleException extends LogicException
+{
+    public static function composerJsonNotFound(): self
+    {
+        return new self('composer.json file not found but it is required.');
+    }
+}

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -82,7 +82,7 @@ final class Config implements ConfigInterface
 
     public function setAppRootDir(string $dir): self
     {
-        $this->appRootDir = $dir;
+        $this->appRootDir = rtrim($dir, '/');
 
         if (empty($this->appRootDir)) {
             $this->appRootDir = getcwd() ?: ''; // @codeCoverageIgnore

--- a/tests/Feature/CodeGenerator/MakeExceptionCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeExceptionCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\CodeGenerator;
+
+use Gacela\Console\Domain\ConsoleException;
+use Gacela\Console\Infrastructure\Command\MakeFileCommand;
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class MakeExceptionCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__ . '/undefined-folder/');
+    }
+
+    public function test_make_module_exception_when_composer_file_not_found(): void
+    {
+        $this->expectExceptionObject(ConsoleException::composerJsonNotFound());
+
+        $input = new StringInput('Psr4CodeGenerator/TestModule');
+        $bootstrap = new MakeModuleCommand();
+        $bootstrap->run($input, new BufferedOutput());
+    }
+
+    public function test_make_file_exception_when_composer_file_not_found(): void
+    {
+        $this->expectExceptionObject(ConsoleException::composerJsonNotFound());
+
+        $input = new StringInput('Psr4CodeGenerator/TestModule facade');
+        $bootstrap = new MakeFileCommand();
+        $bootstrap->run($input, new BufferedOutput());
+    }
+}

--- a/tests/Feature/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeFileCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\CodeGenerator;
 
-use Gacela\Console\Infrastructure\Command\MakeFileCommand;
+use Gacela\Console\Infrastructure\ConsoleBootstrap;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
@@ -29,11 +29,12 @@ final class MakeFileCommandTest extends TestCase
      */
     public function test_make_file(string $action, string $fileName, string $shortName): void
     {
-        $input = new StringInput(sprintf('%s Psr4CodeGenerator/TestModule %s', $shortName, $action));
+        $input = new StringInput("make:file Psr4CodeGenerator/TestModule {$action} {$shortName}");
         $output = new BufferedOutput();
 
-        $command = new MakeFileCommand();
-        $command->run($input, $output);
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run($input, $output);
 
         self::assertSame("> Path 'src/TestModule/{$fileName}.php' created successfully", trim($output->fetch()));
         self::assertFileExists("./src/TestModule/{$fileName}.php");

--- a/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\CodeGenerator;
 
-use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Console\Infrastructure\ConsoleBootstrap;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
@@ -29,11 +29,12 @@ final class MakeModuleCommandTest extends TestCase
      */
     public function test_make_module(string $fileName, string $shortName): void
     {
-        $input = new StringInput("Psr4CodeGenerator/TestModule {$shortName}");
+        $input = new StringInput("make:module Psr4CodeGenerator/TestModule {$shortName}");
         $output = new BufferedOutput();
 
-        $command = new MakeModuleCommand();
-        $command->run($input, $output);
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run($input, $output);
 
         $expectedOutput = <<<OUT
 > Path 'src/TestModule/{$fileName}Facade.php' created successfully

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -33,4 +33,14 @@ final class ConfigTest extends TestCase
     {
         self::assertNull(Config::getInstance()->get('undefined-key', null));
     }
+
+    public function test_normalize_app_root_dir(): void
+    {
+        $config = Config::getInstance();
+        $config->setAppRootDir('/directory1');
+        self::assertSame('/directory1', $config->getAppRootDir());
+
+        $config->setAppRootDir('/directory2/');
+        self::assertSame('/directory2', $config->getAppRootDir());
+    }
 }


### PR DESCRIPTION
## 📚 Description

There were still some areas without code coverage.

## 🔖 Changes

- Normalize the `appRootDir`
- Introduce custom `ConsoleException::composerJsonNotFound()` instead of a generic `LogicException` when the composer.json file is not found (when using the gacela make commands)
- Improve the code coverage over the Gacela/Console module

---

You can verify the code coverage running this in your local:
```bash
composer test-coverage
```

### BEFORE
<img width="1164" alt="Screenshot 2022-10-01 at 17 06 02" src="https://user-images.githubusercontent.com/5256287/193415802-d5a66fb5-4025-4169-b56e-6dfb5ebb2861.png">

### AFTER
<img width="1160" alt="Screenshot 2022-10-01 at 17 05 33" src="https://user-images.githubusercontent.com/5256287/193415787-1aae290d-3909-4d60-981c-e5ae9fbc3d58.png">

