### PR TITLE
Cache default resolved gacela class

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -57,7 +57,9 @@ abstract class AbstractClassResolver
         }
 
         $resolvedClassName = $this->findClassName($classInfo);
-        if ($resolvedClassName === null) {
+        if ($resolvedClassName !== null) {
+            $instance = $this->createInstance($resolvedClassName);
+        } else {
             // Try again with its parent class
             if (is_object($caller)) {
                 $parentClass = get_parent_class($caller);
@@ -66,10 +68,10 @@ abstract class AbstractClassResolver
                 }
             }
 
-            return $this->createDefaultGacelaClass();
+            $instance = $this->createDefaultGacelaClass();
         }
 
-        self::$cachedInstances[$cacheKey] = $this->createInstance($resolvedClassName);
+        self::$cachedInstances[$cacheKey] = $instance;
 
         return self::$cachedInstances[$cacheKey];
     }


### PR DESCRIPTION
## 📚 Description

We are not currently caching (in memory) the default gacela class after been resolved.

## 🔖 Changes

- Update `doResolve()` to cache the "defaultGacelaClass" after been resolved as any other resolved class
