### PR TITLE
Allow running code right after bootstraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Unify `setFileCacheEnabled` and `setFileCacheDirectory` into one single method: `setFileCache(bool $enabled, string $dir)`. Deprecated the former methods.
 - Rename dependency; from `resolver` to `container`.
-- Moved the current `Container` logic to the decoupled `container` dependency. 
+- Moved the current `Container` logic to the decoupled `container` dependency.
+- Add "prePlugins" to run right after the `Gacela::bootstrap()`
 
 ### 1.1.1
 ### 2023-04-19

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="1"
     phpVersion="8.0"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Plugin\PluginInterface;
 
 final class GacelaConfig
 {
@@ -41,6 +42,9 @@ final class GacelaConfig
 
     /** @var array<class-string,list<callable>> */
     private ?array $specificListeners = null;
+
+    /** @var list<class-string<PluginInterface>>  */
+    private ?array $prePlugins = null;
 
     /** @var array<string,list<Closure>> */
     private array $servicesToExtend = [];
@@ -302,6 +306,16 @@ final class GacelaConfig
     }
 
     /**
+     * @param list<class-string<PluginInterface>> $list
+     */
+    public function prePlugins(array $list): self
+    {
+        $this->prePlugins = $list;
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     external-services: array<string,class-string|object|callable>,
      *     config-builder: ConfigBuilder,
@@ -315,6 +329,7 @@ final class GacelaConfig
      *     are-event-listeners-enabled: ?bool,
      *     generic-listeners: ?list<callable>,
      *     specific-listeners: ?array<class-string,list<callable>>,
+     *     pre-plugins: ?list<class-string<PluginInterface>>,
      *     services-to-extend: array<string,list<Closure>>,
      * }
      *
@@ -335,6 +350,7 @@ final class GacelaConfig
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
             'generic-listeners' => $this->genericListeners,
             'specific-listeners' => $this->specificListeners,
+            'pre-plugins' => $this->prePlugins,
             'services-to-extend' => $this->servicesToExtend,
         ];
     }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -12,6 +12,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use Gacela\Framework\Plugin\PluginInterface;
 use RuntimeException;
 
 use function is_callable;
@@ -28,6 +29,7 @@ final class SetupGacela extends AbstractSetupGacela
     public const projectNamespaces = 'projectNamespaces';
     public const configKeyValues = 'configKeyValues';
     public const servicesToExtend = 'servicesToExtend';
+    public const prePlugins = 'prePlugins';
 
     private const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
     private const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
@@ -38,6 +40,7 @@ final class SetupGacela extends AbstractSetupGacela
     private const DEFAULT_GENERIC_LISTENERS = [];
     private const DEFAULT_SPECIFIC_LISTENERS = [];
     private const DEFAULT_SERVICES_TO_EXTEND = [];
+    private const DEFAULT_PRE_PLUGINS = [];
 
     /** @var callable(ConfigBuilder):void */
     private $configFn;
@@ -84,6 +87,9 @@ final class SetupGacela extends AbstractSetupGacela
 
     /** @var ?array<string,list<Closure>> */
     private ?array $servicesToExtend = null;
+
+    /** @var ?list<class-string<PluginInterface>> */
+    private ?array $prePlugins = null;
 
     public function __construct()
     {
@@ -138,6 +144,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
             ->setGenericListeners($build['generic-listeners'])
             ->setSpecificListeners($build['specific-listeners'])
+            ->setPrePlugins($build['pre-plugins'])
             ->setServicesToExtend($build['services-to-extend']);
     }
 
@@ -441,6 +448,14 @@ final class SetupGacela extends AbstractSetupGacela
         $this->setConfigKeyValues(array_merge($this->configKeyValues ?? [], $list));
     }
 
+    /**
+     * @return list<class-string<PluginInterface>>
+     */
+    public function getPrePlugins(): array
+    {
+        return (array)$this->prePlugins;
+    }
+
     private function setAreEventListenersEnabled(?bool $flag): self
     {
         $this->areEventListenersEnabled = $flag ?? self::DEFAULT_ARE_EVENT_LISTENERS_ENABLED;
@@ -471,6 +486,17 @@ final class SetupGacela extends AbstractSetupGacela
     {
         $this->markPropertyChanged(self::servicesToExtend, $list);
         $this->servicesToExtend = $list ?? self::DEFAULT_SERVICES_TO_EXTEND;
+
+        return $this;
+    }
+
+    /**
+     * @param ?list<class-string<PluginInterface>> $list
+     */
+    private function setPrePlugins(?array $list): self
+    {
+        $this->markPropertyChanged(self::prePlugins, $list);
+        $this->prePlugins = $list ?? self::DEFAULT_PRE_PLUGINS;
 
         return $this;
     }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\MappingInterfacesBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Plugin\PluginInterface;
 
 interface SetupGacelaInterface
 {
@@ -76,4 +77,9 @@ interface SetupGacelaInterface
      * @return array<string,list<Closure>>
      */
     public function getServicesToExtend(): array;
+
+    /**
+     * @return list<class-string<PluginInterface>>
+     */
+    public function getPrePlugins(): array;
 }

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -49,7 +49,7 @@ final class Locator
      *
      * @param class-string<T> $className
      *
-     * @return T|null
+     * @return T
      */
     public static function getSingleton(string $className)
     {

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -7,6 +7,9 @@ namespace Gacela\Framework\Container;
 use Gacela\Container\Container as GacelaContainer;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 
+/**
+ * @internal
+ */
 final class Locator
 {
     private static ?Locator $instance = null;
@@ -30,6 +33,12 @@ final class Locator
         self::$instance = null;
     }
 
+    /**
+     * @template T
+     *
+     * @param class-string<T> $key
+     * @param T $value
+     */
     public static function addSingleton(string $key, mixed $value): void
     {
         self::getInstance()->add($key, $value);
@@ -61,7 +70,7 @@ final class Locator
      *
      * @param class-string<T> $className
      *
-     * @return T|null
+     * @return T
      */
     public function get(string $className)
     {
@@ -72,16 +81,21 @@ final class Locator
             return $instance;
         }
 
-        /** @var T|null $locatedInstance */
+        /** @var T $locatedInstance */
         $locatedInstance = AnonymousGlobal::getByClassName($className)
             ?? GacelaContainer::create($className);
 
-        /** @psalm-suppress MixedAssignment */
-        $this->instanceCache[$className] = $locatedInstance;
+        $this->add($className, $locatedInstance);
 
         return $locatedInstance;
     }
 
+    /**
+     * @template T
+     *
+     * @param class-string<T> $key
+     * @param T $value
+     */
     private function add(string $key, mixed $value): self
     {
         $this->instanceCache[$key] = $value;

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -49,7 +49,7 @@ final class Locator
      *
      * @param class-string<T> $className
      *
-     * @return T
+     * @return T|null
      */
     public static function getSingleton(string $className)
     {
@@ -70,7 +70,7 @@ final class Locator
      *
      * @param class-string<T> $className
      *
-     * @return T
+     * @return T|null
      */
     public function get(string $className)
     {
@@ -81,7 +81,7 @@ final class Locator
             return $instance;
         }
 
-        /** @var T $locatedInstance */
+        /** @var T|null $locatedInstance */
         $locatedInstance = AnonymousGlobal::getByClassName($className)
             ?? GacelaContainer::create($className);
 
@@ -94,9 +94,9 @@ final class Locator
      * @template T
      *
      * @param class-string<T> $key
-     * @param T $value
+     * @param T|null $value
      */
-    private function add(string $key, mixed $value): self
+    private function add(string $key, mixed $value = null): self
     {
         $this->instanceCache[$key] = $value;
 

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -56,7 +56,7 @@ final class Gacela
      *
      * @param class-string<T> $className
      *
-     * @return T
+     * @return T|null
      */
     public static function get(string $className): mixed
     {

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -56,7 +56,7 @@ final class Gacela
      *
      * @param class-string<T> $className
      *
-     * @return T|null
+     * @return T
      */
     public static function get(string $className): mixed
     {

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -16,6 +16,7 @@ use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Container\Container;
+use Gacela\Framework\Container\Locator;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
 use Gacela\Framework\Plugin\PluginInterface;
 
@@ -48,6 +49,18 @@ final class Gacela
             ->init();
 
         self::runPrePlugins($config);
+    }
+
+    /**
+     * @template T
+     *
+     * @param class-string<T> $className
+     *
+     * @return T|null
+     */
+    public static function get(string $className): mixed
+    {
+        return Locator::getSingleton($className);
     }
 
     /**

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -15,7 +15,9 @@ use Gacela\Framework\ClassResolver\ClassResolverCache;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\ConfigFactory;
+use Gacela\Framework\Container\Container;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
+use Gacela\Framework\Plugin\PluginInterface;
 
 final class Gacela
 {
@@ -44,6 +46,8 @@ final class Gacela
         Config::createWithSetup($setup)
             ->setAppRootDir($appRootDir)
             ->init();
+
+        self::runPrePlugins($setup);
     }
 
     /**
@@ -62,5 +66,14 @@ final class Gacela
         }
 
         return new SetupGacela();
+    }
+
+    private static function runPrePlugins(SetupGacelaInterface $setup): void
+    {
+        foreach ($setup->getPrePlugins() as $pluginName) {
+            /** @var PluginInterface $plugin */
+            $plugin = Container::create($pluginName);
+            $plugin->run();
+        }
     }
 }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -43,11 +43,11 @@ final class Gacela
             Config::resetInstance();
         }
 
-        Config::createWithSetup($setup)
-            ->setAppRootDir($appRootDir)
+        $config = Config::createWithSetup($setup);
+        $config->setAppRootDir($appRootDir)
             ->init();
 
-        self::runPrePlugins($setup);
+        self::runPrePlugins($config);
     }
 
     /**
@@ -68,11 +68,19 @@ final class Gacela
         return new SetupGacela();
     }
 
-    private static function runPrePlugins(SetupGacelaInterface $setup): void
+    private static function runPrePlugins(Config $config): void
     {
-        foreach ($setup->getPrePlugins() as $pluginName) {
+        $prePlugins = $config->getSetupGacela()->getPrePlugins();
+
+        if ($prePlugins === []) {
+            return;
+        }
+
+        $container = Container::withConfig($config);
+
+        foreach ($prePlugins as $pluginName) {
             /** @var PluginInterface $plugin */
-            $plugin = Container::create($pluginName);
+            $plugin = $container->get($pluginName);
             $plugin->run();
         }
     }

--- a/src/Framework/Plugin/PluginInterface.php
+++ b/src/Framework/Plugin/PluginInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Plugin;
+
+interface PluginInterface
+{
+    public function run(): void;
+}

--- a/tests/Feature/Framework/PrePlugins/FeatureTest.php
+++ b/tests/Feature/Framework/PrePlugins/FeatureTest.php
@@ -15,7 +15,7 @@ final class FeatureTest extends TestCase
 {
     public function test_singleton_altered_via_pre_plugin(): void
     {
-        Locator::getInstance()->add('singleton', new StringValue('original'));
+        Locator::addSingleton(StringValue::class, new StringValue('original'));
 
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->prePlugins([
@@ -23,8 +23,7 @@ final class FeatureTest extends TestCase
             ]);
         });
 
-        /** @var StringValue $singleton */
-        $singleton = Locator::getInstance()->get('singleton');
+        $singleton = Locator::getSingleton(StringValue::class);
 
         self::assertSame('updated from plugin', $singleton->value());
     }

--- a/tests/Feature/Framework/PrePlugins/FeatureTest.php
+++ b/tests/Feature/Framework/PrePlugins/FeatureTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PrePlugins;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Container\Locator;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\PrePlugins\Module\Infrastructure\ExamplePlugin;
+use GacelaTest\Fixtures\StringValue;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureTest extends TestCase
+{
+    public function test_singleton_altered_via_pre_plugin(): void
+    {
+        Locator::getInstance()->add('singleton', new StringValue('original'));
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->prePlugins([
+                ExamplePlugin::class,
+            ]);
+        });
+
+        /** @var StringValue $singleton */
+        $singleton = Locator::getInstance()->get('singleton');
+
+        self::assertSame('updated from plugin', $singleton->value());
+    }
+}

--- a/tests/Feature/Framework/PrePlugins/Module/Infrastructure/ExamplePlugin.php
+++ b/tests/Feature/Framework/PrePlugins/Module/Infrastructure/ExamplePlugin.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PrePlugins\Module\Infrastructure;
+
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Plugin\PluginInterface;
+use GacelaTest\Fixtures\StringValue;
+
+final class ExamplePlugin implements PluginInterface
+{
+    public function __construct(
+        private Container $container,
+    ) {
+    }
+
+    public function run(): void
+    {
+        /** @var StringValue $string */
+        $string = $this->container->getLocator()->get('singleton');
+
+        $string->setValue('updated from plugin');
+    }
+}

--- a/tests/Feature/Framework/PrePlugins/Module/Infrastructure/ExamplePlugin.php
+++ b/tests/Feature/Framework/PrePlugins/Module/Infrastructure/ExamplePlugin.php
@@ -17,8 +17,7 @@ final class ExamplePlugin implements PluginInterface
 
     public function run(): void
     {
-        /** @var StringValue $string */
-        $string = $this->container->getLocator()->get('singleton');
+        $string = $this->container->getLocator()->get(StringValue::class);
 
         $string->setValue('updated from plugin');
     }


### PR DESCRIPTION
## 📚 Description

There is no way to run custom code right after calling `Gacela::bootstrap()`. 

The goal is to allow running custom code that doesn't need to be define in the entry `index.php`, mainly to set a more complex custom configuration for the dedicated client app.

> Idea inspired by https://github.com/gacela-project/router/issues/25

## 🔖 Changes

- Create a `PluginInterface` which can be custom logic 
- And you can add your custom class in the `GacelaConfig::prePlugings()`
  - Note: it has to extends that new `PluginInterface`

## 🧪  Example

```php
Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
    $config->prePlugins([
      YourCustomLogicPlugin::class,
    ]);
});
```

>**Note**: The `YourCustomLogicPlugin` will be instantiated with the gacela container, which means we got auto-wiring for its dependencies/collaborators.

#### Using the `Container->getLocator()->get(class)`

This img is just an example of another app using this new feature and showing its potential and usage:

![Screenshot 2023-04-25 at 16 21 41](https://user-images.githubusercontent.com/5256287/234306982-c396fe60-9286-4fb1-a17b-4d13277f1dd1.png)

#### Using the global `Gacela::get(class)`

Another option would be to use `Gacela::get(class)` directly there:

![Screenshot 2023-04-25 at 16 28 06](https://user-images.githubusercontent.com/5256287/234308961-1db6df0a-f970-4015-9b02-589fe1d26c53.png)




