### PR TITLE
Normalize ContainerInterface

### DIFF
--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -101,12 +101,8 @@ final class Container implements ContainerInterface
         return $resolvedService;
     }
 
-    public function factory(object $service): object
+    public function factory(Closure $service): Closure
     {
-        if (!method_exists($service, '__invoke')) {
-            throw ContainerException::serviceNotInvokable();
-        }
-
         $this->factoryServices->attach($service);
 
         return $service;
@@ -146,7 +142,7 @@ final class Container implements ContainerInterface
         return $extended;
     }
 
-    public function protect(object $service): object
+    public function protect(Closure $service): Closure
     {
         $this->protectedServices->attach($service);
 

--- a/src/Framework/Container/ContainerInterface.php
+++ b/src/Framework/Container/ContainerInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Container;
 
+use Closure;
 use Gacela\Framework\Container\Exception\ContainerKeyNotFoundException;
 
 interface ContainerInterface
@@ -23,4 +24,10 @@ interface ContainerInterface
     public function set(string $id, $service): void;
 
     public function remove(string $id): void;
+
+    public function factory(Closure $service): object;
+
+    public function extend(string $id, Closure $service): Closure;
+
+    public function protect(Closure $service): object;
 }

--- a/src/Framework/Container/ContainerInterface.php
+++ b/src/Framework/Container/ContainerInterface.php
@@ -5,29 +5,54 @@ declare(strict_types=1);
 namespace Gacela\Framework\Container;
 
 use Closure;
+use Gacela\Framework\Container\Exception\ContainerException;
 use Gacela\Framework\Container\Exception\ContainerKeyNotFoundException;
 
 interface ContainerInterface
 {
     /**
+     * Get the resolved value of the service.
+     * Unless it is protected, in such a case it will get the raw service as it was set.
+     *
      * @throws ContainerKeyNotFoundException
      *
      * @return mixed
      */
     public function get(string $id);
 
+    /**
+     * Check if a service exists.
+     */
     public function has(string $id): bool;
 
     /**
+     * Set a new service. You cannot override an existing service, but you can extend it.
+     *
      * @param mixed $service
+     *
+     * @throws ContainerException
      */
     public function set(string $id, $service): void;
 
+    /**
+     * Remove a known service.
+     */
     public function remove(string $id): void;
 
+    /**
+     * Ensure the service is returning a new instance everytime.
+     */
     public function factory(Closure $service): object;
 
+    /**
+     * Extend the functionality of a service, even before it is defined.
+     *
+     * @throws ContainerException
+     */
     public function extend(string $id, Closure $service): Closure;
 
+    /**
+     * Protect a service to be resolved. A protected service cannot be extended.
+     */
     public function protect(Closure $service): object;
 }

--- a/src/Framework/Container/Exception/ContainerException.php
+++ b/src/Framework/Container/Exception/ContainerException.php
@@ -9,11 +9,6 @@ use Psr\Container\ContainerExceptionInterface;
 
 final class ContainerException extends Exception implements ContainerExceptionInterface
 {
-    public static function serviceNotInvokable(): self
-    {
-        return new self('The passed service is not invokable.');
-    }
-
     public static function serviceNotExtendable(): self
     {
         return new self('The passed service is not extendable.');

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -9,7 +9,6 @@ use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Exception\ContainerException;
 use Gacela\Framework\Container\Exception\ContainerKeyNotFoundException;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 final class ContainerTest extends TestCase
 {
@@ -109,16 +108,6 @@ final class ContainerTest extends TestCase
         self::assertNotSame(
             $this->container->get('service_name'),
             $this->container->get('service_name')
-        );
-    }
-
-    public function test_resolve_factory_service_not_invokable(): void
-    {
-        $this->expectExceptionObject(ContainerException::serviceNotInvokable());
-
-        $this->container->set(
-            'service_name',
-            $this->container->factory(new stdClass())
         );
     }
 
@@ -296,7 +285,7 @@ final class ContainerTest extends TestCase
     {
         $this->container->set(
             'service_name',
-            $this->container->protect(new ArrayObject([1, 2]))
+            $this->container->protect(static fn () => new ArrayObject([1, 2]))
         );
 
         $this->expectExceptionObject(ContainerException::serviceProtected('service_name'));


### PR DESCRIPTION
## 🔖 Changes

- `Container::factory()` and `Container::protect()` expects a `Closure`
