### PR TITLE
Color list modules command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- Added command `gacela list:modules`
+- Added command `gacela list:modules [--detailed|-d]`
 - Fixed Windows support
 
 ### 1.4.0

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -60,14 +60,15 @@ final class ListModulesCommand extends Command
     private function generateDetailedView(array $modules): string
     {
         $result = '';
-        foreach ($modules as $module) {
+        foreach ($modules as $i => $module) {
+            $n = $i + 1;
             $factory = $module->factoryClass() ?? 'None';
             $config = $module->configClass() ?? 'None';
             $dependencyProviderClass = $module->dependencyProviderClass() ?? 'None';
 
             $result .= <<<TXT
 ============================
-<fg=green>{$module->moduleName()}</>
+{$n}.- <fg=green>{$module->moduleName()}</>
 ----------------------------
 <fg=cyan>Facade</>: {$module->facadeClass()}
 <fg=cyan>Factory</>: {$factory}
@@ -87,7 +88,7 @@ TXT;
         $result = '';
 
         foreach ($modules as $i => $module) {
-            $n = $i+1;
+            $n = $i + 1;
             $result .= <<<TXT
 {$n}.- <fg=green>{$module->moduleName()}</>
 

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -66,13 +66,13 @@ final class ListModulesCommand extends Command
             $dependencyProviderClass = $module->dependencyProviderClass() ?? 'None';
 
             $result .= <<<TXT
-==============
-{$module->moduleName()}
---------------
-Facade: {$module->facadeClass()}
-Factory: {$factory}
-Config: {$config}
-DependencyProvider: {$dependencyProviderClass}
+============================
+<fg=green>{$module->moduleName()}</>
+----------------------------
+<fg=cyan>Facade</>: {$module->facadeClass()}
+<fg=cyan>Factory</>: {$factory}
+<fg=cyan>Config</>: {$config}
+<fg=cyan>DependencyProvider</>: {$dependencyProviderClass}
 
 TXT;
         }
@@ -86,10 +86,10 @@ TXT;
     {
         $result = '';
 
-        foreach ($modules as $module) {
+        foreach ($modules as $i => $module) {
+            $n = $i+1;
             $result .= <<<TXT
-==============
-{$module->moduleName()}
+{$n}.- <fg=green>{$module->moduleName()}</>
 
 TXT;
         }

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -50,21 +50,21 @@ TXT;
 
         $expected = <<<TXT
 ============================
-TestModule3
+1.- TestModule3
 ----------------------------
 Facade: GacelaTest\Feature\Console\ListModules\LevelUp\TestModule3\TestModule3Facade
 Factory: GacelaTest\Feature\Console\ListModules\LevelUp\TestModule3\TestModule3Factory
 Config: GacelaTest\Feature\Console\ListModules\LevelUp\TestModule3\TestModule3Config
 DependencyProvider: None
 ============================
-TestModule1
+2.- TestModule1
 ----------------------------
 Facade: GacelaTest\Feature\Console\ListModules\TestModule1\TestModule1Facade
 Factory: GacelaTest\Feature\Console\ListModules\TestModule1\TestModule1Factory
 Config: None
 DependencyProvider: GacelaTest\Feature\Console\ListModules\TestModule1\TestModule1DependencyProvider
 ============================
-TestModule2
+3.- TestModule2
 ----------------------------
 Facade: GacelaTest\Feature\Console\ListModules\TestModule2\TestModule2Facade
 Factory: None

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -27,12 +27,9 @@ final class ListModulesCommandTest extends TestCase
         $bootstrap->run($input, $output);
 
         $expected = <<<TXT
-==============
-TestModule3
-==============
-TestModule1
-==============
-TestModule2
+1.- TestModule3
+2.- TestModule1
+3.- TestModule2
 
 TXT;
         self::assertSame($expected, $output->fetch());
@@ -52,23 +49,23 @@ TXT;
         $bootstrap->run($input, $output);
 
         $expected = <<<TXT
-==============
+============================
 TestModule3
---------------
+----------------------------
 Facade: GacelaTest\Feature\Console\ListModules\LevelUp\TestModule3\TestModule3Facade
 Factory: GacelaTest\Feature\Console\ListModules\LevelUp\TestModule3\TestModule3Factory
 Config: GacelaTest\Feature\Console\ListModules\LevelUp\TestModule3\TestModule3Config
 DependencyProvider: None
-==============
+============================
 TestModule1
---------------
+----------------------------
 Facade: GacelaTest\Feature\Console\ListModules\TestModule1\TestModule1Facade
 Factory: GacelaTest\Feature\Console\ListModules\TestModule1\TestModule1Factory
 Config: None
 DependencyProvider: GacelaTest\Feature\Console\ListModules\TestModule1\TestModule1DependencyProvider
-==============
+============================
 TestModule2
---------------
+----------------------------
 Facade: GacelaTest\Feature\Console\ListModules\TestModule2\TestModule2Facade
 Factory: None
 Config: None


### PR DESCRIPTION
> Follow up after https://github.com/gacela-project/gacela/pull/293

## 🔖 Changes

- Add some color to the `gacela list:modules` command and improve its output

## 🖼️ Screenshots

Project example used to run this command: https://github.com/phel-lang/phel-lang

### BEFORE

<img width="584" alt="Screenshot 2023-06-14 at 15 07 29" src="https://github.com/gacela-project/gacela/assets/5256287/e8046543-282b-4452-8a16-ce2e251315f3">

### AFTER

<img width="593" alt="Screenshot 2023-06-14 at 15 06 52" src="https://github.com/gacela-project/gacela/assets/5256287/991608fd-304d-4d7e-ab46-26ff58ff4f0d">

