### PR TITLE
Simplify FactoryResolverAwareTrait

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,4 @@ parameters:
         - '#Method Gacela\\.*::.* should return array<.*> but returns array#'
         - '#Method .*::__callStatic\(\) has no return type specified.*#'
         - '#Method .*::__call\(\) has no return type specified.*#'
-        - '#.* calls parent::__call.*\(\) but .* does not extend any class.#'
         - '#Cannot cast mixed to string.#'

--- a/src/Framework/FactoryResolverAwareTrait.php
+++ b/src/Framework/FactoryResolverAwareTrait.php
@@ -26,11 +26,6 @@ trait FactoryResolverAwareTrait
             return self::doGetFactory();
         }
 
-        if (method_exists(static::class, $name)) {
-            /** @psalm-suppress ParentNotFound */
-            return parent::__callStatic($name, $arguments);
-        }
-
         throw new RuntimeException("Method unknown: '{$name}'");
     }
 
@@ -38,11 +33,6 @@ trait FactoryResolverAwareTrait
     {
         if ($name === 'getFactory') {
             return self::doGetFactory();
-        }
-
-        if (method_exists(static::class, $name)) {
-            /** @psalm-suppress ParentNotFound */
-            return parent::__call($name, $arguments);
         }
 
         throw new RuntimeException("Method unknown: '{$name}'");


### PR DESCRIPTION
## 📚 Description

This condition is no longer needed and it was dead code 🥳 

## 🔖 Changes

- Remove method_exists(static::class, $name) to call parent::__call or __callStatic
