### PR TITLE
Add internal cache on PathFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-
 ## Unreleased
 
 - Improve internal `AnonymousGlobal::getByKey()` 
+- Add internal cache on `PathFinder` 
 
 ## [1.9.1](https://github.com/gacela-project/gacela/compare/1.9.0...1.9.1) - 2024-12-12
 

--- a/src/Framework/Config/PathFinder.php
+++ b/src/Framework/Config/PathFinder.php
@@ -9,6 +9,9 @@ use function defined;
 
 final class PathFinder implements PathFinderInterface
 {
+    /** @var array<string,array<int,string>> */
+    private static array $cache = [];
+
     /**
      * @return string[]
      */
@@ -18,9 +21,13 @@ final class PathFinder implements PathFinderInterface
             return [];
         }
 
+        if (isset(self::$cache[$pattern])) {
+            return self::$cache[$pattern];
+        }
+
         $this->ensureGlobBraceIsDefined();
 
-        return glob($pattern, GLOB_BRACE) ?: [];
+        return self::$cache[$pattern] = glob($pattern, GLOB_BRACE) ?: [];
     }
 
     /**


### PR DESCRIPTION
## 🔖 Changes

- Added an internal cache to `PathFinder` to memoize glob results and skip repeated filesystem scans, improving loading performance

- Updated `AbstractPhpFileCache` to avoid rewriting unchanged cache files and to use `LOCK_EX` for safer writes
