### PR TITLE
Use detailed by default instead of simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- Added command `gacela list:modules [--detailed|-d]`
+- Added command `gacela list:modules [--simple|-s]`
 - Fixed Windows support
 
 ### 1.4.0

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -25,7 +25,7 @@ final class ListModulesCommand extends Command
         $this->setName('list:modules')
             ->setDescription('Render all modules found')
             ->addArgument('filter', InputArgument::OPTIONAL, 'Any filter to simplify the output')
-            ->addOption('detailed', 'd', InputOption::VALUE_NONE, 'Display a detailed information of each module');
+            ->addOption('simple', 's', InputOption::VALUE_NONE, 'Display just the module names');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -33,7 +33,7 @@ final class ListModulesCommand extends Command
         $filter = (string)$input->getArgument('filter');
 
         $listOfModules = $this->generateListOfModules(
-            (bool)$input->getOption('detailed'),
+            (bool)$input->getOption('simple'),
             $this->getFacade()->findAllAppModules($filter),
         );
 
@@ -45,13 +45,29 @@ final class ListModulesCommand extends Command
     /**
      * @param list<AppModule> $modules
      */
-    private function generateListOfModules(bool $isDetailed, array $modules): string
+    private function generateListOfModules(bool $isSimple, array $modules): string
     {
-        if ($isDetailed) {
-            return $this->generateDetailedView($modules);
+        return ($isSimple)
+            ? $this->generateSimpleView($modules)
+            : $this->generateDetailedView($modules);
+    }
+
+    /**
+     * @param list<AppModule> $modules
+     */
+    private function generateSimpleView(array $modules): string
+    {
+        $result = '';
+
+        foreach ($modules as $i => $module) {
+            $n = $i + 1;
+            $result .= <<<TXT
+{$n}.- <fg=green>{$module->moduleName()}</>
+
+TXT;
         }
 
-        return $this->generateNonDetailedView($modules);
+        return $result;
     }
 
     /**
@@ -77,24 +93,6 @@ final class ListModulesCommand extends Command
 
 TXT;
         }
-        return $result;
-    }
-
-    /**
-     * @param list<AppModule> $modules
-     */
-    private function generateNonDetailedView(array $modules): string
-    {
-        $result = '';
-
-        foreach ($modules as $i => $module) {
-            $n = $i + 1;
-            $result .= <<<TXT
-{$n}.- <fg=green>{$module->moduleName()}</>
-
-TXT;
-        }
-
         return $result;
     }
 }

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -13,13 +13,13 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class ListModulesCommandTest extends TestCase
 {
-    public function test_list_modules(): void
+    public function test_list_modules_simple(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
         });
 
-        $input = new StringInput('list:modules');
+        $input = new StringInput('list:modules --simple');
         $output = new BufferedOutput();
 
         $bootstrap = new ConsoleBootstrap();
@@ -35,13 +35,13 @@ TXT;
         self::assertSame($expected, $output->fetch());
     }
 
-    public function test_list_detailed_modules(): void
+    public function test_list_modules(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
         });
 
-        $input = new StringInput('list:modules --detailed');
+        $input = new StringInput('list:modules');
         $output = new BufferedOutput();
 
         $bootstrap = new ConsoleBootstrap();
@@ -82,7 +82,7 @@ TXT;
     {
         Gacela::bootstrap(__DIR__);
 
-        $input = new StringInput('list:modules ' . $input);
+        $input = new StringInput('list:modules' . $input);
         $output = new BufferedOutput();
 
         $bootstrap = new ConsoleBootstrap();


### PR DESCRIPTION
## 📚 Description

Original idea from @JesusValera.

## 🔖 Changes

- Use the detailed view of the command by default. Keep the simplified view (displaying only the module names) by using an optional option `--simple|-s`
