### PR TITLE
Remove useless ContainerException::notFound()

### DIFF
--- a/src/Framework/Container/Exception/ContainerException.php
+++ b/src/Framework/Container/Exception/ContainerException.php
@@ -9,11 +9,6 @@ use Psr\Container\ContainerExceptionInterface;
 
 final class ContainerException extends Exception implements ContainerExceptionInterface
 {
-    public static function notFound(string $id): self
-    {
-        return new self("The requested service '{$id}' was not found in the container!");
-    }
-
     public static function serviceNotInvokable(): self
     {
         return new self('The passed service is not invokable.');


### PR DESCRIPTION
## 📚 Description

Remove the useless `ContainerException::notFound()` method.