### PR TITLE
Allow optional project namespace on class name finder rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Read autoload-dev psr-4 namespaces for gacela make commands.
 - Cache default resolved gacela class.
+- Allow optional project namespace on class name finder rules.
 
 ### 0.26.0
 #### 2022-10-01

--- a/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefix.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefix.php
@@ -10,9 +10,17 @@ final class FinderRuleWithModulePrefix implements FinderRuleInterface
 {
     public function buildClassCandidate(string $projectNamespace, string $resolvableType, ClassInfo $classInfo): string
     {
+        if ($projectNamespace !== '') {
+            return sprintf(
+                '\\%s\\%s\\%s',
+                trim($projectNamespace, '\\'),
+                $classInfo->getModuleName(),
+                $classInfo->getModuleName() . $resolvableType
+            );
+        }
+
         return sprintf(
-            '\\%s\\%s\\%s',
-            trim($projectNamespace, '\\'),
+            '\\%s\\%s',
             $classInfo->getModuleName(),
             $classInfo->getModuleName() . $resolvableType
         );

--- a/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithoutModulePrefix.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithoutModulePrefix.php
@@ -10,9 +10,17 @@ final class FinderRuleWithoutModulePrefix implements FinderRuleInterface
 {
     public function buildClassCandidate(string $projectNamespace, string $resolvableType, ClassInfo $classInfo): string
     {
+        if ($projectNamespace !== '') {
+            return sprintf(
+                '\\%s\\%s\\%s',
+                trim($projectNamespace, '\\'),
+                $classInfo->getModuleName(),
+                $resolvableType
+            );
+        }
+
         return sprintf(
-            '\\%s\\%s\\%s',
-            trim($projectNamespace, '\\'),
+            '\\%s\\%s',
             $classInfo->getModuleName(),
             $resolvableType
         );

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefixTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefixTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\ClassNameFinder\Rule;
+
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithModulePrefix;
+use PHPUnit\Framework\TestCase;
+
+final class FinderRuleWithModulePrefixTest extends TestCase
+{
+    private FinderRuleWithModulePrefix $rule;
+
+    protected function setUp(): void
+    {
+        $this->rule = new FinderRuleWithModulePrefix();
+    }
+
+    public function test_build_without_project_namespace(): void
+    {
+        $projectNamespace = '';
+        $resolvableType = 'Factory';
+        $classInfo = ClassInfo::from($this);
+
+        $actual = $this->rule->buildClassCandidate($projectNamespace, $resolvableType, $classInfo);
+
+        self::assertSame('\Rule\RuleFactory', $actual);
+    }
+
+    public function test_build_with_project_namespace(): void
+    {
+        $projectNamespace = 'App';
+        $resolvableType = 'Factory';
+        $classInfo = ClassInfo::from($this);
+
+        $actual = $this->rule->buildClassCandidate($projectNamespace, $resolvableType, $classInfo);
+
+        self::assertSame('\App\Rule\RuleFactory', $actual);
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithoutModulePrefixTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithoutModulePrefixTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\ClassNameFinder\Rule;
+
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithoutModulePrefix;
+use PHPUnit\Framework\TestCase;
+
+final class FinderRuleWithoutModulePrefixTest extends TestCase
+{
+    private FinderRuleWithoutModulePrefix $rule;
+
+    protected function setUp(): void
+    {
+        $this->rule = new FinderRuleWithoutModulePrefix();
+    }
+
+    public function test_build_without_project_namespace(): void
+    {
+        $projectNamespace = '';
+        $resolvableType = 'Factory';
+        $classInfo = ClassInfo::from($this);
+
+        $actual = $this->rule->buildClassCandidate($projectNamespace, $resolvableType, $classInfo);
+
+        self::assertSame('\Rule\Factory', $actual);
+    }
+
+    public function test_build_with_project_namespace(): void
+    {
+        $projectNamespace = 'App';
+        $resolvableType = 'Factory';
+        $classInfo = ClassInfo::from($this);
+
+        $actual = $this->rule->buildClassCandidate($projectNamespace, $resolvableType, $classInfo);
+
+        self::assertSame('\App\Rule\Factory', $actual);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Currently, it's not possible to have a simple project with only 1 level in the namespace.

## 🔖 Changes

- Allow optional project namespace on class name finder rules.
