### PR TITLE
Rename addPlugin() to addAfterPlugin()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Rename PluginInterface main method from `run()` to `__invoke()` 
+- Rename `addPlugin()` to `addAfterPlugin()`
 
 ### 1.2.0
 ### 2023-04-29

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -44,7 +44,7 @@ final class GacelaConfig
     private ?array $specificListeners = null;
 
     /** @var list<class-string<PluginInterface>>  */
-    private ?array $plugins = null;
+    private ?array $afterPlugins = null;
 
     /** @var array<string,list<Closure>> */
     private array $servicesToExtend = [];
@@ -316,13 +316,23 @@ final class GacelaConfig
 
         return $this;
     }
-
     /**
+     * @deprecated in favor of `addAfterPlugin()`
+     * It will be removed in the next release
+     *
      * @param class-string<PluginInterface> $plugin
      */
     public function addPlugin(string $plugin): self
     {
-        $this->plugins[] = $plugin;
+        return $this->addAfterPlugin($plugin);
+    }
+
+    /**
+     * @param class-string<PluginInterface> $plugin
+     */
+    public function addAfterPlugin(string $plugin): self
+    {
+        $this->afterPlugins[] = $plugin;
 
         return $this;
     }
@@ -330,9 +340,9 @@ final class GacelaConfig
     /**
      * @param list<class-string<PluginInterface>> $list
      */
-    public function addPlugins(array $list): self
+    public function addAfterPlugins(array $list): self
     {
-        $this->plugins = array_merge($this->plugins ?? [], $list);
+        $this->afterPlugins = array_merge($this->afterPlugins ?? [], $list);
 
         return $this;
     }
@@ -351,7 +361,7 @@ final class GacelaConfig
      *     are-event-listeners-enabled: ?bool,
      *     generic-listeners: ?list<callable>,
      *     specific-listeners: ?array<class-string,list<callable>>,
-     *     plugins: ?list<class-string<PluginInterface>>,
+     *     after-plugins: ?list<class-string<PluginInterface>>,
      *     services-to-extend: array<string,list<Closure>>,
      * }
      *
@@ -372,7 +382,7 @@ final class GacelaConfig
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
             'generic-listeners' => $this->genericListeners,
             'specific-listeners' => $this->specificListeners,
-            'plugins' => $this->plugins,
+            'after-plugins' => $this->afterPlugins,
             'services-to-extend' => $this->servicesToExtend,
         ];
     }

--- a/src/Framework/Bootstrap/SetupCombinator.php
+++ b/src/Framework/Bootstrap/SetupCombinator.php
@@ -102,8 +102,8 @@ final class SetupCombinator
 
     private function combinePlugins(SetupGacela $other): void
     {
-        if ($other->isPropertyChanged(SetupGacela::plugins)) {
-            $this->original->combinePlugins($other->getPlugins());
+        if ($other->isPropertyChanged(SetupGacela::afterPlugins)) {
+            $this->original->combinePlugins($other->getAfterPlugins());
         }
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -29,7 +29,7 @@ final class SetupGacela extends AbstractSetupGacela
     public const projectNamespaces = 'projectNamespaces';
     public const configKeyValues = 'configKeyValues';
     public const servicesToExtend = 'servicesToExtend';
-    public const plugins = 'plugins';
+    public const afterPlugins = 'afterPlugins';
 
     private const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
     private const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
@@ -89,7 +89,7 @@ final class SetupGacela extends AbstractSetupGacela
     private ?array $servicesToExtend = null;
 
     /** @var ?list<class-string<PluginInterface>> */
-    private ?array $plugins = null;
+    private ?array $afterPlugins = null;
 
     public function __construct()
     {
@@ -144,7 +144,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
             ->setGenericListeners($build['generic-listeners'])
             ->setSpecificListeners($build['specific-listeners'])
-            ->setPlugins($build['plugins'])
+            ->setAfterPlugins($build['after-plugins'])
             ->setServicesToExtend($build['services-to-extend']);
     }
 
@@ -453,15 +453,15 @@ final class SetupGacela extends AbstractSetupGacela
      */
     public function combinePlugins(array $list): void
     {
-        $this->setPlugins(array_merge($this->plugins ?? [], $list));
+        $this->setAfterPlugins(array_merge($this->afterPlugins ?? [], $list));
     }
 
     /**
      * @return list<class-string<PluginInterface>>
      */
-    public function getPlugins(): array
+    public function getAfterPlugins(): array
     {
-        return (array)$this->plugins;
+        return (array)$this->afterPlugins;
     }
 
     private function setAreEventListenersEnabled(?bool $flag): self
@@ -501,10 +501,10 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param ?list<class-string<PluginInterface>> $list
      */
-    private function setPlugins(?array $list): self
+    private function setAfterPlugins(?array $list): self
     {
-        $this->markPropertyChanged(self::plugins, $list);
-        $this->plugins = $list ?? self::DEFAULT_PLUGINS;
+        $this->markPropertyChanged(self::afterPlugins, $list);
+        $this->afterPlugins = $list ?? self::DEFAULT_PLUGINS;
 
         return $this;
     }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -81,5 +81,5 @@ interface SetupGacelaInterface
     /**
      * @return list<class-string<PluginInterface>>
      */
-    public function getPlugins(): array;
+    public function getAfterPlugins(): array;
 }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -89,7 +89,7 @@ final class Gacela
 
     private static function runPlugins(Config $config): void
     {
-        $plugins = $config->getSetupGacela()->getPlugins();
+        $plugins = $config->getSetupGacela()->getAfterPlugins();
 
         if ($plugins === []) {
             return;

--- a/tests/Feature/Framework/Plugins/AfterFeatureTest.php
+++ b/tests/Feature/Framework/Plugins/AfterFeatureTest.php
@@ -11,12 +11,12 @@ use GacelaTest\Feature\Framework\Plugins\Module\Infrastructure\ExamplePluginWith
 use GacelaTest\Fixtures\StringValue;
 use PHPUnit\Framework\TestCase;
 
-final class FeatureTest extends TestCase
+final class AfterFeatureTest extends TestCase
 {
     public function test_singleton_altered_via_plugin_with_constructor(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addPlugin(ExamplePluginWithConstructor::class);
+            $config->addAfterPlugin(ExamplePluginWithConstructor::class);
         });
 
         /** @var StringValue $singleton */
@@ -28,7 +28,7 @@ final class FeatureTest extends TestCase
     public function test_singleton_altered_via_plugin_without_constructor(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addPlugin(ExamplePluginWithoutConstructor::class);
+            $config->addAfterPlugin(ExamplePluginWithoutConstructor::class);
         });
 
         /** @var StringValue $singleton */
@@ -40,7 +40,7 @@ final class FeatureTest extends TestCase
     public function test_multiple_plugins_latest_win(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->addPlugins([
+            $config->addAfterPlugins([
                 ExamplePluginWithConstructor::class,
                 ExamplePluginWithoutConstructor::class,
             ]);

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -205,11 +205,11 @@ final class SetupGacelaTest extends TestCase
     {
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->addPlugin(ExamplePluginWithoutConstructor::class),
+                ->addAfterPlugin(ExamplePluginWithoutConstructor::class),
         );
         $setup2 = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->addPlugin(ExamplePluginWithConstructor::class),
+                ->addAfterPlugin(ExamplePluginWithConstructor::class),
         );
 
         $setup->combine($setup2);
@@ -217,6 +217,6 @@ final class SetupGacelaTest extends TestCase
         self::assertEquals([
             ExamplePluginWithoutConstructor::class,
             ExamplePluginWithConstructor::class,
-        ], $setup->getPlugins());
+        ], $setup->getAfterPlugins());
     }
 }


### PR DESCRIPTION
## 📚 Description

Currently, we have only plugins that are executed right after bootstrapping gacela.

We want to add plugins before the bootstrapping, therefore the first step is to rename the "neutral plugins methods" to distinguish them between before and after.

## 🔖 Changes

- Rename `addPlugin()` to `addAfterPlugin()`

## ⛓️ Follow up

Add `GacelaConfig->addBeforePlugin()`
