### PR TITLE
Replace / by DIRECTORY_SEPARATOR constant

### DIFF
--- a/tests/Feature/Console/CodeGenerator/MakeExceptionCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeExceptionCommandTest.php
@@ -16,7 +16,7 @@ final class MakeExceptionCommandTest extends TestCase
 {
     protected function setUp(): void
     {
-        Gacela::bootstrap(__DIR__ . '/undefined-folder/');
+        Gacela::bootstrap(__DIR__ . DIRECTORY_SEPARATOR . 'undefined-folder' . DIRECTORY_SEPARATOR);
     }
 
     public function test_make_module_exception_when_composer_file_not_found(): void

--- a/tests/Feature/Console/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeFileCommandTest.php
@@ -13,15 +13,17 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MakeFileCommandTest extends TestCase
 {
+    private const CACHE_DIR = '.' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'TestModule';
+
     public static function tearDownAfterClass(): void
     {
-        DirectoryUtil::removeDir('./src/TestModule');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__);
-        DirectoryUtil::removeDir('./src/TestModule');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     /**

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -13,15 +13,17 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MakeModuleCommandTest extends TestCase
 {
+    private const CACHE_DIR = '.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'TestModule';
+
     public static function tearDownAfterClass(): void
     {
-        DirectoryUtil::removeDir('./data/TestModule');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__);
-        DirectoryUtil::removeDir('./data/TestModule');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     /**

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -13,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 final class FileCacheFeatureTest extends TestCase
 {
+    private const CACHE_DIR = __DIR__ . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'cache-dir';
+
     public static function tearDownAfterClass(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
@@ -20,12 +22,12 @@ final class FileCacheFeatureTest extends TestCase
             $config->setFileCache(false);
         });
 
-        DirectoryUtil::removeDir(__DIR__ . '/custom/cache-dir');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     protected function setUp(): void
     {
-        DirectoryUtil::removeDir(__DIR__ . '/custom/cache-dir');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     public function test_custom_cache_dir(): void

--- a/tests/Feature/Framework/UsingAbstractGacelaClassesByDefault/FeatureTest.php
+++ b/tests/Feature/Framework/UsingAbstractGacelaClassesByDefault/FeatureTest.php
@@ -9,6 +9,9 @@ use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
 {
+    private const FACADE_ROOT_DIR = 'tests' . DIRECTORY_SEPARATOR . 'Feature' . DIRECTORY_SEPARATOR
+                                    . 'Framework' . DIRECTORY_SEPARATOR . 'UsingAbstractGacelaClassesByDefault';
+
     public function setUp(): void
     {
         Gacela::bootstrap(__DIR__);
@@ -18,9 +21,6 @@ final class FeatureTest extends TestCase
     {
         $facade = new Module\Facade();
 
-        self::assertStringContainsString(
-            'tests/Feature/Framework/UsingAbstractGacelaClassesByDefault',
-            $facade->getAppRootDir(),
-        );
+        self::assertStringContainsString(self::FACADE_ROOT_DIR, $facade->getAppRootDir());
     }
 }

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverCustomServicesAwareTest.php
@@ -14,9 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 final class DocBlockResolverCustomServicesAwareTest extends TestCase
 {
+    private const CACHE_DIR = __DIR__ . DIRECTORY_SEPARATOR . '.gacela';
+
     public static function setUpBeforeClass(): void
     {
-        DirectoryUtil::removeDir(__DIR__ . '/.gacela');
+        DirectoryUtil::removeDir(self::CACHE_DIR);
     }
 
     protected function setUp(): void

--- a/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
+++ b/tests/Integration/Framework/DocBlockResolverAware/DocBlockResolverInMemoryAwareTest.php
@@ -16,7 +16,7 @@ final class DocBlockResolverInMemoryAwareTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        DirectoryUtil::removeDir(__DIR__ . '/.gacela');
+        DirectoryUtil::removeDir(__DIR__ . DIRECTORY_SEPARATOR . '.gacela');
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## 📚 Description

It seems the when we write a path as follows `./something/else`, it doesn't work 100% on Windows.
In such case, let's replace the slash `/` by the PHP constant `DIRECTORY_SEPARATOR` which works in all OS.