### PR TITLE
Frozen used Container services

### DIFF
--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -76,6 +76,8 @@ final class Container implements ContainerInterface
             throw new ContainerKeyNotFoundException($this, $id);
         }
 
+        $this->frozenServices[$id] = true;
+
         if (
             isset($this->raw[$id])
             || !is_object($this->services[$id])
@@ -96,7 +98,6 @@ final class Container implements ContainerInterface
         /** @var mixed $resolvedService */
         $resolvedService = $this->services[$id];
         $this->raw[$id] = $rawService;
-        $this->frozenServices[$id] = true;
 
         return $resolvedService;
     }

--- a/src/Framework/Container/Exception/ContainerException.php
+++ b/src/Framework/Container/Exception/ContainerException.php
@@ -18,4 +18,9 @@ final class ContainerException extends Exception implements ContainerExceptionIn
     {
         return new self('The passed service is not extendable.');
     }
+
+    public static function serviceFrozen(string $id): self
+    {
+        return new self("The service '{$id}' is frozen and cannot be extendable.");
+    }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -56,7 +56,7 @@ final class ContainerTest extends TestCase
 
     public function test_resolve_service_as_function(): void
     {
-        $this->container->set('service_name', static fn (): string => 'value');
+        $this->container->set('service_name', static fn () => 'value');
 
         $resolvedService = $this->container->get('service_name');
         self::assertSame('value', $resolvedService);
@@ -191,17 +191,14 @@ final class ContainerTest extends TestCase
     public function test_extend_existing_used_object_service_is_allowed(): void
     {
         $this->container->set('service_name', new ArrayObject([1, 2]));
-        $this->container->get('service_name'); // not frozen because it's an object
+        $this->container->get('service_name'); // and get frozen
+
+        $this->expectExceptionObject(ContainerException::serviceFrozen('service_name'));
 
         $this->container->extend(
             'service_name',
             static fn (ArrayObject $arrayObject) => $arrayObject->append(3)
         );
-
-        /** @var ArrayObject $actual */
-        $actual = $this->container->get('service_name');
-
-        self::assertEquals(new ArrayObject([1, 2, 3]), $actual);
     }
 
     public function test_extend_existing_used_callable_service_then_error(): void


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/gacela-project/gacela/issues/233

## 🔖 Changes

- Freeze a "used `Container` service" (using `get()`) to avoid altering it after its first usage.
