### PR TITLE
Add Config::createWithSetup()

### DIFF
--- a/src/Framework/AbstractConfig.php
+++ b/src/Framework/AbstractConfig.php
@@ -10,7 +10,7 @@ use Gacela\Framework\Exception\ConfigException;
 abstract class AbstractConfig
 {
     /**
-     * Allow easy access to the root dir of the project.
+     * Allow easy access to the root directory of the project.
      */
     public function getAppRootDir(): string
     {

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
-use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\EventListener\EventDispatcherInterface;
 use Gacela\Framework\Exception\ConfigException;
@@ -19,23 +18,23 @@ final class Config implements ConfigInterface
 
     private static ?EventDispatcherInterface $eventDispatcher = null;
 
+    private SetupGacelaInterface $setup;
+
+    private ?ConfigFactory $configFactory = null;
+
     private ?string $appRootDir = null;
 
     /** @var array<string,mixed> */
     private array $config = [];
 
-    private ?SetupGacelaInterface $setup = null;
-
-    private ?ConfigFactory $configFactory = null;
-
-    private function __construct()
+    private function __construct(SetupGacelaInterface $setup)
     {
+        $this->setup = $setup;
     }
 
     public static function createWithSetup(SetupGacelaInterface $setup): self
     {
-        self::$instance = new self();
-        self::$instance->setup = $setup;
+        self::$instance = new self($setup);
 
         return self::$instance;
     }
@@ -128,13 +127,6 @@ final class Config implements ConfigInterface
             . ltrim($this->getSetupGacela()->getFileCacheDirectory(), DIRECTORY_SEPARATOR);
     }
 
-    public function setSetup(SetupGacelaInterface $setup): self
-    {
-        $this->setup = $setup;
-
-        return $this;
-    }
-
     /**
      * @internal
      */
@@ -152,10 +144,6 @@ final class Config implements ConfigInterface
 
     public function getSetupGacela(): SetupGacelaInterface
     {
-        if ($this->setup === null) {
-            $this->setup = new SetupGacela();
-        }
-
         return $this->setup;
     }
 

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -9,6 +9,8 @@ use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\EventListener\EventDispatcherInterface;
 use Gacela\Framework\Exception\ConfigException;
 
+use RuntimeException;
+
 use function array_key_exists;
 
 final class Config implements ConfigInterface
@@ -30,10 +32,18 @@ final class Config implements ConfigInterface
     {
     }
 
+    public static function createWithSetup(SetupGacelaInterface $setup): self
+    {
+        self::$instance = new self();
+        self::$instance->setup = $setup;
+
+        return self::$instance;
+    }
+
     public static function getInstance(): self
     {
         if (self::$instance === null) {
-            self::$instance = new self();
+            throw new RuntimeException('You have to call createWithSetup() first.');
         }
 
         return self::$instance;

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -31,9 +31,8 @@ final class Gacela
             Config::resetInstance();
         }
 
-        Config::getInstance()
+        Config::createWithSetup($setup)
             ->setAppRootDir($appRootDir)
-            ->setSetup($setup)
             ->init();
     }
 

--- a/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
@@ -10,6 +10,7 @@ use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Container\Container;
+use Gacela\Framework\Gacela;
 
 /**
  * @BeforeMethods("setUp")
@@ -20,6 +21,8 @@ final class AnonymousGlobalsBench
 
     public function setUp(): void
     {
+        Gacela::bootstrap(__DIR__);
+
         $this->setupAbstractConfig();
         $this->setupAbstractDependencyProvider();
         $this->setupAbstractFactory();


### PR DESCRIPTION
## 📚 Description

Simplify the Config initialisation by forcing passing the `GacelaSetup` while constructing the `Config` singleton. 

## 🔖 Changes

Before, `getInstance()` was creating a new instance in case there was none. Now, the creation of the `Config` singleton happens only with `Config::createWithSetup($setup)` not on `getInstance()` anymore.
