### PR TITLE
Create a DTO from GacelaConfig

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap;
 
 use Closure;
+use Gacela\Framework\Bootstrap\Setup\GacelaConfigTransfer;
 use Gacela\Framework\Config\ConfigReaderInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
@@ -337,44 +338,26 @@ final class GacelaConfig
     }
 
     /**
-     * @return array{
-     *     external-services: array<string,class-string|object|callable>,
-     *     app-config-builder: AppConfigBuilder,
-     *     suffix-types-builder: SuffixTypesBuilder,
-     *     bindings-builder: BindingsBuilder,
-     *     should-reset-in-memory-cache: ?bool,
-     *     file-cache-enabled: ?bool,
-     *     file-cache-directory: ?string,
-     *     project-namespaces: ?list<string>,
-     *     config-key-values: ?array<string,mixed>,
-     *     are-event-listeners-enabled: ?bool,
-     *     generic-listeners: ?list<callable>,
-     *     specific-listeners: ?array<class-string,list<callable>>,
-     *     gacela-configs-to-extend: ?list<class-string>,
-     *     plugins: ?list<class-string|callable>,
-     *     services-to-extend: array<string,list<Closure>>,
-     * }
-     *
      * @internal
      */
-    public function build(): array
+    public function toTransfer(): GacelaConfigTransfer
     {
-        return [
-            'external-services' => $this->externalServices,
-            'app-config-builder' => $this->appConfigBuilder,
-            'suffix-types-builder' => $this->suffixTypesBuilder,
-            'bindings-builder' => $this->bindingsBuilder,
-            'should-reset-in-memory-cache' => $this->shouldResetInMemoryCache,
-            'file-cache-enabled' => $this->fileCacheEnabled,
-            'file-cache-directory' => $this->fileCacheDirectory,
-            'project-namespaces' => $this->projectNamespaces,
-            'config-key-values' => $this->configKeyValues,
-            'are-event-listeners-enabled' => $this->areEventListenersEnabled,
-            'generic-listeners' => $this->genericListeners,
-            'specific-listeners' => $this->specificListeners,
-            'gacela-configs-to-extend' => $this->gacelaConfigsToExtend,
-            'plugins' => $this->plugins,
-            'services-to-extend' => $this->servicesToExtend,
-        ];
+        return new GacelaConfigTransfer(
+            $this->appConfigBuilder,
+            $this->suffixTypesBuilder,
+            $this->bindingsBuilder,
+            $this->externalServices,
+            $this->shouldResetInMemoryCache,
+            $this->fileCacheEnabled,
+            $this->fileCacheDirectory,
+            $this->projectNamespaces,
+            $this->configKeyValues,
+            $this->genericListeners,
+            $this->specificListeners,
+            $this->areEventListenersEnabled,
+            $this->gacelaConfigsToExtend,
+            $this->plugins,
+            $this->servicesToExtend,
+        );
     }
 }

--- a/src/Framework/Bootstrap/Setup/GacelaConfigExtender.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigExtender.php
@@ -13,7 +13,7 @@ final class GacelaConfigExtender
 {
     public function extend(GacelaConfig $gacelaConfig): void
     {
-        $configsToExtend = $gacelaConfig->build()['gacela-configs-to-extend'] ?? [];
+        $configsToExtend = $gacelaConfig->toTransfer()->getGacelaConfigsToExtend();
 
         if ($configsToExtend === []) {
             return;

--- a/src/Framework/Bootstrap/Setup/GacelaConfigExtender.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigExtender.php
@@ -13,7 +13,7 @@ final class GacelaConfigExtender
 {
     public function extend(GacelaConfig $gacelaConfig): void
     {
-        $configsToExtend = $gacelaConfig->toTransfer()->getGacelaConfigsToExtend();
+        $configsToExtend = $gacelaConfig->toTransfer()->getGacelaConfigsToExtend() ?? [];
 
         if ($configsToExtend === []) {
             return;

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Setup;
+
+use Closure;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+
+final class GacelaConfigTransfer
+{
+    /**
+     * @param array<string, class-string|object|callable> $externalServices
+     * @param list<string> $projectNamespaces
+     * @param array<string,mixed> $configKeyValues
+     * @param list<callable> $genericListeners
+     * @param array<class-string,list<callable>> $specificListeners
+     * @param list<class-string> $gacelaConfigsToExtend
+     * @param list<class-string|callable> $plugins
+     * @param array<string,list<Closure>> $servicesToExtend
+     */
+    public function __construct(
+        private AppConfigBuilder $appConfigBuilder,
+        private SuffixTypesBuilder $suffixTypesBuilder,
+        private BindingsBuilder $bindingsBuilder,
+        private ?array $externalServices,
+        private ?bool $shouldResetInMemoryCache,
+        private ?bool $fileCacheEnabled,
+        private ?string $fileCacheDirectory,
+        private ?array $projectNamespaces,
+        private ?array $configKeyValues,
+        private ?array $genericListeners,
+        private ?array $specificListeners,
+        private ?bool $areEventListenersEnabled,
+        private ?array $gacelaConfigsToExtend,
+        private ?array $plugins,
+        private ?array $servicesToExtend,
+    ) {
+    }
+
+    public function getAppConfigBuilder(): AppConfigBuilder
+    {
+        return $this->appConfigBuilder;
+    }
+
+    public function getSuffixTypesBuilder(): SuffixTypesBuilder
+    {
+        return $this->suffixTypesBuilder;
+    }
+
+    public function getBindingsBuilder(): BindingsBuilder
+    {
+        return $this->bindingsBuilder;
+    }
+
+    /**
+     * @return null|array<string, class-string|object|callable>
+     */
+    public function getExternalServices(): ?array
+    {
+        return $this->externalServices;
+    }
+
+    public function getShouldResetInMemoryCache(): ?bool
+    {
+        return $this->shouldResetInMemoryCache;
+    }
+
+    public function getFileCacheEnabled(): ?bool
+    {
+        return $this->fileCacheEnabled;
+    }
+
+    public function getFileCacheDirectory(): ?string
+    {
+        return $this->fileCacheDirectory;
+    }
+
+    public function getProjectNamespaces(): ?array
+    {
+        return $this->projectNamespaces;
+    }
+
+    public function getConfigKeyValues(): ?array
+    {
+        return $this->configKeyValues;
+    }
+
+    public function getAreEventListenersEnabled(): ?bool
+    {
+        return $this->areEventListenersEnabled;
+    }
+
+    public function getGenericListeners(): ?array
+    {
+        return $this->genericListeners;
+    }
+
+    public function getSpecificListeners(): ?array
+    {
+        return $this->specificListeners;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public function getGacelaConfigsToExtend(): array
+    {
+        return $this->gacelaConfigsToExtend ?? [];
+    }
+
+    public function getPlugins(): ?array
+    {
+        return $this->plugins;
+    }
+
+    public function getServicesToExtend(): ?array
+    {
+        return $this->servicesToExtend;
+    }
+}

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -12,14 +12,14 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 final class GacelaConfigTransfer
 {
     /**
-     * @param array<string, class-string|object|callable> $externalServices
-     * @param list<string> $projectNamespaces
-     * @param array<string,mixed> $configKeyValues
-     * @param list<callable> $genericListeners
-     * @param array<class-string,list<callable>> $specificListeners
-     * @param list<class-string> $gacelaConfigsToExtend
-     * @param list<class-string|callable> $plugins
-     * @param array<string,list<Closure>> $servicesToExtend
+     * @param ?array<string, class-string|object|callable> $externalServices
+     * @param ?list<string> $projectNamespaces
+     * @param ?array<string,mixed> $configKeyValues
+     * @param ?list<callable> $genericListeners
+     * @param ?array<class-string,list<callable>> $specificListeners
+     * @param ?list<class-string> $gacelaConfigsToExtend
+     * @param ?list<class-string|callable> $plugins
+     * @param ?array<string,list<Closure>> $servicesToExtend
      */
     public function __construct(
         private AppConfigBuilder $appConfigBuilder,
@@ -56,7 +56,7 @@ final class GacelaConfigTransfer
     }
 
     /**
-     * @return null|array<string, class-string|object|callable>
+     * @return ?array<string, class-string|object|callable>
      */
     public function getExternalServices(): ?array
     {
@@ -78,11 +78,17 @@ final class GacelaConfigTransfer
         return $this->fileCacheDirectory;
     }
 
+    /**
+     * @return ?list<string>
+     */
     public function getProjectNamespaces(): ?array
     {
         return $this->projectNamespaces;
     }
 
+    /**
+     * @return ?array<string,mixed>
+     */
     public function getConfigKeyValues(): ?array
     {
         return $this->configKeyValues;
@@ -93,29 +99,41 @@ final class GacelaConfigTransfer
         return $this->areEventListenersEnabled;
     }
 
+    /**
+     * @return ?list<callable>
+     */
     public function getGenericListeners(): ?array
     {
         return $this->genericListeners;
     }
 
+    /**
+     * @return ?array<class-string,list<callable>>
+     */
     public function getSpecificListeners(): ?array
     {
         return $this->specificListeners;
     }
 
     /**
-     * @return list<class-string>
+     * @return ?list<class-string>
      */
-    public function getGacelaConfigsToExtend(): array
+    public function getGacelaConfigsToExtend(): ?array
     {
-        return $this->gacelaConfigsToExtend ?? [];
+        return $this->gacelaConfigsToExtend;
     }
 
+    /**
+     * @return ?list<class-string|callable>
+     */
     public function getPlugins(): ?array
     {
         return $this->plugins;
     }
 
+    /**
+     * @return ?array<string,list<Closure>>
+     */
     public function getServicesToExtend(): ?array
     {
         return $this->servicesToExtend;

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -115,30 +115,30 @@ final class SetupGacela extends AbstractSetupGacela
     {
         (new GacelaConfigExtender())->extend($gacelaConfig);
 
-        $build = $gacelaConfig->build();
+        $dto = $gacelaConfig->toTransfer();
 
         return (new self())
-            ->setExternalServices($build['external-services'])
-            ->setAppConfigBuilder($build['app-config-builder'])
-            ->setSuffixTypesBuilder($build['suffix-types-builder'])
-            ->setBindingsBuilder($build['bindings-builder'])
-            ->setShouldResetInMemoryCache($build['should-reset-in-memory-cache'])
-            ->setFileCacheEnabled($build['file-cache-enabled'])
-            ->setFileCacheDirectory($build['file-cache-directory'])
-            ->setProjectNamespaces($build['project-namespaces'])
-            ->setConfigKeyValues($build['config-key-values'])
-            ->setAreEventListenersEnabled($build['are-event-listeners-enabled'])
-            ->setGenericListeners($build['generic-listeners'])
-            ->setSpecificListeners($build['specific-listeners'])
-            ->setGacelaConfigsToExtend($build['gacela-configs-to-extend'])
-            ->setPlugins($build['plugins'])
-            ->setServicesToExtend($build['services-to-extend']);
+            ->setExternalServices($dto->getExternalServices())
+            ->setAppConfigBuilder($dto->getAppConfigBuilder())
+            ->setSuffixTypesBuilder($dto->getSuffixTypesBuilder())
+            ->setBindingsBuilder($dto->getBindingsBuilder())
+            ->setShouldResetInMemoryCache($dto->getShouldResetInMemoryCache())
+            ->setFileCacheEnabled($dto->getFileCacheEnabled())
+            ->setFileCacheDirectory($dto->getFileCacheDirectory())
+            ->setProjectNamespaces($dto->getProjectNamespaces())
+            ->setConfigKeyValues($dto->getConfigKeyValues())
+            ->setAreEventListenersEnabled($dto->getAreEventListenersEnabled())
+            ->setGenericListeners($dto->getGenericListeners())
+            ->setSpecificListeners($dto->getSpecificListeners())
+            ->setGacelaConfigsToExtend($dto->getGacelaConfigsToExtend())
+            ->setPlugins($dto->getPlugins())
+            ->setServicesToExtend($dto->getServicesToExtend());
     }
 
     /**
      * @param array<string,class-string|object|callable> $array
      */
-    public function setExternalServices(array $array): self
+    public function setExternalServices(?array $array): self
     {
         $this->markPropertyChanged(self::externalServices, true);
         $this->externalServices = $array;


### PR DESCRIPTION
## 📚 Description

The `GacelaConfig` class is the public config API that the client/user uses to alter the default behavior of Gacela. 
The changes are purely internal, and instead of manipulating a plain key-value array, it's simpler to use an object.

## 🔖 Changes

- Create `GacelaConfigTransfer` (as DTO) instead of using a plain array from the `GacelaConfig` public API
