### PR TITLE
Normalize toString() from all internal events

### DIFF
--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -60,7 +60,7 @@ final class ClassInfo implements ClassInfoInterface
     public function toString(): string
     {
         return sprintf(
-            'ClassInfo{callerModuleNamespace:"%s", callerModuleName:"%s", resolvableType:"%s", cacheKey:"%s"}',
+            '{callerModuleNamespace:"%s", callerModuleName:"%s", resolvableType:"%s", cacheKey:"%s"}',
             $this->callerModuleNamespace,
             $this->callerModuleName,
             $this->resolvableType,

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -40,7 +40,7 @@ final class ClassNameFinder implements ClassNameFinderInterface
 
         if ($this->cache->has($cacheKey)) {
             $cached = $this->cache->get($cacheKey);
-            self::dispatchEvent(new ClassNameCachedFoundEvent($cached));
+            self::dispatchEvent(new ClassNameCachedFoundEvent($cacheKey, $cached));
 
             return $cached;
         }

--- a/src/Framework/ClassResolver/ClassResolverCache.php
+++ b/src/Framework/ClassResolver/ClassResolverCache.php
@@ -36,9 +36,9 @@ final class ClassResolverCache
         }
 
         if (self::isEnabled()) {
-            self::dispatchEvent(new ClassNamePhpCacheCreatedEvent());
-
-            self::$cache = new ClassNamePhpCache(Config::getInstance()->getCacheDir());
+            $cacheDir = Config::getInstance()->getCacheDir();
+            self::dispatchEvent(new ClassNamePhpCacheCreatedEvent($cacheDir));
+            self::$cache = new ClassNamePhpCache($cacheDir);
         } else {
             self::dispatchEvent(new ClassNameInMemoryCacheCreatedEvent());
             self::$cache = new InMemoryCache(ClassNamePhpCache::class);

--- a/src/Framework/Event/ClassResolver/AbstractGacelaClassResolverEvent.php
+++ b/src/Framework/Event/ClassResolver/AbstractGacelaClassResolverEvent.php
@@ -25,7 +25,7 @@ abstract class AbstractGacelaClassResolverEvent implements GacelaEventInterface
     public function toString(): string
     {
         return sprintf(
-            '%s - %s',
+            '%s {classInfo:"%s"}',
             get_class($this),
             $this->classInfo->toString(),
         );

--- a/src/Framework/Event/ClassResolver/Cache/ClassNameCacheCachedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/ClassNameCacheCachedEvent.php
@@ -10,6 +10,6 @@ final class ClassNameCacheCachedEvent implements GacelaEventInterface
 {
     public function toString(): string
     {
-        return self::class;
+        return sprintf('%s {}', self::class);
     }
 }

--- a/src/Framework/Event/ClassResolver/Cache/ClassNameInMemoryCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/ClassNameInMemoryCacheCreatedEvent.php
@@ -10,6 +10,6 @@ final class ClassNameInMemoryCacheCreatedEvent implements GacelaEventInterface
 {
     public function toString(): string
     {
-        return self::class;
+        return sprintf('%s {}', self::class);
     }
 }

--- a/src/Framework/Event/ClassResolver/Cache/ClassNamePhpCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/ClassNamePhpCacheCreatedEvent.php
@@ -8,8 +8,13 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 final class ClassNamePhpCacheCreatedEvent implements GacelaEventInterface
 {
+    public function __construct(
+        private string $cacheDir,
+    ) {
+    }
+
     public function toString(): string
     {
-        return self::class;
+        return sprintf('%s {cacheDir:"%s"}', self::class, $this->cacheDir);
     }
 }

--- a/src/Framework/Event/ClassResolver/Cache/ClassNamePhpCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/ClassNamePhpCacheCreatedEvent.php
@@ -13,8 +13,17 @@ final class ClassNamePhpCacheCreatedEvent implements GacelaEventInterface
     ) {
     }
 
+    public function cacheDir(): string
+    {
+        return $this->cacheDir;
+    }
+
     public function toString(): string
     {
-        return sprintf('%s {cacheDir:"%s"}', self::class, $this->cacheDir);
+        return sprintf(
+            '%s {cacheDir:"%s"}',
+            self::class,
+            $this->cacheDir,
+        );
     }
 }

--- a/src/Framework/Event/ClassResolver/Cache/CustomServicesCacheCachedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/CustomServicesCacheCachedEvent.php
@@ -10,6 +10,6 @@ final class CustomServicesCacheCachedEvent implements GacelaEventInterface
 {
     public function toString(): string
     {
-        return self::class;
+        return sprintf('%s {}', self::class);
     }
 }

--- a/src/Framework/Event/ClassResolver/Cache/CustomServicesInMemoryCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/CustomServicesInMemoryCacheCreatedEvent.php
@@ -10,6 +10,6 @@ final class CustomServicesInMemoryCacheCreatedEvent implements GacelaEventInterf
 {
     public function toString(): string
     {
-        return self::class;
+        return sprintf('%s {}', self::class);
     }
 }

--- a/src/Framework/Event/ClassResolver/Cache/CustomServicesPhpCacheCreatedEvent.php
+++ b/src/Framework/Event/ClassResolver/Cache/CustomServicesPhpCacheCreatedEvent.php
@@ -10,6 +10,6 @@ final class CustomServicesPhpCacheCreatedEvent implements GacelaEventInterface
 {
     public function toString(): string
     {
-        return self::class;
+        return sprintf('%s {}', self::class);
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameCachedFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameCachedFoundEvent.php
@@ -9,12 +9,13 @@ use Gacela\Framework\Event\GacelaEventInterface;
 final class ClassNameCachedFoundEvent implements GacelaEventInterface
 {
     public function __construct(
+        private string $cacheKey,
         private string $className,
     ) {
     }
 
     public function toString(): string
     {
-        return sprintf('%s - %s', self::class, $this->className);
+        return sprintf('%s {cacheKey:"%s", className:"%s"}', self::class, $this->cacheKey, $this->className);
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameCachedFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameCachedFoundEvent.php
@@ -14,8 +14,23 @@ final class ClassNameCachedFoundEvent implements GacelaEventInterface
     ) {
     }
 
+    public function cacheKey(): string
+    {
+        return $this->cacheKey;
+    }
+
+    public function className(): string
+    {
+        return $this->className;
+    }
+
     public function toString(): string
     {
-        return sprintf('%s {cacheKey:"%s", className:"%s"}', self::class, $this->cacheKey, $this->className);
+        return sprintf(
+            '%s {cacheKey:"%s", className:"%s"}',
+            self::class,
+            $this->cacheKey,
+            $this->className,
+        );
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameInvalidCandidateFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameInvalidCandidateFoundEvent.php
@@ -15,6 +15,6 @@ final class ClassNameInvalidCandidateFoundEvent implements GacelaEventInterface
 
     public function toString(): string
     {
-        return sprintf('%s - %s', self::class, $this->className);
+        return sprintf('%s {className:"%s"}', self::class, $this->className);
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameInvalidCandidateFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameInvalidCandidateFoundEvent.php
@@ -13,8 +13,17 @@ final class ClassNameInvalidCandidateFoundEvent implements GacelaEventInterface
     ) {
     }
 
+    public function className(): string
+    {
+        return $this->className;
+    }
+
     public function toString(): string
     {
-        return sprintf('%s {className:"%s"}', self::class, $this->className);
+        return sprintf(
+            '%s {className:"%s"}',
+            self::class,
+            $this->className,
+        );
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameNotFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameNotFoundEvent.php
@@ -21,7 +21,7 @@ final class ClassNameNotFoundEvent implements GacelaEventInterface
     public function toString(): string
     {
         return sprintf(
-            '%s - %s - %s',
+            '%s {classInfo:"%s", resolvableTypes:"%s"}',
             self::class,
             $this->classInfo->toString(),
             implode(',', $this->resolvableTypes),

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameNotFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameNotFoundEvent.php
@@ -18,6 +18,19 @@ final class ClassNameNotFoundEvent implements GacelaEventInterface
     ) {
     }
 
+    public function classInfo(): ClassInfo
+    {
+        return $this->classInfo;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resolvableTypes(): array
+    {
+        return $this->resolvableTypes;
+    }
+
     public function toString(): string
     {
         return sprintf(

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameValidCandidateFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameValidCandidateFoundEvent.php
@@ -15,6 +15,6 @@ final class ClassNameValidCandidateFoundEvent implements GacelaEventInterface
 
     public function toString(): string
     {
-        return sprintf('%s - %s', self::class, $this->className);
+        return sprintf('%s {className:"%s"}', self::class, $this->className);
     }
 }

--- a/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameValidCandidateFoundEvent.php
+++ b/src/Framework/Event/ClassResolver/ClassNameFinder/ClassNameValidCandidateFoundEvent.php
@@ -13,8 +13,17 @@ final class ClassNameValidCandidateFoundEvent implements GacelaEventInterface
     ) {
     }
 
+    public function className(): string
+    {
+        return $this->className;
+    }
+
     public function toString(): string
     {
-        return sprintf('%s {className:"%s"}', self::class, $this->className);
+        return sprintf(
+            '%s {className:"%s"}',
+            self::class,
+            $this->className,
+        );
     }
 }

--- a/src/Framework/Event/ConfigReader/ReadPhpConfigEvent.php
+++ b/src/Framework/Event/ConfigReader/ReadPhpConfigEvent.php
@@ -23,7 +23,7 @@ final class ReadPhpConfigEvent implements GacelaEventInterface
     public function toString(): string
     {
         return sprintf(
-            '%s - %s',
+            '%s {absolutePath:"%s"}',
             get_class($this),
             $this->absolutePath,
         );

--- a/src/Framework/Event/Dispatcher/ConfigurableEventDispatcher.php
+++ b/src/Framework/Event/Dispatcher/ConfigurableEventDispatcher.php
@@ -25,6 +25,7 @@ final class ConfigurableEventDispatcher implements EventDispatcherInterface
     {
         $this->genericListeners = $genericListeners;
     }
+
     /**
      * @param class-string $event
      */


### PR DESCRIPTION
## 📚 Description

Currently the Events `toString()` return the event class name plus some additional data, but there is no standard.

I want to standardise with something like `EventName {property1:"value1", property2:"value2"}`

## 🔖 Changes

- Normalize toString() from all internal events
