### PR TITLE
Read autoload dev when parsing composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-coverage/
 .idea/
 .gacela/
 .vscode/
-vendor/
-data/
 .phpbench/
+coverage/
+data/
+vendor/
 
 *.cache
 composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Read autoload-dev psr-4 namespaces for gacela make commands.
+
 ### 0.26.0
 #### 2022-10-01
 

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "GacelaData\\": "data",
-            "GacelaTest\\": "tests"
+            "GacelaData\\": "data/",
+            "GacelaTest\\": "tests/"
         }
     },
     "bin": [

--- a/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
@@ -10,11 +10,19 @@ use function count;
 
 final class CommandArgumentsParser implements CommandArgumentsParserInterface
 {
-    /** @var array{autoload: array{psr-4?:array<string,string>}} */
+    /**
+     * @var array{
+     *     autoload:      array{psr-4?:array<string,string>},
+     *     autoload-dev?: array{psr-4?:array<string,string>},
+     * }
+     */
     private array $composerJson;
 
     /**
-     * @param array{autoload: array{psr-4?:array<string,string>}} $composerJson
+     * @param array{
+     *     autoload:      array{psr-4?:array<string,string>},
+     *     autoload-dev?: array{psr-4?:array<string,string>},
+     * } $composerJson
      */
     public function __construct(array $composerJson)
     {
@@ -37,6 +45,8 @@ final class CommandArgumentsParser implements CommandArgumentsParserInterface
         }
 
         $psr4 = $this->composerJson['autoload']['psr-4'];
+        $psr4Dev = $this->composerJson['autoload-dev']['psr-4'] ?? [];
+
         $allPsr4Combinations = $this->allPossiblePsr4Combinations($desiredNamespace);
 
         foreach ($allPsr4Combinations as $psr4Combination) {
@@ -44,6 +54,9 @@ final class CommandArgumentsParser implements CommandArgumentsParserInterface
 
             if (isset($psr4[$psr4Key])) {
                 return $this->foundPsr4($psr4Key, $psr4[$psr4Key], $desiredNamespace);
+            }
+            if (isset($psr4Dev[$psr4Key])) {
+                return $this->foundPsr4($psr4Key, $psr4Dev[$psr4Key], $desiredNamespace);
             }
         }
 

--- a/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/CodeGenerator/MakeModuleCommandTest.php
@@ -15,13 +15,13 @@ final class MakeModuleCommandTest extends TestCase
 {
     public static function tearDownAfterClass(): void
     {
-        DirectoryUtil::removeDir('./src/TestModule');
+        DirectoryUtil::removeDir('./data/TestModule');
     }
 
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__);
-        DirectoryUtil::removeDir('./src/TestModule');
+        DirectoryUtil::removeDir('./data/TestModule');
     }
 
     /**
@@ -29,7 +29,7 @@ final class MakeModuleCommandTest extends TestCase
      */
     public function test_make_module(string $fileName, string $shortName): void
     {
-        $input = new StringInput("make:module Psr4CodeGenerator/TestModule {$shortName}");
+        $input = new StringInput("make:module Psr4CodeGeneratorData/TestModule {$shortName}");
         $output = new BufferedOutput();
 
         $bootstrap = new ConsoleBootstrap();
@@ -37,18 +37,18 @@ final class MakeModuleCommandTest extends TestCase
         $bootstrap->run($input, $output);
 
         $expectedOutput = <<<OUT
-> Path 'src/TestModule/{$fileName}Facade.php' created successfully
-> Path 'src/TestModule/{$fileName}Factory.php' created successfully
-> Path 'src/TestModule/{$fileName}Config.php' created successfully
-> Path 'src/TestModule/{$fileName}DependencyProvider.php' created successfully
+> Path 'data/TestModule/{$fileName}Facade.php' created successfully
+> Path 'data/TestModule/{$fileName}Factory.php' created successfully
+> Path 'data/TestModule/{$fileName}Config.php' created successfully
+> Path 'data/TestModule/{$fileName}DependencyProvider.php' created successfully
 Module 'TestModule' created successfully
 OUT;
         self::assertSame($expectedOutput, trim($output->fetch()));
 
-        self::assertFileExists("./src/TestModule/{$fileName}Facade.php");
-        self::assertFileExists("./src/TestModule/{$fileName}Factory.php");
-        self::assertFileExists("./src/TestModule/{$fileName}Config.php");
-        self::assertFileExists("./src/TestModule/{$fileName}DependencyProvider.php");
+        self::assertFileExists("./data/TestModule/{$fileName}Facade.php");
+        self::assertFileExists("./data/TestModule/{$fileName}Factory.php");
+        self::assertFileExists("./data/TestModule/{$fileName}Config.php");
+        self::assertFileExists("./data/TestModule/{$fileName}DependencyProvider.php");
     }
 
     public function createModulesProvider(): iterable

--- a/tests/Feature/CodeGenerator/composer.json
+++ b/tests/Feature/CodeGenerator/composer.json
@@ -3,5 +3,10 @@
         "psr-4": {
             "Psr4CodeGenerator\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Psr4CodeGeneratorData\\": "data/"
+        }
     }
 }


### PR DESCRIPTION
## 📚 Description

Right now the gacela make commands works only for the psr-4 provided in the autoload, not autoload-dev.

## 🔖 Changes

- Read autoload and autoload-dev from composer.json to fetch the possible psr-4 values.
