### PR TITLE
Add Gacela::rootDir()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- Added `Gacela::get('rootDir')`
+- Added `Gacela::rootDir()`
 
 ### 1.3.0
 ### 2023-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Added `Gacela::get('rootDir')`
+
 ### 1.3.0
 ### 2023-05-08
 

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -53,6 +53,8 @@ final class Gacela
             ->init();
 
         self::runPlugins($config);
+
+        self::$mainContainer?->set('rootDir', $appRootDir);
     }
 
     /**

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -22,6 +22,7 @@ use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
 final class Gacela
 {
     private static ?Container $mainContainer = null;
+    private static ?string $appRootDir = null;
 
     /**
      * Define the entry point of Gacela.
@@ -30,6 +31,7 @@ final class Gacela
      */
     public static function bootstrap(string $appRootDir, Closure $configFn = null): void
     {
+        self::$appRootDir = $appRootDir;
         self::$mainContainer = null;
 
         $setup = self::processConfigFnIntoSetup($appRootDir, $configFn);
@@ -53,8 +55,6 @@ final class Gacela
             ->init();
 
         self::runPlugins($config);
-
-        self::$mainContainer?->set('rootDir', $appRootDir);
     }
 
     /**
@@ -67,6 +67,11 @@ final class Gacela
     public static function get(string $className): mixed
     {
         return Locator::getSingleton($className, self::$mainContainer);
+    }
+
+    public static function rootDir(): ?string
+    {
+        return self::$appRootDir;
     }
 
     /**

--- a/tests/Integration/Framework/GacelaTest.php
+++ b/tests/Integration/Framework/GacelaTest.php
@@ -7,11 +7,19 @@ namespace GacelaTest\Integration\Framework;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 final class GacelaTest extends TestCase
 {
     public function test_null_get_cache_dir(): void
     {
+        // Needed in order to set up the private `Gacela::$appRootDir as null` for this use case
+        // when you try to access it before bootstrapping the application.
+        $reflectionClass = new ReflectionClass(Gacela::class);
+        $reflectionProperty = $reflectionClass->getProperty('appRootDir');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null);
+
         self::assertNull(Gacela::rootDir());
     }
 

--- a/tests/Integration/Framework/GacelaTest.php
+++ b/tests/Integration/Framework/GacelaTest.php
@@ -12,7 +12,7 @@ final class GacelaTest extends TestCase
 {
     public function test_null_get_cache_dir(): void
     {
-        self::assertNull(Gacela::get('rootDir'));
+        self::assertNull(Gacela::rootDir());
     }
 
     /**
@@ -20,10 +20,10 @@ final class GacelaTest extends TestCase
      */
     public function test_get_cache_dir(): void
     {
-        Gacela::bootstrap(__DIR__, function (GacelaConfig $config) {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
         });
 
-        self::assertEquals(__DIR__, Gacela::get('rootDir'));
+        self::assertEquals(__DIR__, Gacela::rootDir());
     }
 }

--- a/tests/Integration/Framework/GacelaTest.php
+++ b/tests/Integration/Framework/GacelaTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class GacelaTest extends TestCase
+{
+    public function test_null_get_cache_dir(): void
+    {
+        self::assertNull(Gacela::get('rootDir'));
+    }
+
+    /**
+     * @depends test_null_get_cache_dir
+     */
+    public function test_get_cache_dir(): void
+    {
+        Gacela::bootstrap(__DIR__, function (GacelaConfig $config) {
+            $config->resetInMemoryCache();
+        });
+
+        self::assertEquals(__DIR__, Gacela::get('rootDir'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

I think it would be useful to be able to access to the rootDir of the application anywhere is needed, especially for configuration stuff.

>**Note** Thanks @JesusValera for the idea 💡 

## 🔖 Changes

- Save the appRootDir as static prop in the Gacela class and make it accesible from anywhere as static method.