### PR TITLE
Optimize DocBlockResolver resolvableType

### DIFF
--- a/src/Framework/DocBlockResolver/DocBlockResolvable.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolvable.php
@@ -17,7 +17,8 @@ final class DocBlockResolvable
     public function __construct(string $className, string $resolvableType)
     {
         $this->resolvableType = $resolvableType;
-        $this->className = $className;
+        /** @psalm-suppress PropertyTypeCoercion */
+        $this->className = '\\' . ltrim($className, '\\'); // @phpstan-ignore-line
     }
 
     /**

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -113,15 +113,16 @@ final class DocBlockResolver
             ? $normalizedResolvableType
             : $resolvableType;
 
-        $result2 = $result;
         if (strpos($result, 'Config') !== false) {
-            $result2 = 'Config';
-        } elseif (strpos($result, 'Facade') !== false) {
-            $result2 = 'Facade';
-        } elseif (strpos($result, 'Factory') !== false) {
-            $result2 = 'Factory';
+            return 'Config';
+        }
+        if (strpos($result, 'Facade') !== false) {
+            return 'Facade';
+        }
+        if (strpos($result, 'Factory') !== false) {
+            return 'Factory';
         }
 
-        return $result2;
+        return $result;
     }
 }

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -116,6 +116,8 @@ final class DocBlockResolver
         $result2 = $result;
         if (strpos($result, 'Config') !== false) {
             $result2 = 'Config';
+        } elseif (strpos($result, 'Facade') !== false) {
+            $result2 = 'Facade';
         }
 
         return $result2;

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -109,8 +109,15 @@ final class DocBlockResolver
         $resolvableTypeParts = explode('\\', $resolvableType);
         $normalizedResolvableType = end($resolvableTypeParts);
 
-        return is_string($normalizedResolvableType)
+        $result = is_string($normalizedResolvableType)
             ? $normalizedResolvableType
             : $resolvableType;
+
+        $result2 = $result;
+        if (strpos($result, 'Config') !== false) {
+            $result2 = 'Config';
+        }
+
+        return $result2;
     }
 }

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -118,6 +118,8 @@ final class DocBlockResolver
             $result2 = 'Config';
         } elseif (strpos($result, 'Facade') !== false) {
             $result2 = 'Facade';
+        } elseif (strpos($result, 'Factory') !== false) {
+            $result2 = 'Factory';
         }
 
         return $result2;

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -14,6 +14,8 @@ use function is_string;
 
 final class DocBlockResolver
 {
+    private const SPECIAL_RESOLVABLE_TYPES = ['Facade', 'Factory', 'Config'];
+
     /** @var array<string,string> [fileName => fileContent] */
     private static array $fileContentCache = [];
 
@@ -113,14 +115,10 @@ final class DocBlockResolver
             ? $normalizedResolvableType
             : $resolvableType;
 
-        if (strpos($result, 'Config') !== false) {
-            return 'Config';
-        }
-        if (strpos($result, 'Facade') !== false) {
-            return 'Facade';
-        }
-        if (strpos($result, 'Factory') !== false) {
-            return 'Factory';
+        foreach (self::SPECIAL_RESOLVABLE_TYPES as $specialName) {
+            if (strpos($result, $specialName) !== false) {
+                return $specialName;
+            }
         }
 
         return $result;

--- a/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
@@ -9,6 +9,10 @@ use Gacela\Framework\DocBlockResolver\DocBlockResolvable;
 use Gacela\Framework\DocBlockResolver\DocBlockResolver;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeCommand;
+use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeConfig;
+use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeFacade;
+use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeFactory;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverTest extends TestCase
@@ -25,9 +29,18 @@ final class DocBlockResolverTest extends TestCase
 
     public function test_normalize_config(): void
     {
-        $resolver = DocBlockResolver::fromCaller($this);
-        $actual = $resolver->getDocBlockResolvable('getMethod');
-        $expected = new DocBlockResolvable(GacelaConfig::class, 'Config');
+        $resolver = DocBlockResolver::fromCaller(new FakeFactory());
+        $actual = $resolver->getDocBlockResolvable('getConfig');
+        $expected = new DocBlockResolvable(FakeConfig::class, 'Config');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_normalize_facade(): void
+    {
+        $resolver = DocBlockResolver::fromCaller(new FakeCommand());
+        $actual = $resolver->getDocBlockResolvable('getFacade');
+        $expected = new DocBlockResolvable(FakeFacade::class, 'Facade');
 
         self::assertEquals($expected, $actual);
     }

--- a/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
@@ -27,20 +27,29 @@ final class DocBlockResolverTest extends TestCase
         });
     }
 
-    public function test_normalize_config(): void
-    {
-        $resolver = DocBlockResolver::fromCaller(new FakeFactory());
-        $actual = $resolver->getDocBlockResolvable('getConfig');
-        $expected = new DocBlockResolvable(FakeConfig::class, 'Config');
-
-        self::assertEquals($expected, $actual);
-    }
-
     public function test_normalize_facade(): void
     {
         $resolver = DocBlockResolver::fromCaller(new FakeCommand());
         $actual = $resolver->getDocBlockResolvable('getFacade');
         $expected = new DocBlockResolvable(FakeFacade::class, 'Facade');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_normalize_factory(): void
+    {
+        $resolver = DocBlockResolver::fromCaller(new FakeFacade());
+        $actual = $resolver->getDocBlockResolvable('getFactory');
+        $expected = new DocBlockResolvable(FakeFactory::class, 'Factory');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_normalize_config(): void
+    {
+        $resolver = DocBlockResolver::fromCaller(new FakeFactory());
+        $actual = $resolver->getDocBlockResolvable('getConfig');
+        $expected = new DocBlockResolvable(FakeConfig::class, 'Config');
 
         self::assertEquals($expected, $actual);
     }

--- a/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
@@ -12,6 +12,7 @@ use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeCommand;
 use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeConfig;
 use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeFacade;
 use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeFactory;
+use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeRandomService;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverTest extends TestCase
@@ -46,6 +47,15 @@ final class DocBlockResolverTest extends TestCase
         $resolver = DocBlockResolver::fromCaller(new FakeFactory());
         $actual = $resolver->getDocBlockResolvable('getConfig');
         $expected = new DocBlockResolvable(FakeConfig::class, 'Config');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_normalize_random(): void
+    {
+        $resolver = DocBlockResolver::fromCaller(new FakeCommand());
+        $actual = $resolver->getDocBlockResolvable('getRandom');
+        $expected = new DocBlockResolvable(FakeRandomService::class, 'FakeRandomService');
 
         self::assertEquals($expected, $actual);
     }

--- a/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolver;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\DocBlockResolver\DocBlockResolvable;
+use Gacela\Framework\DocBlockResolver\DocBlockResolver;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class DocBlockResolverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->registerGenericListener(static function (GacelaEventInterface $event): void {
+                # dump('Triggered -> ' . \get_class($event)); # useful for debugging
+            });
+        });
+    }
+
+    public function test_normalize_config(): void
+    {
+        $resolver = DocBlockResolver::fromCaller($this);
+        $actual = $resolver->getDocBlockResolvable('getMethod');
+        $expected = new DocBlockResolvable(GacelaConfig::class, 'Config');
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
@@ -7,7 +7,6 @@ namespace GacelaTest\Integration\Framework\DocBlockResolver;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\DocBlockResolver\DocBlockResolvable;
 use Gacela\Framework\DocBlockResolver\DocBlockResolver;
-use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
 use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeCommand;
 use GacelaTest\Integration\Framework\DocBlockResolver\Module\FakeConfig;
@@ -21,9 +20,6 @@ final class DocBlockResolverTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->registerGenericListener(static function (GacelaEventInterface $event): void {
-                # dump('Triggered -> ' . \get_class($event)); # useful for debugging
-            });
         });
     }
 

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeCommand.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeCommand.php
@@ -8,6 +8,7 @@ use Gacela\Framework\DocBlockResolverAwareTrait;
 
 /**
  * @method FakeFacade getFacade()
+ * @method FakeRandomService getRandom()
  */
 final class FakeCommand
 {

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeCommand.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolver\Module;
+
+use Gacela\Framework\DocBlockResolverAwareTrait;
+
+/**
+ * @method FakeFacade getFacade()
+ */
+final class FakeCommand
+{
+    use DocBlockResolverAwareTrait;
+}

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeConfig.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeConfig.php
@@ -8,8 +8,4 @@ use Gacela\Framework\AbstractConfig;
 
 final class FakeConfig extends AbstractConfig
 {
-    public function getString(): string
-    {
-        return 'config';
-    }
 }

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeConfig.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolver\Module;
+
+use Gacela\Framework\AbstractConfig;
+
+final class FakeConfig extends AbstractConfig
+{
+    public function getString(): string
+    {
+        return 'config';
+    }
+}

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeFacade.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeFacade.php
@@ -13,7 +13,6 @@ final class FakeFacade extends AbstractFacade
 {
     public function doString(): string
     {
-        return $this->getFactory()
-            ->createString();
+        return $this->getFactory()->createString();
     }
 }

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeFacade.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeFacade.php
@@ -11,8 +11,4 @@ use Gacela\Framework\AbstractFacade;
  */
 final class FakeFacade extends AbstractFacade
 {
-    public function doString(): string
-    {
-        return $this->getFactory()->createString();
-    }
 }

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeFacade.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeFacade.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolver\Module;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method FakeFactory getFactory()
+ */
+final class FakeFacade extends AbstractFacade
+{
+    public function doString(): string
+    {
+        return $this->getFactory()
+            ->createString();
+    }
+}

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeFactory.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolver\Module;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @method FakeConfig getConfig()
+ */
+final class FakeFactory extends AbstractFactory
+{
+    public function createString(): string
+    {
+        return $this->getConfig()->getString();
+    }
+}

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeFactory.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeFactory.php
@@ -11,8 +11,4 @@ use Gacela\Framework\AbstractFactory;
  */
 final class FakeFactory extends AbstractFactory
 {
-    public function createString(): string
-    {
-        return $this->getConfig()->getString();
-    }
 }

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeRandomService.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeRandomService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\DocBlockResolver\Module;
+
+final class FakeRandomService
+{
+}


### PR DESCRIPTION
## 📚 Description

Right now, when using the `DocBlockResolverAwareTrait` we are saving the full class name as resolvableType, which is not "totally optimal" for the internal gacela class names such as Facade, Factory and Config. Those are saved internally without the module prefix, especially when using the file cache system. 

## 🔖 Changes

- Avoid using the module prefix as `resolvableType` when using `DocBlockResolverAwareTrait`
