### PR TITLE
Allow plugins as callables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.0, <8.3",
-        "gacela-project/container": "^0.4"
+        "gacela-project/container": "^0.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -45,7 +45,7 @@ final class GacelaConfig
     /** @var list<class-string>  */
     private ?array $extendConfig = null;
 
-    /** @var list<class-string>  */
+    /** @var list<class-string|callable>  */
     private ?array $plugins = null;
 
     /** @var array<string,list<Closure>> */
@@ -321,9 +321,9 @@ final class GacelaConfig
     }
 
     /**
-     * @param class-string $plugin
+     * @param class-string|callable $plugin
      */
-    public function addPlugin(string $plugin): self
+    public function addPlugin(string|callable $plugin): self
     {
         $this->plugins[] = $plugin;
 
@@ -331,7 +331,7 @@ final class GacelaConfig
     }
 
     /**
-     * @param list<class-string> $list
+     * @param list<class-string|callable> $list
      */
     public function addPlugins(array $list): self
     {
@@ -355,7 +355,7 @@ final class GacelaConfig
      *     generic-listeners: ?list<callable>,
      *     specific-listeners: ?array<class-string,list<callable>>,
      *     before-config: ?list<class-string>,
-     *     after-plugins: ?list<class-string>,
+     *     after-plugins: ?list<class-string|callable>,
      *     services-to-extend: array<string,list<Closure>>,
      * }
      *

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -94,7 +94,7 @@ final class SetupGacela extends AbstractSetupGacela
     /** @var ?list<class-string> */
     private ?array $extendConfig = null;
 
-    /** @var ?list<class-string> */
+    /** @var ?list<class-string|callable> */
     private ?array $plugins = null;
 
     public function __construct()
@@ -465,7 +465,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param list<class-string> $list
+     * @param list<class-string|callable> $list
      */
     public function combinePlugins(array $list): void
     {
@@ -481,7 +481,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return list<class-string>
+     * @return list<class-string|callable>
      */
     public function getPlugins(): array
     {
@@ -549,7 +549,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param ?list<class-string> $list
+     * @param ?list<class-string|callable> $list
      */
     private function setPlugins(?array $list): self
     {

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -83,7 +83,7 @@ interface SetupGacelaInterface
     public function getExtendConfig(): array;
 
     /**
-     * @return list<class-string>
+     * @return list<class-string|callable>
      */
     public function getPlugins(): array;
 }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -20,6 +20,8 @@ use Gacela\Framework\Container\Locator;
 use Gacela\Framework\DocBlockResolver\DocBlockResolverCache;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 
+use function is_string;
+
 final class Gacela
 {
     private static ?Container $mainContainer = null;
@@ -102,10 +104,13 @@ final class Gacela
 
         $plugins = $config->getSetupGacela()->getPlugins();
 
-        foreach ($plugins as $pluginName) {
-            /** @var callable $plugin */
-            $plugin = self::$mainContainer->get($pluginName);
-            $plugin();
+        foreach ($plugins as $plugin) {
+            /** @var callable $current */
+            $current = is_string($plugin)
+                ? self::$mainContainer->get($plugin)
+                : $plugin;
+
+            self::$mainContainer->resolve($current);
         }
     }
 }

--- a/tests/Feature/Framework/Plugins/FeatureTest.php
+++ b/tests/Feature/Framework/Plugins/FeatureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\Plugins;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Framework\Plugins\Module\Infrastructure\ExamplePluginWithConstructor;
 use GacelaTest\Feature\Framework\Plugins\Module\Infrastructure\ExamplePluginWithoutConstructor;
@@ -50,5 +51,20 @@ final class FeatureTest extends TestCase
         $singleton = Gacela::get(StringValue::class);
 
         self::assertSame('Set from plugin ExamplePluginWithoutConstructor', $singleton->value());
+    }
+
+    public function test_singleton_altered_via_plugin_as_callable(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addPlugin(static function (Container $container): void {
+                $string = $container->getLocator()->get(StringValue::class);
+                $string?->setValue('Set from callable');
+            });
+        });
+
+        /** @var StringValue $singleton */
+        $singleton = Gacela::get(StringValue::class);
+
+        self::assertSame('Set from callable', $singleton->value());
     }
 }


### PR DESCRIPTION
## 📚 Description

Currently, plugins are added by class names.

## 🔖 Changes

- Allow plugins as callables

```php
# class GacelaConfig:

public function addPlugin(string|callable $plugin): self
```
