### PR TITLE
Test file content generator with short name

### DIFF
--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Unit\CodeGenerator\Domain\FileContent;
+namespace GacelaTest\Unit\Console\Domain\FileContent;
 
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
 use Gacela\Console\Domain\FileContent\FileContentGenerator;

--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -94,6 +94,30 @@ final class FileContentGeneratorTest extends TestCase
         self::assertSame('Dir/DirFactory.php', $actualPath);
     }
 
+    public function test_factory_maker_template_with_short_name(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/Factory.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'Factory' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::FACTORY,
+            withShortName: true,
+        );
+
+        self::assertSame('Dir/Factory.php', $actualPath);
+    }
+
     public function test_config_maker_template(): void
     {
         $fileContentIo = $this->createMock(FileContentIoInterface::class);

--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -47,6 +47,30 @@ final class FileContentGeneratorTest extends TestCase
         self::assertSame('Dir/DirFacade.php', $actualPath);
     }
 
+    public function test_facade_maker_template_with_short_name(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/Facade.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'Facade' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::FACADE,
+            withShortName: true,
+        );
+
+        self::assertSame('Dir/Facade.php', $actualPath);
+    }
+
     public function test_factory_maker_template(): void
     {
         $fileContentIo = $this->createMock(FileContentIoInterface::class);

--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -141,6 +141,30 @@ final class FileContentGeneratorTest extends TestCase
         self::assertSame('Dir/DirConfig.php', $actualPath);
     }
 
+    public function test_config_maker_template_with_short_name(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/Config.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'Config' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::CONFIG,
+            withShortName: true,
+        );
+
+        self::assertSame('Dir/Config.php', $actualPath);
+    }
+
     public function test_dependency_provider_maker_template(): void
     {
         $fileContentIo = $this->createMock(FileContentIoInterface::class);
@@ -162,5 +186,29 @@ final class FileContentGeneratorTest extends TestCase
         );
 
         self::assertSame('Dir/DirDependencyProvider.php', $actualPath);
+    }
+
+    public function test_dependency_provider_maker_template_with_short_name(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::once())
+            ->method('mkdir')
+            ->with('Dir');
+
+        $fileContentIo->expects(self::once())
+            ->method('filePutContents')
+            ->with('Dir/DependencyProvider.php', 'template-result');
+
+        $generator = new FileContentGenerator($fileContentIo, [
+            'DependencyProvider' => 'template-result',
+        ]);
+
+        $actualPath = $generator->generate(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::DEPENDENCY_PROVIDER,
+            withShortName: true,
+        );
+
+        self::assertSame('Dir/DependencyProvider.php', $actualPath);
     }
 }


### PR DESCRIPTION
## 📚 Description

The main logic for the file content generator was tested but not with the short name flag.

> Discovered thanks to mutation testing!

![Screenshot 2024-02-18 at 21 58 08](https://github.com/gacela-project/gacela/assets/5256287/0397bc1c-2ecb-4ae9-a43a-e821a69a0586)

## 🔖 Changes

- Add tests for `FileContentGenerator` when using `withShortName: true`
