### PR TITLE
Add overrideEventDispatcher() to SetupGacela

### DIFF
--- a/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
+++ b/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
@@ -49,6 +49,7 @@ final class FilenameSanitizer implements FilenameSanitizerInterface
             ));
         }
 
-        return reset($maxValKeys);
+        /** @psalm-suppress RedundantCastGivenDocblockType */
+        return (string)reset($maxValKeys);
     }
 }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -68,4 +68,6 @@ interface SetupGacelaInterface
     public function getConfigKeyValues(): array;
 
     public function getEventDispatcher(): EventDispatcherInterface;
+
+    public function overrideEventDispatcher(SetupGacela $other): self;
 }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -41,6 +41,8 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         $gacelaConfig = $this->createGacelaConfig();
         $setupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
 
+        $this->setup->overrideEventDispatcher($setupGacela);
+
         $configBuilder = $this->createConfigBuilder($setupGacela);
         $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder($setupGacela);
         $suffixTypesBuilder = $this->createSuffixTypesBuilder($setupGacela);

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/FakeEvent.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/FakeEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\GacelaFileConfig\Factory;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+final class FakeEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return 'test event';
+    }
+}


### PR DESCRIPTION
## 📚 Description

With this you will be able to override the gacela listeners from a project that uses a library on top of gacela. 

> For example: `phel-snake` --(which uses)-> `phel-lang` --(which uses)-> `gacela`

Currently from `phel-snake` you are not able to alter any `gacela` configuration. You can play only with the configuration that `phel-lang` exposes to you. Which make sense "by default", but there are certain things that would be good to be able to expose to any level from gacela point of view; eg **registering listeners** for `gacela events`.

## 🔖 Changes

- Allow registering listeners using `gacela.php` configuration file from a project which uses gacela as vendor of a vendor.
