### PR TITLE
Rename PluginInterface main method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Rename PluginInterface main method from `run()` to `__invoke()` 
+
 ### 1.2.0
 ### 2023-04-29
 

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,7 @@
             "php": "8.0"
         },
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "veewee/composer-run-parallel": true
+            "composer/package-versions-deprecated": true
         }
     },
     "scripts": {

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -18,7 +18,6 @@ use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Locator;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
-use Gacela\Framework\Plugin\PluginInterface;
 use RuntimeException;
 
 final class Gacela
@@ -99,9 +98,9 @@ final class Gacela
         self::$mainContainer = Container::withConfig($config);
 
         foreach ($plugins as $pluginName) {
-            /** @var PluginInterface $plugin */
+            /** @var callable $plugin */
             $plugin = self::$mainContainer->get($pluginName);
-            $plugin->run();
+            $plugin();
         }
     }
 }

--- a/src/Framework/Plugin/PluginInterface.php
+++ b/src/Framework/Plugin/PluginInterface.php
@@ -6,5 +6,5 @@ namespace Gacela\Framework\Plugin;
 
 interface PluginInterface
 {
-    public function run(): void;
+    public function __invoke(): void;
 }

--- a/tests/Feature/Framework/Plugins/Module/Infrastructure/ExamplePluginWithConstructor.php
+++ b/tests/Feature/Framework/Plugins/Module/Infrastructure/ExamplePluginWithConstructor.php
@@ -15,7 +15,7 @@ final class ExamplePluginWithConstructor implements PluginInterface
     ) {
     }
 
-    public function run(): void
+    public function __invoke(): void
     {
         $string = $this->container->getLocator()->get(StringValue::class);
 

--- a/tests/Feature/Framework/Plugins/Module/Infrastructure/ExamplePluginWithoutConstructor.php
+++ b/tests/Feature/Framework/Plugins/Module/Infrastructure/ExamplePluginWithoutConstructor.php
@@ -10,7 +10,7 @@ use GacelaTest\Fixtures\StringValue;
 
 final class ExamplePluginWithoutConstructor implements PluginInterface
 {
-    public function run(): void
+    public function __invoke(): void
     {
         $string = Gacela::get(StringValue::class);
 


### PR DESCRIPTION
## 📚 Description

The current `PluginInterface` forces you to implement that interface if you want to create a plugin, which forces you to require the entire gacela package as dependency.

However, it would be useful to allow any invokable/callable thing to be executed as a plugin, so you can define plugins that will be instantiated later without the need of depending on the fully gacela as dependency.

## 🔖 Changes

- Rename the `PluginInterface::run()` as just `PluginInterface::__invoke()`
