### PR TITLE
Refactoring DocBlockResolver

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,9 +7,18 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-<plugins><pluginClass class="Psalm\PhpUnitPlugin\Plugin"/></plugins></psalm>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+
+    <issueHandlers>
+        <MoreSpecificReturnType errorLevel="suppress" />
+        <LessSpecificReturnStatement errorLevel="suppress" />
+    </issueHandlers>
+</psalm>

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
@@ -8,12 +8,14 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\InMemoryClassNameCache;
 use Gacela\Framework\ClassResolver\Profiler\CustomServicesJsonProfiler;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverCustomServicesAwareTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
+        DirectoryUtil::removeDir(__DIR__ . '/.gacela');
         InMemoryClassNameCache::resetCache();
     }
 

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
@@ -8,12 +8,14 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\InMemoryClassNameCache;
 use Gacela\Framework\ClassResolver\Profiler\CustomServicesJsonProfiler;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverInMemoryAwareTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
+        DirectoryUtil::removeDir(__DIR__ . '/.gacela');
         InMemoryClassNameCache::resetCache();
     }
 


### PR DESCRIPTION

## 🔖 Changes

- Remove non-used logic about `callerParentClass` from DocBlockResolver
- Normalize the cacheKey from DocBlockResolver
