### PR TITLE
Fix PhpFileCache

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -6,7 +6,6 @@ namespace Gacela\Framework\ClassResolver;
 
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractFactory;
-use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\ClassNameFinder\ClassNameFinderInterface;
 use Gacela\Framework\ClassResolver\Config\ConfigResolver;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
@@ -113,7 +112,6 @@ abstract class AbstractClassResolver
     {
         if (self::$classNameFinder === null) {
             self::$classNameFinder = (new ClassResolverFactory(
-                new GacelaFileCache(Config::getInstance()),
                 Config::getInstance()->getSetupGacela()
             ))->createClassNameFinder();
         }

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -59,7 +59,7 @@ abstract class AbstractClassResolver
 
         $resolvedClass = $this->resolveCached($cacheKey);
         if ($resolvedClass !== null) {
-            $this->dispatchEvent(new ResolvedClassCachedEvent($classInfo));
+            self::dispatchEvent(new ResolvedClassCachedEvent($classInfo));
 
             return $resolvedClass;
         }
@@ -67,19 +67,19 @@ abstract class AbstractClassResolver
         $resolvedClassName = $this->findClassName($classInfo);
         if ($resolvedClassName !== null) {
             $instance = $this->createInstance($resolvedClassName);
-            $this->dispatchEvent(new ResolvedClassCreatedEvent($classInfo));
+            self::dispatchEvent(new ResolvedClassCreatedEvent($classInfo));
         } else {
             // Try again with its parent class
             if (is_object($caller)) {
                 $parentClass = get_parent_class($caller);
                 if ($parentClass !== false) {
-                    $this->dispatchEvent(new ResolvedClassTriedFromParentEvent($classInfo));
+                    self::dispatchEvent(new ResolvedClassTriedFromParentEvent($classInfo));
 
                     return $this->doResolve($parentClass, $cacheKey);
                 }
             }
 
-            $this->dispatchEvent(new ResolvedCreatedDefaultClassEvent($classInfo));
+            self::dispatchEvent(new ResolvedCreatedDefaultClassEvent($classInfo));
             $instance = $this->createDefaultGacelaClass();
         }
 

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 abstract class AbstractPhpFileCache implements CacheInterface
 {
-    /** @var array<string,string> */
+    /** @var array<class-string,array<string,string>> */
     private static array $cache = [];
 
     private string $cacheDir;
@@ -16,15 +16,7 @@ abstract class AbstractPhpFileCache implements CacheInterface
     public function __construct(string $cacheDir)
     {
         $this->cacheDir = $cacheDir;
-        self::$cache = $this->getExistingCache();
-    }
-
-    /**
-     * @internal
-     */
-    public static function resetCache(): void
-    {
-        self::$cache = [];
+        self::$cache[static::class] = $this->getExistingCache();
     }
 
     /**
@@ -34,31 +26,31 @@ abstract class AbstractPhpFileCache implements CacheInterface
      */
     public static function all(): array
     {
-        return self::$cache;
+        return self::$cache[static::class];
     }
 
     public function has(string $cacheKey): bool
     {
-        return isset(self::$cache[$cacheKey]);
+        return isset(self::$cache[static::class][$cacheKey]);
     }
 
     public function get(string $cacheKey): string
     {
-        return self::$cache[$cacheKey];
+        return self::$cache[static::class][$cacheKey];
     }
 
     public function getAll(): array
     {
-        return self::$cache;
+        return self::$cache[static::class];
     }
 
     public function put(string $cacheKey, string $className): void
     {
-        self::$cache[$cacheKey] = $className;
+        self::$cache[static::class][$cacheKey] = $className;
 
         $fileContent = sprintf(
             '<?php return %s;',
-            var_export(self::$cache, true)
+            var_export(self::$cache[static::class], true)
         );
 
         file_put_contents($this->getAbsoluteCacheFilename(), $fileContent);

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -54,7 +54,7 @@ final class ClassNameFinder implements ClassNameFinderInterface
 
         if ($this->cache->has($cacheKey)) {
             $cached = $this->cache->get($cacheKey);
-            $this->dispatchEvent(new ClassNameCachedFoundEvent($cached));
+            self::dispatchEvent(new ClassNameCachedFoundEvent($cached));
 
             return $cached;
         }
@@ -68,17 +68,17 @@ final class ClassNameFinder implements ClassNameFinderInterface
 
                     if ($this->classValidator->isClassNameValid($className)) {
                         $this->cache->put($cacheKey, $className);
-                        $this->dispatchEvent(new ClassNameValidCandidateFoundEvent($className));
+                        self::dispatchEvent(new ClassNameValidCandidateFoundEvent($className));
 
                         return $className;
                     }
 
-                    $this->dispatchEvent(new ClassNameInvalidCandidateFoundEvent($className));
+                    self::dispatchEvent(new ClassNameInvalidCandidateFoundEvent($className));
                 }
             }
         }
 
-        $this->dispatchEvent(new ClassNameNotFoundEvent($classInfo, $resolvableTypes));
+        self::dispatchEvent(new ClassNameNotFoundEvent($classInfo, $resolvableTypes));
 
         return null;
     }

--- a/src/Framework/ClassResolver/ClassResolverCache.php
+++ b/src/Framework/ClassResolver/ClassResolverCache.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+use Gacela\Framework\ClassResolver\Cache\CacheInterface;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNameCacheCachedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNameInMemoryCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNamePhpCacheCreatedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+
+final class ClassResolverCache
+{
+    use EventDispatchingCapabilities;
+
+    private static ?CacheInterface $cache = null;
+
+    /**
+     * @internal
+     */
+    public static function resetCache(): void
+    {
+        self::$cache = null;
+    }
+
+    public static function getCache(): CacheInterface
+    {
+        if (self::$cache !== null) {
+            self::dispatchEvent(new ClassNameCacheCachedEvent());
+            return self::$cache;
+        }
+
+        if (self::isEnabled()) {
+            self::dispatchEvent(new ClassNamePhpCacheCreatedEvent());
+
+            self::$cache = new ClassNamePhpCache(Config::getInstance()->getCacheDir());
+        } else {
+            self::dispatchEvent(new ClassNameInMemoryCacheCreatedEvent());
+            self::$cache = new InMemoryCache(ClassNamePhpCache::class);
+        }
+
+        return self::$cache;
+    }
+
+    private static function isEnabled(): bool
+    {
+        return (new GacelaFileCache(Config::getInstance()))->isEnabled();
+    }
+}

--- a/src/Framework/Config/ConfigReader/PhpConfigReader.php
+++ b/src/Framework/Config/ConfigReader/PhpConfigReader.php
@@ -25,7 +25,7 @@ final class PhpConfigReader implements ConfigReaderInterface
             return [];
         }
 
-        $this->dispatchEvent(new ReadPhpConfigEvent($absolutePath));
+        self::dispatchEvent(new ReadPhpConfigEvent($absolutePath));
 
         /**
          * @psalm-suppress UnresolvableInclude

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -4,14 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\DocBlockResolver;
 
-use Gacela\Framework\ClassResolver\Cache\CacheInterface;
-use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
-use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
-use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
 use Gacela\Framework\ClassResolver\DocBlockService\DocBlockParser;
 use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
 use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
-use Gacela\Framework\Config\Config;
 use ReflectionClass;
 
 use function get_class;
@@ -53,7 +48,7 @@ final class DocBlockResolver
     private function getClassName(string $method): string
     {
         $cacheKey = $this->generateCacheKey($method);
-        $cache = $this->createCache();
+        $cache = DocBlockResolverCache::getCacheInstance();
 
         if (!$cache->has($cacheKey)) {
             $className = $this->getClassFromDoc($method);
@@ -66,22 +61,6 @@ final class DocBlockResolver
     private function generateCacheKey(string $method): string
     {
         return $this->callerClass . '::' . $method;
-    }
-
-    private function createCache(): CacheInterface
-    {
-        if ($this->isProjectCacheEnabled()) {
-            return new CustomServicesPhpCache(
-                Config::getInstance()->getCacheDir(),
-            );
-        }
-
-        return new InMemoryCache(CustomServicesPhpCache::class);
-    }
-
-    private function isProjectCacheEnabled(): bool
-    {
-        return (new GacelaFileCache(Config::getInstance()))->isEnabled();
     }
 
     /**

--- a/src/Framework/DocBlockResolver/DocBlockResolverCache.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolverCache.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\DocBlockResolver;
+
+use Gacela\Framework\ClassResolver\Cache\CacheInterface;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesCacheCachedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesInMemoryCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesPhpCacheCreatedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+
+final class DocBlockResolverCache
+{
+    use EventDispatchingCapabilities;
+
+    private static ?CacheInterface $cache = null;
+
+    public static function resetCache(): void
+    {
+        self::$cache = null;
+    }
+
+    public static function getCacheInstance(): CacheInterface
+    {
+        if (self::$cache !== null) {
+            self::dispatchEvent(new CustomServicesCacheCachedEvent());
+
+            return self::$cache;
+        }
+
+        if (self::isProjectCacheEnabled()) {
+            self::dispatchEvent(new CustomServicesPhpCacheCreatedEvent());
+            self::$cache = new CustomServicesPhpCache(Config::getInstance()->getCacheDir());
+        } else {
+            self::dispatchEvent(new CustomServicesInMemoryCacheCreatedEvent());
+            self::$cache = new InMemoryCache(CustomServicesPhpCache::class);
+        }
+
+        return self::$cache;
+    }
+
+    private static function isProjectCacheEnabled(): bool
+    {
+        return (new GacelaFileCache(Config::getInstance()))->isEnabled();
+    }
+}

--- a/src/Framework/Event/ClassResolver/Cache/ClassNameCacheCachedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/ClassNameCacheCachedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\ClassResolver\Cache;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+final class ClassNameCacheCachedEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return self::class;
+    }
+}

--- a/src/Framework/Event/ClassResolver/Cache/ClassNameInMemoryCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/ClassNameInMemoryCacheCreatedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\ClassResolver\Cache;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+final class ClassNameInMemoryCacheCreatedEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return self::class;
+    }
+}

--- a/src/Framework/Event/ClassResolver/Cache/CustomServicesCacheCachedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/CustomServicesCacheCachedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\ClassResolver\Cache;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+final class CustomServicesCacheCachedEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return self::class;
+    }
+}

--- a/src/Framework/Event/ClassResolver/Cache/CustomServicesInMemoryCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/CustomServicesInMemoryCacheCreatedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\ClassResolver\Cache;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+final class CustomServicesInMemoryCacheCreatedEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return self::class;
+    }
+}

--- a/src/Framework/Event/ClassResolver/Cache/CustomServicesPhpCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/CustomServicesPhpCacheCreatedEvent.php
@@ -6,7 +6,7 @@ namespace Gacela\Framework\Event\ClassResolver\Cache;
 
 use Gacela\Framework\Event\GacelaEventInterface;
 
-final class InMemoryCacheCreatedEvent implements GacelaEventInterface
+final class CustomServicesPhpCacheCreatedEvent implements GacelaEventInterface
 {
     public function toString(): string
     {

--- a/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
+++ b/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
@@ -9,7 +9,7 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 trait EventDispatchingCapabilities
 {
-    private function dispatchEvent(GacelaEventInterface $event): void
+    private static function dispatchEvent(GacelaEventInterface $event): void
     {
         Config::getEventDispatcher()->dispatch($event);
     }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -11,7 +11,7 @@ use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
-use Gacela\Framework\ClassResolver\ClassResolverFactory;
+use Gacela\Framework\ClassResolver\ClassResolverCache;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
 
@@ -29,7 +29,7 @@ final class Gacela
         if ($setup->shouldResetInMemoryCache()) {
             GacelaFileCache::resetCache();
             DocBlockResolverCache::resetCache();
-            ClassResolverFactory::resetCache(); // TODO: extract cache to its own class, similar as `DocBlockResolverCache`
+            ClassResolverCache::resetCache();
             InMemoryCache::resetCache();
             AbstractClassResolver::resetCache();
             Config::resetInstance();

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -11,7 +11,9 @@ use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\ClassResolver\ClassResolverFactory;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
 
 final class Gacela
 {
@@ -26,6 +28,8 @@ final class Gacela
 
         if ($setup->shouldResetInMemoryCache()) {
             GacelaFileCache::resetCache();
+            DocBlockResolverCache::resetCache();
+            ClassResolverFactory::resetCache(); // TODO: extract cache to its own class, similar as `DocBlockResolverCache`
             InMemoryCache::resetCache();
             AbstractClassResolver::resetCache();
             Config::resetInstance();

--- a/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php
@@ -7,7 +7,7 @@ namespace GacelaTest\Feature\Framework\ListeningEvents\ClassResolver;
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\ClassInfo;
-use Gacela\Framework\Event\ClassResolver\Cache\InMemoryCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNameInMemoryCacheCreatedEvent;
 use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameInvalidCandidateFoundEvent;
 use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameNotFoundEvent;
 use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameValidCandidateFoundEvent;
@@ -46,7 +46,7 @@ final class GacelaClassResolverGeneralListenerTest extends TestCase
         $facade->doString();
 
         self::assertEquals([
-            new InMemoryCacheCreatedEvent(),
+            new ClassNameInMemoryCacheCreatedEvent(),
             new ClassNameInvalidCandidateFoundEvent('\GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\ModuleFactory'),
             new ClassNameValidCandidateFoundEvent('\GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\Factory'),
             new ResolvedClassCreatedEvent(ClassInfo::from(Module\Facade::class, 'Factory')),
@@ -62,7 +62,7 @@ final class GacelaClassResolverGeneralListenerTest extends TestCase
         $facade->doString();
 
         self::assertEquals([
-            new InMemoryCacheCreatedEvent(),
+            new ClassNameInMemoryCacheCreatedEvent(),
             new ClassNameInvalidCandidateFoundEvent('\GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\ModuleFactory'),
             new ClassNameValidCandidateFoundEvent('\GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\Factory'),
             new ResolvedClassCreatedEvent(ClassInfo::from(Module\Facade::class, 'Factory')),
@@ -76,7 +76,7 @@ final class GacelaClassResolverGeneralListenerTest extends TestCase
         $factory->getConfig();
 
         self::assertEquals([
-            new InMemoryCacheCreatedEvent(),
+            new ClassNameInMemoryCacheCreatedEvent(),
             new ClassNameInvalidCandidateFoundEvent('\GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\ModuleConfig'),
             new ClassNameInvalidCandidateFoundEvent('\GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\Config'),
             new ClassNameNotFoundEvent(ClassInfo::from(Module\Factory::class, 'Config'), ['Config']),

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Integration\Framework\DocBlockResolverAware;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +16,6 @@ final class DocBlockResolverCustomServicesAwareTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         DirectoryUtil::removeDir(__DIR__ . '/.gacela');
-        CustomServicesPhpCache::resetCache();
     }
 
     protected function setUp(): void
@@ -23,6 +23,9 @@ final class DocBlockResolverCustomServicesAwareTest extends TestCase
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
             $config->addAppConfig('config/custom-services/*.php');
+            $config->registerGenericListener(static function (GacelaEventInterface $event): void {
+                // dump('Triggered -> ' . \get_class($event)); # useful for debugging
+            });
         });
     }
 

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
@@ -16,7 +16,6 @@ final class DocBlockResolverInMemoryAwareTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         DirectoryUtil::removeDir(__DIR__ . '/.gacela');
-        InMemoryCache::resetCache();
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## 📚 Description

I discover a clear issue with the current implantation for the `PhpFileCache`, because this one was actually slower than the `InMemoryCache`. After some investigation I found that the object holding the `PhpFileCache` was actually being created every time instead of keeping itself cached. I found this thanks to the internal event system we introduced last week.

## 🔖 Changes

- Add more internal events for the `ClassResolver\Cache` scope
- Fix the `PhpFileCache` holding a unique cache across the project, which boost the performance by almost 50%

## 🖼️ Screenshots

### Before

<img width="1133" alt="Screenshot 2022-11-06 at 18 05 02" src="https://user-images.githubusercontent.com/5256287/200184443-90243480-b530-4011-8079-df65f3c7394a.png">

### After

<img width="1330" alt="Screenshot 2022-11-06 at 18 03 27" src="https://user-images.githubusercontent.com/5256287/200184358-e6e82cad-065a-4766-b5fc-6d817264967a.png">

And comparing master with this branch:

<img width="1219" alt="Screenshot 2022-11-06 at 18 14 41" src="https://user-images.githubusercontent.com/5256287/200184935-ce22fe2a-f074-4703-89c0-7bfdf003d0d4.png">


> **Note**: The performance boost is crazy good ⚡ Thanks @dantleech for PHPBench!