### PR TITLE
Locator should not resolve interfaces magically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Allow extending raw arrays as services
+- The Locator cannot resolve any more interface classes only because of the `Interface` suffix in their name
 
 ### 0.32.0
 #### 2022-11-24

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -8,8 +8,6 @@ use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 
 final class Locator
 {
-    private const INTERFACE_SUFFIX = 'Interface';
-
     private static ?Locator $instance = null;
 
     /** @var array<string, mixed> */
@@ -49,32 +47,20 @@ final class Locator
      */
     public function get(string $className)
     {
-        /** @var class-string<T> $concreteClass */
-        $concreteClass = $this->getConcreteClass($className);
-
-        if (isset($this->instanceCache[$concreteClass])) {
+        if (isset($this->instanceCache[$className])) {
             /** @var T $instance */
-            $instance = $this->instanceCache[$concreteClass];
+            $instance = $this->instanceCache[$className];
 
             return $instance;
         }
 
-        $locatedInstance = AnonymousGlobal::getByClassName($concreteClass)
-            ?? $this->newInstance($concreteClass);
+        $locatedInstance = AnonymousGlobal::getByClassName($className)
+            ?? $this->newInstance($className);
 
         /** @psalm-suppress MixedAssignment */
-        $this->instanceCache[$concreteClass] = $locatedInstance;
+        $this->instanceCache[$className] = $locatedInstance;
 
         return $locatedInstance;
-    }
-
-    private function getConcreteClass(string $className): string
-    {
-        if ($this->isInterface($className)) {
-            return $this->getConcreteClassFromInterface($className);
-        }
-
-        return $className;
     }
 
     /**
@@ -92,15 +78,5 @@ final class Locator
         }
 
         return null;
-    }
-
-    private function isInterface(string $className): bool
-    {
-        return mb_strpos($className, self::INTERFACE_SUFFIX) !== false;
-    }
-
-    private function getConcreteClassFromInterface(string $interface): string
-    {
-        return str_replace(self::INTERFACE_SUFFIX, '', $interface);
     }
 }

--- a/tests/Unit/Framework/Container/LocatorTest.php
+++ b/tests/Unit/Framework/Container/LocatorTest.php
@@ -6,7 +6,6 @@ namespace GacelaTest\Unit\Framework\Container;
 
 use Gacela\Framework\Container\Locator;
 use GacelaTest\Fixtures\StringValue;
-use GacelaTest\Fixtures\StringValueInterface;
 use PHPUnit\Framework\TestCase;
 
 final class LocatorTest extends TestCase
@@ -24,7 +23,7 @@ final class LocatorTest extends TestCase
         Locator::resetInstance();
     }
 
-    public function test_get_singleton_from_concrete_class(): void
+    public function test_get_concrete_class(): void
     {
         /** @var StringValue $stringValue */
         $stringValue = $this->locator->get(StringValue::class);
@@ -37,20 +36,7 @@ final class LocatorTest extends TestCase
         self::assertSame('updated value', $stringValue2->value());
     }
 
-    public function test_get_singleton_from_interface(): void
-    {
-        /** @var StringValue $stringValue */
-        $stringValue = $this->locator->get(StringValueInterface::class);
-        self::assertInstanceOf(StringValue::class, $stringValue);
-        self::assertSame('', $stringValue->value());
-        $stringValue->setValue('updated value');
-
-        /** @var StringValue $stringValue2 */
-        $stringValue2 = $this->locator->get(StringValueInterface::class);
-        self::assertSame('updated value', $stringValue2->value());
-    }
-
-    public function test_get_singleton_from_string(): void
+    public function test_get_null_from_non_existing_class(): void
     {
         /** @var null $nullValue */
         $nullValue = $this->locator->get('NonExistingClass');


### PR DESCRIPTION
## 📚 Description

Similar to the [comment](https://github.com/gacela-project/gacela/pull/203#pullrequestreview-1129816016) I wrote at [Allow using Interface suffix for DocBlockResolver](https://github.com/gacela-project/gacela/pull/203).
We should not depend on the class name to resolve a class from its interface.

This PR aims to remove the logic from the locator that adds some magic to the code and makes it less explicit.