### PR TITLE
Rename internal ConfigBuilder to AppConfigBuilder

### DIFF
--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap;
 
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
 abstract class AbstractSetupGacela implements SetupGacelaInterface
@@ -13,7 +13,7 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     /**
      * Define different config sources.
      */
-    public function buildConfig(ConfigBuilder $builder): ConfigBuilder
+    public function buildAppConfig(AppConfigBuilder $builder): AppConfigBuilder
     {
         return $builder;
     }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -6,14 +6,14 @@ namespace Gacela\Framework\Bootstrap;
 
 use Closure;
 use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\GacelaEventInterface;
 
 final class GacelaConfig
 {
-    private ConfigBuilder $configBuilder;
+    private AppConfigBuilder $appConfigBuilder;
 
     private SuffixTypesBuilder $suffixTypesBuilder;
 
@@ -57,7 +57,7 @@ final class GacelaConfig
     public function __construct(array $externalServices = [])
     {
         $this->externalServices = $externalServices;
-        $this->configBuilder = new ConfigBuilder();
+        $this->appConfigBuilder = new AppConfigBuilder();
         $this->suffixTypesBuilder = new SuffixTypesBuilder();
         $this->bindingsBuilder = new BindingsBuilder();
     }
@@ -93,7 +93,7 @@ final class GacelaConfig
      */
     public function addAppConfig(string $path, string $pathLocal = '', $reader = null): self
     {
-        $this->configBuilder->add($path, $pathLocal, $reader);
+        $this->appConfigBuilder->add($path, $pathLocal, $reader);
 
         return $this;
     }
@@ -343,7 +343,7 @@ final class GacelaConfig
     /**
      * @return array{
      *     external-services: array<string,class-string|object|callable>,
-     *     config-builder: ConfigBuilder,
+     *     app-config-builder: AppConfigBuilder,
      *     suffix-types-builder: SuffixTypesBuilder,
      *     bindings-builder: BindingsBuilder,
      *     should-reset-in-memory-cache: ?bool,
@@ -365,7 +365,7 @@ final class GacelaConfig
     {
         return [
             'external-services' => $this->externalServices,
-            'config-builder' => $this->configBuilder,
+            'app-config-builder' => $this->appConfigBuilder,
             'suffix-types-builder' => $this->suffixTypesBuilder,
             'bindings-builder' => $this->bindingsBuilder,
             'should-reset-in-memory-cache' => $this->shouldResetInMemoryCache,

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -6,8 +6,8 @@ namespace Gacela\Framework\Bootstrap;
 
 use Closure;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
@@ -42,8 +42,8 @@ final class SetupGacela extends AbstractSetupGacela
     private const DEFAULT_EXTEND_CONFIG = [];
     private const DEFAULT_PLUGINS = [];
 
-    /** @var callable(ConfigBuilder):void */
-    private $configFn;
+    /** @var callable(AppConfigBuilder):void */
+    private $appConfigFn;
 
     /** @var callable(BindingsBuilder,array<string,mixed>):void */
     private $bindingsFn;
@@ -54,7 +54,7 @@ final class SetupGacela extends AbstractSetupGacela
     /** @var ?array<string,class-string|object|callable> */
     private ?array $externalServices = null;
 
-    private ?ConfigBuilder $configBuilder = null;
+    private ?AppConfigBuilder $appConfigBuilder = null;
 
     private ?SuffixTypesBuilder $suffixTypesBuilder = null;
 
@@ -99,7 +99,7 @@ final class SetupGacela extends AbstractSetupGacela
         $emptyFn = static function (): void {
         };
 
-        $this->configFn = $emptyFn;
+        $this->appConfigFn = $emptyFn;
         $this->bindingsFn = $emptyFn;
         $this->suffixTypesFn = $emptyFn;
     }
@@ -137,7 +137,7 @@ final class SetupGacela extends AbstractSetupGacela
 
         return (new self())
             ->setExternalServices($build['external-services'])
-            ->setConfigBuilder($build['config-builder'])
+            ->setAppConfigBuilder($build['app-config-builder'])
             ->setSuffixTypesBuilder($build['suffix-types-builder'])
             ->setBindingsBuilder($build['bindings-builder'])
             ->setShouldResetInMemoryCache($build['should-reset-in-memory-cache'])
@@ -164,9 +164,9 @@ final class SetupGacela extends AbstractSetupGacela
         return $this;
     }
 
-    public function setConfigBuilder(ConfigBuilder $builder): self
+    public function setAppConfigBuilder(AppConfigBuilder $builder): self
     {
-        $this->configBuilder = $builder;
+        $this->appConfigBuilder = $builder;
 
         return $this;
     }
@@ -186,24 +186,24 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param callable(ConfigBuilder):void $callable
+     * @param callable(AppConfigBuilder):void $callable
      */
-    public function setConfigFn(callable $callable): self
+    public function setAppConfigFn(callable $callable): self
     {
-        $this->configFn = $callable;
+        $this->appConfigFn = $callable;
 
         return $this;
     }
 
-    public function buildConfig(ConfigBuilder $builder): ConfigBuilder
+    public function buildAppConfig(AppConfigBuilder $builder): AppConfigBuilder
     {
-        $builder = parent::buildConfig($builder);
+        $builder = parent::buildAppConfig($builder);
 
-        if ($this->configBuilder) {
-            $builder = $this->configBuilder;
+        if ($this->appConfigBuilder) {
+            $builder = $this->appConfigBuilder;
         }
 
-        ($this->configFn)($builder);
+        ($this->appConfigFn)($builder);
 
         return $builder;
     }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 
@@ -15,7 +15,7 @@ interface SetupGacelaInterface
     /**
      * Define different config sources.
      */
-    public function buildConfig(ConfigBuilder $builder): ConfigBuilder;
+    public function buildAppConfig(AppConfigBuilder $builder): AppConfigBuilder;
 
     /**
      * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.

--- a/src/Framework/Config/GacelaConfigBuilder/AppConfigBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/AppConfigBuilder.php
@@ -10,7 +10,7 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 
 use function is_string;
 
-final class ConfigBuilder
+final class AppConfigBuilder
 {
     /** @var list<GacelaConfigItem> */
     private array $configItems = [];

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config\GacelaFileConfig\Factory;
 
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
@@ -31,9 +31,9 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
             ->setSuffixTypes($suffixTypesBuilder->build());
     }
 
-    private function createConfigBuilder(): ConfigBuilder
+    private function createConfigBuilder(): AppConfigBuilder
     {
-        return $this->bootstrapSetup->buildConfig(new ConfigBuilder());
+        return $this->bootstrapSetup->buildAppConfig(new AppConfigBuilder());
     }
 
     private function createBindingsBuilder(): BindingsBuilder

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -8,8 +8,8 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\FileIoInterface;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
@@ -60,9 +60,9 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         return $gacelaConfig;
     }
 
-    private function createConfigBuilder(SetupGacelaInterface $setupGacela): ConfigBuilder
+    private function createConfigBuilder(SetupGacelaInterface $setupGacela): AppConfigBuilder
     {
-        return $setupGacela->buildConfig(new ConfigBuilder());
+        return $setupGacela->buildAppConfig(new AppConfigBuilder());
     }
 
     private function createBindingsBuilder(SetupGacelaInterface $setupGacela): BindingsBuilder

--- a/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
+++ b/tests/Integration/Framework/Config/ConfigFactory/ConfigFactoryTest.php
@@ -6,8 +6,8 @@ namespace GacelaTest\Integration\Framework\Config\ConfigFactory;
 
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\ConfigFactory;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
@@ -77,7 +77,7 @@ final class ConfigFactoryTest extends TestCase
     {
         $bootstrapSetup = (new SetupGacela())
             ->setExternalServices(['CustomClassFromExternalService' => CustomClass::class])
-            ->setConfigFn(static function (ConfigBuilder $builder): void {
+            ->setAppConfigFn(static function (AppConfigBuilder $builder): void {
                 $builder->add('config/from-bootstrap.php');
             })
             ->setBindingsFn(
@@ -120,7 +120,7 @@ final class ConfigFactoryTest extends TestCase
     {
         $setup = (new SetupGacela())
             ->setExternalServices(['CustomClassFromExternalService' => CustomClass::class])
-            ->setConfigFn(static function (ConfigBuilder $builder): void {
+            ->setAppConfigFn(static function (AppConfigBuilder $builder): void {
                 $builder->add('config/from-bootstrap.php');
             })
             ->setBindingsFn(

--- a/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigBuilder/ConfigBuilderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Config\GacelaConfigBuilder;
 
 use Gacela\Framework\Config\ConfigReaderInterface;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
 use GacelaTest\Fixtures\SimpleEnvConfigReader;
 use PHPUnit\Framework\TestCase;
@@ -14,14 +14,14 @@ final class ConfigBuilderTest extends TestCase
 {
     public function test_empty(): void
     {
-        $builder = new ConfigBuilder();
+        $builder = new AppConfigBuilder();
 
         self::assertEquals([], $builder->build());
     }
 
     public function test_custom_path(): void
     {
-        $builder = new ConfigBuilder();
+        $builder = new AppConfigBuilder();
         $builder->add('custom/*.php');
 
         self::assertEquals(
@@ -32,7 +32,7 @@ final class ConfigBuilderTest extends TestCase
 
     public function test_custom_path_local(): void
     {
-        $builder = new ConfigBuilder();
+        $builder = new AppConfigBuilder();
         $builder->add('', 'custom/local.php');
 
         self::assertEquals(
@@ -50,7 +50,7 @@ final class ConfigBuilderTest extends TestCase
             }
         };
 
-        $builder = new ConfigBuilder();
+        $builder = new AppConfigBuilder();
         $builder->add('custom/*.php', 'custom/local.php', $reader);
 
         self::assertEquals(
@@ -61,7 +61,7 @@ final class ConfigBuilderTest extends TestCase
 
     public function test_custom_reader_by_class_name(): void
     {
-        $builder = new ConfigBuilder();
+        $builder = new AppConfigBuilder();
         $builder->add('custom/*.php', 'custom/local.php', SimpleEnvConfigReader::class);
 
         self::assertEquals(

--- a/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
+++ b/tests/Unit/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactoryTest.php
@@ -6,8 +6,8 @@ namespace GacelaTest\Unit\Framework\Config\GacelaFileConfig\Factory;
 
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigFromBootstrapFactory;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
@@ -39,8 +39,8 @@ final class GacelaConfigFromBootstrapFactoryTest extends TestCase
     public function test_global_service_config(): void
     {
         $factory = new GacelaConfigFromBootstrapFactory(
-            (new SetupGacela())->setConfigFn(
-                static function (ConfigBuilder $configBuilder): void {
+            (new SetupGacela())->setAppConfigFn(
+                static function (AppConfigBuilder $configBuilder): void {
                     $configBuilder->add('custom-path.php', 'custom-path_local.php');
                 },
             ),


### PR DESCRIPTION
## 📚 Description

There is no change to the public API. The GacelaConfig has already `addAppConfig()`:

```php
function addAppConfig(string $path, string $pathLocal = '', $reader = null)
```

## 🔖 Changes

- Rename internal `ConfigBuilder` to `AppConfigBuilder` to avoid confusion
