### PR TITLE
Add tests for DocBlockServiceNotFoundException

### DIFF
--- a/src/Framework/ClassResolver/DocBlockService/DocBlockServiceResolver.php
+++ b/src/Framework/ClassResolver/DocBlockService/DocBlockServiceResolver.php
@@ -18,7 +18,7 @@ final class DocBlockServiceResolver extends AbstractClassResolver
      *
      * @throws DocBlockServiceNotFoundException
      */
-    public function resolve(object|string $caller): ?object
+    public function resolve(object|string $caller): object
     {
         $resolved = $this->doResolve($caller);
 

--- a/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/DocBlockResolver/DocBlockResolverTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Framework\DocBlockResolver;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\DocBlockService\DocBlockServiceNotFoundException;
+use Gacela\Framework\ClassResolver\DocBlockService\DocBlockServiceResolver;
+use Gacela\Framework\ClassResolver\DocBlockService\MissingClassDefinitionException;
 use Gacela\Framework\DocBlockResolver\DocBlockResolvable;
 use Gacela\Framework\DocBlockResolver\DocBlockResolver;
 use Gacela\Framework\Gacela;
@@ -22,6 +25,22 @@ final class DocBlockResolverTest extends TestCase
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
         });
+    }
+
+    public function test_missing_class_definition(): void
+    {
+        $this->expectException(MissingClassDefinitionException::class);
+
+        (new FakeCommand())->getUnknown();
+    }
+
+    public function test_service_not_found(): void
+    {
+        $this->expectException(DocBlockServiceNotFoundException::class);
+
+        $resolver = new DocBlockServiceResolver('');
+        $command = new FakeCommand();
+        $resolver->resolve($command);
     }
 
     public function test_normalize_facade(): void

--- a/tests/Integration/Framework/DocBlockResolver/Module/FakeCommand.php
+++ b/tests/Integration/Framework/DocBlockResolver/Module/FakeCommand.php
@@ -9,6 +9,7 @@ use Gacela\Framework\DocBlockResolverAwareTrait;
 /**
  * @method FakeFacade getFacade()
  * @method FakeRandomService getRandom()
+ * @method FakeUnknown getUnknown() This does not exist and will ended up in an Error
  */
 final class FakeCommand
 {

--- a/tests/Unit/Framework/ClassResolver/DependencyProvider/DependencyProviderNotFoundExceptionTest.php
+++ b/tests/Unit/Framework/ClassResolver/DependencyProvider/DependencyProviderNotFoundExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\DependencyProvider;
+
+use Gacela\Framework\ClassResolver\DependencyProvider\DependencyProviderNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class DependencyProviderNotFoundExceptionTest extends TestCase
+{
+    public function test_exception_message(): void
+    {
+        $exception = new DependencyProviderNotFoundException($this);
+
+        $expected = <<<EOT
+ClassResolver Exception
+Cannot resolve the `DependencyProvider` for your module `DependencyProvider`
+You can fix this by adding the missing `DependencyProvider` to your module.
+E.g. `\GacelaTest\Unit\Framework\ClassResolver\DependencyProvider`
+
+EOT;
+
+        self::assertSame($expected, $exception->getMessage());
+    }
+}


### PR DESCRIPTION

## 🔖 Changes

- Add some tests for `DocBlockServiceNotFoundException` and `MissingClassDefinitionException`
