### PR TITLE
Fix env variable sanitization

### DIFF
--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -105,7 +105,14 @@ final class ConfigFactory extends AbstractFactory
 
     private function env(): string
     {
-        return getenv('APP_ENV') ?: '';
+        $env = getenv('APP_ENV') ?: '';
+
+        // Allow only alphanumeric characters, underscores and hyphens
+        if ($env !== '' && !preg_match('/^[A-Za-z0-9_-]+$/', $env)) {
+            return '';
+        }
+
+        return $env;
     }
 
     private function createPathFinder(): PathFinderInterface


### PR DESCRIPTION
## Summary
- sanitize `APP_ENV` when constructing config paths

## Testing
- `composer test` *(fails: composer not found)*