### PR TITLE
Fix disable event listeners

### DIFF
--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -342,7 +342,7 @@ final class SetupGacela extends AbstractSetupGacela
 
     public function canCreateEventDispatcher(): bool
     {
-        return $this->areEventListenersEnabled !== null
+        return $this->areEventListenersEnabled === true
             && $this->hasEventListeners();
     }
 

--- a/tests/Feature/Framework/ListeningEvents/ClassResolver/DisableListenersTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ClassResolver/DisableListenersTest.php
@@ -7,11 +7,15 @@ namespace GacelaTest\Feature\Framework\ListeningEvents\ClassResolver;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Framework\ListeningEvents\ClassResolver\Module\Facade;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 final class DisableListenersTest extends TestCase
 {
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_disable_class_resolver_listener(): void
     {
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

<img width="1000" alt="Screenshot 2024-08-11 at 12 03 15" src="https://github.com/user-attachments/assets/b91aa557-641d-4900-92d9-e4496c68b00b">

## 🔖 Changes

- Check that `areEventListenersEnabled` is actually true, and not just `not null`, because `false` would be also not a valid value
- Run `test_disable_class_resolver_listener` in a separate process to guarantee it is not affected by any other test - and avoid flackyness"
