### PR TITLE
Refactor setup event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,7 @@
             "php": "8.0"
         },
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "infection/extension-installer": false
+            "composer/package-versions-deprecated": true
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
             "php": "8.0"
         },
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "infection/extension-installer": false
         }
     },
     "scripts": {

--- a/src/Framework/Bootstrap/SetupCombinator.php
+++ b/src/Framework/Bootstrap/SetupCombinator.php
@@ -12,8 +12,9 @@ use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
  */
 final class SetupCombinator
 {
-    public function __construct(private SetupGacela $original)
-    {
+    public function __construct(
+        private SetupGacela $original,
+    ) {
     }
 
     public function combine(SetupGacela $other): SetupGacela

--- a/src/Framework/Bootstrap/SetupEventDispatcher.php
+++ b/src/Framework/Bootstrap/SetupEventDispatcher.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap;
+
+use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+
+final class SetupEventDispatcher
+{
+    public function __construct(
+        private SetupGacela $setupGacela,
+    ) {
+    }
+
+    public function __invoke(): EventDispatcherInterface
+    {
+        if (!$this->setupGacela->canCreateEventDispatcher()) {
+            return new NullEventDispatcher();
+        }
+
+        $dispatcher = new ConfigurableEventDispatcher();
+        $dispatcher->registerGenericListeners($this->setupGacela->getGenericListeners() ?? []);
+
+        foreach ($this->setupGacela->getSpecificListeners() ?? [] as $event => $listeners) {
+            foreach ($listeners as $callable) {
+                $dispatcher->registerSpecificListener($event, $callable);
+            }
+        }
+
+        return $dispatcher;
+    }
+}

--- a/src/Framework/Bootstrap/SetupEventDispatcher.php
+++ b/src/Framework/Bootstrap/SetupEventDispatcher.php
@@ -10,21 +10,16 @@ use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
 
 final class SetupEventDispatcher
 {
-    public function __construct(
-        private SetupGacela $setupGacela,
-    ) {
-    }
-
-    public function __invoke(): EventDispatcherInterface
+    public static function getDispatcher(SetupGacela $setupGacela): EventDispatcherInterface
     {
-        if (!$this->setupGacela->canCreateEventDispatcher()) {
+        if (!$setupGacela->canCreateEventDispatcher()) {
             return new NullEventDispatcher();
         }
 
         $dispatcher = new ConfigurableEventDispatcher();
-        $dispatcher->registerGenericListeners($this->setupGacela->getGenericListeners() ?? []);
+        $dispatcher->registerGenericListeners($setupGacela->getGenericListeners() ?? []);
 
-        foreach ($this->setupGacela->getSpecificListeners() ?? [] as $event => $listeners) {
+        foreach ($setupGacela->getSpecificListeners() ?? [] as $event => $listeners) {
             foreach ($listeners as $callable) {
                 $dispatcher->registerSpecificListener($event, $callable);
             }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -338,7 +338,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function getEventDispatcher(): EventDispatcherInterface
     {
-        return $this->eventDispatcher ??= (new SetupEventDispatcher($this))();
+        return $this->eventDispatcher ??= SetupEventDispatcher::getDispatcher($this);
     }
 
     /**

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -10,9 +10,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Container\Container;
-use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
-use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
 use RuntimeException;
 
 use function is_callable;
@@ -340,24 +338,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function getEventDispatcher(): EventDispatcherInterface
     {
-        if ($this->eventDispatcher !== null) {
-            return $this->eventDispatcher;
-        }
-
-        if ($this->canCreateEventDispatcher()) {
-            $this->eventDispatcher = new ConfigurableEventDispatcher();
-            $this->eventDispatcher->registerGenericListeners($this->genericListeners ?? []);
-
-            foreach ($this->specificListeners ?? [] as $event => $listeners) {
-                foreach ($listeners as $callable) {
-                    $this->eventDispatcher->registerSpecificListener($event, $callable);
-                }
-            }
-        } else {
-            $this->eventDispatcher = new NullEventDispatcher();
-        }
-
-        return $this->eventDispatcher;
+        return $this->eventDispatcher ??= (new SetupEventDispatcher($this))();
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

The current `SetupGacela` class is a bit overloaded. So we need to look for opportunities to extract logic from that class to make it easier to handle.

Scrutinizer score: https://scrutinizer-ci.com/g/gacela-project/gacela/code-structure/main/class/Gacela%5CFramework%5CBootstrap%5CSetupGacela


## 🔖 Changes

- Apply extract-class refactoring in the part where we are getting the event dispatcher from the `SetupGacela` creating a new class named `SetupEventDispatcher`


## 🖼️ Screenshots

### BEFORE
<img width="1220" alt="Screenshot 2023-05-19 at 18 18 52" src="https://github.com/gacela-project/gacela/assets/5256287/401c7fd6-58c5-4a22-ab02-44729ad5adb3">

### AFTER
<img width="1200" alt="Screenshot 2023-05-19 at 18 18 35" src="https://github.com/gacela-project/gacela/assets/5256287/43882a2c-e1bf-49c3-8acb-646c62c64958">

