### PR TITLE
Allow using Interface suffix for DocBlockResolver

### DIFF
--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -21,6 +21,8 @@ use function is_string;
 
 final class DocBlockResolver
 {
+    private const INTERFACE_SUFFIX = 'Interface';
+
     /** @var array<string,string> [fileName => fileContent] */
     private static array $fileContentCache = [];
 
@@ -124,14 +126,24 @@ final class DocBlockResolver
     private function getClassFromDoc(string $method): string
     {
         $reflectionClass = new ReflectionClass($this->callerClass);
+
         $className = $this->searchClassOverDocBlock($reflectionClass, $method);
         if (class_exists($className)) {
             return $className;
         }
+
         $className = $this->searchClassOverUseStatements($reflectionClass, $className);
         if (class_exists($className)) {
             return $className;
         }
+
+        if (($pos = strpos($className, self::INTERFACE_SUFFIX)) !== false) {
+            $className = substr($className, 0, $pos);
+            if (class_exists($className)) {
+                return $className;
+            }
+        }
+
         throw MissingClassDefinitionException::missingDefinition($this->callerClass, $method, $className);
     }
 

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
@@ -4,24 +4,14 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
 
-use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\ClassResolver\DocBlockService\CustomServicesJsonProfiler;
-use Gacela\Framework\ClassResolver\InMemoryClassNameCache;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverCustomServicesAwareTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        InMemoryClassNameCache::resetCache();
-    }
-
     protected function setUp(): void
     {
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addAppConfig('config/custom-services/*.php');
-        });
+        Gacela::bootstrap(__DIR__);
     }
 
     public function test_existing_service(): void
@@ -29,22 +19,15 @@ final class DocBlockResolverCustomServicesAwareTest extends TestCase
         $dummy = new DummyDocBlockResolverAware();
         $actual = $dummy->getRepository()->findName();
 
-        self::assertCount(1, InMemoryClassNameCache::getAllFromKey(CustomServicesJsonProfiler::class));
         self::assertSame('name', $actual);
     }
 
-    /**
-     * @depends test_existing_service
-     */
-    public function test_existing_service_cached(): void
+    public function test_service_as_interface(): void
     {
-        self::assertCount(1, InMemoryClassNameCache::getAllFromKey(CustomServicesJsonProfiler::class));
-
         $dummy = new DummyDocBlockResolverAware();
-        $dummy->getRepository()->findName();
-        $dummy->getRepository()->findName();
+        $actual = $dummy->getService()->getName();
 
-        self::assertCount(1, InMemoryClassNameCache::getAllFromKey(CustomServicesJsonProfiler::class));
+        self::assertSame('fake-service.name', $actual);
     }
 
     public function test_non_existing_service(): void

--- a/tests/Integration/Framework/DocBlockResolverAware/DummyDocBlockResolverAware.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DummyDocBlockResolverAware.php
@@ -6,9 +6,11 @@ namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
 
 use Gacela\Framework\DocBlockResolverAwareTrait;
 use GacelaTest\Integration\Framework\DocBlockResolverAware\Persistence\FakeRepository;
+use GacelaTest\Integration\Framework\DocBlockResolverAware\Service\FakeServiceInterface;
 
 /**
  * @method FakeRepository getRepository()
+ * @method FakeServiceInterface getService()
  */
 final class DummyDocBlockResolverAware
 {

--- a/tests/Integration/Framework/DocBlockResolverAware/Service/FakeService.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/Service/FakeService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolverAware\Service;
+
+final class FakeService implements FakeServiceInterface
+{
+    public function getName(): string
+    {
+        return 'fake-service.name';
+    }
+}

--- a/tests/Integration/Framework/DocBlockResolverAware/Service/FakeServiceInterface.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/Service/FakeServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolverAware\Service;
+
+interface FakeServiceInterface
+{
+    public function getName(): string;
+}

--- a/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/custom-services/default.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Gacela\Framework\ClassResolver\Profiler\GacelaProfiler;
-
-return [
-    GacelaProfiler::KEY_ENABLED  => true,
-];

--- a/tests/Integration/Framework/DocBlockResolverAware/config/in-memory/default.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/config/in-memory/default.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Gacela\Framework\ClassResolver\Profiler\GacelaProfiler;
-
-return [
-    GacelaProfiler::KEY_ENABLED => false,
-];


### PR DESCRIPTION
## 📚 Description

Allow using an interface of your Facade (or any Service) specified as DocBlock resolvable, for example:

```php
/**
 * @method FakeServiceInterface getService()
 */
final class DummyDocBlockResolverAware
{
    use DocBlockResolverAwareTrait;
}
```

## 🔖 Changes

- On `getClassFromDoc()` add a last condition checking if the class name has `Interface` on it, and try finding a class name without the interface suffix.

### Things to consider

This feature assumes that:
- ...your interface will be on the same namespace as the concrete implementation
- ...the concrete implementation has the same name as the interface

> I would personally use the concrete class name in the DocBlock resolvable, but it might be useful for other scenarios.