### PR TITLE
Refactoring PathFinder::matchingPattern()

### DIFF
--- a/src/Framework/Config/PathFinder.php
+++ b/src/Framework/Config/PathFinder.php
@@ -6,7 +6,6 @@ namespace Gacela\Framework\Config;
 
 use function define;
 use function defined;
-use function is_array;
 
 final class PathFinder implements PathFinderInterface
 {
@@ -17,9 +16,7 @@ final class PathFinder implements PathFinderInterface
     {
         $this->ensureGlobBraceIsDefined();
 
-        $glob = glob($pattern, GLOB_BRACE);
-
-        return is_array($glob) ? $glob : [];
+        return glob($pattern, GLOB_BRACE) ?: [];
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

The `glob()` signature is actually:
```php
function glob(string $pattern, int $flags = 0): array|false {}
```
Which means that it returns an `array` or `false`. Therefore, we can use the [Elvis operator](https://en.wikipedia.org/wiki/Elvis_operator) here to simplify the code.

## 🔖 Changes

- Simplify the `PathFinder::matchingPattern()` using the [Elvis operator](https://en.wikipedia.org/wiki/Elvis_operator).
