### PR TITLE
Fix: Replace `locked` with `highest` in matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dependencies: [ "locked", "highest" ]
+        dependencies: [ "lowest", "highest" ]
         php-version: [ "8.0" , "8.1", "8.2" ]
         operating-system:
           - "ubuntu-latest"
@@ -37,16 +37,12 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
+          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-"
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
         run: "composer update --prefer-lowest --no-interaction --no-progress"
-
-      - name: "Install locked dependencies"
-        if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress"
 
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}


### PR DESCRIPTION
## 📚 Description

This pull request

- [x] replaces `locked` with `highest` in the matrix

💁‍♂️ `composer.lock` is currently not checked in, so there is no way to install locked dependencies.

## 🔖 Changes

- List individual changes in more detail
