### PR TITLE
Make static the ClassNameFinder

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -30,7 +30,7 @@ abstract class AbstractClassResolver
     /** @var array<string,null|object> */
     private static array $cachedInstances = [];
 
-    private ?ClassNameFinderInterface $classNameFinder = null;
+    private static ?ClassNameFinderInterface $classNameFinder = null;
 
     private ?GacelaConfigFileInterface $gacelaFileConfig = null;
 
@@ -42,6 +42,7 @@ abstract class AbstractClassResolver
     public static function resetCache(): void
     {
         self::$cachedInstances = [];
+        self::$classNameFinder = null;
     }
 
     /**
@@ -110,14 +111,14 @@ abstract class AbstractClassResolver
 
     private function getClassNameFinder(): ClassNameFinderInterface
     {
-        if ($this->classNameFinder === null) {
-            $this->classNameFinder = (new ClassResolverFactory(
+        if (self::$classNameFinder === null) {
+            self::$classNameFinder = (new ClassResolverFactory(
                 new GacelaFileCache(Config::getInstance()),
                 Config::getInstance()->getSetupGacela()
             ))->createClassNameFinder();
         }
 
-        return $this->classNameFinder;
+        return self::$classNameFinder;
     }
 
     /**

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/FeatureTest.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/FeatureTest.php
@@ -22,6 +22,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
             $config->setFileCacheEnabled(false);
 
             $config->setProjectNamespaces([

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
@@ -15,7 +15,10 @@ final class FeatureTest extends TestCase
 {
     public function setUp(): void
     {
-        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php');
+        });
     }
 
     public function test_load_module_a(): void


### PR DESCRIPTION
## 📚 Description

Before we were creating a new instance of `ClassNameFinder` for each resolvable, which doesn't make much sense. Instead, we can keep it static, so this is a share object between all "Class Resolvers" which will improve the performance.

## 🔖 Changes

- Make static the ClassNameFinder from AbstractClassResolver


## 🖼️ Screenshots

Let's consider I introduce a listener inside the `phel-snake` project to see which events are triggered: 
```php
# gacela.php
return static function (GacelaConfig $config): void {
    $config->registerGenericListener(static function (GacelaEventInterface $event): void {
        echo $event->toString() . PHP_EOL;
    });
};
```

### 🧪 Before

Notice there are a lot of `InMemoryCacheCreatedEvent`:
<img width="1519" alt="Screenshot 2022-11-04 at 22 10 34" src="https://user-images.githubusercontent.com/5256287/200075341-3957cc46-eaa8-497a-b398-02da9336ed77.png">

### 🧪 After
There is just one `InMemoryCacheCreatedEvent`:
<img width="1523" alt="Screenshot 2022-11-04 at 22 11 17" src="https://user-images.githubusercontent.com/5256287/200075421-dd270eb3-9c7f-4f50-8add-3e998952bb16.png">

