### PR TITLE
Update code to PHP 8.0 changes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -112,7 +112,7 @@ return (new Config())
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline' => [
-            'elements' => ['arrays'],
+            'elements' => ['arguments', 'arrays', 'match', 'parameters'],
         ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    phpVersion="7.4"
+    phpVersion="8.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -29,7 +29,7 @@ final class ConsoleFacade extends AbstractFacade
     public function generateFileContent(
         CommandArguments $commandArguments,
         string $filename,
-        bool $withShortName = false
+        bool $withShortName = false,
     ): string {
         return $this->getFactory()
             ->createFileContentGenerator()

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -33,7 +33,7 @@ final class ConsoleFactory extends AbstractFactory
     public function createCommandArgumentsParser(): CommandArgumentsParserInterface
     {
         return new CommandArgumentsParser(
-            $this->getConfig()->getComposerJsonContentAsArray()
+            $this->getConfig()->getComposerJsonContentAsArray(),
         );
     }
 
@@ -46,7 +46,7 @@ final class ConsoleFactory extends AbstractFactory
     {
         return new FileContentGenerator(
             $this->createFileContentIo(),
-            $this->getTemplateByFilenameMap()
+            $this->getTemplateByFilenameMap(),
         );
     }
 

--- a/src/Console/Domain/CommandArguments/CommandArguments.php
+++ b/src/Console/Domain/CommandArguments/CommandArguments.php
@@ -6,13 +6,10 @@ namespace Gacela\Console\Domain\CommandArguments;
 
 final class CommandArguments
 {
-    private string $namespace;
-    private string $directory;
-
-    public function __construct(string $namespace, string $directory)
-    {
-        $this->namespace = $namespace;
-        $this->directory = $directory;
+    public function __construct(
+        private string $namespace,
+        private string $directory,
+    ) {
     }
 
     public function namespace(): string

--- a/src/Console/Domain/CommandArguments/CommandArgumentsException.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsException.php
@@ -29,8 +29,8 @@ final class CommandArgumentsException extends RuntimeException
             sprintf(
                 'No autoload psr-4 match found for %s. Known PSR-4: %s',
                 $desiredNamespace,
-                implode(', ', $parsedKnownPsr4)
-            )
+                implode(', ', $parsedKnownPsr4),
+            ),
         );
     }
 }

--- a/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
@@ -11,22 +11,14 @@ use function count;
 final class CommandArgumentsParser implements CommandArgumentsParserInterface
 {
     /**
-     * @var array{
-     *     autoload:      array{psr-4?:array<string,string>},
-     *     autoload-dev?: array{psr-4?:array<string,string>},
-     * }
-     */
-    private array $composerJson;
-
-    /**
      * @param array{
-     *     autoload:      array{psr-4?:array<string,string>},
+     *     autoload: array{psr-4?:array<string,string>},
      *     autoload-dev?: array{psr-4?:array<string,string>},
      * } $composerJson
      */
-    public function __construct(array $composerJson)
-    {
-        $this->composerJson = $composerJson;
+    public function __construct(
+        private array $composerJson,
+    ) {
     }
 
     /**

--- a/src/Console/Domain/FileContent/FileContentGenerator.php
+++ b/src/Console/Domain/FileContent/FileContentGenerator.php
@@ -9,20 +9,13 @@ use RuntimeException;
 
 final class FileContentGenerator implements FileContentGeneratorInterface
 {
-    private FileContentIoInterface $fileContentIo;
-
-    /** @var array<string,string> */
-    private array $templateByFilenameMap;
-
     /**
      * @param array<string,string> $templateByFilenameMap
      */
     public function __construct(
-        FileContentIoInterface $fileContentIo,
-        array $templateByFilenameMap
+        private FileContentIoInterface $fileContentIo,
+        private array $templateByFilenameMap,
     ) {
-        $this->fileContentIo = $fileContentIo;
-        $this->templateByFilenameMap = $templateByFilenameMap;
     }
 
     /**

--- a/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
+++ b/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
@@ -35,7 +35,7 @@ final class FilenameSanitizer implements FilenameSanitizerInterface
         $percents = [];
 
         foreach (self::EXPECTED_FILENAMES as $expected) {
-            $percents[$expected] = similar_text($expected, $filename, $percent);
+            $percents[$expected] = similar_text($expected, $filename);
         }
 
         $maxVal = max($percents);
@@ -45,7 +45,7 @@ final class FilenameSanitizer implements FilenameSanitizerInterface
             throw new RuntimeException(sprintf(
                 'When using "%s", which filename do you mean [%s]?',
                 $filename,
-                implode(' or ', $maxValKeys)
+                implode(' or ', $maxValKeys),
             ));
         }
 

--- a/src/Console/Infrastructure/Command/MakeFileCommand.php
+++ b/src/Console/Infrastructure/Command/MakeFileCommand.php
@@ -36,7 +36,7 @@ final class MakeFileCommand extends Command
 
         $filenames = array_map(
             fn (string $raw): string => $this->getFacade()->sanitizeFilename($raw),
-            $inputFileNames
+            $inputFileNames,
         );
 
         /** @var string $path */
@@ -48,7 +48,7 @@ final class MakeFileCommand extends Command
             $absolutePath = $this->getFacade()->generateFileContent(
                 $commandArguments,
                 $filename,
-                $shortName
+                $shortName,
             );
             $output->writeln("> Path '{$absolutePath}' created successfully");
         }

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -39,7 +39,7 @@ final class MakeModuleCommand extends Command
             $fullPath = $this->getFacade()->generateFileContent(
                 $commandArguments,
                 $filename,
-                $shortName
+                $shortName,
             );
             $output->writeln("> Path '{$fullPath}' created successfully");
         }

--- a/src/Framework/AbstractConfig.php
+++ b/src/Framework/AbstractConfig.php
@@ -18,13 +18,9 @@ abstract class AbstractConfig
     }
 
     /**
-     * @param null|mixed $default
-     *
      * @throws ConfigException
-     *
-     * @return mixed
      */
-    protected function get(string $key, $default = Config::DEFAULT_CONFIG_VALUE)
+    protected function get(string $key, mixed $default = Config::DEFAULT_CONFIG_VALUE): mixed
     {
         return Config::getInstance()->get($key, $default);
     }

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -19,10 +19,8 @@ abstract class AbstractFactory
 
     /**
      * @throws ContainerKeyNotFoundException
-     *
-     * @return mixed
      */
-    protected function getProvidedDependency(string $key)
+    protected function getProvidedDependency(string $key): mixed
     {
         return $this->getContainer()->get($key);
     }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -194,7 +194,7 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function buildMappingInterfaces(
         MappingInterfacesBuilder $builder,
-        array $externalServices
+        array $externalServices,
     ): MappingInterfacesBuilder {
         if ($this->mappingInterfacesBuilder) {
             $builder = $this->mappingInterfacesBuilder;
@@ -433,7 +433,7 @@ final class SetupGacela extends AbstractSetupGacela
                 $this->servicesToExtend[$serviceId] ??= [];
                 $this->servicesToExtend[$serviceId] = array_merge(
                     $this->servicesToExtend[$serviceId],
-                    $otherServiceToExtend
+                    $otherServiceToExtend,
                 );
             }
         }
@@ -495,10 +495,7 @@ final class SetupGacela extends AbstractSetupGacela
         return $this;
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function markPropertyChanged(string $name, $value): void
+    private function markPropertyChanged(string $name, mixed $value): void
     {
         $this->changedProperties[$name] = ($value !== null);
     }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -24,7 +24,7 @@ interface SetupGacelaInterface
      */
     public function buildMappingInterfaces(
         MappingInterfacesBuilder $builder,
-        array $externalServices
+        array $externalServices,
     ): MappingInterfacesBuilder;
 
     /**

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -47,14 +47,14 @@ abstract class AbstractClassResolver
     /**
      * @param object|class-string $caller
      */
-    abstract public function resolve($caller): ?object;
+    abstract public function resolve(object|string $caller): ?object;
 
     abstract protected function getResolvableType(): string;
 
     /**
      * @param object|class-string $caller
      */
-    protected function doResolve($caller, ?string $previousCacheKey = null): ?object
+    protected function doResolve(object|string $caller, ?string $previousCacheKey = null): ?object
     {
         $classInfo = ClassInfo::from($caller, $this->getResolvableType());
         $cacheKey = $previousCacheKey ?? $classInfo->getCacheKey();
@@ -104,7 +104,7 @@ abstract class AbstractClassResolver
     {
         return $this->getClassNameFinder()->findClassName(
             $classInfo,
-            $this->getPossibleResolvableTypes()
+            $this->getPossibleResolvableTypes(),
         );
     }
 
@@ -112,7 +112,7 @@ abstract class AbstractClassResolver
     {
         if (self::$classNameFinder === null) {
             self::$classNameFinder = (new ClassResolverFactory(
-                Config::getInstance()->getSetupGacela()
+                Config::getInstance()->getSetupGacela(),
             ))->createClassNameFinder();
         }
 

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -11,11 +11,9 @@ abstract class AbstractPhpFileCache implements CacheInterface
     /** @var array<class-string,array<string,string>> */
     private static array $cache = [];
 
-    private string $cacheDir;
-
-    public function __construct(string $cacheDir)
-    {
-        $this->cacheDir = $cacheDir;
+    public function __construct(
+        private string $cacheDir,
+    ) {
         self::$cache[static::class] = $this->getExistingCache();
     }
 
@@ -50,7 +48,7 @@ abstract class AbstractPhpFileCache implements CacheInterface
 
         $fileContent = sprintf(
             '<?php return %s;',
-            var_export(self::$cache[static::class], true)
+            var_export(self::$cache[static::class], true),
         );
 
         file_put_contents($this->getAbsoluteCacheFilename(), $fileContent);

--- a/src/Framework/ClassResolver/Cache/GacelaFileCache.php
+++ b/src/Framework/ClassResolver/Cache/GacelaFileCache.php
@@ -14,11 +14,9 @@ final class GacelaFileCache
 
     private static ?bool $isEnabled = null;
 
-    private ConfigInterface $config;
-
-    public function __construct(ConfigInterface $config)
-    {
-        $this->config = $config;
+    public function __construct(
+        private ConfigInterface $config,
+    ) {
     }
 
     /**

--- a/src/Framework/ClassResolver/Cache/InMemoryCache.php
+++ b/src/Framework/ClassResolver/Cache/InMemoryCache.php
@@ -9,11 +9,9 @@ final class InMemoryCache implements CacheInterface
     /** @var array<string, array<string,string>> */
     private static array $cache = [];
 
-    private string $key;
-
-    public function __construct(string $key)
-    {
-        $this->key = $key;
+    public function __construct(
+        private string $key,
+    ) {
     }
 
     /**

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -17,27 +17,18 @@ final class ClassInfo implements ClassInfoInterface
     /** @var array<string,array<string,self>> */
     private static array $callerClassCache;
 
-    private string $callerModuleNamespace;
-    private string $callerModuleName;
-    private string $cacheKey;
-    private string $resolvableType;
-
     public function __construct(
-        string $callerModuleNamespace,
-        string $callerModuleName,
-        string $cacheKey,
-        string $resolvableType = ''
+        private string $callerModuleNamespace,
+        private string $callerModuleName,
+        private string $cacheKey,
+        private string $resolvableType = '',
     ) {
-        $this->callerModuleNamespace = $callerModuleNamespace;
-        $this->callerModuleName = $callerModuleName;
-        $this->cacheKey = $cacheKey;
-        $this->resolvableType = $resolvableType;
     }
 
     /**
      * @param object|class-string $caller
      */
-    public static function from($caller, string $resolvableType = ''): self
+    public static function from(object|string $caller, string $resolvableType = ''): self
     {
         if (is_object($caller)) {
             return self::fromObject($caller, $resolvableType);
@@ -95,7 +86,7 @@ final class ClassInfo implements ClassInfoInterface
         $filepath = is_string($lastCallerClassPart) ? $lastCallerClassPart : '';
         $filename = self::normalizeFilename($filepath);
 
-        if (strpos($filepath, 'anonymous') !== false) {
+        if (str_contains($filepath, 'anonymous')) {
             $callerClassParts = [
                 self::MODULE_NAME_ANONYMOUS . '\\' . $filename,
                 $filepath,

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -17,30 +17,16 @@ final class ClassNameFinder implements ClassNameFinderInterface
 {
     use EventDispatchingCapabilities;
 
-    private ClassValidatorInterface $classValidator;
-
-    /** @var list<FinderRuleInterface> */
-    private array $finderRules;
-
-    private CacheInterface $cache;
-
-    /** @var list<string> */
-    private array $projectNamespaces;
-
     /**
      * @param list<FinderRuleInterface> $finderRules
      * @param list<string> $projectNamespaces
      */
     public function __construct(
-        ClassValidatorInterface $classValidator,
-        array $finderRules,
-        CacheInterface $cache,
-        array $projectNamespaces
+        private ClassValidatorInterface $classValidator,
+        private array $finderRules,
+        private CacheInterface $cache,
+        private array $projectNamespaces,
     ) {
-        $this->classValidator = $classValidator;
-        $this->finderRules = $finderRules;
-        $this->cache = $cache;
-        $this->projectNamespaces = $projectNamespaces;
     }
 
     /**

--- a/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefix.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefix.php
@@ -18,14 +18,14 @@ final class FinderRuleWithModulePrefix implements FinderRuleInterface
                 '\\%s\\%s\\%s',
                 trim($projectNamespace, '\\'),
                 $classInfo->getModuleName(),
-                $classInfo->getModuleName() . $resolvableType
+                $classInfo->getModuleName() . $resolvableType,
             );
         }
 
         return sprintf(
             '\\%s\\%s',
             $classInfo->getModuleName(),
-            $classInfo->getModuleName() . $resolvableType
+            $classInfo->getModuleName() . $resolvableType,
         );
     }
 }

--- a/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithoutModulePrefix.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithoutModulePrefix.php
@@ -15,14 +15,14 @@ final class FinderRuleWithoutModulePrefix implements FinderRuleInterface
                 '\\%s\\%s\\%s',
                 trim($projectNamespace, '\\'),
                 $classInfo->getModuleName(),
-                $resolvableType
+                $resolvableType,
             );
         }
 
         return sprintf(
             '\\%s\\%s',
             $classInfo->getModuleName(),
-            $resolvableType
+            $resolvableType,
         );
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -9,7 +9,7 @@ trait ClassResolverExceptionTrait
     /**
      * @param object|class-string $caller
      */
-    private function buildMessage($caller, string $resolvableType): string
+    private function buildMessage(object|string $caller, string $resolvableType): string
     {
         $callerClassInfo = ClassInfo::from($caller, $resolvableType);
 
@@ -22,12 +22,12 @@ trait ClassResolverExceptionTrait
 
         $message .= sprintf(
             'You can fix this by adding the missing `%s` to your module.',
-            $resolvableType
+            $resolvableType,
         ) . PHP_EOL;
 
         $message .= sprintf(
             'E.g. `%s`',
-            $this->findClassNameExample($callerClassInfo, $resolvableType)
+            $this->findClassNameExample($callerClassInfo, $resolvableType),
         ) . PHP_EOL;
 
         return $message;
@@ -38,7 +38,7 @@ trait ClassResolverExceptionTrait
         return sprintf(
             '\\%s\\%s',
             $classInfo->getModuleNamespace(),
-            $resolvableType
+            $resolvableType,
         );
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverFactory.php
+++ b/src/Framework/ClassResolver/ClassResolverFactory.php
@@ -16,11 +16,9 @@ use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithoutModuleP
 
 final class ClassResolverFactory
 {
-    private SetupGacelaInterface $setupGacela;
-
-    public function __construct(SetupGacelaInterface $setupGacela)
-    {
-        $this->setupGacela = $setupGacela;
+    public function __construct(
+        private SetupGacelaInterface $setupGacela,
+    ) {
     }
 
     public function createClassNameFinder(): ClassNameFinderInterface
@@ -29,7 +27,7 @@ final class ClassResolverFactory
             $this->createClassValidator(),
             $this->createFinderRules(),
             $this->getCache(),
-            $this->getProjectNamespaces()
+            $this->getProjectNamespaces(),
         );
     }
 

--- a/src/Framework/ClassResolver/Config/ConfigResolver.php
+++ b/src/Framework/ClassResolver/Config/ConfigResolver.php
@@ -16,7 +16,7 @@ final class ConfigResolver extends AbstractClassResolver
      *
      * @throws ConfigNotFoundException
      */
-    public function resolve($caller): AbstractConfig
+    public function resolve(object|string $caller): AbstractConfig
     {
         /** @var ?AbstractConfig $resolved */
         $resolved = $this->doResolve($caller);

--- a/src/Framework/ClassResolver/DependencyProvider/DependencyProviderResolver.php
+++ b/src/Framework/ClassResolver/DependencyProvider/DependencyProviderResolver.php
@@ -14,7 +14,7 @@ final class DependencyProviderResolver extends AbstractClassResolver
      *
      * @throws DependencyProviderNotFoundException
      */
-    public function resolve($caller): AbstractDependencyProvider
+    public function resolve(object|string $caller): AbstractDependencyProvider
     {
         /** @var ?AbstractDependencyProvider $resolved */
         $resolved = $this->doResolve($caller);

--- a/src/Framework/ClassResolver/DependencyResolver/DependencyResolver.php
+++ b/src/Framework/ClassResolver/DependencyResolver/DependencyResolver.php
@@ -14,15 +14,12 @@ use function is_object;
 
 final class DependencyResolver
 {
-    /** @var array<class-string,class-string|callable|object> */
-    private array $mappingInterfaces;
-
     /**
      * @param array<class-string,class-string|callable|object> $mappingInterfaces
      */
-    public function __construct(array $mappingInterfaces)
-    {
-        $this->mappingInterfaces = $mappingInterfaces;
+    public function __construct(
+        private array $mappingInterfaces,
+    ) {
     }
 
     /**
@@ -51,10 +48,7 @@ final class DependencyResolver
         return $dependencies;
     }
 
-    /**
-     * @return mixed
-     */
-    private function resolveDependenciesRecursively(ReflectionParameter $parameter)
+    private function resolveDependenciesRecursively(ReflectionParameter $parameter): mixed
     {
         $this->checkInvalidArgumentParam($parameter);
 
@@ -95,10 +89,8 @@ final class DependencyResolver
 
     /**
      * @param class-string $paramTypeName
-     *
-     * @return mixed
      */
-    private function resolveClass(string $paramTypeName)
+    private function resolveClass(string $paramTypeName): mixed
     {
         /** @var mixed $mappedClass */
         $mappedClass = $this->mappingInterfaces[$paramTypeName] ?? null;

--- a/src/Framework/ClassResolver/DocBlockService/DocBlockParser.php
+++ b/src/Framework/ClassResolver/DocBlockService/DocBlockParser.php
@@ -14,7 +14,7 @@ final class DocBlockParser
 
         $lines = array_filter(
             explode(PHP_EOL, $docBlock),
-            static fn (string $l) => str_contains($l, $method)
+            static fn (string $l) => str_contains($l, $method),
         );
         /** @psalm-suppress RedundantCast */
         $lineSplit = (array)explode(' ', (string)reset($lines));

--- a/src/Framework/ClassResolver/DocBlockService/DocBlockServiceResolver.php
+++ b/src/Framework/ClassResolver/DocBlockService/DocBlockServiceResolver.php
@@ -8,11 +8,9 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 
 final class DocBlockServiceResolver extends AbstractClassResolver
 {
-    private string $resolvableType;
-
-    public function __construct(string $resolvableType)
-    {
-        $this->resolvableType = $resolvableType;
+    public function __construct(
+        private string $resolvableType,
+    ) {
     }
 
     /**
@@ -20,7 +18,7 @@ final class DocBlockServiceResolver extends AbstractClassResolver
      *
      * @throws DocBlockServiceNotFoundException
      */
-    public function resolve($caller): ?object
+    public function resolve(object|string $caller): ?object
     {
         $resolved = $this->doResolve($caller);
 

--- a/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
+++ b/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
@@ -28,7 +28,7 @@ final class UseBlockParser
 
         $lines = array_filter(
             explode(PHP_EOL, $phpCode),
-            static fn (string $l) => strncmp($l, 'use ', 4) === 0 && str_contains($l, $needle)
+            static fn (string $l) => strncmp($l, 'use ', 4) === 0 && str_contains($l, $needle),
         );
 
         /** @psalm-suppress RedundantCast */
@@ -41,7 +41,7 @@ final class UseBlockParser
     {
         $lines = array_filter(
             explode(PHP_EOL, $phpCode),
-            static fn (string $l) => strncmp($l, 'namespace ', 10) === 0
+            static fn (string $l) => strncmp($l, 'namespace ', 10) === 0,
         );
         /** @psalm-suppress RedundantCast */
         $lineSplit = (array)explode(' ', (string)reset($lines));

--- a/src/Framework/ClassResolver/Facade/FacadeResolver.php
+++ b/src/Framework/ClassResolver/Facade/FacadeResolver.php
@@ -14,7 +14,7 @@ final class FacadeResolver extends AbstractClassResolver
      *
      * @throws FacadeNotFoundException
      */
-    public function resolve($caller): AbstractFacade
+    public function resolve(object|string $caller): AbstractFacade
     {
         /** @var ?AbstractFacade $resolved */
         $resolved = $this->doResolve($caller);

--- a/src/Framework/ClassResolver/Factory/FactoryResolver.php
+++ b/src/Framework/ClassResolver/Factory/FactoryResolver.php
@@ -16,7 +16,7 @@ final class FactoryResolver extends AbstractClassResolver
      *
      * @throws FactoryNotFoundException
      */
-    public function resolve($caller): AbstractFactory
+    public function resolve(object|string $caller): AbstractFactory
     {
         /** @var ?AbstractFactory $resolved */
         $resolved = $this->doResolve($caller);

--- a/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
+++ b/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
@@ -41,10 +41,7 @@ final class AnonymousGlobal
         return $instance;
     }
 
-    /**
-     * @return ?object
-     */
-    public static function getByKey(string $key)
+    public static function getByKey(string $key): ?object
     {
         return self::$cachedGlobalInstances[$key] ?? null;
     }
@@ -53,10 +50,8 @@ final class AnonymousGlobal
      * Add an anonymous class as 'Config', 'Factory' or 'DependencyProvider' as a global resource
      * bound to the context that it's pass as first argument. It can be the string-key
      * (from a non-class/file context) or the class/object itself.
-     *
-     * @param object|string $context
      */
-    public static function addGlobal($context, object $resolvedClass): void
+    public static function addGlobal(object|string $context, object $resolvedClass): void
     {
         $contextName = self::extractContextNameFromContext($context);
         $parentClass = get_parent_class($resolvedClass);
@@ -78,10 +73,7 @@ final class AnonymousGlobal
         self::addCachedGlobalInstance($key, $resolvedClass);
     }
 
-    /**
-     * @param object|string $context
-     */
-    private static function extractContextNameFromContext($context): string
+    private static function extractContextNameFromContext(object|string $context): string
     {
         if (is_string($context)) {
             return $context;
@@ -100,7 +92,7 @@ final class AnonymousGlobal
     {
         if (!in_array($type, self::ALLOWED_TYPES_FOR_ANONYMOUS_GLOBAL, true)) {
             throw new RuntimeException(
-                "Type '{$type}' not allowed. Valid types: " . implode(', ', self::ALLOWED_TYPES_FOR_ANONYMOUS_GLOBAL)
+                "Type '{$type}' not allowed. Valid types: " . implode(', ', self::ALLOWED_TYPES_FOR_ANONYMOUS_GLOBAL),
             );
         }
     }

--- a/src/Framework/ClassResolver/GlobalKey.php
+++ b/src/Framework/ClassResolver/GlobalKey.php
@@ -22,7 +22,7 @@ final class GlobalKey
         return sprintf(
             '\\%s\\%s',
             ltrim($matches['pre_namespace'], '\\'),
-            $resolvableType->resolvableType()
+            $resolvableType->resolvableType(),
         );
     }
 }

--- a/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
+++ b/src/Framework/ClassResolver/InstanceCreator/InstanceCreator.php
@@ -9,16 +9,14 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 final class InstanceCreator
 {
-    private GacelaConfigFileInterface $gacelaConfigFile;
-
     private ?DependencyResolver $dependencyResolver = null;
 
     /** @var array<class-string,list<mixed>> */
     private array $cachedDependencies = [];
 
-    public function __construct(GacelaConfigFileInterface $gacelaConfigFile)
-    {
-        $this->gacelaConfigFile = $gacelaConfigFile;
+    public function __construct(
+        private GacelaConfigFileInterface $gacelaConfigFile,
+    ) {
     }
 
     /**
@@ -44,7 +42,7 @@ final class InstanceCreator
     {
         if ($this->dependencyResolver === null) {
             $this->dependencyResolver = new DependencyResolver(
-                $this->gacelaConfigFile->getMappingInterfaces()
+                $this->gacelaConfigFile->getMappingInterfaces(),
             );
         }
 

--- a/src/Framework/ClassResolver/ResolvableType.php
+++ b/src/Framework/ClassResolver/ResolvableType.php
@@ -30,7 +30,7 @@ final class ResolvableType
     public static function fromClassName(string $className): self
     {
         foreach (self::DEFAULT_ALLOWED_TYPES as $resolvableType) {
-            if (strpos($className, $resolvableType) !== false) {
+            if (str_contains($className, $resolvableType)) {
                 $moduleName = substr($className, 0, strlen($className) - strlen($resolvableType));
                 return new self($resolvableType, $moduleName);
             }

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -17,8 +17,6 @@ final class Config implements ConfigInterface
 
     private static ?EventDispatcherInterface $eventDispatcher = null;
 
-    private SetupGacelaInterface $setup;
-
     private ?ConfigFactory $configFactory = null;
 
     private ?string $appRootDir = null;
@@ -26,9 +24,9 @@ final class Config implements ConfigInterface
     /** @var array<string,mixed> */
     private array $config = [];
 
-    private function __construct(SetupGacelaInterface $setup)
-    {
-        $this->setup = $setup;
+    private function __construct(
+        private SetupGacelaInterface $setup,
+    ) {
     }
 
     public static function createWithSetup(SetupGacelaInterface $setup): self
@@ -68,13 +66,9 @@ final class Config implements ConfigInterface
     }
 
     /**
-     * @param null|mixed $default
-     *
      * @throws ConfigException
-     *
-     * @return mixed
      */
-    public function get(string $key, $default = self::DEFAULT_CONFIG_VALUE)
+    public function get(string $key, mixed $default = self::DEFAULT_CONFIG_VALUE): mixed
     {
         if (empty($this->config)) {
             $this->init();
@@ -134,7 +128,7 @@ final class Config implements ConfigInterface
         if ($this->configFactory === null) {
             $this->configFactory = new ConfigFactory(
                 $this->getAppRootDir(),
-                $this->getSetupGacela()
+                $this->getSetupGacela(),
             );
         }
 

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -18,14 +18,10 @@ final class ConfigFactory extends AbstractFactory
     private const GACELA_PHP_CONFIG_FILENAME = 'gacela';
     private const GACELA_PHP_CONFIG_EXTENSION = '.php';
 
-    private string $appRootDir;
-
-    private SetupGacelaInterface $setup;
-
-    public function __construct(string $appRootDir, SetupGacelaInterface $setup)
-    {
-        $this->appRootDir = $appRootDir;
-        $this->setup = $setup;
+    public function __construct(
+        private string $appRootDir,
+        private SetupGacelaInterface $setup,
+    ) {
     }
 
     public function createConfigLoader(): ConfigLoader
@@ -57,7 +53,7 @@ final class ConfigFactory extends AbstractFactory
         return array_reduce(
             $gacelaConfigFiles,
             static fn (GacelaConfigFileInterface $carry, GacelaConfigFileInterface $item) => $carry->combine($item),
-            (new GacelaConfigFromBootstrapFactory($this->setup))->createGacelaFileConfig()
+            (new GacelaConfigFromBootstrapFactory($this->setup))->createGacelaFileConfig(),
         );
     }
 
@@ -72,7 +68,7 @@ final class ConfigFactory extends AbstractFactory
             '%s/%s%s',
             $this->appRootDir,
             self::GACELA_PHP_CONFIG_FILENAME,
-            self::GACELA_PHP_CONFIG_EXTENSION
+            self::GACELA_PHP_CONFIG_EXTENSION,
         );
     }
 
@@ -83,7 +79,7 @@ final class ConfigFactory extends AbstractFactory
             $this->appRootDir,
             self::GACELA_PHP_CONFIG_FILENAME,
             $this->env(),
-            self::GACELA_PHP_CONFIG_EXTENSION
+            self::GACELA_PHP_CONFIG_EXTENSION,
         );
     }
 

--- a/src/Framework/Config/ConfigInterface.php
+++ b/src/Framework/Config/ConfigInterface.php
@@ -12,13 +12,11 @@ interface ConfigInterface
     public const DEFAULT_CONFIG_VALUE = 'Gacela\Framework\Config::DEFAULT_CONFIG_VALUE';
 
     /**
-     * @param null|mixed $default
-     *
      * @throws ConfigException
      *
      * @return mixed
      */
-    public function get(string $key, $default = self::DEFAULT_CONFIG_VALUE);
+    public function get(string $key, mixed $default = self::DEFAULT_CONFIG_VALUE);
 
     public function getSetupGacela(): SetupGacelaInterface;
 

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -9,20 +9,11 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 
 final class ConfigLoader
 {
-    private GacelaConfigFileInterface $gacelaConfigFile;
-
-    private PathFinderInterface $pathFinder;
-
-    private PathNormalizerInterface $pathNormalizer;
-
     public function __construct(
-        GacelaConfigFileInterface $gacelaConfigFile,
-        PathFinderInterface $pathFinder,
-        PathNormalizerInterface $configPathGenerator
+        private GacelaConfigFileInterface $gacelaConfigFile,
+        private PathFinderInterface $pathFinder,
+        private PathNormalizerInterface $pathNormalizer,
     ) {
-        $this->gacelaConfigFile = $gacelaConfigFile;
-        $this->pathFinder = $pathFinder;
-        $this->pathNormalizer = $configPathGenerator;
     }
 
     /**
@@ -84,7 +75,7 @@ final class ConfigLoader
     private function readAbsolutePatternPath(
         string $pattern,
         GacelaConfigItem $configItem,
-        array &$cacheConfigFileContent
+        array &$cacheConfigFileContent,
     ): array {
         $matchingPattern = $this->pathFinder->matchingPattern($pattern);
         $excludePattern = [$this->normalizePathLocal($configItem)];

--- a/src/Framework/Config/FileIo.php
+++ b/src/Framework/Config/FileIo.php
@@ -11,10 +11,7 @@ final class FileIo implements FileIoInterface
         return file_exists($filePath);
     }
 
-    /**
-     * @return mixed
-     */
-    public function include(string $filePath)
+    public function include(string $filePath): mixed
     {
         /** @psalm-suppress UnresolvableInclude */
         return include $filePath;

--- a/src/Framework/Config/FileIoInterface.php
+++ b/src/Framework/Config/FileIoInterface.php
@@ -8,8 +8,5 @@ interface FileIoInterface
 {
     public function existsFile(string $filePath): bool;
 
-    /**
-     * @return mixed
-     */
-    public function include(string $filePath);
+    public function include(string $filePath): mixed;
 }

--- a/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/ConfigBuilder.php
@@ -20,7 +20,7 @@ final class ConfigBuilder
      * @param string $pathLocal define the path where Gacela will read the local config file
      * @param class-string<ConfigReaderInterface>|ConfigReaderInterface|null $reader Define the reader class which will read and parse the config files
      */
-    public function add(string $path, string $pathLocal = '', $reader = null): self
+    public function add(string $path, string $pathLocal = '', string|ConfigReaderInterface $reader = null): self
     {
         $readerInstance = $this->normalizeReader($reader);
 
@@ -40,7 +40,7 @@ final class ConfigBuilder
     /**
      * @param class-string<ConfigReaderInterface>|ConfigReaderInterface|null $reader
      */
-    private function normalizeReader($reader): ConfigReaderInterface
+    private function normalizeReader(string|ConfigReaderInterface|null $reader): ConfigReaderInterface
     {
         if ($reader instanceof ConfigReaderInterface) {
             return $reader;

--- a/src/Framework/Config/GacelaConfigBuilder/MappingInterfacesBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/MappingInterfacesBuilder.php
@@ -11,9 +11,9 @@ final class MappingInterfacesBuilder
 
     /**
      * @param class-string $key
-     * @param class-string|object|callable $value
+     * @param callable|object|class-string $value
      */
-    public function bind(string $key, $value): self
+    public function bind(string $key, callable|object|string $value): self
     {
         $this->mapping[$key] = $value;
 

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -14,11 +14,9 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryInterface
 {
-    private SetupGacelaInterface $bootstrapSetup;
-
-    public function __construct(SetupGacelaInterface $bootstrapSetup)
-    {
-        $this->bootstrapSetup = $bootstrapSetup;
+    public function __construct(
+        private SetupGacelaInterface $bootstrapSetup,
+    ) {
     }
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -20,20 +20,11 @@ use function is_callable;
 
 final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFactoryInterface
 {
-    private string $gacelaPhpPath;
-
-    private SetupGacelaInterface $bootstrapSetup;
-
-    private FileIoInterface $fileIo;
-
     public function __construct(
-        string $gacelaPhpPath,
-        SetupGacelaInterface $bootstrapSetup,
-        FileIoInterface $fileIo
+        private string $gacelaPhpPath,
+        private SetupGacelaInterface $bootstrapSetup,
+        private FileIoInterface $fileIo,
     ) {
-        $this->gacelaPhpPath = $gacelaPhpPath;
-        $this->bootstrapSetup = $bootstrapSetup;
-        $this->fileIo = $fileIo;
     }
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigItem.php
@@ -16,7 +16,7 @@ final class GacelaConfigItem
     public function __construct(
         string $path,
         string $pathLocal = '',
-        ?ConfigReaderInterface $reader = null
+        ?ConfigReaderInterface $reader = null,
     ) {
         $this->path = $path;
         $this->pathLocal = $pathLocal;

--- a/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
+++ b/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
@@ -12,15 +12,12 @@ final class AbsolutePathNormalizer implements PathNormalizerInterface
     public const WITHOUT_SUFFIX = 'WITHOUT_SUFFIX';
     public const WITH_SUFFIX = 'WITH_SUFFIX';
 
-    /** @var array<string,AbsolutePathStrategyInterface> */
-    private array $absolutePathStrategies;
-
     /**
      * @param array<string,AbsolutePathStrategyInterface> $absolutePathStrategies
      */
-    public function __construct(array $absolutePathStrategies)
-    {
-        $this->absolutePathStrategies = $absolutePathStrategies;
+    public function __construct(
+        private array $absolutePathStrategies,
+    ) {
     }
 
     public function normalizePathPattern(GacelaConfigItem $configItem): string

--- a/src/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategy.php
@@ -6,16 +6,10 @@ namespace Gacela\Framework\Config\PathNormalizer;
 
 final class WithSuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
 {
-    private string $appRootDir;
-
-    private string $configFileNameSuffix;
-
     public function __construct(
-        string $appRootDir,
-        string $configFileNameSuffix = ''
+        private string $appRootDir,
+        private string $configFileNameSuffix = '',
     ) {
-        $this->appRootDir = $appRootDir;
-        $this->configFileNameSuffix = $configFileNameSuffix;
     }
 
     public function generateAbsolutePath(string $relativePath): string
@@ -39,7 +33,7 @@ final class WithSuffixAbsolutePathStrategy implements AbsolutePathStrategyInterf
         return sprintf(
             '%s/%s',
             rtrim($this->appRootDir, '/'),
-            ltrim($relativePathWithFileSuffix, '/')
+            ltrim($relativePathWithFileSuffix, '/'),
         );
     }
 }

--- a/src/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategy.php
+++ b/src/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategy.php
@@ -6,11 +6,9 @@ namespace Gacela\Framework\Config\PathNormalizer;
 
 final class WithoutSuffixAbsolutePathStrategy implements AbsolutePathStrategyInterface
 {
-    private string $appRootDir;
-
-    public function __construct(string $appRootDir)
-    {
-        $this->appRootDir = $appRootDir;
+    public function __construct(
+        private string $appRootDir,
+    ) {
     }
 
     public function generateAbsolutePath(string $relativePath): string
@@ -18,7 +16,7 @@ final class WithoutSuffixAbsolutePathStrategy implements AbsolutePathStrategyInt
         return sprintf(
             '%s/%s',
             rtrim($this->appRootDir, '/'),
-            ltrim($relativePath, '/')
+            ltrim($relativePath, '/'),
         );
     }
 }

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -46,7 +46,7 @@ final class Container implements ContainerInterface
         return Locator::getInstance();
     }
 
-    public function set(string $id, $service): void
+    public function set(string $id, mixed $service): void
     {
         if (isset($this->frozenServices[$id])) {
             throw ContainerException::serviceFrozen($id);
@@ -68,10 +68,8 @@ final class Container implements ContainerInterface
 
     /**
      * @throws ContainerKeyNotFoundException
-     *
-     * @return mixed
      */
-    public function get(string $id)
+    public function get(string $id): mixed
     {
         if (!$this->has($id)) {
             throw new ContainerKeyNotFoundException($this, $id);
@@ -160,10 +158,8 @@ final class Container implements ContainerInterface
 
     /**
      * @psalm-suppress MissingClosureReturnType,MixedAssignment
-     *
-     * @param mixed $factory
      */
-    private function generateExtendedService(Closure $service, $factory): Closure
+    private function generateExtendedService(Closure $service, mixed $factory): Closure
     {
         if (is_callable($factory)) {
             return static function (self $container) use ($service, $factory) {

--- a/src/Framework/Container/ContainerInterface.php
+++ b/src/Framework/Container/ContainerInterface.php
@@ -15,10 +15,8 @@ interface ContainerInterface
      * Unless it is protected, in such a case it will get the raw service as it was set.
      *
      * @throws ContainerKeyNotFoundException
-     *
-     * @return mixed
      */
-    public function get(string $id);
+    public function get(string $id): mixed;
 
     /**
      * Check if a service exists.
@@ -28,11 +26,9 @@ interface ContainerInterface
     /**
      * Set a new service. You cannot override an existing service, but you can extend it.
      *
-     * @param mixed $service
-     *
      * @throws ContainerException
      */
-    public function set(string $id, $service): void;
+    public function set(string $id, mixed $service): void;
 
     /**
      * Remove a known service.

--- a/src/Framework/Container/Exception/ContainerKeyNotFoundException.php
+++ b/src/Framework/Container/Exception/ContainerKeyNotFoundException.php
@@ -9,10 +9,7 @@ use RuntimeException;
 
 final class ContainerKeyNotFoundException extends RuntimeException
 {
-    /**
-     * @param object $caller
-     */
-    public function __construct($caller, string $key)
+    public function __construct(object $caller, string $key)
     {
         $classInfo = ClassInfo::from($caller);
 
@@ -26,7 +23,7 @@ final class ContainerKeyNotFoundException extends RuntimeException
         $message .= sprintf(
             'You can fix this by adding the key "%s" to your "%sDependencyProvider"',
             $key,
-            $callerClassInfo->getModuleName()
+            $callerClassInfo->getModuleName(),
         );
 
         return $message;

--- a/src/Framework/DocBlockResolver/DocBlockResolvable.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolvable.php
@@ -16,9 +16,9 @@ final class DocBlockResolvable
      */
     public function __construct(string $className, string $resolvableType)
     {
-        $this->resolvableType = $resolvableType;
         /** @psalm-suppress PropertyTypeCoercion */
         $this->className = '\\' . ltrim($className, '\\'); // @phpstan-ignore-line
+        $this->resolvableType = $resolvableType;
     }
 
     /**

--- a/src/Framework/DocBlockResolver/DocBlockResolver.php
+++ b/src/Framework/DocBlockResolver/DocBlockResolver.php
@@ -116,7 +116,7 @@ final class DocBlockResolver
             : $resolvableType;
 
         foreach (self::SPECIAL_RESOLVABLE_TYPES as $specialName) {
-            if (strpos($result, $specialName) !== false) {
+            if (str_contains($result, $specialName)) {
                 return $specialName;
             }
         }

--- a/src/Framework/Event/ClassResolver/AbstractGacelaClassResolverEvent.php
+++ b/src/Framework/Event/ClassResolver/AbstractGacelaClassResolverEvent.php
@@ -12,11 +12,9 @@ use function get_class;
 
 abstract class AbstractGacelaClassResolverEvent implements GacelaEventInterface
 {
-    private ClassInfo $classInfo;
-
-    public function __construct(ClassInfo $classInfo)
-    {
-        $this->classInfo = $classInfo;
+    public function __construct(
+        private ClassInfo $classInfo,
+    ) {
     }
 
     public function classInfo(): ClassInfoInterface
@@ -29,7 +27,7 @@ abstract class AbstractGacelaClassResolverEvent implements GacelaEventInterface
         return sprintf(
             '%s - %s',
             get_class($this),
-            $this->classInfo->toString()
+            $this->classInfo->toString(),
         );
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameCachedFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameCachedFoundEvent.php
@@ -8,11 +8,9 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 final class ClassNameCachedFoundEvent implements GacelaEventInterface
 {
-    private string $className;
-
-    public function __construct(string $className)
-    {
-        $this->className = $className;
+    public function __construct(
+        private string $className,
+    ) {
     }
 
     public function toString(): string

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameInvalidCandidateFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameInvalidCandidateFoundEvent.php
@@ -8,11 +8,9 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 final class ClassNameInvalidCandidateFoundEvent implements GacelaEventInterface
 {
-    private string $className;
-
-    public function __construct(string $className)
-    {
-        $this->className = $className;
+    public function __construct(
+        private string $className,
+    ) {
     }
 
     public function toString(): string

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameNotFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameNotFoundEvent.php
@@ -9,18 +9,13 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 final class ClassNameNotFoundEvent implements GacelaEventInterface
 {
-    private ClassInfo $classInfo;
-
-    /** @var list<string> */
-    private array $resolvableTypes;
-
     /**
      * @param list<string> $resolvableTypes
      */
-    public function __construct(ClassInfo $classInfo, array $resolvableTypes)
-    {
-        $this->classInfo = $classInfo;
-        $this->resolvableTypes = $resolvableTypes;
+    public function __construct(
+        private ClassInfo $classInfo,
+        private array $resolvableTypes,
+    ) {
     }
 
     public function toString(): string
@@ -29,7 +24,7 @@ final class ClassNameNotFoundEvent implements GacelaEventInterface
             '%s - %s - %s',
             self::class,
             $this->classInfo->toString(),
-            implode(',', $this->resolvableTypes)
+            implode(',', $this->resolvableTypes),
         );
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameValidCandidateFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameValidCandidateFoundEvent.php
@@ -8,11 +8,9 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 final class ClassNameValidCandidateFoundEvent implements GacelaEventInterface
 {
-    private string $className;
-
-    public function __construct(string $className)
-    {
-        $this->className = $className;
+    public function __construct(
+        private string $className,
+    ) {
     }
 
     public function toString(): string

--- a/src/Framework/Event/ConfigReader/ReadPhpConfigEvent.php
+++ b/src/Framework/Event/ConfigReader/ReadPhpConfigEvent.php
@@ -10,11 +10,9 @@ use function get_class;
 
 final class ReadPhpConfigEvent implements GacelaEventInterface
 {
-    private string $absolutePath;
-
-    public function __construct(string $absolutePath)
-    {
-        $this->absolutePath = $absolutePath;
+    public function __construct(
+        private string $absolutePath,
+    ) {
     }
 
     public function absolutePath(): string
@@ -27,7 +25,7 @@ final class ReadPhpConfigEvent implements GacelaEventInterface
         return sprintf(
             '%s - %s',
             get_class($this),
-            $this->absolutePath
+            $this->absolutePath,
         );
     }
 }

--- a/src/Framework/Exception/ConfigException.php
+++ b/src/Framework/Exception/ConfigException.php
@@ -10,10 +10,6 @@ final class ConfigException extends RuntimeException
 {
     public static function keyNotFound(string $key, string $class): self
     {
-        return new self(sprintf(
-            'Could not find config key "%s" in "%s"',
-            $key,
-            $class
-        ));
+        return new self(sprintf('Could not find config key "%s" in "%s"', $key, $class));
     }
 }

--- a/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/AnonymousGlobal/AnonymousGlobalsBench.php
@@ -44,7 +44,7 @@ final class AnonymousGlobalsBench
                 {
                     return ['1', 2, [3]];
                 }
-            }
+            },
         );
     }
 
@@ -57,7 +57,7 @@ final class AnonymousGlobalsBench
                 {
                     $container->set('key', 'value');
                 }
-            }
+            },
         );
     }
 
@@ -80,7 +80,7 @@ final class AnonymousGlobalsBench
 
                         public function __construct(
                             array $configValues,
-                            string $valueFromDependencyProvider
+                            string $valueFromDependencyProvider,
                         ) {
                             $this->configValues = $configValues;
                             $this->valueFromDependencyProvider = $valueFromDependencyProvider;
@@ -97,7 +97,7 @@ final class AnonymousGlobalsBench
                         }
                     };
                 }
-            }
+            },
         );
     }
 

--- a/tests/Benchmark/Framework/ClassResolver/NormalModule/Domain/DomainClass.php
+++ b/tests/Benchmark/Framework/ClassResolver/NormalModule/Domain/DomainClass.php
@@ -11,7 +11,7 @@ final class DomainClass
 
     public function __construct(
         array $configValues,
-        string $valueFromDependencyProvider
+        string $valueFromDependencyProvider,
     ) {
         $this->configValues = $configValues;
         $this->valueFromDependencyProvider = $valueFromDependencyProvider;

--- a/tests/Feature/Framework/AnonymousGlobalExtendsExistingClass/FeatureTest.php
+++ b/tests/Feature/Framework/AnonymousGlobalExtendsExistingClass/FeatureTest.php
@@ -27,7 +27,7 @@ final class FeatureTest extends TestCase
                     $this->getConfigValue();
                     return new StringValue('other');
                 }
-            }
+            },
         );
 
         $facade = new Module\Facade();

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/FeatureTest.php
@@ -31,7 +31,7 @@ final class FeatureTest extends TestCase
                 'float' => 1.2,
                 'array' => ['array'],
             ],
-            $this->facade->generateResolvedClass()
+            $this->facade->generateResolvedClass(),
         );
     }
 
@@ -39,7 +39,7 @@ final class FeatureTest extends TestCase
     {
         self::assertSame(
             AbstractFromAnonymousClass::class,
-            $this->facade->generateResolveAbstractFromAnonymousClass()
+            $this->facade->generateResolveAbstractFromAnonymousClass(),
         );
     }
 
@@ -47,7 +47,7 @@ final class FeatureTest extends TestCase
     {
         self::assertSame(
             AbstractFromCallable::class,
-            $this->facade->generateResolveAbstractFromCallable()
+            $this->facade->generateResolveAbstractFromCallable(),
         );
     }
 
@@ -55,7 +55,7 @@ final class FeatureTest extends TestCase
     {
         self::assertSame(
             InterfaceFromAnonymousClass::class,
-            $this->facade->generateResolveInterfaceFromAnonymousClass()
+            $this->facade->generateResolveInterfaceFromAnonymousClass(),
         );
     }
 
@@ -63,7 +63,7 @@ final class FeatureTest extends TestCase
     {
         self::assertSame(
             InterfaceFromCallable::class,
-            $this->facade->generateResolveInterfaceFromCallable()
+            $this->facade->generateResolveInterfaceFromCallable(),
         );
     }
 }

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/LocalConfig/Domain/Service.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/LocalConfig/Domain/Service.php
@@ -6,24 +6,13 @@ namespace GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\Local
 
 final class Service
 {
-    private AbstractClass $resolvedClass;
-    private AbstractFromAnonymousClass $resolveAbstractFromAnonymousClass;
-    private AbstractFromCallable $resolveAbstractFromCallable;
-    private InterfaceFromAnonymousClass $resolveInterfaceFromAnonymousClass;
-    private InterfaceFromCallable $resolveInterfaceFromCallable;
-
     public function __construct(
-        AbstractClass $resolvedClass,
-        AbstractFromAnonymousClass $resolveAbstractFromAnonymousClass,
-        AbstractFromCallable $resolvingAbstractAnonClassCallable,
-        InterfaceFromAnonymousClass $resolveInterfaceFromAnonymousClass,
-        InterfaceFromCallable $resolveInterfaceFromCallable
+        private AbstractClass $resolvedClass,
+        private AbstractFromAnonymousClass $resolveAbstractFromAnonymousClass,
+        private AbstractFromCallable $resolveAbstractFromCallable,
+        private InterfaceFromAnonymousClass $resolveInterfaceFromAnonymousClass,
+        private InterfaceFromCallable $resolveInterfaceFromCallable,
     ) {
-        $this->resolvedClass = $resolvedClass;
-        $this->resolveAbstractFromAnonymousClass = $resolveAbstractFromAnonymousClass;
-        $this->resolveAbstractFromCallable = $resolvingAbstractAnonClassCallable;
-        $this->resolveInterfaceFromAnonymousClass = $resolveInterfaceFromAnonymousClass;
-        $this->resolveInterfaceFromCallable = $resolveInterfaceFromCallable;
     }
 
     public function generateResolvedClass(): array

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/LocalConfig/Factory.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/LocalConfig/Factory.php
@@ -14,24 +14,13 @@ use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig
 
 final class Factory extends AbstractFactory
 {
-    private AbstractClass $resolvedClass;
-    private AbstractFromAnonymousClass $resolvingAbstractAnonClassFunction;
-    private AbstractFromCallable $resolvingAbstractAnonClassCallable;
-    private InterfaceFromAnonymousClass $resolvingAnonClassFunction;
-    private InterfaceFromCallable $resolvingAnonClassCallable;
-
     public function __construct(
-        AbstractClass $resolvedClass,
-        AbstractFromAnonymousClass $resolvingAbstractAnonClassFunction,
-        AbstractFromCallable $resolvingAbstractAnonClassCallable,
-        InterfaceFromAnonymousClass $resolvingAnonClassFunction,
-        InterfaceFromCallable $resolvingAnonClassCallable
+        private AbstractClass $resolvedClass,
+        private AbstractFromAnonymousClass $resolvingAbstractAnonClassFunction,
+        private AbstractFromCallable $resolvingAbstractAnonClassCallable,
+        private InterfaceFromAnonymousClass $resolvingAnonClassFunction,
+        private InterfaceFromCallable $resolvingAnonClassCallable,
     ) {
-        $this->resolvedClass = $resolvedClass;
-        $this->resolvingAbstractAnonClassFunction = $resolvingAbstractAnonClassFunction;
-        $this->resolvingAbstractAnonClassCallable = $resolvingAbstractAnonClassCallable;
-        $this->resolvingAnonClassFunction = $resolvingAnonClassFunction;
-        $this->resolvingAnonClassCallable = $resolvingAnonClassCallable;
     }
 
     public function createCompanyService(): Service
@@ -41,7 +30,7 @@ final class Factory extends AbstractFactory
             $this->resolvingAbstractAnonClassFunction,
             $this->resolvingAbstractAnonClassCallable,
             $this->resolvingAnonClassFunction,
-            $this->resolvingAnonClassCallable
+            $this->resolvingAnonClassCallable,
         );
     }
 }

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/LocalConfig/Infrastructure/ConcreteClass.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/LocalConfig/Infrastructure/ConcreteClass.php
@@ -8,19 +8,13 @@ use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig
 
 final class ConcreteClass extends AbstractClass
 {
-    private bool $bool;
-    private string $string;
-    private int $int;
-    private float $float;
-    private array $array;
-
-    public function __construct(bool $bool, string $string, int $int, float $float, array $array)
-    {
-        $this->bool = $bool;
-        $this->string = $string;
-        $this->int = $int;
-        $this->float = $float;
-        $this->array = $array;
+    public function __construct(
+        private bool $bool,
+        private string $string,
+        private int $int,
+        private float $float,
+        private array $array,
+    ) {
     }
 
     public function getTypes(): array

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/gacela.php
@@ -16,7 +16,7 @@ use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig
 return static fn (GacelaConfig $config) => $config
     ->addMappingInterface(
         AbstractClass::class,
-        new ConcreteClass(true, 'string', 1, 1.2, ['array'])
+        new ConcreteClass(true, 'string', 1, 1.2, ['array']),
     )
     // Resolve anonymous-classes/callables from abstract classes and interfaces
     ->addMappingInterface(
@@ -26,7 +26,7 @@ return static fn (GacelaConfig $config) => $config
             {
                 return AbstractFromAnonymousClass::class;
             }
-        }
+        },
     )
     ->addMappingInterface(
         AbstractFromCallable::class,
@@ -35,7 +35,7 @@ return static fn (GacelaConfig $config) => $config
             {
                 return AbstractFromCallable::class;
             }
-        }
+        },
     )
     ->addMappingInterface(
         InterfaceFromAnonymousClass::class,
@@ -44,7 +44,7 @@ return static fn (GacelaConfig $config) => $config
             {
                 return InterfaceFromAnonymousClass::class;
             }
-        }
+        },
     )
     ->addMappingInterface(
         InterfaceFromCallable::class,
@@ -53,5 +53,5 @@ return static fn (GacelaConfig $config) => $config
             {
                 return InterfaceFromCallable::class;
             }
-        }
+        },
     );

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
@@ -14,14 +14,14 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static fn (GacelaConfig $config) => $config
-            ->addExternalService('greeterGenerator', CorrectCompanyGenerator::class));
+            ->addExternalService('greeterGenerator', CorrectCompanyGenerator::class), );
     }
 
     public function test_mapping_interfaces_from_config(): void
     {
         self::assertSame(
             'Hello Gacela! Name: Chemaclass & Jesus',
-            (new LocalConfig\Facade())->generateCompanyAndName()
+            (new LocalConfig\Facade())->generateCompanyAndName(),
         );
     }
 }

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/LocalConfig/Domain/Greeter/CorrectCompanyGenerator.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/LocalConfig/Domain/Greeter/CorrectCompanyGenerator.php
@@ -8,15 +8,13 @@ use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalCon
 
 final class CorrectCompanyGenerator implements GreeterGeneratorInterface
 {
-    private CustomNameGenerator $nameGenerator;
-
     /**
      * @param CustomNameGenerator $nameGenerator This will be automagically resolved.
      *                                           See gacela.php in this Feature test.
      */
-    public function __construct(CustomNameGenerator $nameGenerator)
-    {
-        $this->nameGenerator = $nameGenerator;
+    public function __construct(
+        private CustomNameGenerator $nameGenerator,
+    ) {
     }
 
     public function company(string $name): string

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/LocalConfig/Domain/GreeterService.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/LocalConfig/Domain/GreeterService.php
@@ -6,11 +6,9 @@ namespace GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\Lo
 
 final class GreeterService
 {
-    private GreeterGeneratorInterface $greeter;
-
-    public function __construct(GreeterGeneratorInterface $greeter)
-    {
-        $this->greeter = $greeter;
+    public function __construct(
+        private GreeterGeneratorInterface $greeter,
+    ) {
     }
 
     public function generateCompanyAndName(): string

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/LocalConfig/Factory.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/LocalConfig/Factory.php
@@ -10,11 +10,9 @@ use GacelaTest\Feature\Framework\BindingInterfacesWithInnerDependencies\LocalCon
 
 final class Factory extends AbstractFactory
 {
-    private GreeterGeneratorInterface $greeterGenerator;
-
-    public function __construct(GreeterGeneratorInterface $greeterGenerator)
-    {
-        $this->greeterGenerator = $greeterGenerator;
+    public function __construct(
+        private GreeterGeneratorInterface $greeterGenerator,
+    ) {
     }
 
     public function createGreeterService(): GreeterService

--- a/tests/Feature/Framework/DocBlockServiceAware/FeatureTest.php
+++ b/tests/Feature/Framework/DocBlockServiceAware/FeatureTest.php
@@ -23,7 +23,7 @@ final class FeatureTest extends TestCase
 
         (new HelloCommand())->run(
             $this->createStub(InputInterface::class),
-            $output
+            $output,
         );
 
         $expected = <<<TXT

--- a/tests/Feature/Framework/DocBlockServiceAware/Module/Infrastructure/Command/RepositoryInSameNamespace.php
+++ b/tests/Feature/Framework/DocBlockServiceAware/Module/Infrastructure/Command/RepositoryInSameNamespace.php
@@ -8,11 +8,9 @@ use GacelaTest\Feature\Framework\DocBlockServiceAware\Module\Infrastructure\Pers
 
 final class RepositoryInSameNamespace
 {
-    private FakeDoctrineEntityManager $entityManager;
-
-    public function __construct(FakeDoctrineEntityManager $entityManager)
-    {
-        $this->entityManager = $entityManager;
+    public function __construct(
+        private FakeDoctrineEntityManager $entityManager,
+    ) {
     }
 
     public function findNameById(int $id): string

--- a/tests/Feature/Framework/DocBlockServiceAware/Module/Infrastructure/Persistence/CustomHelloRepository.php
+++ b/tests/Feature/Framework/DocBlockServiceAware/Module/Infrastructure/Persistence/CustomHelloRepository.php
@@ -6,11 +6,9 @@ namespace GacelaTest\Feature\Framework\DocBlockServiceAware\Module\Infrastructur
 
 final class CustomHelloRepository
 {
-    private FakeDoctrineEntityManager $entityManager;
-
-    public function __construct(FakeDoctrineEntityManager $entityManager)
-    {
-        $this->entityManager = $entityManager;
+    public function __construct(
+        private FakeDoctrineEntityManager $entityManager,
+    ) {
     }
 
     public function findNameById(int $id): string

--- a/tests/Feature/Framework/ExtendService/FeatureTest.php
+++ b/tests/Feature/Framework/ExtendService/FeatureTest.php
@@ -23,14 +23,14 @@ final class FeatureTest extends TestCase
                 DependencyProvider::ARRAY_AS_OBJECT,
                 static function (ArrayObject $arrayObject): void {
                     $arrayObject->append(3);
-                }
+                },
             );
 
             $config->extendService(
                 DependencyProvider::ARRAY_FROM_FUNCTION,
                 static function (ArrayObject $arrayObject): void {
                     $arrayObject->append(4);
-                }
+                },
             );
         });
 
@@ -41,7 +41,7 @@ final class FeatureTest extends TestCase
     {
         self::assertEquals(
             new ArrayObject([1, 2, 3]),
-            $this->facade->getArrayAsObject()
+            $this->facade->getArrayAsObject(),
         );
     }
 
@@ -49,7 +49,7 @@ final class FeatureTest extends TestCase
     {
         self::assertEquals(
             new ArrayObject([1, 2, 4]),
-            $this->facade->getArrayFromFunction()
+            $this->facade->getArrayFromFunction(),
         );
     }
 }

--- a/tests/Feature/Framework/FacadeAware/FeatureTest.php
+++ b/tests/Feature/Framework/FacadeAware/FeatureTest.php
@@ -25,7 +25,7 @@ final class FeatureTest extends TestCase
 
         $hiCommand->run(
             $this->createStub(InputInterface::class),
-            $output
+            $output,
         );
 
         self::assertSame('Hi', $output->fetch());

--- a/tests/Feature/Framework/FileCache/Module/Facade.php
+++ b/tests/Feature/Framework/FileCache/Module/Facade.php
@@ -6,6 +6,9 @@ namespace GacelaTest\Feature\Framework\FileCache\Module;
 
 use Gacela\Framework\AbstractFacade;
 
+/**
+ * @method Factory getFactory()
+ */
 final class Facade extends AbstractFacade
 {
     public function getName(): string

--- a/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Factory.php
+++ b/tests/Feature/Framework/GacelaConfigAddAppConfigKeyValues/Module/Factory.php
@@ -7,7 +7,7 @@ namespace GacelaTest\Feature\Framework\GacelaConfigAddAppConfigKeyValues\Module;
 use Gacela\Framework\AbstractFactory;
 
 /**
- * @method Config getConfig
+ * @method Config getConfig()
  */
 final class Factory extends AbstractFactory
 {

--- a/tests/Feature/Framework/MissingFile/MissingConfigFile/Facade.php
+++ b/tests/Feature/Framework/MissingFile/MissingConfigFile/Facade.php
@@ -7,6 +7,9 @@ namespace GacelaTest\Feature\Framework\MissingFile\MissingConfigFile;
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractFacade;
 
+/**
+ * @method Factory getFactory()
+ */
 final class Facade extends AbstractFacade
 {
     public function getConfig(): AbstractConfig

--- a/tests/Feature/Framework/MissingFile/MissingConfigFile/Factory.php
+++ b/tests/Feature/Framework/MissingFile/MissingConfigFile/Factory.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\MissingFile\MissingConfigFile;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+}

--- a/tests/Feature/Framework/ModuleWithExternalDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/ModuleWithExternalDependencies/FeatureTest.php
@@ -26,7 +26,7 @@ final class FeatureTest extends TestCase
                 'Hello, Gacela from Supplier.',
                 'Hello, Gacela from Dependent.',
             ],
-            $facade->greet('Gacela')
+            $facade->greet('Gacela'),
         );
     }
 }

--- a/tests/Feature/Framework/ModuleWithExternalDependencies/Supplier/Factory.php
+++ b/tests/Feature/Framework/ModuleWithExternalDependencies/Supplier/Factory.php
@@ -13,7 +13,7 @@ final class Factory extends AbstractFactory
     public function createGreeter(): HelloName
     {
         return new HelloName(
-            $this->getDependentFacade()
+            $this->getDependentFacade(),
         );
     }
 

--- a/tests/Feature/Framework/ModuleWithoutDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/ModuleWithoutDependencies/FeatureTest.php
@@ -20,7 +20,7 @@ final class FeatureTest extends TestCase
 
         self::assertEquals(
             ['Hello, Gacela from WithPrefix.'],
-            $facade->greet('Gacela')
+            $facade->greet('Gacela'),
         );
     }
 
@@ -30,7 +30,7 @@ final class FeatureTest extends TestCase
 
         self::assertEquals(
             ['Hello, Gacela from WithoutPrefix.'],
-            $facade->greet('Gacela')
+            $facade->greet('Gacela'),
         );
     }
 }

--- a/tests/Feature/Framework/UsingAbstractGacelaClassesByDefault/FeatureTest.php
+++ b/tests/Feature/Framework/UsingAbstractGacelaClassesByDefault/FeatureTest.php
@@ -20,7 +20,7 @@ final class FeatureTest extends TestCase
 
         self::assertStringContainsString(
             'tests/Feature/Framework/UsingAbstractGacelaClassesByDefault',
-            $facade->getAppRootDir()
+            $facade->getAppRootDir(),
         );
     }
 }

--- a/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
@@ -28,7 +28,7 @@ final class FeatureTest extends TestCase
                 'from-default-env-override' => 1,
                 'from-local-override' => 4,
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 
@@ -46,7 +46,7 @@ final class FeatureTest extends TestCase
                 'from-default-env-override' => 2,
                 'from-local-override' => 4,
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 
@@ -64,7 +64,7 @@ final class FeatureTest extends TestCase
                 'from-default-env-override' => 3,
                 'from-local-override' => 4,
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 }

--- a/tests/Feature/Framework/UsingConfigTypePhp/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigTypePhp/FeatureTest.php
@@ -25,7 +25,7 @@ final class FeatureTest extends TestCase
                 'local' => 3,
                 'override_from_local' => 4,
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 }

--- a/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
@@ -29,7 +29,7 @@ final class FeatureTest extends TestCase
                 'config_local' => 2,
                 'override' => 5,
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 }

--- a/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
+++ b/tests/Feature/Framework/UsingCustomSuffixTypes/FeatureTest.php
@@ -30,7 +30,7 @@ final class FeatureTest extends TestCase
                 'config-key' => 'config-value',
                 'provided-dependency' => 'dependency-value',
             ],
-            $commandA->execute()
+            $commandA->execute(),
         );
     }
 
@@ -43,7 +43,7 @@ final class FeatureTest extends TestCase
                 'config-key' => 'config-value',
                 'provided-dependency' => 'dependency-value',
             ],
-            $commandB->execute()
+            $commandB->execute(),
         );
     }
 
@@ -56,7 +56,7 @@ final class FeatureTest extends TestCase
                 'config-key' => 'config-value',
                 'provided-dependency' => 'dependency-value',
             ],
-            $commandC->execute()
+            $commandC->execute(),
         );
     }
 }

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
@@ -26,7 +26,7 @@ final class FeatureTest extends TestCase
                 'default_key' => 'from:default',
                 'key' => 'from:default',
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 
@@ -43,7 +43,7 @@ final class FeatureTest extends TestCase
                 'default_key' => 'from:default',
                 'key' => 'from:dev',
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 
@@ -60,7 +60,7 @@ final class FeatureTest extends TestCase
                 'default_key' => 'from:default',
                 'key' => 'from:prod',
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 
@@ -77,7 +77,7 @@ final class FeatureTest extends TestCase
                 'default_key' => 'from:default',
                 'key' => 'from:default',
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 }

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -31,7 +31,7 @@ final class FeatureTest extends TestCase
                 'override' => 4,
                 'local' => 5,
             ],
-            $facade->doSomething()
+            $facade->doSomething(),
         );
     }
 }

--- a/tests/Feature/Util/DirectoryUtil.php
+++ b/tests/Feature/Util/DirectoryUtil.php
@@ -19,7 +19,7 @@ final class DirectoryUtil
 
         $files = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($target, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
 
         /** @var SplFileInfo $file */

--- a/tests/Fixtures/SimpleEnvConfigReader.php
+++ b/tests/Fixtures/SimpleEnvConfigReader.php
@@ -36,7 +36,7 @@ final class SimpleEnvConfigReader implements ConfigReaderInterface
 
     private function canRead(string $absolutePath): bool
     {
-        return strpos($absolutePath, '.env') !== false
+        return str_contains($absolutePath, '.env')
             && is_file($absolutePath);
     }
 }

--- a/tests/Fixtures/StringValue.php
+++ b/tests/Fixtures/StringValue.php
@@ -6,11 +6,9 @@ namespace GacelaTest\Fixtures;
 
 final class StringValue implements StringValueInterface
 {
-    private string $value;
-
-    public function __construct(string $value = '')
-    {
-        $this->value = $value;
+    public function __construct(
+        private string $value = '',
+    ) {
     }
 
     public function setValue(string $value): void

--- a/tests/Integration/Framework/ClassResolver/InstanceCreator/InstanceCreatorTest.php
+++ b/tests/Integration/Framework/ClassResolver/InstanceCreator/InstanceCreatorTest.php
@@ -29,7 +29,7 @@ final class InstanceCreatorTest extends TestCase
 
         self::assertEquals(
             new CustomClass(),
-            $instanceCreator->createByClassName(CustomClass::class)
+            $instanceCreator->createByClassName(CustomClass::class),
         );
     }
 
@@ -44,7 +44,7 @@ final class InstanceCreatorTest extends TestCase
 
         self::assertEquals(
             new CustomClassWithDependencies(new StringValue('custom-string')),
-            $instanceCreator->createByClassName(CustomClassWithDependencies::class)
+            $instanceCreator->createByClassName(CustomClassWithDependencies::class),
         );
     }
 

--- a/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
@@ -66,7 +66,7 @@ final class ConfigFactoryTest extends TestCase
                 static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
                     $mappingInterfacesBuilder->bind(
                         CustomInterface::class,
-                        $externalServices['CustomClassFromExternalService']
+                        $externalServices['CustomClassFromExternalService'],
                     );
                 },
             )
@@ -109,7 +109,7 @@ final class ConfigFactoryTest extends TestCase
                 static function (MappingInterfacesBuilder $mappingInterfacesBuilder, array $externalServices): void {
                     $mappingInterfacesBuilder->bind(
                         AbstractCustom::class,
-                        $externalServices['CustomClassFromExternalService']
+                        $externalServices['CustomClassFromExternalService'],
                     );
                 },
             )

--- a/tests/Integration/Framework/GlobalServices/AnonymousClassesTest.php
+++ b/tests/Integration/Framework/GlobalServices/AnonymousClassesTest.php
@@ -61,7 +61,7 @@ final class AnonymousClassesTest extends TestCase
                 {
                     return [1, 2, 3, 4, 5];
                 }
-            }
+            },
         );
     }
 
@@ -88,7 +88,7 @@ final class AnonymousClassesTest extends TestCase
 
                         public function __construct(
                             object $myService,
-                            int ...$configValues
+                            int ...$configValues,
                         ) {
                             $this->myService = $myService;
                             $this->configValues = $configValues;
@@ -105,7 +105,7 @@ final class AnonymousClassesTest extends TestCase
                         }
                     };
                 }
-            }
+            },
         );
     }
 
@@ -123,7 +123,7 @@ final class AnonymousClassesTest extends TestCase
                         }
                     });
                 }
-            }
+            },
         );
     }
 }

--- a/tests/Unit/CodeGenerator/Domain/CommandArguments/CommandArgumentsParserTest.php
+++ b/tests/Unit/CodeGenerator/Domain/CommandArguments/CommandArgumentsParserTest.php
@@ -75,7 +75,7 @@ final class CommandArgumentsParserTest extends TestCase
     public function test_no_autoload_psr4_match_found(): void
     {
         $this->expectExceptionObject(
-            CommandArgumentsException::noAutoloadPsr4MatchFound('Unknown/Module', ['App'])
+            CommandArgumentsException::noAutoloadPsr4MatchFound('Unknown/Module', ['App']),
         );
 
         $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());

--- a/tests/Unit/CodeGenerator/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/CodeGenerator/Domain/FileContent/FileContentGeneratorTest.php
@@ -20,7 +20,7 @@ final class FileContentGeneratorTest extends TestCase
         $this->expectExceptionMessage("Unknown template for 'unknown_template'?");
         $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
-            'unknown_template'
+            'unknown_template',
         );
     }
 
@@ -41,7 +41,7 @@ final class FileContentGeneratorTest extends TestCase
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
-            FilenameSanitizer::FACADE
+            FilenameSanitizer::FACADE,
         );
 
         self::assertSame('Dir/DirFacade.php', $actualPath);
@@ -64,7 +64,7 @@ final class FileContentGeneratorTest extends TestCase
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
-            FilenameSanitizer::FACTORY
+            FilenameSanitizer::FACTORY,
         );
 
         self::assertSame('Dir/DirFactory.php', $actualPath);
@@ -87,7 +87,7 @@ final class FileContentGeneratorTest extends TestCase
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
-            FilenameSanitizer::CONFIG
+            FilenameSanitizer::CONFIG,
         );
 
         self::assertSame('Dir/DirConfig.php', $actualPath);
@@ -110,7 +110,7 @@ final class FileContentGeneratorTest extends TestCase
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
-            FilenameSanitizer::DEPENDENCY_PROVIDER
+            FilenameSanitizer::DEPENDENCY_PROVIDER,
         );
 
         self::assertSame('Dir/DirDependencyProvider.php', $actualPath);

--- a/tests/Unit/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizerTest.php
+++ b/tests/Unit/CodeGenerator/Domain/FilenameSanitizer/FilenameSanitizerTest.php
@@ -36,7 +36,7 @@ final class FilenameSanitizerTest extends TestCase
     {
         self::assertSame(
             FilenameSanitizer::FACADE,
-            $this->filenameSanitizer->sanitize($filename)
+            $this->filenameSanitizer->sanitize($filename),
         );
     }
 
@@ -56,7 +56,7 @@ final class FilenameSanitizerTest extends TestCase
     {
         self::assertSame(
             FilenameSanitizer::FACTORY,
-            $this->filenameSanitizer->sanitize($filename)
+            $this->filenameSanitizer->sanitize($filename),
         );
     }
 
@@ -77,7 +77,7 @@ final class FilenameSanitizerTest extends TestCase
     {
         self::assertSame(
             FilenameSanitizer::CONFIG,
-            $this->filenameSanitizer->sanitize($filename)
+            $this->filenameSanitizer->sanitize($filename),
         );
     }
 
@@ -97,7 +97,7 @@ final class FilenameSanitizerTest extends TestCase
     {
         self::assertSame(
             FilenameSanitizer::DEPENDENCY_PROVIDER,
-            $this->filenameSanitizer->sanitize($filename)
+            $this->filenameSanitizer->sanitize($filename),
         );
     }
 

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -36,8 +36,8 @@ final class SetupGacelaTest extends TestCase
                 static function (GacelaEventInterface $event) use (&$listenerDispatched1): void {
                     self::assertInstanceOf(FakeEvent::class, $event);
                     $listenerDispatched1 = true;
-                }
-            )
+                },
+            ),
         );
 
         self::assertInstanceOf(ConfigurableEventDispatcher::class, $setup->getEventDispatcher());
@@ -48,8 +48,8 @@ final class SetupGacelaTest extends TestCase
                 static function (GacelaEventInterface $event) use (&$listenerDispatched2): void {
                     self::assertInstanceOf(FakeEvent::class, $event);
                     $listenerDispatched2 = true;
-                }
-            )
+                },
+            ),
         );
         $setup->combine($setup2);
 
@@ -65,11 +65,11 @@ final class SetupGacelaTest extends TestCase
     public function test_combine_config_key_values(): void
     {
         $setup = SetupGacela::fromGacelaConfig(
-            (new GacelaConfig())->addAppConfigKeyValue('key1', 1)
+            (new GacelaConfig())->addAppConfigKeyValue('key1', 1),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
-            (new GacelaConfig())->addAppConfigKeyValues(['key2' => 'value2'])
+            (new GacelaConfig())->addAppConfigKeyValues(['key2' => 'value2']),
         );
 
         $setup->combine($setup2);
@@ -83,11 +83,11 @@ final class SetupGacelaTest extends TestCase
     public function test_combine_project_namespaces(): void
     {
         $setup = SetupGacela::fromGacelaConfig(
-            (new GacelaConfig())->setProjectNamespaces(['App1'])
+            (new GacelaConfig())->setProjectNamespaces(['App1']),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
-            (new GacelaConfig())->setProjectNamespaces(['App2'])
+            (new GacelaConfig())->setProjectNamespaces(['App2']),
         );
 
         $setup->combine($setup2);
@@ -100,13 +100,13 @@ final class SetupGacelaTest extends TestCase
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
                 ->setFileCacheEnabled(false)
-                ->setFileCacheDirectory('original/dir')
+                ->setFileCacheDirectory('original/dir'),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
                 ->setFileCacheEnabled(true)
-                ->setFileCacheDirectory('override/dir')
+                ->setFileCacheDirectory('override/dir'),
         );
 
         self::assertFalse($setup->isFileCacheEnabled());
@@ -123,7 +123,7 @@ final class SetupGacelaTest extends TestCase
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
                 ->setFileCacheEnabled(true)
-                ->setFileCacheDirectory('original/dir')
+                ->setFileCacheDirectory('original/dir'),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(new GacelaConfig());
@@ -142,7 +142,7 @@ final class SetupGacelaTest extends TestCase
         $setup = SetupGacela::fromGacelaConfig(new GacelaConfig());
 
         $setup2 = SetupGacela::fromGacelaConfig(
-            (new GacelaConfig())->resetInMemoryCache()
+            (new GacelaConfig())->resetInMemoryCache(),
         );
 
         self::assertFalse($setup->shouldResetInMemoryCache());
@@ -154,13 +154,13 @@ final class SetupGacelaTest extends TestCase
     {
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->addExternalService('service1', static fn () => 1)
+                ->addExternalService('service1', static fn () => 1),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
                 ->addExternalService('service2', static fn () => 2)
-                ->addExternalService('service3', new stdClass())
+                ->addExternalService('service3', new stdClass()),
         );
 
         self::assertEquals([
@@ -180,13 +180,13 @@ final class SetupGacelaTest extends TestCase
     {
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->extendService('service', static fn (ArrayObject $ao) => $ao->append(1))
+                ->extendService('service', static fn (ArrayObject $ao) => $ao->append(1)),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
                 ->extendService('service', static fn (ArrayObject $ao) => $ao->append(2))
-                ->extendService('service-2', static fn (ArrayObject $ao) => $ao->append(3))
+                ->extendService('service-2', static fn (ArrayObject $ao) => $ao->append(3)),
         );
 
         $setup->combine($setup2);

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -29,7 +29,7 @@ final class ClassNameFinderTest extends TestCase
             $this->createMock(ClassValidatorInterface::class),
             [],
             $this->createMock(CacheInterface::class),
-            []
+            [],
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
@@ -53,7 +53,7 @@ final class ClassNameFinderTest extends TestCase
             $classValidator,
             [$finderRule],
             $this->createMock(CacheInterface::class),
-            []
+            [],
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
@@ -77,7 +77,7 @@ final class ClassNameFinderTest extends TestCase
             $classValidator,
             [$finderRule],
             $this->createMock(CacheInterface::class),
-            []
+            [],
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
@@ -101,7 +101,7 @@ final class ClassNameFinderTest extends TestCase
             $classValidator,
             [$finderRule],
             $this->createMock(CacheInterface::class),
-            []
+            [],
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');
@@ -125,7 +125,7 @@ final class ClassNameFinderTest extends TestCase
             $classValidator,
             [$finderRule],
             new InMemoryCache(ClassInfo::class),
-            []
+            [],
         );
 
         $classInfo = new ClassInfo('callerNamespace', 'callerModuleName', 'cacheKey');

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockParserTest.php
@@ -31,7 +31,7 @@ final class DocBlockParserTest extends TestCase
 TXT;
         self::assertSame(
             '\App\Module\ClassName',
-            $this->parser->getClassFromMethod($input, 'getClass()')
+            $this->parser->getClassFromMethod($input, 'getClass()'),
         );
     }
 }

--- a/tests/Unit/Framework/ClassResolver/GlobalKeyTest.php
+++ b/tests/Unit/Framework/ClassResolver/GlobalKeyTest.php
@@ -23,7 +23,7 @@ final class GlobalKeyTest extends TestCase
     {
         self::assertSame(
             '\App\ModuleExample\Facade',
-            GlobalKey::fromClassName('App\ModuleExample\ModuleFacade')
+            GlobalKey::fromClassName('App\ModuleExample\ModuleFacade'),
         );
     }
 
@@ -31,7 +31,7 @@ final class GlobalKeyTest extends TestCase
     {
         self::assertSame(
             '\App\ModuleExample\Facade',
-            GlobalKey::fromClassName('\App\ModuleExample\ModuleFacade')
+            GlobalKey::fromClassName('\App\ModuleExample\ModuleFacade'),
         );
     }
 
@@ -39,7 +39,7 @@ final class GlobalKeyTest extends TestCase
     {
         self::assertSame(
             '\App\ModuleExample\Facade',
-            GlobalKey::fromClassName('App\ModuleExample\Facade')
+            GlobalKey::fromClassName('App\ModuleExample\Facade'),
         );
     }
 
@@ -47,7 +47,7 @@ final class GlobalKeyTest extends TestCase
     {
         self::assertSame(
             '\App\ModuleExample\Facade',
-            GlobalKey::fromClassName('\App\ModuleExample\Facade')
+            GlobalKey::fromClassName('\App\ModuleExample\Facade'),
         );
     }
 
@@ -55,7 +55,7 @@ final class GlobalKeyTest extends TestCase
     {
         self::assertSame(
             '\App\ModuleExample\DependencyProvider',
-            GlobalKey::fromClassName('\App\ModuleExample\ModuleDependencyProvider')
+            GlobalKey::fromClassName('\App\ModuleExample\ModuleDependencyProvider'),
         );
     }
 
@@ -63,7 +63,7 @@ final class GlobalKeyTest extends TestCase
     {
         self::assertSame(
             '\App\ModuleExample\DependencyProvider',
-            GlobalKey::fromClassName('\App\ModuleExample\DependencyProvider')
+            GlobalKey::fromClassName('\App\ModuleExample\DependencyProvider'),
         );
     }
 }

--- a/tests/Unit/Framework/Config/ConfigInitTest.php
+++ b/tests/Unit/Framework/Config/ConfigInitTest.php
@@ -19,7 +19,7 @@ final class ConfigInitTest extends TestCase
         $configInit = new ConfigLoader(
             new GacelaConfigFile(),
             $this->createMock(PathFinderInterface::class),
-            $this->createMock(PathNormalizerInterface::class)
+            $this->createMock(PathNormalizerInterface::class),
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -33,7 +33,7 @@ final class ConfigInitTest extends TestCase
         $configInit = new ConfigLoader(
             new GacelaConfigFile(),
             $pathFinder,
-            $this->createMock(PathNormalizerInterface::class)
+            $this->createMock(PathNormalizerInterface::class),
         );
 
         self::assertSame([], $configInit->loadAll());
@@ -65,7 +65,7 @@ final class ConfigInitTest extends TestCase
         $configInit = new ConfigLoader(
             $gacelaConfigFile,
             $this->createMock(PathFinderInterface::class),
-            $this->createMock(PathNormalizerInterface::class)
+            $this->createMock(PathNormalizerInterface::class),
         );
 
         self::assertSame(['key' => 'value'], $configInit->loadAll());

--- a/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
@@ -26,7 +26,7 @@ final class ConfigBuilderTest extends TestCase
 
         self::assertEquals(
             [new GacelaConfigItem('custom/*.php', '')],
-            $builder->build()
+            $builder->build(),
         );
     }
 
@@ -37,7 +37,7 @@ final class ConfigBuilderTest extends TestCase
 
         self::assertEquals(
             [new GacelaConfigItem('', 'custom/local.php')],
-            $builder->build()
+            $builder->build(),
         );
     }
 
@@ -55,7 +55,7 @@ final class ConfigBuilderTest extends TestCase
 
         self::assertEquals(
             [new GacelaConfigItem('custom/*.php', 'custom/local.php', $reader)],
-            $builder->build()
+            $builder->build(),
         );
     }
 
@@ -66,7 +66,7 @@ final class ConfigBuilderTest extends TestCase
 
         self::assertEquals(
             [new GacelaConfigItem('custom/*.php', 'custom/local.php', new SimpleEnvConfigReader())],
-            $builder->build()
+            $builder->build(),
         );
     }
 }

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -28,7 +28,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     public function test_no_special_global_services_then_default(): void
     {
         $setupGacela = (new SetupGacela())->setExternalServices([
-            'randomKey' => 'randomValue',
+            'randomKey' => static fn () => 'randomValue',
         ]);
 
         $factory = new GacelaConfigFromBootstrapFactory($setupGacela);
@@ -42,8 +42,8 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
             (new SetupGacela())->setConfigFn(
                 static function (ConfigBuilder $configBuilder): void {
                     $configBuilder->add('custom-path.php', 'custom-path_local.php');
-                }
-            )
+                },
+            ),
         );
 
         $expected = (new GacelaConfigFile())
@@ -56,14 +56,14 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     {
         $factory = new GacelaConfigFromBootstrapFactory(
             (new SetupGacela())
-                ->setExternalServices(['externalServiceKey' => 'externalServiceValue'])
+                ->setExternalServices(['externalServiceKey' => static fn () => 'externalServiceValue'])
                 ->setMappingInterfacesFn(static function (
                     MappingInterfacesBuilder $interfacesBuilder,
-                    array $externalServices
+                    array $externalServices,
                 ): void {
-                    self::assertSame($externalServices['externalServiceKey'], 'externalServiceValue');
+                    self::assertSame($externalServices['externalServiceKey']->__invoke(), 'externalServiceValue');
                     $interfacesBuilder->bind(CustomInterface::class, CustomClass::class);
-                })
+                }),
         );
 
         $expected = (new GacelaConfigFile())
@@ -80,7 +80,7 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
                     static function (SuffixTypesBuilder $suffixTypesBuilder): void {
                         $suffixTypesBuilder->addDependencyProvider('DPCustom');
                     },
-                )
+                ),
         );
 
         $expected = (new GacelaConfigFile())

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactoryTest.php
@@ -26,13 +26,13 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo = $this->createStub(FileIoInterface::class);
         $fileIo->method('include')->willReturn(
             new class() {
-            }
+            },
         );
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',
             $this->createStub(SetupGacelaInterface::class),
-            $fileIo
+            $fileIo,
         );
 
         $this->expectErrorMessage('`gacela.php` file should return a `callable(GacelaConfig)`');
@@ -48,7 +48,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',
             $this->createStub(SetupGacelaInterface::class),
-            $fileIo
+            $fileIo,
         );
 
         self::assertEquals(new GacelaConfigFile(), $factory->createGacelaFileConfig());
@@ -57,13 +57,14 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
     public function test_gacela_file_set_config(): void
     {
         $fileIo = $this->createStub(FileIoInterface::class);
-        $fileIo->method('include')->willReturn(static fn (GacelaConfig $config) => $config
-            ->addAppConfig('custom-path.php', 'custom-path_local.php'));
+        $fileIo->method('include')->willReturn(
+            static fn (GacelaConfig $config) => $config->addAppConfig('custom-path.php', 'custom-path_local.php'),
+        );
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',
             $this->createStub(SetupGacelaInterface::class),
-            $fileIo
+            $fileIo,
         );
 
         $expected = (new GacelaConfigFile())
@@ -81,13 +82,13 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
                 self::assertSame('externalServiceValue', $config->getExternalService('externalServiceKey')->__invoke());
                 $config->addMappingInterface(CustomInterface::class, new CustomClass());
                 $config->addMappingInterface(CustomInterface::class, CustomClass::class);
-            }
+            },
         );
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',
             $this->createStub(SetupGacelaInterface::class),
-            $fileIo
+            $fileIo,
         );
 
         $expected = (new GacelaConfigFile())
@@ -101,13 +102,13 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo = $this->createStub(FileIoInterface::class);
         $fileIo->method('include')->willReturn(
             static fn (GacelaConfig $config) => $config
-                ->addSuffixTypeDependencyProvider('Binding')
+                ->addSuffixTypeDependencyProvider('Binding'),
         );
 
         $factory = new GacelaConfigUsingGacelaPhpFileFactory(
             'gacelaPhpPath',
             $this->createStub(SetupGacelaInterface::class),
-            $fileIo
+            $fileIo,
         );
 
         $expected = (new GacelaConfigFile())
@@ -134,7 +135,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo->method('include')->willReturn(
             static function (GacelaConfig $config) use ($listener): void {
                 $config->registerGenericListener($listener);
-            }
+            },
         );
 
         $setup = new SetupGacela();
@@ -163,7 +164,7 @@ final class GacelaConfigUsingGacelaPhpFileFactoryTest extends TestCase
         $fileIo->method('include')->willReturn(
             static function (GacelaConfig $config) use ($listener): void {
                 $config->registerSpecificListener(FakeEvent::class, $listener);
-            }
+            },
         );
 
         $setup = new SetupGacela();

--- a/tests/Unit/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/WithSuffixAbsolutePathStrategyTest.php
@@ -24,7 +24,7 @@ final class WithSuffixAbsolutePathStrategyTest extends TestCase
 
         self::assertSame(
             '/app/root/file-name-suffix',
-            $strategy->generateAbsolutePath($relativePath)
+            $strategy->generateAbsolutePath($relativePath),
         );
     }
 
@@ -43,7 +43,7 @@ final class WithSuffixAbsolutePathStrategyTest extends TestCase
 
         self::assertSame(
             '/app/root/file-name-suffix.ext',
-            $strategy->generateAbsolutePath($relativePath)
+            $strategy->generateAbsolutePath($relativePath),
         );
     }
 }

--- a/tests/Unit/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategyTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/WithoutSuffixAbsolutePathStrategyTest.php
@@ -16,7 +16,7 @@ final class WithoutSuffixAbsolutePathStrategyTest extends TestCase
 
         self::assertSame(
             '/app/root/file-name',
-            $strategy->generateAbsolutePath($relativePath)
+            $strategy->generateAbsolutePath($relativePath),
         );
     }
 
@@ -27,7 +27,7 @@ final class WithoutSuffixAbsolutePathStrategyTest extends TestCase
 
         self::assertSame(
             '/app/root/file-name.ext',
-            $strategy->generateAbsolutePath($relativePath)
+            $strategy->generateAbsolutePath($relativePath),
         );
     }
 }

--- a/tests/Unit/Framework/Container/ContainerTest.php
+++ b/tests/Unit/Framework/Container/ContainerTest.php
@@ -73,7 +73,7 @@ final class ContainerTest extends TestCase
                 {
                     return 'value';
                 }
-            }
+            },
         );
 
         $resolvedService = $this->container->get('service_name');
@@ -87,12 +87,12 @@ final class ContainerTest extends TestCase
     {
         $this->container->set(
             'service_name',
-            static fn () => 'value_' . random_int(0, PHP_INT_MAX)
+            static fn () => 'value_' . random_int(0, PHP_INT_MAX),
         );
 
         self::assertSame(
             $this->container->get('service_name'),
-            $this->container->get('service_name')
+            $this->container->get('service_name'),
         );
     }
 
@@ -101,13 +101,13 @@ final class ContainerTest extends TestCase
         $this->container->set(
             'service_name',
             $this->container->factory(
-                static fn () => 'value_' . random_int(0, PHP_INT_MAX)
-            )
+                static fn () => 'value_' . random_int(0, PHP_INT_MAX),
+            ),
         );
 
         self::assertNotSame(
             $this->container->get('service_name'),
-            $this->container->get('service_name')
+            $this->container->get('service_name'),
         );
     }
 
@@ -121,12 +121,12 @@ final class ContainerTest extends TestCase
             static function (ArrayObject $arrayObject, Container $container) {
                 $arrayObject->append($container->get('n3'));
                 return $arrayObject;
-            }
+            },
         );
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(4)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4),
         );
 
         /** @var ArrayObject $actual */
@@ -145,14 +145,14 @@ final class ContainerTest extends TestCase
             static function (ArrayObject $arrayObject, Container $container) {
                 $arrayObject->append($container->get('n3'));
                 return $arrayObject;
-            }
+            },
         );
 
         $this->container->extend(
             'service_name',
             static function (ArrayObject $arrayObject): void {
                 $arrayObject->append(4);
-            }
+            },
         );
 
         /** @var ArrayObject $actual */
@@ -170,14 +170,14 @@ final class ContainerTest extends TestCase
             static function (array $arrayObject): array {
                 $arrayObject[] = 3;
                 return $arrayObject;
-            }
+            },
         );
 
         $this->container->extend(
             'service_name',
             static function (array &$arrayObject): void {
                 $arrayObject[] = 4;
-            }
+            },
         );
 
         /** @var ArrayObject $actual */
@@ -211,7 +211,7 @@ final class ContainerTest extends TestCase
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(3)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
         );
     }
 
@@ -224,7 +224,7 @@ final class ContainerTest extends TestCase
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(3)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
         );
     }
 
@@ -232,7 +232,7 @@ final class ContainerTest extends TestCase
     {
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(3)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
         );
 
         $this->container->set('service_name', new ArrayObject([1, 2]));
@@ -242,7 +242,7 @@ final class ContainerTest extends TestCase
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(4)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4),
         );
     }
 
@@ -250,7 +250,7 @@ final class ContainerTest extends TestCase
     {
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(3)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
         );
 
         $this->container->set('service_name', static fn () => new ArrayObject([1, 2]));
@@ -260,7 +260,7 @@ final class ContainerTest extends TestCase
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject->append(4)
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4),
         );
     }
 
@@ -285,14 +285,14 @@ final class ContainerTest extends TestCase
     {
         $this->container->set(
             'service_name',
-            $this->container->protect(static fn () => new ArrayObject([1, 2]))
+            $this->container->protect(static fn () => new ArrayObject([1, 2])),
         );
 
         $this->expectExceptionObject(ContainerException::serviceProtected('service_name'));
 
         $this->container->extend(
             'service_name',
-            static fn (ArrayObject $arrayObject) => $arrayObject
+            static fn (ArrayObject $arrayObject) => $arrayObject,
         );
     }
 }


### PR DESCRIPTION
## 📚 Description

Update code with PHP 8.0 upgrades

## 🔖 Changes

- Named constructors
- Trailing comma
- `mixed` type
- `str_contains()`
- Union types
- and other small improvements...