### PR TITLE
Combine and override different SetupGacela objects

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
-use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
@@ -23,25 +22,25 @@ final class GacelaConfig
     /** @var array<string, class-string|object|callable> */
     private array $externalServices;
 
-    private bool $shouldResetInMemoryCache = false;
+    private ?bool $shouldResetInMemoryCache = null;
 
-    private bool $fileCacheEnabled = GacelaFileCache::DEFAULT_ENABLED_VALUE;
+    private ?bool $fileCacheEnabled = null;
 
-    private string $fileCacheDirectory = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
+    private ?string $fileCacheDirectory = null;
 
     /** @var list<string> */
-    private array $projectNamespaces = [];
+    private ?array $projectNamespaces = null;
 
     /** @var array<string,mixed> */
-    private array $configKeyValues = [];
+    private ?array $configKeyValues = null;
 
-    private bool $areEventListenersEnabled = true;
+    private ?bool $areEventListenersEnabled = null;
 
     /** @var list<callable> */
-    private array $genericListeners = [];
+    private ?array $genericListeners = null;
 
     /** @var array<class-string,list<callable>> */
-    private array $specificListeners = [];
+    private ?array $specificListeners = null;
 
     /**
      * @param array<string,class-string|object|callable> $externalServices
@@ -216,7 +215,7 @@ final class GacelaConfig
      */
     public function addAppConfigKeyValues(array $config): self
     {
-        $this->configKeyValues = array_merge($this->configKeyValues, $config);
+        $this->configKeyValues = array_merge($this->configKeyValues ?? [], $config);
 
         return $this;
     }
@@ -239,6 +238,9 @@ final class GacelaConfig
      */
     public function registerGenericListener(callable $listener): self
     {
+        if ($this->genericListeners === null) {
+            $this->genericListeners = [];
+        }
         $this->genericListeners[] = $listener;
 
         return $this;
@@ -252,28 +254,31 @@ final class GacelaConfig
      */
     public function registerSpecificListener(string $event, callable $listener): self
     {
+        if ($this->specificListeners === null) {
+            $this->specificListeners = [];
+        }
         $this->specificListeners[$event][] = $listener;
 
         return $this;
     }
 
     /**
-     * @internal
-     *
      * @return array{
-     *     external-services: array<string,class-string|object|callable>,
+     *     external-services: ?array<string,class-string|object|callable>,
      *     config-builder: ConfigBuilder,
      *     suffix-types-builder: SuffixTypesBuilder,
      *     mapping-interfaces-builder: MappingInterfacesBuilder,
-     *     should-reset-in-memory-cache: bool,
-     *     file-cache-enabled: bool,
-     *     file-cache-directory: string,
-     *     project-namespaces: list<string>,
-     *     config-key-values: array<string,mixed>,
-     *     are-event-listeners-enabled: bool,
-     *     generic-listeners: list<callable>,
-     *     specific-listeners: array<class-string,list<callable>>,
+     *     should-reset-in-memory-cache: ?bool,
+     *     file-cache-enabled: ?bool,
+     *     file-cache-directory: ?string,
+     *     project-namespaces: ?list<string>,
+     *     config-key-values: ?array<string,mixed>,
+     *     are-event-listeners-enabled: ?bool,
+     *     generic-listeners: ?list<callable>,
+     *     specific-listeners: ?array<class-string,list<callable>>,
      * }
+     *
+     * @internal
      */
     public function build(): array
     {

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -237,9 +237,11 @@ final class GacelaConfig
      *
      * @param callable(GacelaEventInterface):void $listener
      */
-    public function registerGenericListener(callable $listener): void
+    public function registerGenericListener(callable $listener): self
     {
         $this->genericListeners[] = $listener;
+
+        return $this;
     }
 
     /**
@@ -248,9 +250,11 @@ final class GacelaConfig
      * @param class-string $event
      * @param callable(GacelaEventInterface):void $listener
      */
-    public function registerSpecificListener(string $event, callable $listener): void
+    public function registerSpecificListener(string $event, callable $listener): self
     {
         $this->specificListeners[$event][] = $listener;
+
+        return $this;
     }
 
     /**

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -319,7 +319,14 @@ final class SetupGacela extends AbstractSetupGacela
         return $this;
     }
 
-    public function overrideEventDispatcher(self $other): self
+    public function combine(self $other): self
+    {
+        $this->combineEventDispatcher($other);
+
+        return $this;
+    }
+
+    private function combineEventDispatcher(self $other): void
     {
         if ($other->canCreateEventDispatcher()) {
             if (!($this->eventDispatcher instanceof ConfigurableEventDispatcher)) {
@@ -335,8 +342,6 @@ final class SetupGacela extends AbstractSetupGacela
         } else {
             $this->eventDispatcher = new NullEventDispatcher();
         }
-
-        return $this;
     }
 
     private function canCreateEventDispatcher(): bool

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -321,9 +321,15 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function combine(self $other): self
     {
+        $this->combineConfigKeyValues($other);
         $this->combineEventDispatcher($other);
 
         return $this;
+    }
+
+    private function combineConfigKeyValues(self $other): void
+    {
+        $this->configKeyValues = array_merge($this->configKeyValues, $other->getConfigKeyValues());
     }
 
     private function combineEventDispatcher(self $other): void

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -344,12 +344,20 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function combine(self $other): self
     {
+        $this->overrideResetInMemoryCache($other);
         $this->overrideFileCacheSettings($other);
         $this->combineProjectNamespaces($other);
         $this->combineConfigKeyValues($other);
         $this->combineEventDispatcher($other);
 
         return $this;
+    }
+
+    private function overrideResetInMemoryCache(self $other): void
+    {
+        if ($other->isPropertyChanged('shouldResetInMemoryCache')) {
+            $this->shouldResetInMemoryCache = $other->shouldResetInMemoryCache();
+        }
     }
 
     private function overrideFileCacheSettings(self $other): void

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -13,11 +13,19 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
 use RuntimeException;
 
-use function count;
 use function is_callable;
 
 final class SetupGacela extends AbstractSetupGacela
 {
+    private const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
+    private const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
+    private const DEFAULT_FILE_CACHE_ENABLED = GacelaFileCache::DEFAULT_ENABLED_VALUE;
+    private const DEFAULT_FILE_CACHE_DIRECTORY = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
+    private const DEFAULT_PROJECT_NAMESPACES = [];
+    private const DEFAULT_CONFIG_KEY_VALUES = [];
+    private const DEFAULT_GENERIC_LISTENERS = [];
+    private const DEFAULT_SPECIFIC_LISTENERS = [];
+
     /** @var callable(ConfigBuilder):void */
     private $configFn;
 
@@ -27,8 +35,8 @@ final class SetupGacela extends AbstractSetupGacela
     /** @var callable(SuffixTypesBuilder):void */
     private $suffixTypesFn;
 
-    /** @var array<string,class-string|object|callable> */
-    private array $externalServices = [];
+    /** @var ?array<string,class-string|object|callable> */
+    private ?array $externalServices = null;
 
     private ?ConfigBuilder $configBuilder = null;
 
@@ -36,27 +44,30 @@ final class SetupGacela extends AbstractSetupGacela
 
     private ?MappingInterfacesBuilder $mappingInterfacesBuilder = null;
 
-    private bool $shouldResetInMemoryCache = false;
+    private ?bool $shouldResetInMemoryCache = null;
 
-    private bool $fileCacheEnabled = GacelaFileCache::DEFAULT_ENABLED_VALUE;
+    private ?bool $fileCacheEnabled = null;
 
-    private string $fileCacheDirectory = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
+    private ?string $fileCacheDirectory = null;
 
-    /** @var list<string> */
-    private array $projectNamespaces = [];
+    /** @var ?list<string> */
+    private ?array $projectNamespaces = null;
 
-    /** @var array<string,mixed> */
-    private array $configKeyValues = [];
+    /** @var ?array<string,mixed> */
+    private ?array $configKeyValues = null;
 
-    private bool $areEventListenersEnabled = true;
+    private ?bool $areEventListenersEnabled = null;
 
-    /** @var list<callable> */
-    private array $genericListeners = [];
+    /** @var ?list<callable> */
+    private ?array $genericListeners = null;
 
-    /** @var array<class-string,list<callable>> */
-    private array $specificListeners = [];
+    /** @var ?array<class-string,list<callable>> */
+    private ?array $specificListeners = null;
 
     private ?EventDispatcherInterface $eventDispatcher = null;
+
+    /** @var ?array<string,bool> */
+    private ?array $changedProperties = null;
 
     public function __construct()
     {
@@ -99,10 +110,10 @@ final class SetupGacela extends AbstractSetupGacela
         $build = $gacelaConfig->build();
 
         return (new self())
+            ->setExternalServices($build['external-services'])
             ->setConfigBuilder($build['config-builder'])
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
             ->setMappingInterfacesBuilder($build['mapping-interfaces-builder'])
-            ->setExternalServices($build['external-services'])
             ->setShouldResetInMemoryCache($build['should-reset-in-memory-cache'])
             ->setFileCacheEnabled($build['file-cache-enabled'])
             ->setFileCacheDirectory($build['file-cache-directory'])
@@ -115,6 +126,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function setMappingInterfacesBuilder(MappingInterfacesBuilder $builder): self
     {
+        $this->markPropertyChanged('mappingInterfacesBuilder', true);
         $this->mappingInterfacesBuilder = $builder;
 
         return $this;
@@ -122,6 +134,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function setSuffixTypesBuilder(SuffixTypesBuilder $builder): self
     {
+        $this->markPropertyChanged('suffixTypesBuilder', true);
         $this->suffixTypesBuilder = $builder;
 
         return $this;
@@ -129,6 +142,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function setConfigBuilder(ConfigBuilder $builder): self
     {
+        $this->markPropertyChanged('configBuilder', true);
         $this->configBuilder = $builder;
 
         return $this;
@@ -139,6 +153,7 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function setConfigFn(callable $callable): self
     {
+        $this->markPropertyChanged('configFn', true);
         $this->configFn = $callable;
 
         return $this;
@@ -160,6 +175,7 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function setMappingInterfacesFn(callable $callable): self
     {
+        $this->markPropertyChanged('mappingInterfacesFn', true);
         $this->mappingInterfacesFn = $callable;
 
         return $this;
@@ -180,7 +196,7 @@ final class SetupGacela extends AbstractSetupGacela
 
         ($this->mappingInterfacesFn)(
             $builder,
-            array_merge($this->externalServices, $externalServices)
+            array_merge($this->externalServices??[], $externalServices)
         );
 
         return $builder;
@@ -191,6 +207,7 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function setSuffixTypesFn(callable $callable): self
     {
+        $this->markPropertyChanged('suffixTypesFn', true);
         $this->suffixTypesFn = $callable;
 
         return $this;
@@ -213,8 +230,9 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param array<string,class-string|object|callable> $array
      */
-    public function setExternalServices(array $array): self
+    public function setExternalServices(?array $array): self
     {
+        $this->markPropertyChanged('externalServices', $array);
         $this->externalServices = $array;
 
         return $this;
@@ -225,51 +243,55 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function externalServices(): array
     {
-        return $this->externalServices;
+        return (array)$this->externalServices;
     }
 
-    public function setShouldResetInMemoryCache(bool $flag): self
+    public function setShouldResetInMemoryCache(?bool $flag): self
     {
-        $this->shouldResetInMemoryCache = $flag;
+        $this->markPropertyChanged('shouldResetInMemoryCache', $flag);
+        $this->shouldResetInMemoryCache = $flag ?? self::DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE;
 
         return $this;
     }
 
     public function shouldResetInMemoryCache(): bool
     {
-        return $this->shouldResetInMemoryCache;
+        return (bool)$this->shouldResetInMemoryCache;
     }
 
-    public function setFileCacheEnabled(bool $flag): self
+    public function setFileCacheEnabled(?bool $flag): self
     {
-        $this->fileCacheEnabled = $flag;
+        $this->markPropertyChanged('fileCacheEnabled', $flag);
+        $this->fileCacheEnabled = $flag ?? self::DEFAULT_FILE_CACHE_ENABLED;
 
         return $this;
     }
 
     public function isFileCacheEnabled(): bool
     {
-        return $this->fileCacheEnabled;
+        return (bool)$this->fileCacheEnabled;
     }
 
     public function getFileCacheDirectory(): string
     {
-        return $this->fileCacheDirectory;
+        return (string)$this->fileCacheDirectory;
     }
 
-    public function setFileCacheDirectory(string $dir): self
+    public function setFileCacheDirectory(?string $dir): self
     {
-        $this->fileCacheDirectory = $dir;
+        $this->markPropertyChanged('fileCacheDirectory', $dir);
+        $this->fileCacheDirectory = $dir ?? self::DEFAULT_FILE_CACHE_DIRECTORY;
 
         return $this;
     }
 
     /**
-     * @param list<string> $list
+     * @param ?list<string> $list
      */
-    public function setProjectNamespaces(array $list): self
+    public function setProjectNamespaces(?array $list): self
     {
-        $this->projectNamespaces = $list;
+        $this->markPropertyChanged('projectNamespaces', $list);
+        $this->projectNamespaces = $list ?? self::DEFAULT_PROJECT_NAMESPACES;
 
         return $this;
     }
@@ -279,7 +301,7 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function getProjectNamespaces(): array
     {
-        return $this->projectNamespaces;
+        return (array)$this->projectNamespaces;
     }
 
     /**
@@ -287,7 +309,7 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function getConfigKeyValues(): array
     {
-        return $this->configKeyValues;
+        return (array)$this->configKeyValues;
     }
 
     public function getEventDispatcher(): EventDispatcherInterface
@@ -298,9 +320,9 @@ final class SetupGacela extends AbstractSetupGacela
 
         if ($this->canCreateEventDispatcher()) {
             $this->eventDispatcher = new ConfigurableEventDispatcher();
-            $this->eventDispatcher->registerGenericListeners($this->genericListeners);
+            $this->eventDispatcher->registerGenericListeners($this->genericListeners ?? []);
 
-            foreach ($this->specificListeners as $event => $listeners) {
+            foreach ($this->specificListeners ?? [] as $event => $listeners) {
                 foreach ($listeners as $callable) {
                     $this->eventDispatcher->registerSpecificListener($event, $callable);
                 }
@@ -312,9 +334,10 @@ final class SetupGacela extends AbstractSetupGacela
         return $this->eventDispatcher;
     }
 
-    public function setAreEventListenersEnabled(bool $flag): self
+    public function setAreEventListenersEnabled(?bool $flag): self
     {
-        $this->areEventListenersEnabled = $flag;
+        $this->markPropertyChanged('areEventListenersEnabled', $flag);
+        $this->areEventListenersEnabled = $flag ?? self::DEFAULT_ARE_EVENT_LISTENERS_ENABLED;
 
         return $this;
     }
@@ -331,18 +354,26 @@ final class SetupGacela extends AbstractSetupGacela
 
     private function overrideFileCacheSettings(self $other): void
     {
-        $this->fileCacheEnabled = $other->isFileCacheEnabled();
-        $this->fileCacheDirectory = $other->getFileCacheDirectory();
+        if ($other->isPropertyChanged('fileCacheEnabled')) {
+            $this->fileCacheEnabled = $other->isFileCacheEnabled();
+        }
+        if ($other->isPropertyChanged('fileCacheDirectory')) {
+            $this->fileCacheDirectory = $other->getFileCacheDirectory();
+        }
     }
 
     private function combineProjectNamespaces(self $other): void
     {
-        $this->projectNamespaces = array_merge($this->projectNamespaces, $other->getProjectNamespaces());
+        if ($other->isPropertyChanged('projectNamespaces')) {
+            $this->projectNamespaces = array_merge($this->projectNamespaces ?? [], $other->getProjectNamespaces());
+        }
     }
 
     private function combineConfigKeyValues(self $other): void
     {
-        $this->configKeyValues = array_merge($this->configKeyValues, $other->getConfigKeyValues());
+        if ($other->isPropertyChanged('configKeyValues')) {
+            $this->configKeyValues = array_merge($this->configKeyValues ?? [], $other->getConfigKeyValues());
+        }
     }
 
     private function combineEventDispatcher(self $other): void
@@ -351,9 +382,9 @@ final class SetupGacela extends AbstractSetupGacela
             if (!($this->eventDispatcher instanceof ConfigurableEventDispatcher)) {
                 $this->eventDispatcher = new ConfigurableEventDispatcher();
             }
-            $this->eventDispatcher->registerGenericListeners($other->genericListeners);
+            $this->eventDispatcher->registerGenericListeners((array)$other->genericListeners);
 
-            foreach ($other->specificListeners as $event => $listeners) {
+            foreach ($other->specificListeners ?? [] as $event => $listeners) {
                 foreach ($listeners as $callable) {
                     $this->eventDispatcher->registerSpecificListener($event, $callable);
                 }
@@ -371,16 +402,17 @@ final class SetupGacela extends AbstractSetupGacela
 
     private function hasEventListeners(): bool
     {
-        return count($this->genericListeners) > 0
-            || count($this->specificListeners) > 0;
+        return !empty($this->genericListeners)
+            || !empty($this->specificListeners);
     }
 
     /**
      * @param array<string,mixed> $configKeyValues
      */
-    private function setConfigKeyValues(array $configKeyValues): self
+    private function setConfigKeyValues(?array $configKeyValues): self
     {
-        $this->configKeyValues = $configKeyValues;
+        $this->markPropertyChanged('configKeyValues', $configKeyValues);
+        $this->configKeyValues = $configKeyValues ?? self::DEFAULT_CONFIG_KEY_VALUES;
 
         return $this;
     }
@@ -388,9 +420,10 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param list<callable> $listeners
      */
-    private function setGenericListeners(array $listeners): self
+    private function setGenericListeners(?array $listeners): self
     {
-        $this->genericListeners = $listeners;
+        $this->markPropertyChanged('genericListeners', $listeners);
+        $this->genericListeners = $listeners ?? self::DEFAULT_GENERIC_LISTENERS;
 
         return $this;
     }
@@ -398,10 +431,24 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param array<class-string,list<callable>> $listeners
      */
-    private function setSpecificListeners(array $listeners): self
+    private function setSpecificListeners(?array $listeners): self
     {
-        $this->specificListeners = $listeners;
+        $this->markPropertyChanged('specificListeners', $listeners);
+        $this->specificListeners = $listeners ?? self::DEFAULT_SPECIFIC_LISTENERS;
 
         return $this;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function markPropertyChanged(string $name, $value): void
+    {
+        $this->changedProperties[$name] = ($value !== null);
+    }
+
+    private function isPropertyChanged(string $name): bool
+    {
+        return $this->changedProperties[$name] ?? false;
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -196,7 +196,7 @@ final class SetupGacela extends AbstractSetupGacela
 
         ($this->mappingInterfacesFn)(
             $builder,
-            array_merge($this->externalServices??[], $externalServices)
+            array_merge($this->externalServices ?? [], $externalServices)
         );
 
         return $builder;
@@ -228,7 +228,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,class-string|object|callable> $array
+     * @param ?array<string,class-string|object|callable> $array
      */
     public function setExternalServices(?array $array): self
     {
@@ -424,7 +424,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,mixed> $configKeyValues
+     * @param ?array<string,mixed> $configKeyValues
      */
     private function setConfigKeyValues(?array $configKeyValues): self
     {
@@ -435,7 +435,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param list<callable> $listeners
+     * @param ?list<callable> $listeners
      */
     private function setGenericListeners(?array $listeners): self
     {
@@ -446,7 +446,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<class-string,list<callable>> $listeners
+     * @param ?array<class-string,list<callable>> $listeners
      */
     private function setSpecificListeners(?array $listeners): self
     {

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -321,11 +321,18 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function combine(self $other): self
     {
+        $this->overrideFileCacheSettings($other);
         $this->combineProjectNamespaces($other);
         $this->combineConfigKeyValues($other);
         $this->combineEventDispatcher($other);
 
         return $this;
+    }
+
+    private function overrideFileCacheSettings(self $other): void
+    {
+        $this->fileCacheEnabled = $other->isFileCacheEnabled();
+        $this->fileCacheDirectory = $other->getFileCacheDirectory();
     }
 
     private function combineProjectNamespaces(self $other): void

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -322,7 +322,9 @@ final class SetupGacela extends AbstractSetupGacela
     public function overrideEventDispatcher(self $other): self
     {
         if ($other->canCreateEventDispatcher()) {
-            $this->eventDispatcher = new ConfigurableEventDispatcher();
+            if (!($this->eventDispatcher instanceof ConfigurableEventDispatcher)) {
+                $this->eventDispatcher = new ConfigurableEventDispatcher();
+            }
             $this->eventDispatcher->registerGenericListeners($other->genericListeners);
 
             foreach ($other->specificListeners as $event => $listeners) {

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -346,11 +346,20 @@ final class SetupGacela extends AbstractSetupGacela
     {
         $this->overrideResetInMemoryCache($other);
         $this->overrideFileCacheSettings($other);
+
+        $this->combineExternalServices($other);
         $this->combineProjectNamespaces($other);
         $this->combineConfigKeyValues($other);
         $this->combineEventDispatcher($other);
 
         return $this;
+    }
+
+    private function combineExternalServices(self $other): void
+    {
+        if ($other->isPropertyChanged('externalServices')) {
+            $this->externalServices = array_merge($this->externalServices ?? [], $other->externalServices());
+        }
     }
 
     private function overrideResetInMemoryCache(self $other): void

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -321,10 +321,16 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function combine(self $other): self
     {
+        $this->combineProjectNamespaces($other);
         $this->combineConfigKeyValues($other);
         $this->combineEventDispatcher($other);
 
         return $this;
+    }
+
+    private function combineProjectNamespaces(self $other): void
+    {
+        $this->projectNamespaces = array_merge($this->projectNamespaces, $other->getProjectNamespaces());
     }
 
     private function combineConfigKeyValues(self $other): void

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -69,5 +69,5 @@ interface SetupGacelaInterface
 
     public function getEventDispatcher(): EventDispatcherInterface;
 
-    public function overrideEventDispatcher(SetupGacela $other): self;
+    public function combine(SetupGacela $other): self;
 }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -14,11 +14,11 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryInterface
 {
-    private SetupGacelaInterface $setup;
+    private SetupGacelaInterface $bootstrapSetup;
 
-    public function __construct(SetupGacelaInterface $setup)
+    public function __construct(SetupGacelaInterface $bootstrapSetup)
     {
-        $this->setup = $setup;
+        $this->bootstrapSetup = $bootstrapSetup;
     }
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
@@ -35,16 +35,16 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
 
     private function createConfigBuilder(): ConfigBuilder
     {
-        return $this->setup->buildConfig(new ConfigBuilder());
+        return $this->bootstrapSetup->buildConfig(new ConfigBuilder());
     }
 
     private function createMappingInterfacesBuilder(): MappingInterfacesBuilder
     {
-        return $this->setup->buildMappingInterfaces(new MappingInterfacesBuilder(), []);
+        return $this->bootstrapSetup->buildMappingInterfaces(new MappingInterfacesBuilder(), []);
     }
 
     private function createSuffixTypesBuilder(): SuffixTypesBuilder
     {
-        return $this->setup->buildSuffixTypes(new SuffixTypesBuilder());
+        return $this->bootstrapSetup->buildSuffixTypes(new SuffixTypesBuilder());
     }
 }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -28,18 +28,18 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
     public function __construct(
         string $gacelaPhpPath,
-        SetupGacelaInterface $setup,
+        SetupGacelaInterface $bootstrapSetup,
         FileIoInterface $fileIo
     ) {
         $this->gacelaPhpPath = $gacelaPhpPath;
-        $this->bootstrapSetup = $setup;
+        $this->bootstrapSetup = $bootstrapSetup;
         $this->fileIo = $fileIo;
     }
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $gacelaConfig = $this->createGacelaConfig();
-        $projectSetupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
+        $projectGacelaConfig = $this->createGacelaConfig();
+        $projectSetupGacela = SetupGacela::fromGacelaConfig($projectGacelaConfig);
 
         $this->bootstrapSetup->combine($projectSetupGacela);
 

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -22,7 +22,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 {
     private string $gacelaPhpPath;
 
-    private SetupGacelaInterface $setup;
+    private SetupGacelaInterface $bootstrapSetup;
 
     private FileIoInterface $fileIo;
 
@@ -32,20 +32,20 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         FileIoInterface $fileIo
     ) {
         $this->gacelaPhpPath = $gacelaPhpPath;
-        $this->setup = $setup;
+        $this->bootstrapSetup = $setup;
         $this->fileIo = $fileIo;
     }
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
         $gacelaConfig = $this->createGacelaConfig();
-        $setupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
+        $projectSetupGacela = SetupGacela::fromGacelaConfig($gacelaConfig);
 
-        $this->setup->overrideEventDispatcher($setupGacela);
+        $this->bootstrapSetup->combine($projectSetupGacela);
 
-        $configBuilder = $this->createConfigBuilder($setupGacela);
-        $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder($setupGacela);
-        $suffixTypesBuilder = $this->createSuffixTypesBuilder($setupGacela);
+        $configBuilder = $this->createConfigBuilder($projectSetupGacela);
+        $mappingInterfacesBuilder = $this->createMappingInterfacesBuilder($projectSetupGacela);
+        $suffixTypesBuilder = $this->createSuffixTypesBuilder($projectSetupGacela);
 
         return (new GacelaConfigFile())
             ->setConfigItems($configBuilder->build())
@@ -55,7 +55,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
     private function createGacelaConfig(): GacelaConfig
     {
-        $gacelaConfig = new GacelaConfig($this->setup->externalServices());
+        $gacelaConfig = new GacelaConfig($this->bootstrapSetup->externalServices());
 
         /** @var callable(GacelaConfig):void|null $configFn */
         $configFn = $this->fileIo->include($this->gacelaPhpPath);
@@ -76,7 +76,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
     private function createMappingInterfacesBuilder(SetupGacelaInterface $setupGacela): MappingInterfacesBuilder
     {
-        return $setupGacela->buildMappingInterfaces(new MappingInterfacesBuilder(), $this->setup->externalServices());
+        return $setupGacela->buildMappingInterfaces(new MappingInterfacesBuilder(), $this->bootstrapSetup->externalServices());
     }
 
     private function createSuffixTypesBuilder(SetupGacelaInterface $setupGacela): SuffixTypesBuilder

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -42,7 +42,7 @@ final class SetupGacelaTest extends TestCase
         self::assertTrue($listenerDispatched);
     }
 
-    public function test_override_event_dispatcher(): void
+    public function test_combine_event_dispatcher(): void
     {
         $listenerDispatched1 = false;
         $listenerDispatched2 = false;

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -76,4 +76,22 @@ final class SetupGacelaTest extends TestCase
         self::assertTrue($listenerDispatched1);
         self::assertTrue($listenerDispatched2);
     }
+
+    public function test_combine_config_key_values(): void
+    {
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->addAppConfigKeyValue('key1', 1)
+        );
+
+        $setup2 = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->addAppConfigKeyValues(['key2' => 'value2'])
+        );
+
+        $setup->combine($setup2);
+
+        self::assertSame([
+            'key1' => 1,
+            'key2' => 'value2',
+        ], $setup->getConfigKeyValues());
+    }
 }

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -132,4 +132,17 @@ final class SetupGacelaTest extends TestCase
         self::assertTrue($setup->isFileCacheEnabled());
         self::assertSame('original/dir', $setup->getFileCacheDirectory());
     }
+
+    public function test_override_reset_in_memory_cache(): void
+    {
+        $setup = SetupGacela::fromGacelaConfig(new GacelaConfig());
+
+        $setup2 = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->resetInMemoryCache()
+        );
+
+        self::assertFalse($setup->shouldResetInMemoryCache());
+        $setup->combine($setup2);
+        self::assertTrue($setup->shouldResetInMemoryCache());
+    }
 }

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -109,4 +109,27 @@ final class SetupGacelaTest extends TestCase
 
         self::assertSame(['App1', 'App2'], $setup->getProjectNamespaces());
     }
+
+    public function test_override_file_cache_settings(): void
+    {
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())
+                ->setFileCacheEnabled(false)
+                ->setFileCacheDirectory('original/dir')
+        );
+
+        $setup2 = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())
+                ->setFileCacheEnabled(true)
+                ->setFileCacheDirectory('override/dir')
+        );
+
+        self::assertFalse($setup->isFileCacheEnabled());
+        self::assertSame('original/dir', $setup->getFileCacheDirectory());
+
+        $setup->combine($setup2);
+
+        self::assertTrue($setup->isFileCacheEnabled());
+        self::assertSame('override/dir', $setup->getFileCacheDirectory());
+    }
 }

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -94,4 +94,19 @@ final class SetupGacelaTest extends TestCase
             'key2' => 'value2',
         ], $setup->getConfigKeyValues());
     }
+
+    public function test_combine_project_namespaces(): void
+    {
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->setProjectNamespaces(['App1'])
+        );
+
+        $setup2 = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->setProjectNamespaces(['App2'])
+        );
+
+        $setup->combine($setup2);
+
+        self::assertSame(['App1', 'App2'], $setup->getProjectNamespaces());
+    }
 }

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -23,25 +23,6 @@ final class SetupGacelaTest extends TestCase
         $setup->getEventDispatcher()->dispatch(new FakeEvent());
     }
 
-    public function test_configurable_event_dispatcher(): void
-    {
-        $listenerDispatched = false;
-        $listener = static function (GacelaEventInterface $event) use (&$listenerDispatched): void {
-            self::assertInstanceOf(FakeEvent::class, $event);
-            $listenerDispatched = true;
-        };
-
-        $config = (new GacelaConfig())->registerGenericListener($listener);
-
-        $setup = SetupGacela::fromGacelaConfig($config);
-
-        self::assertInstanceOf(ConfigurableEventDispatcher::class, $setup->getEventDispatcher());
-
-        self::assertFalse($listenerDispatched);
-        $setup->getEventDispatcher()->dispatch(new FakeEvent());
-        self::assertTrue($listenerDispatched);
-    }
-
     public function test_combine_event_dispatcher(): void
     {
         $listenerDispatched1 = false;
@@ -131,5 +112,24 @@ final class SetupGacelaTest extends TestCase
 
         self::assertTrue($setup->isFileCacheEnabled());
         self::assertSame('override/dir', $setup->getFileCacheDirectory());
+    }
+
+    public function test_not_override_file_cache_settings_when_using_default(): void
+    {
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())
+                ->setFileCacheEnabled(true)
+                ->setFileCacheDirectory('original/dir')
+        );
+
+        $setup2 = SetupGacela::fromGacelaConfig(new GacelaConfig());
+
+        self::assertTrue($setup->isFileCacheEnabled());
+        self::assertSame('original/dir', $setup->getFileCacheDirectory());
+
+        $setup->combine($setup2);
+
+        self::assertTrue($setup->isFileCacheEnabled());
+        self::assertSame('original/dir', $setup->getFileCacheDirectory());
     }
 }

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use Gacela\Framework\Event\GacelaEventInterface;
+use GacelaTest\Unit\Framework\Config\GacelaFileConfig\Factory\FakeEvent;
+use PHPUnit\Framework\TestCase;
+
+final class SetupGacelaTest extends TestCase
+{
+    public function test_null_event_dispatcher(): void
+    {
+        $config = new GacelaConfig();
+        $setup = SetupGacela::fromGacelaConfig($config);
+
+        self::assertInstanceOf(NullEventDispatcher::class, $setup->getEventDispatcher());
+        $setup->getEventDispatcher()->dispatch(new FakeEvent());
+    }
+
+    public function test_configurable_event_dispatcher(): void
+    {
+        $listenerDispatched = false;
+        $listener = static function (GacelaEventInterface $event) use (&$listenerDispatched): void {
+            self::assertInstanceOf(FakeEvent::class, $event);
+            $listenerDispatched = true;
+        };
+
+        $config = (new GacelaConfig())->registerGenericListener($listener);
+
+        $setup = SetupGacela::fromGacelaConfig($config);
+
+        self::assertInstanceOf(ConfigurableEventDispatcher::class, $setup->getEventDispatcher());
+
+        self::assertFalse($listenerDispatched);
+        $setup->getEventDispatcher()->dispatch(new FakeEvent());
+        self::assertTrue($listenerDispatched);
+    }
+
+    public function test_override_event_dispatcher(): void
+    {
+        $listenerDispatched1 = false;
+        $listenerDispatched2 = false;
+
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->registerSpecificListener(
+                FakeEvent::class,
+                static function (GacelaEventInterface $event) use (&$listenerDispatched1): void {
+                    self::assertInstanceOf(FakeEvent::class, $event);
+                    $listenerDispatched1 = true;
+                }
+            )
+        );
+
+        self::assertInstanceOf(ConfigurableEventDispatcher::class, $setup->getEventDispatcher());
+
+        $setup2 = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->registerSpecificListener(
+                FakeEvent::class,
+                static function (GacelaEventInterface $event) use (&$listenerDispatched2): void {
+                    self::assertInstanceOf(FakeEvent::class, $event);
+                    $listenerDispatched2 = true;
+                }
+            )
+        );
+        $setup->combine($setup2);
+
+        self::assertFalse($listenerDispatched1);
+        self::assertFalse($listenerDispatched2);
+        $setup->getEventDispatcher()->dispatch(new FakeEvent());
+        self::assertTrue($listenerDispatched1);
+        self::assertTrue($listenerDispatched2);
+    }
+}


### PR DESCRIPTION
## 📚 Description

This PR is a follow up PR of https://github.com/gacela-project/gacela/pull/222 Currently there is no possibility of overriding or combine different `SetupGacela` objects. Just overriding the `eventDispatcher`.


## 🔖 Changes

- Rename `overrideEventDispatcher()` to `combine()`
  - Instead of creating a new `eventDispatcher`, create a new `ConfigurableEventDispatcher` if there was none before
  - combine ExternalServices
  - combine ProjectNamespaces
  - combine ConfigKeyValues
  - combine EventDispatcher
  - override ResetInMemoryCache
  - override FileCacheSettings
