### PR TITLE
ResetInMemoryCache also from anonymous globals and factory containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Allow using static facade methods
+- ResetInMemoryCache also from anonymous globals and factory containers
 
 ### 1.0.1
 ### 2023-03-12

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -18,6 +18,14 @@ abstract class AbstractFactory
     private static array $containers = [];
 
     /**
+     * @internal
+     */
+    public static function resetCache(): void
+    {
+        self::$containers = [];
+    }
+
+    /**
      * @throws ContainerKeyNotFoundException
      */
     protected function getProvidedDependency(string $key): mixed

--- a/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
+++ b/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
@@ -21,6 +21,14 @@ final class AnonymousGlobal
     private static array $cachedGlobalInstances = [];
 
     /**
+     * @internal
+     */
+    public static function resetCache(): void
+    {
+        self::$cachedGlobalInstances = [];
+    }
+
+    /**
      * @template T
      *
      * @param class-string<T> $className

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -12,6 +12,7 @@ use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
 use Gacela\Framework\ClassResolver\ClassResolverCache;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
@@ -28,6 +29,8 @@ final class Gacela
         $setup = self::processConfigFnIntoSetup($appRootDir, $configFn);
 
         if ($setup->shouldResetInMemoryCache()) {
+            AnonymousGlobal::resetCache();
+            AbstractFactory::resetCache();
             GacelaFileCache::resetCache();
             DocBlockResolverCache::resetCache();
             ClassResolverCache::resetCache();


### PR DESCRIPTION
## 📚 Description

When using `resetInMemoryCache()` we should remove the internal cached state from Gacela; this is really useful for feature/integration tests. Eg:

```php
Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
    $config->resetInMemoryCache();
});
```

## 🔖 Changes

- `ResetInMemoryCache` should work also from "anonymous globals" and "factory containers"
