### PR TITLE
Use main container on plugins

### DIFF
--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -22,6 +22,6 @@ final class Container extends GacelaContainer implements ContainerInterface
 
     public function getLocator(): LocatorInterface
     {
-        return Locator::getInstance();
+        return Locator::getInstance($this);
     }
 }

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Container;
 
-use Gacela\Container\Container as GacelaContainer;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 
 /**
@@ -17,8 +16,12 @@ final class Locator implements LocatorInterface
     /** @var array<string, mixed> */
     private array $instanceCache = [];
 
-    private function __construct()
-    {
+    private Container $container;
+
+    private function __construct(
+        ?Container $container = null,
+    ) {
+        $this->container = $container ?? new Container();
     }
 
     /**
@@ -51,15 +54,15 @@ final class Locator implements LocatorInterface
      *
      * @return T|null
      */
-    public static function getSingleton(string $className)
+    public static function getSingleton(string $className, ?Container $container = null)
     {
-        return self::getInstance()->get($className);
+        return self::getInstance($container)->get($className);
     }
 
-    public static function getInstance(): self
+    public static function getInstance(?Container $container = null): self
     {
         if (self::$instance === null) {
-            self::$instance = new self();
+            self::$instance = new self($container);
         }
 
         return self::$instance;
@@ -83,7 +86,7 @@ final class Locator implements LocatorInterface
 
         /** @var T|null $locatedInstance */
         $locatedInstance = AnonymousGlobal::getByClassName($className)
-            ?? GacelaContainer::create($className);
+            ?? $this->container->get($className);
 
         $this->add($className, $locatedInstance);
 

--- a/tests/Unit/Framework/Container/LocatorTest.php
+++ b/tests/Unit/Framework/Container/LocatorTest.php
@@ -4,21 +4,14 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Container;
 
+use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Locator;
 use GacelaTest\Fixtures\StringValue;
 use PHPUnit\Framework\TestCase;
 
 final class LocatorTest extends TestCase
 {
-    private Locator $locator;
-
     public function setUp(): void
-    {
-        Locator::resetInstance();
-        $this->locator = Locator::getInstance();
-    }
-
-    public function tearDown(): void
     {
         Locator::resetInstance();
     }
@@ -26,21 +19,14 @@ final class LocatorTest extends TestCase
     public function test_get_concrete_class(): void
     {
         /** @var StringValue $stringValue */
-        $stringValue = $this->locator->get(StringValue::class);
+        $stringValue = Locator::getInstance()->get(StringValue::class);
         self::assertInstanceOf(StringValue::class, $stringValue);
         self::assertSame('', $stringValue->value());
         $stringValue->setValue('updated value');
 
         /** @var StringValue $stringValue2 */
-        $stringValue2 = $this->locator->get(StringValue::class);
+        $stringValue2 = Locator::getInstance()->get(StringValue::class);
         self::assertSame('updated value', $stringValue2->value());
-    }
-
-    public function test_get_null_from_non_existing_class(): void
-    {
-        $nullValue = $this->locator->get(NonExisting::class);
-
-        self::assertNull($nullValue);
     }
 
     public function test_get_non_existing_singleton(): void
@@ -55,6 +41,17 @@ final class LocatorTest extends TestCase
         Locator::addSingleton(StringValue::class, new StringValue('str'));
 
         $singleton = Locator::getSingleton(StringValue::class);
+
+        self::assertEquals(new StringValue('str'), $singleton);
+    }
+
+    public function test_get_existing_singleton_from_container(): void
+    {
+        $container = new Container(bindings: [
+            StringValue::class => new StringValue('str'),
+        ]);
+
+        $singleton = Locator::getSingleton(StringValue::class, $container);
 
         self::assertEquals(new StringValue('str'), $singleton);
     }


### PR DESCRIPTION
## 📚 Description

I discovered a bug while developing a `api-skeleton` repository, where I am using all gacela components together:
 
<img width="1079" alt="Screenshot 2023-04-28 at 20 17 22" src="https://user-images.githubusercontent.com/5256287/235223444-aaaf1aea-46ba-4f39-87c8-7825358698a0.png">

The reason was that after the change https://github.com/gacela-project/router/pull/28 we removed the three collaborator classes (via constructor) and instead we are passing an optional Clojure to the Router class. This, however, wasn't working fine with our current gacela container because it didn't know how to resolve those dependencies.

The solution was to allow defining external global bindings (currently known as `mappingInterfaces` at `GacelaConfig` level (extra: there is an issue to rename this concept to bindings https://github.com/gacela-project/gacela/issues/266 as done in the [gacela container project](https://github.com/gacela-project/container/blob/main/src/Container/Container.php#L40)).

## 🔖 Changes

- Pass down the main container to the Locator singleton created when doing `Gacela::bootstrap()`.
  - This is mandatory step to setup Gacela in your project.
  - This allow you to setup global singletons that you can access later on at any time using `Gacela::get(key)` which is useful, for example, if you want to define a single instance of a Router and you want to alter it to add different routes depending on each module.
