### PR TITLE
Add cache GacelaFileConfig to ConfigFactory

### DIFF
--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -13,6 +13,7 @@ use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
 use Gacela\Framework\ClassResolver\ClassResolverCache;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
 
 final class Gacela
@@ -32,6 +33,7 @@ final class Gacela
             ClassResolverCache::resetCache();
             InMemoryCache::resetCache();
             AbstractClassResolver::resetCache();
+            ConfigFactory::resetCache();
             Config::resetInstance();
         }
 

--- a/tests/Feature/Framework/AnonymousGlobalExtendsExistingClass/FeatureTest.php
+++ b/tests/Feature/Framework/AnonymousGlobalExtendsExistingClass/FeatureTest.php
@@ -14,7 +14,10 @@ final class FeatureTest extends TestCase
 {
     public function setUp(): void
     {
-        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php', 'config/local.php');
+        });
     }
 
     public function test_override_factory_as_anonymous_global_when_config_method_is_called(): void

--- a/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesInGacelaConfigFile/FeatureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractFromAnonymousClass;
 use GacelaTest\Feature\Framework\BindingInterfacesInGacelaConfigFile\LocalConfig\Domain\AbstractFromCallable;
@@ -17,7 +18,10 @@ final class FeatureTest extends TestCase
 
     public function setUp(): void
     {
-        Gacela::bootstrap(__DIR__);
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
         $this->facade = new LocalConfig\Facade();
     }
 

--- a/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
+++ b/tests/Feature/Framework/BindingInterfacesWithInnerDependencies/FeatureTest.php
@@ -13,8 +13,10 @@ final class FeatureTest extends TestCase
 {
     public function setUp(): void
     {
-        Gacela::bootstrap(__DIR__, static fn (GacelaConfig $config) => $config
-            ->addExternalService('greeterGenerator', CorrectCompanyGenerator::class), );
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addExternalService('greeterGenerator', CorrectCompanyGenerator::class);
+        });
     }
 
     public function test_mapping_interfaces_from_config(): void

--- a/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigFromCustomEnv/FeatureTest.php
@@ -18,7 +18,7 @@ final class FeatureTest extends TestCase
 
     public function test_load_config_from_custom_env_default(): void
     {
-        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -36,7 +36,7 @@ final class FeatureTest extends TestCase
     {
         putenv('APP_ENV=dev');
 
-        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -54,7 +54,7 @@ final class FeatureTest extends TestCase
     {
         putenv('APP_ENV=prod');
 
-        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -66,5 +66,13 @@ final class FeatureTest extends TestCase
             ],
             $facade->doSomething(),
         );
+    }
+
+    private function bootstrapGacela(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php', 'config/local.php');
+        });
     }
 }

--- a/tests/Feature/Framework/UsingConfigTypePhp/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigTypePhp/FeatureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingConfigTypePhp;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -11,7 +12,9 @@ final class FeatureTest extends TestCase
 {
     public function setUp(): void
     {
-        Gacela::bootstrap(__DIR__);
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
     }
 
     public function test_config_php_files(): void

--- a/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
+++ b/tests/Feature/Framework/UsingConfigWithBootstrapSetup/FeatureTest.php
@@ -13,6 +13,7 @@ final class FeatureTest extends TestCase
     public function setUp(): void
     {
         $configFn = static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
             $config->addAppConfig('custom-config.php', 'custom-config_local.php');
         };
 

--- a/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
+++ b/tests/Feature/Framework/UsingGacelaFileFromCustomEnv/FeatureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Framework\UsingGacelaFileFromCustomEnv;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +18,7 @@ final class FeatureTest extends TestCase
 
     public function test_load_gacela_default_file(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -34,7 +35,7 @@ final class FeatureTest extends TestCase
     {
         putenv('APP_ENV=dev');
 
-        Gacela::bootstrap(__DIR__);
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -51,7 +52,7 @@ final class FeatureTest extends TestCase
     {
         putenv('APP_ENV=prod');
 
-        Gacela::bootstrap(__DIR__);
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -68,7 +69,7 @@ final class FeatureTest extends TestCase
     {
         putenv('APP_ENV=custom');
 
-        Gacela::bootstrap(__DIR__);
+        $this->bootstrapGacela();
 
         $facade = new LocalConfig\Facade();
 
@@ -79,5 +80,12 @@ final class FeatureTest extends TestCase
             ],
             $facade->doSomething(),
         );
+    }
+
+    private function bootstrapGacela(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
     }
 }

--- a/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
+++ b/tests/Feature/Framework/UsingMultipleConfig/FeatureTest.php
@@ -15,6 +15,7 @@ final class FeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config
+                ->resetInMemoryCache()
                 ->addAppConfig('config/.env*', '', SimpleEnvConfigReader::class)
                 ->addAppConfig('config/*.php');
         });

--- a/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework\Config\ConfigFactory;
 
-use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
@@ -12,8 +11,6 @@ use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
-use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
-use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\AbstractCustom;
 use GacelaTest\Fixtures\CustomClass;
 use GacelaTest\Fixtures\CustomInterface;
@@ -21,6 +18,11 @@ use PHPUnit\Framework\TestCase;
 
 final class ConfigFactoryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        ConfigFactory::resetCache();
+    }
+
     public function test_empty_setup_then_default_gacela_config_file(): void
     {
         $setup = new SetupGacela();
@@ -33,7 +35,6 @@ final class ConfigFactoryTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-
     public function test_cache_gacela_file_config(): void
     {
         $setup = new SetupGacela();
@@ -43,7 +44,6 @@ final class ConfigFactoryTest extends TestCase
 
         $actual = (new ConfigFactory(__DIR__ . '/WithoutGacelaFile', $setup))
             ->createGacelaFileConfig();
-
 
         self::assertSame($expected, $actual);
     }

--- a/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework\Config\ConfigFactory;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
@@ -11,6 +12,8 @@ use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
+use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\AbstractCustom;
 use GacelaTest\Fixtures\CustomClass;
 use GacelaTest\Fixtures\CustomInterface;
@@ -28,6 +31,21 @@ final class ConfigFactoryTest extends TestCase
         $expected = new GacelaConfigFile();
 
         self::assertEquals($expected, $actual);
+    }
+
+
+    public function test_cache_gacela_file_config(): void
+    {
+        $setup = new SetupGacela();
+
+        $expected = (new ConfigFactory(__DIR__ . '/WithoutGacelaFile', $setup))
+            ->createGacelaFileConfig();
+
+        $actual = (new ConfigFactory(__DIR__ . '/WithoutGacelaFile', $setup))
+            ->createGacelaFileConfig();
+
+
+        self::assertSame($expected, $actual);
     }
 
     public function test_only_gacela_file_exists(): void


### PR DESCRIPTION
## 📚 Description

I found a bug when registering specific listeners [with `PhelConfig::registerSpecificListener()`] that when creating the GacelaFileConfig object [`createGacelaFileConfig()`] when defined in `$gacelaPhpDefaultPath` (aka at the root of a project which uses Gacela in vendor), then it was calling twice the `createGacelaFileConfig()` which is mutating the `bootstrapSetup` combining it with the `$projectSetupGacela`. This ended up into a duplication of "specific listeners".

The solution is rather simple, just keep a singleton copy of the `GacelaFileConfig` in memory, because once it's generated it wont change it during the execution of the program.

## 🔖 Changes

- Add `GacelaFileConfig` as a memory cache to `ConfigFactory`
