### PR TITLE
Refactor SetupGacela

### DIFF
--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -4,12 +4,35 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap;
 
+use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
 abstract class AbstractSetupGacela implements SetupGacelaInterface
 {
+    public const shouldResetInMemoryCache = 'shouldResetInMemoryCache';
+    public const fileCacheEnabled = 'fileCacheEnabled';
+    public const fileCacheDirectory = 'fileCacheDirectory';
+    public const externalServices = 'externalServices';
+    public const projectNamespaces = 'projectNamespaces';
+    public const configKeyValues = 'configKeyValues';
+    public const servicesToExtend = 'servicesToExtend';
+    public const plugins = 'plugins';
+    public const gacelaConfigsToExtend = 'gacelaConfigsToExtend';
+
+    protected const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
+    protected const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
+    protected const DEFAULT_FILE_CACHE_ENABLED = GacelaFileCache::DEFAULT_ENABLED_VALUE;
+    protected const DEFAULT_FILE_CACHE_DIRECTORY = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
+    protected const DEFAULT_PROJECT_NAMESPACES = [];
+    protected const DEFAULT_CONFIG_KEY_VALUES = [];
+    protected const DEFAULT_GENERIC_LISTENERS = [];
+    protected const DEFAULT_SPECIFIC_LISTENERS = [];
+    protected const DEFAULT_SERVICES_TO_EXTEND = [];
+    protected const DEFAULT_GACELA_CONFIGS_TO_EXTEND = [];
+    protected const DEFAULT_PLUGINS = [];
+
     /**
      * Define different config sources.
      */

--- a/src/Framework/Bootstrap/Setup/GacelaConfigExtender.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigExtender.php
@@ -9,9 +9,9 @@ use Gacela\Framework\Container\Container;
 
 use function is_callable;
 
-final class RunExtendConfig
+final class GacelaConfigExtender
 {
-    public function __invoke(GacelaConfig $gacelaConfig): void
+    public function extend(GacelaConfig $gacelaConfig): void
     {
         $configsToExtend = $gacelaConfig->build()['gacela-configs-to-extend'] ?? [];
 

--- a/src/Framework/Bootstrap/Setup/RunExtendConfig.php
+++ b/src/Framework/Bootstrap/Setup/RunExtendConfig.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Setup;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Container\Container;
+
+use function is_callable;
+
+final class RunExtendConfig
+{
+    public function __invoke(GacelaConfig $gacelaConfig): void
+    {
+        $configsToExtend = $gacelaConfig->build()['gacela-configs-to-extend'] ?? [];
+
+        if ($configsToExtend === []) {
+            return;
+        }
+
+        $container = new Container();
+
+        foreach ($configsToExtend as $className) {
+            /** @var callable|null $configToExtend */
+            $configToExtend = $container->get($className);
+            if (is_callable($configToExtend)) {
+                $configToExtend($gacelaConfig);
+            }
+        }
+    }
+}

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
+use Gacela\Framework\Bootstrap\Setup\RunExtendConfig;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
-use Gacela\Framework\Container\Container;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use RuntimeException;
 
@@ -136,7 +136,8 @@ final class SetupGacela extends AbstractSetupGacela
 
     public static function fromGacelaConfig(GacelaConfig $gacelaConfig): self
     {
-        self::runExtendConfig($gacelaConfig);
+        (new RunExtendConfig())->__invoke($gacelaConfig);
+
         $build = $gacelaConfig->build();
 
         return (new self())
@@ -472,25 +473,6 @@ final class SetupGacela extends AbstractSetupGacela
     public function getPlugins(): array
     {
         return (array)$this->plugins;
-    }
-
-    private static function runExtendConfig(GacelaConfig $gacelaConfig): void
-    {
-        $configsToExtend = $gacelaConfig->build()['gacela-configs-to-extend'] ?? [];
-
-        if ($configsToExtend === []) {
-            return;
-        }
-
-        $container = new Container();
-
-        foreach ($configsToExtend as $className) {
-            /** @var callable|null $configToExtend */
-            $configToExtend = $container->get($className);
-            if (is_callable($configToExtend)) {
-                $configToExtend($gacelaConfig);
-            }
-        }
     }
 
     private function setAreEventListenersEnabled(?bool $flag): self

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
-use Gacela\Framework\Bootstrap\Setup\RunExtendConfig;
+use Gacela\Framework\Bootstrap\Setup\GacelaConfigExtender;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
@@ -136,7 +136,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public static function fromGacelaConfig(GacelaConfig $gacelaConfig): self
     {
-        (new RunExtendConfig())->__invoke($gacelaConfig);
+        (new GacelaConfigExtender())->extend($gacelaConfig);
 
         $build = $gacelaConfig->build();
 

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -6,7 +6,6 @@ namespace Gacela\Framework\Bootstrap;
 
 use Closure;
 use Gacela\Framework\Bootstrap\Setup\GacelaConfigExtender;
-use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
@@ -21,28 +20,6 @@ use function is_callable;
  */
 final class SetupGacela extends AbstractSetupGacela
 {
-    public const shouldResetInMemoryCache = 'shouldResetInMemoryCache';
-    public const fileCacheEnabled = 'fileCacheEnabled';
-    public const fileCacheDirectory = 'fileCacheDirectory';
-    public const externalServices = 'externalServices';
-    public const projectNamespaces = 'projectNamespaces';
-    public const configKeyValues = 'configKeyValues';
-    public const servicesToExtend = 'servicesToExtend';
-    public const plugins = 'plugins';
-    public const gacelaConfigsToExtend = 'gacelaConfigsToExtend';
-
-    private const DEFAULT_ARE_EVENT_LISTENERS_ENABLED = true;
-    private const DEFAULT_SHOULD_RESET_IN_MEMORY_CACHE = false;
-    private const DEFAULT_FILE_CACHE_ENABLED = GacelaFileCache::DEFAULT_ENABLED_VALUE;
-    private const DEFAULT_FILE_CACHE_DIRECTORY = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
-    private const DEFAULT_PROJECT_NAMESPACES = [];
-    private const DEFAULT_CONFIG_KEY_VALUES = [];
-    private const DEFAULT_GENERIC_LISTENERS = [];
-    private const DEFAULT_SPECIFIC_LISTENERS = [];
-    private const DEFAULT_SERVICES_TO_EXTEND = [];
-    private const DEFAULT_GACELA_CONFIGS_TO_EXTEND = [];
-    private const DEFAULT_PLUGINS = [];
-
     /** @var callable(AppConfigBuilder):void */
     private $appConfigFn;
 


### PR DESCRIPTION
## 📚 Description

The aim is to reduce the complexity of `SetupGacela` class.

https://scrutinizer-ci.com/g/gacela-project/gacela/inspections/9d5d29e3-f35c-4175-81ee-55fc933a8a48/code-structure/class/Gacela%5CFramework%5CBootstrap%5CSetupGacela 
<img width="1029" alt="Screenshot 2023-08-13 at 18 44 49" src="https://github.com/gacela-project/gacela/assets/5256287/df6bb735-97ff-430f-a7f7-7be55da2878d">

## 🔖 Changes

- Extract method `runExtendConfig()` to class `GacelaConfigExtender`
- Move constants from `SetupGacela` to `AbstractSetupGacela` class 

## 🖼️  Screenshots


### BEFORE

<img width="429" alt="Screenshot 2023-08-13 at 18 50 24" src="https://github.com/gacela-project/gacela/assets/5256287/920d56ec-84a6-45d5-ac06-71313b61d831">


### AFTER

<img width="447" alt="Screenshot 2023-08-13 at 18 50 12" src="https://github.com/gacela-project/gacela/assets/5256287/f405a3b5-2c8b-483e-9343-f4b1870da996">




