### PR TITLE
Refactoring and renaming internal variables

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -354,8 +354,8 @@ final class GacelaConfig
      *     are-event-listeners-enabled: ?bool,
      *     generic-listeners: ?list<callable>,
      *     specific-listeners: ?array<class-string,list<callable>>,
-     *     before-config: ?list<class-string>,
-     *     after-plugins: ?list<class-string|callable>,
+     *     extend-config: ?list<class-string>,
+     *     plugins: ?list<class-string|callable>,
      *     services-to-extend: array<string,list<Closure>>,
      * }
      *
@@ -376,8 +376,8 @@ final class GacelaConfig
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
             'generic-listeners' => $this->genericListeners,
             'specific-listeners' => $this->specificListeners,
-            'before-config' => $this->extendConfig,
-            'after-plugins' => $this->plugins,
+            'extend-config' => $this->extendConfig,
+            'plugins' => $this->plugins,
             'services-to-extend' => $this->servicesToExtend,
         ];
     }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -17,7 +17,7 @@ final class GacelaConfig
 
     private SuffixTypesBuilder $suffixTypesBuilder;
 
-    private BindingsBuilder $bindingBuilder;
+    private BindingsBuilder $bindingsBuilder;
 
     /** @var array<string, class-string|object|callable> */
     private array $externalServices;
@@ -59,7 +59,7 @@ final class GacelaConfig
         $this->externalServices = $externalServices;
         $this->configBuilder = new ConfigBuilder();
         $this->suffixTypesBuilder = new SuffixTypesBuilder();
-        $this->bindingBuilder = new BindingsBuilder();
+        $this->bindingsBuilder = new BindingsBuilder();
     }
 
     /**
@@ -158,7 +158,7 @@ final class GacelaConfig
      */
     public function addBinding(string $key, string|object|callable $value): self
     {
-        $this->bindingBuilder->bind($key, $value);
+        $this->bindingsBuilder->bind($key, $value);
 
         return $this;
     }
@@ -345,7 +345,7 @@ final class GacelaConfig
      *     external-services: array<string,class-string|object|callable>,
      *     config-builder: ConfigBuilder,
      *     suffix-types-builder: SuffixTypesBuilder,
-     *     mapping-interfaces-builder: BindingsBuilder,
+     *     bindings-builder: BindingsBuilder,
      *     should-reset-in-memory-cache: ?bool,
      *     file-cache-enabled: ?bool,
      *     file-cache-directory: ?string,
@@ -356,7 +356,7 @@ final class GacelaConfig
      *     specific-listeners: ?array<class-string,list<callable>>,
      *     extend-config: ?list<class-string>,
      *     plugins: ?list<class-string|callable>,
-     *     services-to-extend: array<string,list<Closure>>,
+     *     instances-to-extend: array<string,list<Closure>>,
      * }
      *
      * @internal
@@ -367,7 +367,7 @@ final class GacelaConfig
             'external-services' => $this->externalServices,
             'config-builder' => $this->configBuilder,
             'suffix-types-builder' => $this->suffixTypesBuilder,
-            'mapping-interfaces-builder' => $this->bindingBuilder,
+            'bindings-builder' => $this->bindingsBuilder,
             'should-reset-in-memory-cache' => $this->shouldResetInMemoryCache,
             'file-cache-enabled' => $this->fileCacheEnabled,
             'file-cache-directory' => $this->fileCacheDirectory,
@@ -378,7 +378,7 @@ final class GacelaConfig
             'specific-listeners' => $this->specificListeners,
             'extend-config' => $this->extendConfig,
             'plugins' => $this->plugins,
-            'services-to-extend' => $this->servicesToExtend,
+            'instances-to-extend' => $this->servicesToExtend,
         ];
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -151,8 +151,8 @@ final class SetupGacela extends AbstractSetupGacela
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
             ->setGenericListeners($build['generic-listeners'])
             ->setSpecificListeners($build['specific-listeners'])
-            ->setExtendConfig($build['before-config'])
-            ->setPlugins($build['after-plugins'])
+            ->setExtendConfig($build['extend-config'])
+            ->setPlugins($build['plugins'])
             ->setServicesToExtend($build['services-to-extend']);
     }
 
@@ -488,18 +488,18 @@ final class SetupGacela extends AbstractSetupGacela
         return (array)$this->plugins;
     }
 
-    private static function runExtendConfig(GacelaConfig $config): void
+    private static function runExtendConfig(GacelaConfig $gacelaConfig): void
     {
-        $plugins = $config->build()['before-config'] ?? [];
+        $extendConfigs = $gacelaConfig->build()['extend-config'] ?? [];
 
-        if ($plugins === []) {
+        if ($extendConfigs === []) {
             return;
         }
 
-        foreach ($plugins as $pluginName) {
-            /** @var callable $plugin */
-            $plugin = Container::create($pluginName);
-            $plugin($config);
+        foreach ($extendConfigs as $extendConfig) {
+            /** @var callable $configToExtend */
+            $configToExtend = Container::create($extendConfig);
+            $configToExtend($gacelaConfig);
         }
     }
 

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -495,10 +495,7 @@ final class SetupGacela extends AbstractSetupGacela
             return;
         }
 
-        $container = new Container(
-            $gacelaConfig->build()['bindings-builder']->build(),
-            $gacelaConfig->build()['instances-to-extend'],
-        );
+        $container = new Container();
 
         foreach ($extendConfigs as $extendConfig) {
             /** @var callable $configToExtend */

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -13,7 +13,6 @@ use Gacela\Framework\Container\Container;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
-
 use RuntimeException;
 
 use function is_callable;
@@ -142,7 +141,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setExternalServices($build['external-services'])
             ->setConfigBuilder($build['config-builder'])
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
-            ->setBindingsBuilder($build['mapping-interfaces-builder'])
+            ->setBindingsBuilder($build['bindings-builder'])
             ->setShouldResetInMemoryCache($build['should-reset-in-memory-cache'])
             ->setFileCacheEnabled($build['file-cache-enabled'])
             ->setFileCacheDirectory($build['file-cache-directory'])
@@ -153,7 +152,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setSpecificListeners($build['specific-listeners'])
             ->setExtendConfig($build['extend-config'])
             ->setPlugins($build['plugins'])
-            ->setServicesToExtend($build['services-to-extend']);
+            ->setServicesToExtend($build['instances-to-extend']);
     }
 
     /**
@@ -496,9 +495,14 @@ final class SetupGacela extends AbstractSetupGacela
             return;
         }
 
+        $container = new Container(
+            $gacelaConfig->build()['bindings-builder']->build(),
+            $gacelaConfig->build()['instances-to-extend'],
+        );
+
         foreach ($extendConfigs as $extendConfig) {
             /** @var callable $configToExtend */
-            $configToExtend = Container::create($extendConfig);
+            $configToExtend = $container->get($extendConfig);
             $configToExtend($gacelaConfig);
         }
     }


### PR DESCRIPTION
## 🔖 Changes

- Apply refactorings such as
  - renaming internal variables
  - reuse a "container instance" instead of the `Container::create()` static method
