### PR TITLE
Rename method to extendGacelaConfig()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `Gacela::rootDir()`
 - Added plugins as callable
     - `GacelaConfig::addPlugin(string|callable)`
-- Rename `addExtendConfig()` to `extendGacelaConfig()`
+- Rename `addExtendConfig()` to `extendGacelaConfig()` in `GacelaConfig`
 
 ### 1.3.0
 ### 2023-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `Gacela::rootDir()`
 - Added plugins as callable
     - `GacelaConfig::addPlugin(string|callable)`
+- Rename `addExtendConfig()` to `extendGacelaConfig()`
 
 ### 1.3.0
 ### 2023-05-08

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -43,7 +43,7 @@ final class GacelaConfig
     private ?array $specificListeners = null;
 
     /** @var list<class-string>  */
-    private ?array $extendGacelaConfigs = null;
+    private ?array $gacelaConfigsToExtend = null;
 
     /** @var list<class-string|callable>  */
     private ?array $plugins = null;
@@ -301,7 +301,7 @@ final class GacelaConfig
      */
     public function extendGacelaConfig(string $className): self
     {
-        $this->extendGacelaConfigs[] = $className;
+        $this->gacelaConfigsToExtend[] = $className;
 
         return $this;
     }
@@ -311,7 +311,7 @@ final class GacelaConfig
      */
     public function extendGacelaConfigs(array $list): self
     {
-        $this->extendGacelaConfigs = array_merge($this->extendGacelaConfigs ?? [], $list);
+        $this->gacelaConfigsToExtend = array_merge($this->gacelaConfigsToExtend ?? [], $list);
 
         return $this;
     }
@@ -350,7 +350,7 @@ final class GacelaConfig
      *     are-event-listeners-enabled: ?bool,
      *     generic-listeners: ?list<callable>,
      *     specific-listeners: ?array<class-string,list<callable>>,
-     *     extend-gacela-configs: ?list<class-string>,
+     *     gacela-configs-to-extend: ?list<class-string>,
      *     plugins: ?list<class-string|callable>,
      *     instances-to-extend: array<string,list<Closure>>,
      * }
@@ -372,7 +372,7 @@ final class GacelaConfig
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
             'generic-listeners' => $this->genericListeners,
             'specific-listeners' => $this->specificListeners,
-            'extend-gacela-configs' => $this->extendGacelaConfigs,
+            'gacela-configs-to-extend' => $this->gacelaConfigsToExtend,
             'plugins' => $this->plugins,
             'instances-to-extend' => $this->servicesToExtend,
         ];

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -43,7 +43,7 @@ final class GacelaConfig
     private ?array $specificListeners = null;
 
     /** @var list<class-string>  */
-    private ?array $extendConfig = null;
+    private ?array $extendGacelaConfigs = null;
 
     /** @var list<class-string|callable>  */
     private ?array $plugins = null;
@@ -261,9 +261,7 @@ final class GacelaConfig
      */
     public function registerGenericListener(callable $listener): self
     {
-        if ($this->genericListeners === null) {
-            $this->genericListeners = [];
-        }
+        $this->genericListeners ??= [];
         $this->genericListeners[] = $listener;
 
         return $this;
@@ -277,9 +275,7 @@ final class GacelaConfig
      */
     public function registerSpecificListener(string $event, callable $listener): self
     {
-        if ($this->specificListeners === null) {
-            $this->specificListeners = [];
-        }
+        $this->specificListeners[$event] ??= [];
         $this->specificListeners[$event][] = $listener;
 
         return $this;
@@ -301,11 +297,11 @@ final class GacelaConfig
      * __invoke(GacelaConfig $config): void
      * ```
      *
-     * @param class-string $configClass
+     * @param class-string $gacelaConfigClass
      */
-    public function addExtendConfig(string $configClass): self
+    public function addExtendGacelaConfig(string $gacelaConfigClass): self
     {
-        $this->extendConfig[] = $configClass;
+        $this->extendGacelaConfigs[] = $gacelaConfigClass;
 
         return $this;
     }
@@ -313,9 +309,9 @@ final class GacelaConfig
     /**
      * @param list<class-string> $list
      */
-    public function addExtendConfigs(array $list): self
+    public function addExtendGacelaConfigs(array $list): self
     {
-        $this->extendConfig = array_merge($this->extendConfig ?? [], $list);
+        $this->extendGacelaConfigs = array_merge($this->extendGacelaConfigs ?? [], $list);
 
         return $this;
     }
@@ -354,7 +350,7 @@ final class GacelaConfig
      *     are-event-listeners-enabled: ?bool,
      *     generic-listeners: ?list<callable>,
      *     specific-listeners: ?array<class-string,list<callable>>,
-     *     extend-config: ?list<class-string>,
+     *     extend-gacela-configs: ?list<class-string>,
      *     plugins: ?list<class-string|callable>,
      *     instances-to-extend: array<string,list<Closure>>,
      * }
@@ -376,7 +372,7 @@ final class GacelaConfig
             'are-event-listeners-enabled' => $this->areEventListenersEnabled,
             'generic-listeners' => $this->genericListeners,
             'specific-listeners' => $this->specificListeners,
-            'extend-config' => $this->extendConfig,
+            'extend-gacela-configs' => $this->extendGacelaConfigs,
             'plugins' => $this->plugins,
             'instances-to-extend' => $this->servicesToExtend,
         ];

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -297,11 +297,11 @@ final class GacelaConfig
      * __invoke(GacelaConfig $config): void
      * ```
      *
-     * @param class-string $gacelaConfigClass
+     * @param class-string $className
      */
-    public function addExtendGacelaConfig(string $gacelaConfigClass): self
+    public function extendGacelaConfig(string $className): self
     {
-        $this->extendGacelaConfigs[] = $gacelaConfigClass;
+        $this->extendGacelaConfigs[] = $className;
 
         return $this;
     }
@@ -309,7 +309,7 @@ final class GacelaConfig
     /**
      * @param list<class-string> $list
      */
-    public function addExtendGacelaConfigs(array $list): self
+    public function extendGacelaConfigs(array $list): self
     {
         $this->extendGacelaConfigs = array_merge($this->extendGacelaConfigs ?? [], $list);
 

--- a/src/Framework/Bootstrap/SetupCombinator.php
+++ b/src/Framework/Bootstrap/SetupCombinator.php
@@ -28,7 +28,7 @@ final class SetupCombinator
         $this->combineEventDispatcher($other);
         $this->combineServicesToExtend($other);
         $this->combinePlugins($other);
-        $this->combineExtendGacelaConfigs($other);
+        $this->combineGacelaConfigsToExtend($other);
 
         return $this->original;
     }
@@ -109,10 +109,10 @@ final class SetupCombinator
         }
     }
 
-    private function combineExtendGacelaConfigs(SetupGacela $other): void
+    private function combineGacelaConfigsToExtend(SetupGacela $other): void
     {
-        if ($other->isPropertyChanged(SetupGacela::extendGacelaConfigs)) {
-            $this->original->combineExtendGacelaConfigs($other->getExtendGacelaConfigs());
+        if ($other->isPropertyChanged(SetupGacela::gacelaConfigsToExtend)) {
+            $this->original->combineGacelaConfigsToExtend($other->getGacelaConfigsToExtend());
         }
     }
 }

--- a/src/Framework/Bootstrap/SetupCombinator.php
+++ b/src/Framework/Bootstrap/SetupCombinator.php
@@ -28,7 +28,7 @@ final class SetupCombinator
         $this->combineEventDispatcher($other);
         $this->combineServicesToExtend($other);
         $this->combinePlugins($other);
-        $this->combineExtendConfig($other);
+        $this->combineExtendGacelaConfigs($other);
 
         return $this->original;
     }
@@ -109,10 +109,10 @@ final class SetupCombinator
         }
     }
 
-    private function combineExtendConfig(SetupGacela $other): void
+    private function combineExtendGacelaConfigs(SetupGacela $other): void
     {
-        if ($other->isPropertyChanged(SetupGacela::extendConfig)) {
-            $this->original->combineExtendConfig($other->getExtendConfig());
+        if ($other->isPropertyChanged(SetupGacela::extendGacelaConfigs)) {
+            $this->original->combineExtendGacelaConfigs($other->getExtendGacelaConfigs());
         }
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -28,7 +28,7 @@ final class SetupGacela extends AbstractSetupGacela
     public const configKeyValues = 'configKeyValues';
     public const servicesToExtend = 'servicesToExtend';
     public const plugins = 'plugins';
-    public const extendGacelaConfigs = 'extendGacelaConfigs';
+    public const gacelaConfigsToExtend = 'gacelaConfigsToExtend';
 
     private const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
     private const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
@@ -39,7 +39,7 @@ final class SetupGacela extends AbstractSetupGacela
     private const DEFAULT_GENERIC_LISTENERS = [];
     private const DEFAULT_SPECIFIC_LISTENERS = [];
     private const DEFAULT_SERVICES_TO_EXTEND = [];
-    private const DEFAULT_EXTEND_GACELA_CONFIGS = [];
+    private const DEFAULT_GACELA_CONFIGS_TO_EXTEND = [];
     private const DEFAULT_PLUGINS = [];
 
     /** @var callable(AppConfigBuilder):void */
@@ -89,7 +89,7 @@ final class SetupGacela extends AbstractSetupGacela
     private ?array $servicesToExtend = null;
 
     /** @var ?list<class-string> */
-    private ?array $extendGacelaConfigs = null;
+    private ?array $gacelaConfigsToExtend = null;
 
     /** @var ?list<class-string|callable> */
     private ?array $plugins = null;
@@ -148,7 +148,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
             ->setGenericListeners($build['generic-listeners'])
             ->setSpecificListeners($build['specific-listeners'])
-            ->setExtendGacelaConfigs($build['extend-gacela-configs'])
+            ->setGacelaConfigsToExtend($build['gacela-configs-to-extend'])
             ->setPlugins($build['plugins'])
             ->setServicesToExtend($build['instances-to-extend']);
     }
@@ -439,9 +439,9 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param list<class-string> $list
      */
-    public function combineExtendGacelaConfigs(array $list): void
+    public function combineGacelaConfigsToExtend(array $list): void
     {
-        $this->setExtendGacelaConfigs(array_merge($this->extendGacelaConfigs ?? [], $list));
+        $this->setGacelaConfigsToExtend(array_merge($this->gacelaConfigsToExtend ?? [], $list));
     }
 
     /**
@@ -455,9 +455,9 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @return list<class-string>
      */
-    public function getExtendGacelaConfigs(): array
+    public function getGacelaConfigsToExtend(): array
     {
-        return (array)$this->extendGacelaConfigs;
+        return (array)$this->gacelaConfigsToExtend;
     }
 
     /**
@@ -470,17 +470,17 @@ final class SetupGacela extends AbstractSetupGacela
 
     private static function runExtendConfig(GacelaConfig $gacelaConfig): void
     {
-        $extendConfigs = $gacelaConfig->build()['extend-gacela-configs'] ?? [];
+        $configsToExtend = $gacelaConfig->build()['gacela-configs-to-extend'] ?? [];
 
-        if ($extendConfigs === []) {
+        if ($configsToExtend === []) {
             return;
         }
 
         $container = new Container();
 
-        foreach ($extendConfigs as $extendConfig) {
+        foreach ($configsToExtend as $className) {
             /** @var callable $configToExtend */
-            $configToExtend = $container->get($extendConfig);
+            $configToExtend = $container->get($className);
             $configToExtend($gacelaConfig);
         }
     }
@@ -522,10 +522,10 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param ?list<class-string> $list
      */
-    private function setExtendGacelaConfigs(?array $list): self
+    private function setGacelaConfigsToExtend(?array $list): self
     {
-        $this->markPropertyChanged(self::extendGacelaConfigs, $list);
-        $this->extendGacelaConfigs = $list ?? self::DEFAULT_EXTEND_GACELA_CONFIGS;
+        $this->markPropertyChanged(self::gacelaConfigsToExtend, $list);
+        $this->gacelaConfigsToExtend = $list ?? self::DEFAULT_GACELA_CONFIGS_TO_EXTEND;
 
         return $this;
     }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -28,7 +28,7 @@ final class SetupGacela extends AbstractSetupGacela
     public const configKeyValues = 'configKeyValues';
     public const servicesToExtend = 'servicesToExtend';
     public const plugins = 'plugins';
-    public const extendConfig = 'extendConfig';
+    public const extendGacelaConfigs = 'extendGacelaConfigs';
 
     private const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
     private const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
@@ -39,7 +39,7 @@ final class SetupGacela extends AbstractSetupGacela
     private const DEFAULT_GENERIC_LISTENERS = [];
     private const DEFAULT_SPECIFIC_LISTENERS = [];
     private const DEFAULT_SERVICES_TO_EXTEND = [];
-    private const DEFAULT_EXTEND_CONFIG = [];
+    private const DEFAULT_EXTEND_GACELA_CONFIGS = [];
     private const DEFAULT_PLUGINS = [];
 
     /** @var callable(AppConfigBuilder):void */
@@ -89,7 +89,7 @@ final class SetupGacela extends AbstractSetupGacela
     private ?array $servicesToExtend = null;
 
     /** @var ?list<class-string> */
-    private ?array $extendConfig = null;
+    private ?array $extendGacelaConfigs = null;
 
     /** @var ?list<class-string|callable> */
     private ?array $plugins = null;
@@ -148,7 +148,7 @@ final class SetupGacela extends AbstractSetupGacela
             ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
             ->setGenericListeners($build['generic-listeners'])
             ->setSpecificListeners($build['specific-listeners'])
-            ->setExtendConfig($build['extend-config'])
+            ->setExtendGacelaConfigs($build['extend-gacela-configs'])
             ->setPlugins($build['plugins'])
             ->setServicesToExtend($build['instances-to-extend']);
     }
@@ -439,9 +439,9 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param list<class-string> $list
      */
-    public function combineExtendConfig(array $list): void
+    public function combineExtendGacelaConfigs(array $list): void
     {
-        $this->setExtendConfig(array_merge($this->extendConfig ?? [], $list));
+        $this->setExtendGacelaConfigs(array_merge($this->extendGacelaConfigs ?? [], $list));
     }
 
     /**
@@ -455,9 +455,9 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @return list<class-string>
      */
-    public function getExtendConfig(): array
+    public function getExtendGacelaConfigs(): array
     {
-        return (array)$this->extendConfig;
+        return (array)$this->extendGacelaConfigs;
     }
 
     /**
@@ -470,7 +470,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     private static function runExtendConfig(GacelaConfig $gacelaConfig): void
     {
-        $extendConfigs = $gacelaConfig->build()['extend-config'] ?? [];
+        $extendConfigs = $gacelaConfig->build()['extend-gacela-configs'] ?? [];
 
         if ($extendConfigs === []) {
             return;
@@ -522,10 +522,10 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @param ?list<class-string> $list
      */
-    private function setExtendConfig(?array $list): self
+    private function setExtendGacelaConfigs(?array $list): self
     {
-        $this->markPropertyChanged(self::extendConfig, $list);
-        $this->extendConfig = $list ?? self::DEFAULT_EXTEND_CONFIG;
+        $this->markPropertyChanged(self::extendGacelaConfigs, $list);
+        $this->extendGacelaConfigs = $list ?? self::DEFAULT_EXTEND_GACELA_CONFIGS;
 
         return $this;
     }

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -80,7 +80,7 @@ interface SetupGacelaInterface
     /**
      * @return list<class-string>
      */
-    public function getExtendGacelaConfigs(): array;
+    public function getGacelaConfigsToExtend(): array;
 
     /**
      * @return list<class-string|callable>

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -80,7 +80,7 @@ interface SetupGacelaInterface
     /**
      * @return list<class-string>
      */
-    public function getExtendConfig(): array;
+    public function getExtendGacelaConfigs(): array;
 
     /**
      * @return list<class-string|callable>

--- a/tests/Feature/Framework/ExtendConfig/FeatureTest.php
+++ b/tests/Feature/Framework/ExtendConfig/FeatureTest.php
@@ -16,7 +16,7 @@ final class FeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->addExtendConfig(BindingStringValue::class);
+            $config->addExtendGacelaConfig(BindingStringValue::class);
         });
 
         /** @var StringValue $singleton */

--- a/tests/Feature/Framework/ExtendConfig/FeatureTest.php
+++ b/tests/Feature/Framework/ExtendConfig/FeatureTest.php
@@ -16,7 +16,7 @@ final class FeatureTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
-            $config->addExtendGacelaConfig(BindingStringValue::class);
+            $config->extendGacelaConfig(BindingStringValue::class);
         });
 
         /** @var StringValue $singleton */


### PR DESCRIPTION
## 🔖 Changes

Change `addExtendConfig()` to `extendGacelaConfig()`, eg:

```diff
-$config->addExtendConfig(BindingStringValue::class);
+$config->extendGacelaConfig(BindingStringValue::class);
```
