### PR TITLE
Normalize UseBlockParser

### DIFF
--- a/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
+++ b/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
@@ -14,12 +14,12 @@ final class UseBlockParser
 
         $fullyQualifiedClassName = $this->searchInUsesStatements($className, $phpCode);
         if ($fullyQualifiedClassName !== '') {
-            return $fullyQualifiedClassName;
+            return '\\' . ltrim($fullyQualifiedClassName, '\\');
         }
 
         $namespace = $this->lookInCurrentNamespace($phpCode);
 
-        return sprintf('%s\\%s', $namespace, $className);
+        return sprintf('\\%s\\%s', $namespace, $className);
     }
 
     private function searchInUsesStatements(string $className, string $phpCode): string

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -32,7 +32,8 @@ final class DocBlockResolver
      */
     private function __construct(string $callerClass)
     {
-        $this->callerClass = $callerClass;
+        /** @psalm-suppress PropertyTypeCoercion */
+        $this->callerClass = '\\' . ltrim($callerClass, '\\'); // @phpstan-ignore-line
     }
 
     public static function fromCaller(object $caller): self
@@ -77,7 +78,7 @@ final class DocBlockResolver
 
     private function generateCacheKey(string $method): string
     {
-        return '\\' . ltrim($this->callerClass, '\\') . '::' . $method;
+        return $this->callerClass . '::' . $method;
     }
 
     private function createClassNameCache(): ClassNameCacheInterface
@@ -109,10 +110,12 @@ final class DocBlockResolver
         if (class_exists($className)) {
             return $className;
         }
+
         $className = $this->searchClassOverUseStatements($reflectionClass, $className);
         if (class_exists($className)) {
             return $className;
         }
+
         throw MissingClassDefinitionException::missingDefinition($this->callerClass, $method, $className);
     }
 

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
@@ -27,35 +27,35 @@ final class UseBlockParserTest extends TestCase
     {
         $actual = $this->parser->getUseStatement('ExistingClassInOtherNs', $this->phpCode());
 
-        self::assertSame('Ns\Test\Other\ExistingClassInOtherNs', $actual);
+        self::assertSame('\Ns\Test\Other\ExistingClassInOtherNs', $actual);
     }
 
     public function test_get_class_in_same_namespace(): void
     {
         $actual = $this->parser->getUseStatement('ExistingClassInSameNs', $this->phpCode());
 
-        self::assertSame('Ns\Test\ExistingClassInSameNs', $actual);
+        self::assertSame('\Ns\Test\ExistingClassInSameNs', $actual);
     }
 
     public function test_get_class_with_alias(): void
     {
         $actual = $this->parser->getUseStatement('AliasClass', $this->phpCode());
 
-        self::assertSame('Ns\Test\Other\WithAliasClassInOtherNs', $actual);
+        self::assertSame('\Ns\Test\Other\WithAliasClassInOtherNs', $actual);
     }
 
     public function test_get_commented_use_with_double_slash_then_uses_current_namespace(): void
     {
         $actual = $this->parser->getUseStatement('CommentedClassInOtherNs', $this->phpCode());
 
-        self::assertSame('Ns\Test\CommentedClassInOtherNs', $actual);
+        self::assertSame('\Ns\Test\CommentedClassInOtherNs', $actual);
     }
 
     public function test_get_commented_use_with_hashtag_then_uses_current_namespace(): void
     {
         $actual = $this->parser->getUseStatement('CommentedClassInAnotherNs', $this->phpCode());
 
-        self::assertSame('Ns\Test\CommentedClassInAnotherNs', $actual);
+        self::assertSame('\Ns\Test\CommentedClassInAnotherNs', $actual);
     }
 
     private function phpCode(): string


### PR DESCRIPTION
## 🔖 Changes

The value of the profiler/cache files resulting from the `UseBlockParser` is missing the left `\` char in the files `gacela-custom-services.json`. We currently have for the `gacela-class-names.json` file, so we want to keep that left char in both files.
