### PR TITLE
Add container extend method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Unreleased
+
+- Added `Container::factory(service)`
+- Added `Container::extend(id, service)`
+
 ### 0.30.1
 #### 2022-11-09
 

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -119,20 +119,20 @@ final class Container implements ContainerInterface
      */
     private function generateExtendedService(Closure $service, $factory): Closure
     {
-        if (!is_callable($factory) && is_object($factory)) {
-            return static function (self $container) use ($service, $factory) {
-                $r = $service($factory, $container);
-
-                return $r ?? $factory;
-            };
-        }
-
         if (is_callable($factory)) {
             return static function (self $container) use ($service, $factory) {
                 $r1 = $factory($container);
                 $r2 = $service($r1, $container);
 
                 return $r2 ?? $r1;
+            };
+        }
+
+        if (is_object($factory)) {
+            return static function (self $container) use ($service, $factory) {
+                $r = $service($factory, $container);
+
+                return $r ?? $factory;
             };
         }
 

--- a/src/Framework/Container/Exception/ContainerException.php
+++ b/src/Framework/Container/Exception/ContainerException.php
@@ -18,4 +18,9 @@ final class ContainerException extends Exception implements ContainerExceptionIn
     {
         return new self('The passed service is not invokable.');
     }
+
+    public static function serviceNotExtendable(): self
+    {
+        return new self('The passed service is not extendable.');
+    }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -124,15 +124,21 @@ final class ContainerTest extends TestCase
 
     public function test_extend_existing_service(): void
     {
-        $this->container->set('service_name', new ArrayObject([1, 2]));
-        $this->container->extend('service_name', static function (ArrayObject $arrayObject): void {
-            $arrayObject->append(3);
-            $arrayObject->append(4);
-        });
+        $this->container->set('n3', 3);
+        $this->container->set('service_name', static fn () => new ArrayObject([1, 2]));
 
-        self::assertSame(
-            [1, 2, 3, 4],
-            $this->container->get('service_name')
+        $this->container->extend(
+            'service_name',
+            static function (ArrayObject $arrayObject, Container $container) {
+                $arrayObject->append($container->get('n3'));
+                $arrayObject->append(4);
+                return $arrayObject;
+            }
         );
+
+        /** @var ArrayObject $actual */
+        $actual = $this->container->get('service_name');
+
+        self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
     }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -161,4 +161,12 @@ final class ContainerTest extends TestCase
 
         self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
     }
+
+    public function test_service_not_extendable(): void
+    {
+        $this->container->set('service_name', 'raw string');
+
+        $this->expectExceptionObject(ContainerException::serviceNotExtendable());
+        $this->container->extend('service_name', static fn (string $str) => $str);
+    }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -122,10 +122,30 @@ final class ContainerTest extends TestCase
         );
     }
 
-    public function test_extend_existing_service(): void
+    public function test_extend_existing_callable_service(): void
     {
         $this->container->set('n3', 3);
         $this->container->set('service_name', static fn () => new ArrayObject([1, 2]));
+
+        $this->container->extend(
+            'service_name',
+            static function (ArrayObject $arrayObject, Container $container) {
+                $arrayObject->append($container->get('n3'));
+                $arrayObject->append(4);
+                return $arrayObject;
+            }
+        );
+
+        /** @var ArrayObject $actual */
+        $actual = $this->container->get('service_name');
+
+        self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
+    }
+
+    public function test_extend_existing_object_service(): void
+    {
+        $this->container->set('n3', 3);
+        $this->container->set('service_name', new ArrayObject([1, 2]));
 
         $this->container->extend(
             'service_name',

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -170,6 +170,14 @@ final class ContainerTest extends TestCase
         self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
     }
 
+    public function test_extend_non_existing_service(): void
+    {
+        $this->container->extend('service_name', static fn () => '');
+
+        $this->expectException(ContainerKeyNotFoundException::class);
+        $this->container->get('service_name');
+    }
+
     public function test_service_not_extendable(): void
     {
         $this->container->set('service_name', 'raw string');

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Container;
 
+use ArrayObject;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Exception\ContainerException;
 use Gacela\Framework\Container\Exception\ContainerKeyNotFoundException;
@@ -118,6 +119,20 @@ final class ContainerTest extends TestCase
         $this->container->set(
             'service_name',
             $this->container->factory(new stdClass())
+        );
+    }
+
+    public function test_extend_existing_service(): void
+    {
+        $this->container->set('service_name', new ArrayObject([1, 2]));
+        $this->container->extend('service_name', static function (ArrayObject $arrayObject): void {
+            $arrayObject->append(3);
+            $arrayObject->append(4);
+        });
+
+        self::assertSame(
+            [1, 2, 3, 4],
+            $this->container->get('service_name')
         );
     }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -131,9 +131,13 @@ final class ContainerTest extends TestCase
             'service_name',
             static function (ArrayObject $arrayObject, Container $container) {
                 $arrayObject->append($container->get('n3'));
-                $arrayObject->append(4);
                 return $arrayObject;
             }
+        );
+
+        $this->container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4)
         );
 
         /** @var ArrayObject $actual */
@@ -151,9 +155,13 @@ final class ContainerTest extends TestCase
             'service_name',
             static function (ArrayObject $arrayObject, Container $container) {
                 $arrayObject->append($container->get('n3'));
-                $arrayObject->append(4);
                 return $arrayObject;
             }
+        );
+
+        $this->container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4)
         );
 
         /** @var ArrayObject $actual */

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -161,7 +161,9 @@ final class ContainerTest extends TestCase
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(4)
+            static function (ArrayObject $arrayObject): void {
+                $arrayObject->append(4);
+            }
         );
 
         /** @var ArrayObject $actual */


### PR DESCRIPTION
## 📚 Description

Currently, there is no possibility of extending a particular service from the `Container`.

## 🔖 Changes

- Added `Container::extend(id, service)`
  - You can extend a (calable|object) `service`
  - See `tests/Unit/Framework/Container/ContainerTest.php` for a deeper look at the examples