### PR TITLE
Fix flacky feature static facade tests

### DIFF
--- a/tests/Feature/Framework/StaticFacade/FeatureTest.php
+++ b/tests/Feature/Framework/StaticFacade/FeatureTest.php
@@ -9,6 +9,8 @@ use GacelaTest\Feature\Framework\StaticFacade\ModuleA\Facade as TestStaticFacade
 use GacelaTest\Feature\Framework\StaticFacade\ModuleA\Factory as StaticFactory;
 use GacelaTest\Feature\Framework\StaticFacade\ModuleB\Facade as TestObjectFacade;
 use GacelaTest\Feature\Framework\StaticFacade\ModuleB\Factory as ObjectFactory;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 final class FeatureTest extends TestCase
@@ -18,6 +20,8 @@ final class FeatureTest extends TestCase
         Gacela::bootstrap(__DIR__);
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_unknown_static_facade_method(): void
     {
         $this->expectExceptionMessage("Method unknown: 'unknown'");
@@ -25,6 +29,8 @@ final class FeatureTest extends TestCase
         TestStaticFacade::unknown();
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_unknown_object_factory_method(): void
     {
         $this->expectExceptionMessage("Method unknown: 'unknown'");
@@ -32,6 +38,8 @@ final class FeatureTest extends TestCase
         (new TestObjectFacade())->unknown();
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_unknown_static_factory_method(): void
     {
         $this->expectExceptionMessage("Method unknown: 'innerUnknownFacadeMethod'");
@@ -39,6 +47,8 @@ final class FeatureTest extends TestCase
         TestStaticFacade::unknownFacadeMethod();
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_module_a_static_facade(): void
     {
         $actual = TestStaticFacade::createString();
@@ -46,6 +56,8 @@ final class FeatureTest extends TestCase
         self::assertSame(StaticFactory::STR, $actual);
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_module_a_object_facade(): void
     {
         $actual = (new TestObjectFacade())->createString();
@@ -53,6 +65,8 @@ final class FeatureTest extends TestCase
         self::assertSame(ObjectFactory::STR, $actual);
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_factory_static_facade_method(): void
     {
         $actual = TestStaticFacade::getFactory()->createString();


### PR DESCRIPTION
## 📚 Description

The `tests/Feature/Framework/StaticFacade/FeatureTest.php` are flacky tests. Running them in isolation might help.

PHPUnit docs: https://docs.phpunit.de/en/11.3/annotations.html#preserveglobalstate

## 🔖 Changes

```php
#[RunInSeparateProcess]
#[PreserveGlobalState(false)]
```
