### PR TITLE
Enable env var to define cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Compatibility with PHP 8.4
+- Added `GACELA_CACHE_DIR` env variable to override where to place the cache files
 
 ## [1.8.1](https://github.com/gacela-project/gacela/compare/1.8.0...1.8.1) - 2024-11-09
 
@@ -10,11 +11,11 @@
 
 ## [1.8.0](https://github.com/gacela-project/gacela/compare/1.7.1...1.8.0) - 2024-08-17
 
-- Move `./gacela` script to `bin/` directory
+- Moved `./gacela` script to `bin/` directory
 - Fixed disable event listeners
-- Add `Gacela::addGlobal()`
-- Add `Gacela::overrideExistingResolvedClass()`
-- Deprecate `AbstractDependencyProvider` in favor of `AbstractProvider`
+- Added `Gacela::addGlobal()`
+- Added `Gacela::overrideExistingResolvedClass()`
+- Deprecated `AbstractDependencyProvider` in favor of `AbstractProvider`
 
 ## [1.7.1](https://github.com/gacela-project/gacela/compare/1.7.0...1.7.1) - 2024-04-16
 

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -10,7 +10,6 @@ use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
 
 use function array_key_exists;
-use function is_string;
 
 final class Config implements ConfigInterface
 {
@@ -126,16 +125,11 @@ final class Config implements ConfigInterface
             return $this->cacheDir;
         }
 
-        $cacheDir = getenv('GACELA_CACHE_DIR');
-        if (is_string($cacheDir)) {
-            $this->cacheDir = rtrim($cacheDir, DIRECTORY_SEPARATOR);
-            return $this->cacheDir;
-        }
-
-        $this->cacheDir = $this->getAppRootDir()
+        $this->cacheDir = getenv('GACELA_CACHE_DIR') ?: $this->getAppRootDir()
             . DIRECTORY_SEPARATOR
             . ltrim($this->setup->getFileCacheDirectory(), DIRECTORY_SEPARATOR);
-        return $this->cacheDir;
+
+        return rtrim($this->cacheDir, DIRECTORY_SEPARATOR);
     }
 
     /**

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
 
 use function array_key_exists;
+use function is_string;
 
 final class Config implements ConfigInterface
 {
@@ -119,9 +120,9 @@ final class Config implements ConfigInterface
 
     public function getCacheDir(): string
     {
-        if (isset($_ENV['GACELA_CACHE_DIR'])) {
-            /** @psalm-suppress RedundantCast */
-            return rtrim((string) $_ENV['GACELA_CACHE_DIR'], DIRECTORY_SEPARATOR);
+        $cacheDir = getenv('GACELA_CACHE_DIR');
+        if (is_string($cacheDir)) {
+            return rtrim($cacheDir, DIRECTORY_SEPARATOR);
         }
 
         return $this->getAppRootDir()

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -25,6 +25,8 @@ final class Config implements ConfigInterface
     /** @var array<string,mixed> */
     private array $config = [];
 
+    private ?string $cacheDir = null;
+
     private function __construct(
         private readonly SetupGacelaInterface $setup,
     ) {
@@ -120,14 +122,20 @@ final class Config implements ConfigInterface
 
     public function getCacheDir(): string
     {
-        $cacheDir = getenv('GACELA_CACHE_DIR');
-        if (is_string($cacheDir)) {
-            return rtrim($cacheDir, DIRECTORY_SEPARATOR);
+        if ($this->cacheDir !== null) {
+            return $this->cacheDir;
         }
 
-        return $this->getAppRootDir()
+        $cacheDir = getenv('GACELA_CACHE_DIR');
+        if (is_string($cacheDir)) {
+            $this->cacheDir = rtrim($cacheDir, DIRECTORY_SEPARATOR);
+            return $this->cacheDir;
+        }
+
+        $this->cacheDir = $this->getAppRootDir()
             . DIRECTORY_SEPARATOR
             . ltrim($this->setup->getFileCacheDirectory(), DIRECTORY_SEPARATOR);
+        return $this->cacheDir;
     }
 
     /**

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -119,6 +119,11 @@ final class Config implements ConfigInterface
 
     public function getCacheDir(): string
     {
+        if (isset($_ENV['GACELA_CACHE_DIR'])) {
+            /** @psalm-suppress RedundantCast */
+            return rtrim((string) $_ENV['GACELA_CACHE_DIR'], DIRECTORY_SEPARATOR);
+        }
+
         return $this->getAppRootDir()
             . DIRECTORY_SEPARATOR
             . ltrim($this->setup->getFileCacheDirectory(), DIRECTORY_SEPARATOR);

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -42,6 +42,21 @@ final class FileCacheFeatureTest extends TestCase
         self::assertFileExists(__DIR__ . '/custom/cache-dir/' . CustomServicesPhpCache::FILENAME);
     }
 
+    public function test_custom_env_gacela_cache_dir(): void
+    {
+        $_ENV['GACELA_CACHE_DIR'] = __DIR__ . '/custom/cache-dir';
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $facade = new Module\Facade();
+        self::assertSame('name', $facade->getName());
+
+        self::assertFileExists(__DIR__ . '/custom/cache-dir/' . ClassNamePhpCache::FILENAME);
+        self::assertFileExists(__DIR__ . '/custom/cache-dir/' . CustomServicesPhpCache::FILENAME);
+    }
+
     public function test_custom_cache_dir_but_cache_disable(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -44,7 +44,7 @@ final class FileCacheFeatureTest extends TestCase
 
     public function test_custom_env_gacela_cache_dir(): void
     {
-        $_ENV['GACELA_CACHE_DIR'] = __DIR__ . '/custom/cache-dir';
+        putenv('GACELA_CACHE_DIR=' . __DIR__ . '/custom/cache-dir');
 
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -48,6 +48,7 @@ final class FileCacheFeatureTest extends TestCase
 
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
+            $config->enableFileCache('/custom/this-will-be-overwritten');
         });
 
         $facade = new Module\Facade();
@@ -55,6 +56,9 @@ final class FileCacheFeatureTest extends TestCase
 
         self::assertFileExists(__DIR__ . '/custom/cache-dir/' . ClassNamePhpCache::FILENAME);
         self::assertFileExists(__DIR__ . '/custom/cache-dir/' . CustomServicesPhpCache::FILENAME);
+
+        self::assertFileDoesNotExist(__DIR__ . '/custom/this-will-be-overwritten/' . ClassNamePhpCache::FILENAME);
+        self::assertFileDoesNotExist(__DIR__ . '/custom/this-will-be-overwritten/' . CustomServicesPhpCache::FILENAME);
     }
 
     public function test_custom_cache_dir_but_cache_disable(): void


### PR DESCRIPTION
## 📚 Description

Related: https://github.com/NixOS/nixpkgs/pull/314348#issuecomment-2509618056

> _A cache directory is being created in the Nix store which is immutable._
> _Is there a way to configure this cache directory with an environment variable or some other thing?_

This PR introduces an env variable that would override the full path of the cache dir where gacela cache files are stored.

## 🔖 Changes

- Added `GACELA_CACHE_DIR` env variable to override where to place the cache files

## 🖼️ Demo

Using phel connected to my local gacela project with this PR changes to reproduce it and test it as well:

<img width="1308" alt="Screenshot 2024-12-01 at 11 54 12" src="https://github.com/user-attachments/assets/b51e1d11-8017-41b3-914b-39282fda27cf">

