### PR TITLE
Add Container::protect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Unreleased
+
+- Froze a "Container service" after its first usage with `get()`
+- Added `Container::protect(service)`
+
 ### 0.31.0
 #### 2022-11-15
 

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -134,6 +134,10 @@ final class Container implements ContainerInterface
             throw ContainerException::serviceFrozen($id);
         }
 
+        if (is_object($this->services[$id]) && isset($this->protectedServices[$this->services[$id]])) {
+            throw ContainerException::serviceProtected($id);
+        }
+
         $factory = $this->services[$id];
         $extended = $this->generateExtendedService($service, $factory);
         $this->set($id, $extended);
@@ -141,7 +145,7 @@ final class Container implements ContainerInterface
         return $extended;
     }
 
-    public function protect($service)
+    public function protect(object $service): object
     {
         $this->protectedServices->attach($service);
 

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -141,7 +141,7 @@ final class Container implements ContainerInterface
         return $extended;
     }
 
-    public function protect(Closure $service): Closure
+    public function protect($service)
     {
         $this->protectedServices->attach($service);
 

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -20,6 +20,8 @@ final class Container implements ContainerInterface
 
     private SplObjectStorage $factoryServices;
 
+    private SplObjectStorage $protectedServices;
+
     /** @var array<string,list<Closure>> */
     private array $servicesToExtend;
 
@@ -35,6 +37,7 @@ final class Container implements ContainerInterface
     {
         $this->servicesToExtend = $servicesToExtend;
         $this->factoryServices = new SplObjectStorage();
+        $this->protectedServices = new SplObjectStorage();
     }
 
     public function getLocator(): Locator
@@ -76,6 +79,7 @@ final class Container implements ContainerInterface
         $this->frozenServices[$id] = true;
 
         if (!is_object($this->services[$id])
+            || isset($this->protectedServices[$this->services[$id]])
             || !method_exists($this->services[$id], '__invoke')
         ) {
             return $this->services[$id];
@@ -135,6 +139,13 @@ final class Container implements ContainerInterface
         $this->set($id, $extended);
 
         return $extended;
+    }
+
+    public function protect(Closure $service): Closure
+    {
+        $this->protectedServices->attach($service);
+
+        return $service;
     }
 
     private function extendLater(string $id, Closure $service): void

--- a/src/Framework/Container/Exception/ContainerException.php
+++ b/src/Framework/Container/Exception/ContainerException.php
@@ -23,4 +23,9 @@ final class ContainerException extends Exception implements ContainerExceptionIn
     {
         return new self("The service '{$id}' is frozen and cannot be extendable.");
     }
+
+    public static function serviceProtected(string $id): self
+    {
+        return new self("The service '{$id}' is protected and cannot be extendable.");
+    }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -274,7 +274,7 @@ final class ContainerTest extends TestCase
             $this->container->protect(new ArrayObject([1, 2]))
         );
 
-        $this->expectExceptionObject(ContainerException::serviceFrozen('service_name'));
+        $this->expectExceptionObject(ContainerException::serviceProtected('service_name'));
 
         $this->container->extend(
             'service_name',

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -266,4 +266,19 @@ final class ContainerTest extends TestCase
 
         self::assertSame($service, $this->container->get('service_name'));
     }
+
+    public function test_protect_service_cannot_be_extended(): void
+    {
+        $this->container->set(
+            'service_name',
+            $this->container->protect(new ArrayObject([1, 2]))
+        );
+
+        $this->expectExceptionObject(ContainerException::serviceFrozen('service_name'));
+
+        $this->container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject
+        );
+    }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -258,4 +258,12 @@ final class ContainerTest extends TestCase
         $this->expectExceptionObject(ContainerException::serviceFrozen('service_name'));
         $this->container->set('service_name', static fn () => new ArrayObject([3]));
     }
+
+    public function test_protect_service_is_not_resolved(): void
+    {
+        $service = static fn () => 'value';
+        $this->container->set('service_name', $this->container->protect($service));
+
+        self::assertSame($service, $this->container->get('service_name'));
+    }
 }


### PR DESCRIPTION
## 📚 Description

Currently, the `DependenyProvider` can define only services that will be resolved on the `Factory`. There is no way to define a service that won't be resolved for any reason.

This PR is about allowing the creation of a service(callable) that won't be resolved when it's been used.

## 🔖 Changes

- A protected service wont be resolved when it's used
- A protected service cannot be extended
