### PR TITLE
Remove deprecated setFileCacheEnabled() & setFileCacheDirectory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 - Deleted `PluginInterface`
   - A plugin can be any class that implements `__invoke()`
 - Added `GacelaConfig::addExtendConfig()`
+- Remove the deprecated methods `setFileCacheEnabled()` & `setFileCacheDirectory()`
 
 ### 1.2.0
 ### 2023-04-29
 
-- Unify `setFileCacheEnabled` and `setFileCacheDirectory` into one single method: `setFileCache(bool $enabled, string $dir)`. Deprecated the former methods.
+- Unify `setFileCacheEnabled` and `setFileCacheDirectory` into one single method: `setFileCache(bool $enabled, string $dir)`. Deprecated the former methods
 - Rename dependency; from `resolver` to `container`.
-- Moved the current `Container` logic to the decoupled `container` dependency.
+- Moved the current `Container` logic to the decoupled `container` dependency
 - Add "plugins" to run right after the `Gacela::bootstrap()`
 - Deprecated `addMappingInterface()` in favor of `addBinding()`
 

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -208,32 +208,6 @@ final class GacelaConfig
     }
 
     /**
-     * Define whether the file cache flag is enabled.
-     *
-     * @deprecated in favor of setFileCache()
-     * It will be removed in the next release
-     */
-    public function setFileCacheEnabled(bool $flag): self
-    {
-        $this->fileCacheEnabled = $flag;
-
-        return $this;
-    }
-
-    /**
-     * Define the file cache directory.
-     *
-     * @deprecated in favor of setFileCache()
-     * It will be removed in the next release
-     */
-    public function setFileCacheDirectory(string $dir): self
-    {
-        $this->fileCacheDirectory = $dir;
-
-        return $this;
-    }
-
-    /**
      * Define a list of project namespaces.
      *
      * @param list<string> $list


### PR DESCRIPTION
## 📚 Description

Remove from `GacelaConfig` the deprecated methods `setFileCacheEnabled()` and `setFileCacheDirectory()`.