### PR TITLE
Add GacelaConfig::registerGenericListener()

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -37,6 +37,9 @@ final class GacelaConfig
 
     private bool $areEventListenersEnabled = true;
 
+    /** @var list<callable> */
+    private array $genericListeners = [];
+
     /** @var array<class-string,list<callable>> */
     private array $listenersPerEvent = [];
 
@@ -229,12 +232,20 @@ final class GacelaConfig
     }
 
     /**
+     * Register a generic listener when any event happens.
+     */
+    public function registerGenericListener(callable $listener): void
+    {
+        $this->genericListeners[] = $listener;
+    }
+
+    /**
      * Register a listener when some event happens.
      *
      * @param class-string $event
      * @param callable(GacelaEventInterface):void $listener
      */
-    public function registerListener(string $event, callable $listener): void
+    public function registerSpecificListener(string $event, callable $listener): void
     {
         $this->listenersPerEvent[$event][] = $listener;
     }
@@ -253,6 +264,7 @@ final class GacelaConfig
      *     project-namespaces: list<string>,
      *     config-key-values: array<string,mixed>,
      *     are-event-listeners-enabled: bool,
+     *     generic-listeners: list<callable>,
      *     listeners-per-event: array<class-string,list<callable>>,
      * }
      */
@@ -269,6 +281,7 @@ final class GacelaConfig
             'project-namespaces' => $this->projectNamespaces,
             'config-key-values' => $this->configKeyValues,
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
+            'generic-listeners' => $this->genericListeners,
             'listeners-per-event' => $this->listenersPerEvent,
         ];
     }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -41,7 +41,7 @@ final class GacelaConfig
     private array $genericListeners = [];
 
     /** @var array<class-string,list<callable>> */
-    private array $listenersPerEvent = [];
+    private array $specificListeners = [];
 
     /**
      * @param array<string,class-string|object|callable> $externalServices
@@ -233,6 +233,9 @@ final class GacelaConfig
 
     /**
      * Register a generic listener when any event happens.
+     * The callable argument must be the type `GacelaEventInterface`.
+     *
+     * @param callable(GacelaEventInterface):void $listener
      */
     public function registerGenericListener(callable $listener): void
     {
@@ -247,7 +250,7 @@ final class GacelaConfig
      */
     public function registerSpecificListener(string $event, callable $listener): void
     {
-        $this->listenersPerEvent[$event][] = $listener;
+        $this->specificListeners[$event][] = $listener;
     }
 
     /**
@@ -265,7 +268,7 @@ final class GacelaConfig
      *     config-key-values: array<string,mixed>,
      *     are-event-listeners-enabled: bool,
      *     generic-listeners: list<callable>,
-     *     listeners-per-event: array<class-string,list<callable>>,
+     *     specific-listeners: array<class-string,list<callable>>,
      * }
      */
     public function build(): array
@@ -282,7 +285,7 @@ final class GacelaConfig
             'config-key-values' => $this->configKeyValues,
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
             'generic-listeners' => $this->genericListeners,
-            'listeners-per-event' => $this->listenersPerEvent,
+            'specific-listeners' => $this->specificListeners,
         ];
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -49,6 +49,9 @@ final class SetupGacela extends AbstractSetupGacela
 
     private bool $areEventListenersEnabled = false;
 
+    /** @var list<callable> */
+    private array $genericListeners = [];
+
     /** @var array<class-string,list<callable>> */
     private array $listenersPerEvent = [];
 
@@ -105,6 +108,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setProjectNamespaces($build['project-namespaces'])
             ->setConfigKeyValues($build['config-key-values'])
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
+            ->setGenericListeners($build['generic-listeners'])
             ->setListenersPerEvent($build['listeners-per-event']);
     }
 
@@ -293,6 +297,8 @@ final class SetupGacela extends AbstractSetupGacela
 
         if ($this->areEventListenersEnabled) {
             $this->eventDispatcher = new EventDispatcher();
+            $this->eventDispatcher->registerGenericListeners($this->genericListeners);
+
             foreach ($this->listenersPerEvent as $event => $listeners) {
                 foreach ($listeners as $callable) {
                     $this->eventDispatcher->registerSpecificListener($event, $callable);
@@ -323,11 +329,21 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<class-string,list<callable>> $listenersPerEvent
+     * @param list<callable> $listeners
      */
-    private function setListenersPerEvent(array $listenersPerEvent): self
+    private function setGenericListeners(array $listeners): self
     {
-        $this->listenersPerEvent = $listenersPerEvent;
+        $this->genericListeners = $listeners;
+
+        return $this;
+    }
+
+    /**
+     * @param array<class-string,list<callable>> $listeners
+     */
+    private function setListenersPerEvent(array $listeners): self
+    {
+        $this->listenersPerEvent = $listeners;
 
         return $this;
     }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -53,7 +53,7 @@ final class SetupGacela extends AbstractSetupGacela
     private array $genericListeners = [];
 
     /** @var array<class-string,list<callable>> */
-    private array $listenersPerEvent = [];
+    private array $specificListeners = [];
 
     private ?EventDispatcherInterface $eventDispatcher = null;
 
@@ -109,7 +109,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setConfigKeyValues($build['config-key-values'])
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
             ->setGenericListeners($build['generic-listeners'])
-            ->setListenersPerEvent($build['listeners-per-event']);
+            ->setSpecificListeners($build['specific-listeners']);
     }
 
     public function setMappingInterfacesBuilder(MappingInterfacesBuilder $builder): self
@@ -299,7 +299,7 @@ final class SetupGacela extends AbstractSetupGacela
             $this->eventDispatcher = new EventDispatcher();
             $this->eventDispatcher->registerGenericListeners($this->genericListeners);
 
-            foreach ($this->listenersPerEvent as $event => $listeners) {
+            foreach ($this->specificListeners as $event => $listeners) {
                 foreach ($listeners as $callable) {
                     $this->eventDispatcher->registerSpecificListener($event, $callable);
                 }
@@ -341,9 +341,9 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param array<class-string,list<callable>> $listeners
      */
-    private function setListenersPerEvent(array $listeners): self
+    private function setSpecificListeners(array $listeners): self
     {
-        $this->listenersPerEvent = $listeners;
+        $this->specificListeners = $listeners;
 
         return $this;
     }

--- a/src/Framework/EventListener/EventDispatcher.php
+++ b/src/Framework/EventListener/EventDispatcher.php
@@ -13,7 +13,7 @@ final class EventDispatcher implements EventDispatcherInterface
     private array $genericListeners = [];
 
     /** @var array<class-string,list<callable>> */
-    private array $listenersPerEvent = [];
+    private array $specificListeners = [];
 
     public function __construct()
     {
@@ -31,7 +31,7 @@ final class EventDispatcher implements EventDispatcherInterface
      */
     public function registerSpecificListener(string $event, callable $listener): void
     {
-        $this->listenersPerEvent[$event][] = $listener;
+        $this->specificListeners[$event][] = $listener;
     }
 
     public function dispatchAll(array $events): void
@@ -47,7 +47,7 @@ final class EventDispatcher implements EventDispatcherInterface
             $this->notifyListener($listener, $event);
         }
 
-        foreach ($this->listenersPerEvent[get_class($event)] ?? [] as $listener) {
+        foreach ($this->specificListeners[get_class($event)] ?? [] as $listener) {
             $this->notifyListener($listener, $event);
         }
     }

--- a/src/Framework/EventListener/EventDispatcher.php
+++ b/src/Framework/EventListener/EventDispatcher.php
@@ -9,6 +9,9 @@ use function is_callable;
 
 final class EventDispatcher implements EventDispatcherInterface
 {
+    /** @var array<callable> */
+    private array $genericListeners = [];
+
     /** @var array<class-string,list<callable>> */
     private array $listenersPerEvent = [];
 
@@ -16,6 +19,13 @@ final class EventDispatcher implements EventDispatcherInterface
     {
     }
 
+    /**
+     * @param list<callable> $genericListeners
+     */
+    public function registerGenericListeners(array $genericListeners): void
+    {
+        $this->genericListeners = $genericListeners;
+    }
     /**
      * @param class-string $event
      */
@@ -33,6 +43,10 @@ final class EventDispatcher implements EventDispatcherInterface
 
     public function dispatch(object $event): void
     {
+        foreach ($this->genericListeners as $listener) {
+            $this->notifyListener($listener, $event);
+        }
+
         foreach ($this->listenersPerEvent[get_class($event)] ?? [] as $listener) {
             $this->notifyListener($listener, $event);
         }

--- a/tests/Feature/Framework/ListeningEvents/ClassResolver/DisableListenersTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ClassResolver/DisableListenersTest.php
@@ -21,10 +21,10 @@ final class DisableListenersTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->disableEventListeners();
 
-            $config->registerListener(ResolvedClassCachedEvent::class, [$this, 'throwExceptionListener']);
-            $config->registerListener(ResolvedClassCreatedEvent::class, [$this, 'throwExceptionListener']);
-            $config->registerListener(ResolvedClassTriedFromParentEvent::class, [$this, 'throwExceptionListener']);
-            $config->registerListener(ResolvedCreatedDefaultClassEvent::class, [$this, 'throwExceptionListener']);
+            $config->registerSpecificListener(ResolvedClassCachedEvent::class, [$this, 'throwExceptionListener']);
+            $config->registerSpecificListener(ResolvedClassCreatedEvent::class, [$this, 'throwExceptionListener']);
+            $config->registerSpecificListener(ResolvedClassTriedFromParentEvent::class, [$this, 'throwExceptionListener']);
+            $config->registerSpecificListener(ResolvedCreatedDefaultClassEvent::class, [$this, 'throwExceptionListener']);
         });
 
         $facade = new Facade();

--- a/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\ClassResolver;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\EventListener\ClassResolver\ResolvedClassCachedEvent;
+use Gacela\Framework\EventListener\ClassResolver\ResolvedClassCreatedEvent;
+use Gacela\Framework\EventListener\ClassResolver\ResolvedClassTriedFromParentEvent;
+use Gacela\Framework\EventListener\ClassResolver\ResolvedCreatedDefaultClassEvent;
+use Gacela\Framework\EventListener\GacelaEventInterface;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class GacelaClassResolverGeneralListenerTest extends TestCase
+{
+    /** @var list<GacelaEventInterface> */
+    private static array $inMemoryEvents = [];
+
+    public function setUp(): void
+    {
+        self::$inMemoryEvents = [];
+
+        Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+
+            $config->registerGenericListener([$this, 'saveInMemoryEvent']);
+        });
+    }
+
+    public function saveInMemoryEvent(GacelaEventInterface $event): void
+    {
+        self::$inMemoryEvents[] = $event;
+    }
+
+    public function test_resolved_class_created(): void
+    {
+        $facade = new Module\Facade();
+        $facade->doString();
+
+        self::assertEquals([
+            new ResolvedClassCreatedEvent(ClassInfo::from(Module\Facade::class, 'Factory')),
+        ], self::$inMemoryEvents);
+    }
+
+    public function test_resolved_class_cached(): void
+    {
+        $facade = new Module\Facade();
+        $facade->doString();
+
+        $facade = new Module\Facade();
+        $facade->doString();
+
+        self::assertEquals([
+            new ResolvedClassCreatedEvent(ClassInfo::from(Module\Facade::class, 'Factory')),
+            new ResolvedClassCachedEvent(ClassInfo::from(Module\Facade::class, 'Factory')),
+        ], self::$inMemoryEvents);
+    }
+
+    public function test_resolved_parent_and_default_class(): void
+    {
+        $factory = new Module\Factory();
+        $factory->getConfig();
+
+        self::assertEquals([
+            new ResolvedClassTriedFromParentEvent(ClassInfo::from(Module\Factory::class, 'Config')),
+            new ResolvedCreatedDefaultClassEvent(ClassInfo::from(AbstractFactory::class, 'Config')),
+        ], self::$inMemoryEvents);
+
+        // And again would simply load the cached event
+        self::$inMemoryEvents = [];
+        $factory = new Module\Factory();
+        $factory->getConfig();
+
+        self::assertEquals([
+            new ResolvedClassCachedEvent(ClassInfo::from(Module\Factory::class, 'Config')),
+        ], self::$inMemoryEvents);
+    }
+}

--- a/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverSpecificListenerTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverSpecificListenerTest.php
@@ -15,7 +15,7 @@ use Gacela\Framework\EventListener\GacelaEventInterface;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
-final class GacelaClassResolverListenerTest extends TestCase
+final class GacelaClassResolverSpecificListenerTest extends TestCase
 {
     /** @var list<GacelaEventInterface> */
     private static array $inMemoryEvents = [];
@@ -27,10 +27,10 @@ final class GacelaClassResolverListenerTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
 
-            $config->registerListener(ResolvedClassCachedEvent::class, [$this, 'saveInMemoryEvent']);
-            $config->registerListener(ResolvedClassCreatedEvent::class, [$this, 'saveInMemoryEvent']);
-            $config->registerListener(ResolvedClassTriedFromParentEvent::class, [$this, 'saveInMemoryEvent']);
-            $config->registerListener(ResolvedCreatedDefaultClassEvent::class, [$this, 'saveInMemoryEvent']);
+            $config->registerSpecificListener(ResolvedClassCachedEvent::class, [$this, 'saveInMemoryEvent']);
+            $config->registerSpecificListener(ResolvedClassCreatedEvent::class, [$this, 'saveInMemoryEvent']);
+            $config->registerSpecificListener(ResolvedClassTriedFromParentEvent::class, [$this, 'saveInMemoryEvent']);
+            $config->registerSpecificListener(ResolvedCreatedDefaultClassEvent::class, [$this, 'saveInMemoryEvent']);
         });
     }
 

--- a/tests/Feature/Framework/ListeningEvents/ConfigReader/GacelaConfigReaderListenerTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ConfigReader/GacelaConfigReaderListenerTest.php
@@ -25,7 +25,7 @@ final class GacelaConfigReaderListenerTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->addAppConfig('config/*.php');
             $config->resetInMemoryCache();
-            $config->registerListener(ReadPhpConfigEvent::class, [$this, 'saveInMemoryEvent']);
+            $config->registerSpecificListener(ReadPhpConfigEvent::class, [$this, 'saveInMemoryEvent']);
         });
 
         self::assertEquals([
@@ -39,7 +39,7 @@ final class GacelaConfigReaderListenerTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->addAppConfig('config/*.yaml');
             $config->resetInMemoryCache();
-            $config->registerListener(ReadPhpConfigEvent::class, [$this, 'saveInMemoryEvent']);
+            $config->registerSpecificListener(ReadPhpConfigEvent::class, [$this, 'saveInMemoryEvent']);
         });
 
         self::assertEmpty(self::$inMemoryEvents);


### PR DESCRIPTION
## 📚 Description

We added the possibility to register a listener to a particular event https://github.com/gacela-project/gacela/pull/215 
It would be useful to be able to register a listener to all posible events.

## 🔖 Changes

- Added `registerGenericListener()` to be able to register a generic listener for all events.
```php
GacelaConfig::registerGenericListener(callable $listener): void
```

## 🧪 A visual example
```php
$renderEvent = static function (GacelaEventInterface $event): void {
    echo sprintf("%s - %s\n", \get_class($event), $event->toString());
};

Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($renderEvent): void {
    // All of these individual specific listeners
    $config->registerSpecificListener(ResolvedClassCachedEvent::class, $renderEvent);
    $config->registerSpecificListener(ResolvedClassCreatedEvent::class, $renderEvent);
    $config->registerSpecificListener(ResolvedClassTriedFromParentEvent::class, $renderEvent);
    $config->registerSpecificListener(ResolvedCreatedDefaultClassEvent::class, $renderEvent);
    $config->registerSpecificListener(ReadPhpConfigEvent::class, $renderEvent);

    // would be the same as registering this generic listener
    $config->registerGenericListener($renderEvent);
});
```

## 🙇🏼  Especial thanks 

Credits to @matthiasnoback. I got the inspiration for this implementation thanks to the "[Layers, ports, and adapters workshop](https://github.com/matthiasnoback/layers-ports-and-adapters-workshop)" I did with him last year. 