### PR TITLE
Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         dependencies: [ "locked", "highest" ]
-        php-version: [ "7.4" , "8.0" , "8.1", "8.2" ]
+        php-version: [ "8.0" , "8.1", "8.2" ]
         operating-system:
           - "ubuntu-latest"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow extending raw arrays as services
 - The Locator cannot resolve any more interface classes only because of the `Interface` suffix in their name
+- Drop support for PHP 7.4
 
 ### 0.32.0
 #### 2022-11-24

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4"
+        "php": "^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
@@ -63,7 +63,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.4"
+            "php": "8.0"
         },
         "allow-plugins": {
             "composer/package-versions-deprecated": true


### PR DESCRIPTION
## 📚 Description

As 7.4 is [not supported anymore](https://www.php.net/supported-versions.php), I would encourage everyone to upgrade to at least 8.0 (or higher), in order to avoid accumulating more tech debt as time passes by...

<img width="1120" alt="Screenshot 2022-12-10 at 16 32 50" src="https://user-images.githubusercontent.com/5256287/206862808-321f90aa-18ff-45f0-8bcf-c71affcc25e5.png">

## 🔖 Changes

- Drop support for PHP 7.4

This unlock the project to use the [new features that comes with PHP 8.0 ](https://www.php.net/releases/8.0/en.php).
