### PR TITLE
Disable file cache after running feature tests

### DIFF
--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -15,6 +15,11 @@ final class FileCacheFeatureTest extends TestCase
 {
     public static function tearDownAfterClass(): void
     {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCacheEnabled(false);
+        });
+
         DirectoryUtil::removeDir(__DIR__ . '/custom/cache-dir');
     }
 


### PR DESCRIPTION
## 📚 Description

Sometimes there "gacela cache files" are not deleted (even after running all tests), because the feature test which enable them contains was trigger the latest, and then it remains that state for some tests that are running afterwards:

<img width="292" alt="Screenshot 2022-12-03 at 12 24 54" src="https://user-images.githubusercontent.com/5256287/205438579-031410bc-f0ad-43ac-9141-ab06c9e757d2.png">


## 🔖 Changes

- Ensure that we disable the "gacela file cache" on the `tearDownAfterClass()`
