### PR TITLE
Add GacelaConfig->setFileCache()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Unify `setFileCacheEnabled` and `setFileCacheDirectory` into one single method: `setFileCache(bool $enabled, string $dir)`. Deprecated the former methods.
+
 ### 1.1.1
 ### 2023-04-19
 

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -178,7 +178,22 @@ final class GacelaConfig
     }
 
     /**
+     * Define whether the file cache flag is enabled,
+     * and the file cache directory.
+     */
+    public function setFileCache(bool $enabled, string $dir = null): self
+    {
+        $this->fileCacheEnabled = $enabled;
+        $this->fileCacheDirectory = $dir;
+
+        return $this;
+    }
+
+    /**
      * Define whether the file cache flag is enabled.
+     *
+     * @deprecated in favor of setFileCache()
+     * It will be removed in the next release
      */
     public function setFileCacheEnabled(bool $flag): self
     {
@@ -189,6 +204,9 @@ final class GacelaConfig
 
     /**
      * Define the file cache directory.
+     *
+     * @deprecated in favor of setFileCache()
+     * It will be removed in the next release
      */
     public function setFileCacheDirectory(string $dir): self
     {

--- a/tests/Benchmark/Framework/ClassResolver/FileCache/FileCacheBench.php
+++ b/tests/Benchmark/Framework/ClassResolver/FileCache/FileCacheBench.php
@@ -49,7 +49,7 @@ final class FileCacheBench
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheEnabled): void {
             $config->resetInMemoryCache();
             $config->addAppConfig('config/*.php');
-            $config->setFileCacheEnabled($cacheEnabled);
+            $config->setFileCache($cacheEnabled);
 
             $config->addMappingInterface(StringValueInterface::class, new StringValue('testing-string'));
 

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -17,7 +17,7 @@ final class FileCacheFeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->setFileCacheEnabled(false);
+            $config->setFileCache(false);
         });
 
         DirectoryUtil::removeDir(__DIR__ . '/custom/cache-dir');
@@ -32,8 +32,7 @@ final class FileCacheFeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->setFileCacheEnabled(true);
-            $config->setFileCacheDirectory('/custom/cache-dir');
+            $config->setFileCache(true, '/custom/cache-dir');
         });
 
         $facade = new Module\Facade();
@@ -47,8 +46,7 @@ final class FileCacheFeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->setFileCacheEnabled(false);
-            $config->setFileCacheDirectory('/custom/cache-dir');
+            $config->setFileCache(false, '/custom/cache-dir');
         });
 
         $facade = new Module\Facade();

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/FeatureTest.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/FeatureTest.php
@@ -23,7 +23,7 @@ final class FeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->setFileCacheEnabled(false);
+            $config->setFileCache(false);
 
             $config->setProjectNamespaces([
                 'GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\src\Main',

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -14,7 +14,7 @@ final class ConfigTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->setFileCacheEnabled(false);
+            $config->setFileCache(false);
         });
     }
 

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -99,14 +99,12 @@ final class SetupGacelaTest extends TestCase
     {
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->setFileCacheEnabled(false)
-                ->setFileCacheDirectory('original/dir'),
+                ->setFileCache(false, 'original/dir'),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->setFileCacheEnabled(true)
-                ->setFileCacheDirectory('override/dir'),
+                ->setFileCache(true, 'override/dir'),
         );
 
         self::assertFalse($setup->isFileCacheEnabled());
@@ -122,8 +120,7 @@ final class SetupGacelaTest extends TestCase
     {
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->setFileCacheEnabled(true)
-                ->setFileCacheDirectory('original/dir'),
+                ->setFileCache(true, 'original/dir'),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(new GacelaConfig());

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinderTest.php
@@ -19,7 +19,7 @@ final class ClassNameFinderTest extends TestCase
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->setFileCacheEnabled(false);
+            $config->setFileCache(false);
         });
     }
 


### PR DESCRIPTION

## 🔖 Changes

- Unify `setFileCacheEnabled` and `setFileCacheDirectory` into one single method: `setFileCache(bool $enabled, string $dir)`. Deprecated the former methods.
