### PR TITLE
Allow extending raw arrays as services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Allow extending raw arrays as services
+
 ### 0.32.0
 #### 2022-11-24
 

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -178,15 +178,7 @@ final class Container implements ContainerInterface
             };
         }
 
-        if (is_object($factory)) {
-            return static function (self $container) use ($service, $factory) {
-                $r = $service($factory, $container);
-
-                return $r ?? $factory;
-            };
-        }
-
-        if (is_array($factory)) {
+        if (is_object($factory) || is_array($factory)) {
             return static function (self $container) use ($service, $factory) {
                 $r = $service($factory, $container);
 

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Container\Exception\ContainerKeyNotFoundException;
 use SplObjectStorage;
 
 use function count;
+use function is_array;
 use function is_callable;
 use function is_object;
 
@@ -178,6 +179,14 @@ final class Container implements ContainerInterface
         }
 
         if (is_object($factory)) {
+            return static function (self $container) use ($service, $factory) {
+                $r = $service($factory, $container);
+
+                return $r ?? $factory;
+            };
+        }
+
+        if (is_array($factory)) {
             return static function (self $container) use ($service, $factory) {
                 $r = $service($factory, $container);
 

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -172,6 +172,31 @@ final class ContainerTest extends TestCase
         self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
     }
 
+    public function test_extend_existing_array_service(): void
+    {
+        $this->container->set('service_name', [1, 2]);
+
+        $this->container->extend(
+            'service_name',
+            static function (array $arrayObject) {
+                $arrayObject[] = 3;
+                return $arrayObject;
+            }
+        );
+
+        $this->container->extend(
+            'service_name',
+            static function (array &$arrayObject): void {
+                $arrayObject[] = 4;
+            }
+        );
+
+        /** @var ArrayObject $actual */
+        $actual = $this->container->get('service_name');
+
+        self::assertEquals([1, 2, 3, 4], $actual);
+    }
+
     public function test_extend_non_existing_service(): void
     {
         $this->container->extend('service_name', static fn () => '');

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -178,7 +178,7 @@ final class ContainerTest extends TestCase
 
         $this->container->extend(
             'service_name',
-            static function (array $arrayObject) {
+            static function (array $arrayObject): array {
                 $arrayObject[] = 3;
                 return $arrayObject;
             }


### PR DESCRIPTION
## 📚 Description

Currently it's possible to extend a service only when using a callable or an object, but not a raw array.

## 🔖 Changes

- Allow extending array services. Similar behaviour as we currently do when extending objects
