### PR TITLE
feat(console): add doctor command for environmental health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add `HealthStatus` with levels (OK, WARNING, ERROR, CRITICAL) for categorizing issues
 - Add `HealthCheckReport` for detailed health check analysis and reporting
 - Add comprehensive health check documentation with practical examples
+- Add `doctor` command aggregating environmental and wiring health checks (cache staleness, suffix mismatches) with per-check remediation hints
 
 ## [1.12.0](https://github.com/gacela-project/gacela/compare/1.11.0...1.12.0) - 2025-11-09
 

--- a/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
+++ b/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Closure;
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use ReflectionClass;
+use ReflectionException;
+
+use function sprintf;
+
+final class CacheStalenessCheck implements HealthCheck
+{
+    /** @var Closure(string):?string */
+    private readonly Closure $sourceFileResolver;
+
+    /**
+     * @param null|Closure(string):?string $sourceFileResolver resolves a class-name to its source file path
+     */
+    public function __construct(
+        private readonly string $cacheDir,
+        ?Closure $sourceFileResolver = null,
+    ) {
+        $this->sourceFileResolver = $sourceFileResolver ?? static function (string $className): ?string {
+            if (!class_exists($className) && !interface_exists($className)) {
+                return null;
+            }
+            try {
+                $file = (new ReflectionClass($className))->getFileName();
+            } catch (ReflectionException) {
+                return null;
+            }
+
+            return $file === false ? null : $file;
+        };
+    }
+
+    public function name(): string
+    {
+        return 'cache staleness';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->cacheDir === '' || !is_dir($this->cacheDir)) {
+            return CheckResult::ok($this->name(), 'no cache directory — nothing to check');
+        }
+
+        $stale = [];
+        $missing = [];
+
+        foreach ([ClassNamePhpCache::FILENAME, CustomServicesPhpCache::FILENAME] as $filename) {
+            $cacheFile = $this->cacheDir . DIRECTORY_SEPARATOR . $filename;
+            if (!is_file($cacheFile)) {
+                continue;
+            }
+
+            $cacheMtime = (int) filemtime($cacheFile);
+            /** @var array<string,string> $entries */
+            $entries = require $cacheFile;
+
+            foreach ($entries as $cacheKey => $className) {
+                $source = ($this->sourceFileResolver)($className);
+                if ($source === null) {
+                    $missing[] = sprintf('%s → %s (source file not found)', $cacheKey, $className);
+                    continue;
+                }
+                if (!is_file($source)) {
+                    $missing[] = sprintf('%s → %s (%s)', $cacheKey, $className, $source);
+                    continue;
+                }
+                if ((int) filemtime($source) > $cacheMtime) {
+                    $stale[] = sprintf('%s → %s', $cacheKey, $className);
+                }
+            }
+        }
+
+        if ($stale === [] && $missing === []) {
+            return CheckResult::ok($this->name(), 'all cache entries are fresh');
+        }
+
+        $details = [];
+        foreach ($stale as $entry) {
+            $details[] = 'stale: ' . $entry;
+        }
+        foreach ($missing as $entry) {
+            $details[] = 'missing source: ' . $entry;
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            $details,
+            'run `bin/gacela cache:clear && bin/gacela cache:warm` to rebuild',
+        );
+    }
+}

--- a/src/Console/Application/Doctor/Check/SuffixMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/SuffixMismatchCheck.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+
+use function count;
+use function sprintf;
+
+final class SuffixMismatchCheck implements HealthCheck
+{
+    /** @var array{Facade: list<string>, Factory: list<string>, Config: list<string>, Provider: list<string>} */
+    private readonly array $suffixTypes;
+
+    /**
+     * @param list<AppModule> $modules
+     * @param array{Facade?: list<string>, Factory?: list<string>, Config?: list<string>, Provider?: list<string>} $suffixTypes
+     */
+    public function __construct(
+        private readonly array $modules,
+        array $suffixTypes,
+    ) {
+        $this->suffixTypes = [
+            'Facade' => $suffixTypes['Facade'] ?? ['Facade'],
+            'Factory' => $suffixTypes['Factory'] ?? ['Factory'],
+            'Config' => $suffixTypes['Config'] ?? ['Config'],
+            'Provider' => $suffixTypes['Provider'] ?? ['Provider'],
+        ];
+    }
+
+    public function name(): string
+    {
+        return 'suffix configuration';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->modules === []) {
+            return CheckResult::ok($this->name(), 'no modules discovered');
+        }
+
+        $errors = [];
+        $warnings = [];
+
+        foreach ($this->modules as $module) {
+            $this->inspect('Facade', $module->facadeClass(), $this->suffixTypes['Facade'], $errors);
+            $this->inspectOptional('Factory', $module->factoryClass(), $this->suffixTypes['Factory'], $warnings);
+            $this->inspectOptional('Config', $module->configClass(), $this->suffixTypes['Config'], $warnings);
+            $this->inspectOptional('Provider', $module->providerClass(), $this->suffixTypes['Provider'], $warnings);
+        }
+
+        if ($errors !== []) {
+            return CheckResult::error(
+                $this->name(),
+                [...$errors, ...$warnings],
+                'add the missing suffix via `SuffixTypesBuilder::addFacade/Factory/Config/Provider` in gacela.php',
+            );
+        }
+
+        if ($warnings !== []) {
+            return CheckResult::warn(
+                $this->name(),
+                $warnings,
+                'configure the suffix in gacela.php or rename the file to match a configured suffix',
+            );
+        }
+
+        return CheckResult::ok($this->name(), sprintf('%d module(s) use configured suffixes', count($this->modules)));
+    }
+
+    /**
+     * @param list<string> $configured
+     * @param list<string> $bucket
+     */
+    private function inspect(string $kind, string $className, array $configured, array &$bucket): void
+    {
+        if (!$this->endsWithAny($className, $configured)) {
+            $bucket[] = sprintf(
+                '%s "%s" does not end with any configured %s suffix [%s]',
+                $kind,
+                $className,
+                $kind,
+                implode(', ', $configured),
+            );
+        }
+    }
+
+    /**
+     * @param list<string> $configured
+     * @param list<string> $bucket
+     */
+    private function inspectOptional(string $kind, ?string $className, array $configured, array &$bucket): void
+    {
+        if ($className === null) {
+            return;
+        }
+        $this->inspect($kind, $className, $configured, $bucket);
+    }
+
+    /**
+     * @param list<string> $suffixes
+     */
+    private function endsWithAny(string $className, array $suffixes): bool
+    {
+        foreach ($suffixes as $suffix) {
+            if (str_ends_with($className, $suffix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Console/Application/Doctor/CheckResult.php
+++ b/src/Console/Application/Doctor/CheckResult.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor;
+
+final class CheckResult
+{
+    /**
+     * @param list<string> $details
+     */
+    private function __construct(
+        public readonly CheckStatus $status,
+        public readonly string $title,
+        public readonly array $details,
+        public readonly string $remediation,
+    ) {
+    }
+
+    public static function ok(string $title, string $detail = ''): self
+    {
+        return new self(CheckStatus::Ok, $title, $detail === '' ? [] : [$detail], '');
+    }
+
+    /**
+     * @param list<string> $details
+     */
+    public static function warn(string $title, array $details, string $remediation = ''): self
+    {
+        return new self(CheckStatus::Warn, $title, $details, $remediation);
+    }
+
+    /**
+     * @param list<string> $details
+     */
+    public static function error(string $title, array $details, string $remediation = ''): self
+    {
+        return new self(CheckStatus::Error, $title, $details, $remediation);
+    }
+}

--- a/src/Console/Application/Doctor/CheckStatus.php
+++ b/src/Console/Application/Doctor/CheckStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor;
+
+enum CheckStatus: string
+{
+    case Ok = 'ok';
+    case Warn = 'warn';
+    case Error = 'error';
+}

--- a/src/Console/Application/Doctor/HealthCheck.php
+++ b/src/Console/Application/Doctor/HealthCheck.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor;
+
+interface HealthCheck
+{
+    public function name(): string;
+
+    public function run(): CheckResult;
+}

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -7,6 +7,7 @@ namespace Gacela\Console;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Console\Infrastructure\Command\DoctorCommand;
 use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\MakeFileCommand;
 use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
@@ -40,6 +41,7 @@ final class ConsoleProvider extends AbstractProvider
             new CacheWarmCommand(),
             new ValidateConfigCommand(),
             new ProfileReportCommand(),
+            new DoctorCommand(),
         ]);
     }
 

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
+use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function sprintf;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+final class DoctorCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('doctor')
+            ->setDescription('Run environmental & wiring health checks for the current Gacela setup')
+            ->addArgument('filter', InputArgument::OPTIONAL, 'Restrict module-scoped checks to this namespace', '');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('');
+        $output->writeln('<info>Gacela Doctor</info>');
+        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
+        $output->writeln('');
+
+        $filter = (string) $input->getArgument('filter');
+        $checks = $this->buildChecks($filter);
+        $worst = CheckStatus::Ok;
+
+        foreach ($checks as $check) {
+            $result = $check->run();
+            $this->renderResult($result, $output);
+            $worst = $this->worseOf($worst, $result->status);
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
+
+        return match ($worst) {
+            CheckStatus::Error => $this->finish($output, '<error>✗ Doctor found errors</error>', Command::FAILURE),
+            CheckStatus::Warn => $this->finish($output, '<fg=yellow>⚠ Doctor finished with warnings</>', Command::SUCCESS),
+            CheckStatus::Ok => $this->finish($output, '<fg=green>✓ All checks passed</>', Command::SUCCESS),
+        };
+    }
+
+    /**
+     * @return list<HealthCheck>
+     */
+    private function buildChecks(string $filter): array
+    {
+        $config = Config::getInstance();
+        $modules = $this->getFacade()->findAllAppModules($filter);
+        $suffixTypes = $config->getFactory()->createGacelaFileConfig()->getSuffixTypes();
+
+        return [
+            new CacheStalenessCheck($config->getCacheDir()),
+            new SuffixMismatchCheck($modules, $suffixTypes),
+        ];
+    }
+
+    private function renderResult(CheckResult $result, OutputInterface $output): void
+    {
+        [$marker, $tag] = match ($result->status) {
+            CheckStatus::Ok => ['✓', 'fg=green'],
+            CheckStatus::Warn => ['⚠', 'fg=yellow'],
+            CheckStatus::Error => ['✗', 'error'],
+        };
+
+        $output->writeln(sprintf('<%s>%s %s</>', $tag, $marker, $result->title));
+
+        foreach ($result->details as $detail) {
+            $output->writeln('    ' . $detail);
+        }
+
+        if ($result->remediation !== '') {
+            $output->writeln(sprintf('    <comment>→ %s</comment>', $result->remediation));
+        }
+
+        $output->writeln('');
+    }
+
+    private function worseOf(CheckStatus $a, CheckStatus $b): CheckStatus
+    {
+        $rank = static fn (CheckStatus $s): int => match ($s) {
+            CheckStatus::Ok => 0,
+            CheckStatus::Warn => 1,
+            CheckStatus::Error => 2,
+        };
+        return $rank($a) >= $rank($b) ? $a : $b;
+    }
+
+    private function finish(OutputInterface $output, string $line, int $code): int
+    {
+        $output->writeln($line);
+        $output->writeln('');
+        return $code;
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use PHPUnit\Framework\TestCase;
+
+use function is_string;
+
+final class CacheStalenessCheckTest extends TestCase
+{
+    private string $tempDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/gacela-doctor-' . uniqid('', true);
+        mkdir($this->tempDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ((array) glob($this->tempDir . '/*') as $file) {
+            is_string($file) && @unlink($file);
+        }
+        @rmdir($this->tempDir);
+    }
+
+    public function test_missing_cache_dir_returns_ok(): void
+    {
+        $check = new CacheStalenessCheck('/nonexistent/path/xyz');
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function test_empty_cache_dir_returns_ok(): void
+    {
+        $check = new CacheStalenessCheck($this->tempDir);
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function test_fresh_cache_returns_ok(): void
+    {
+        $sourceFile = $this->tempDir . '/Source.php';
+        file_put_contents($sourceFile, '<?php');
+        touch($sourceFile, time() - 120);
+
+        $cacheFile = $this->tempDir . '/' . ClassNamePhpCache::FILENAME;
+        file_put_contents(
+            $cacheFile,
+            '<?php return ' . var_export(['SomeKey' => 'Some\\Class'], true) . ';',
+        );
+        touch($cacheFile, time());
+
+        $check = new CacheStalenessCheck(
+            $this->tempDir,
+            static fn (string $className): string => $sourceFile,
+        );
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function test_source_newer_than_cache_returns_warn(): void
+    {
+        $sourceFile = $this->tempDir . '/Source.php';
+        file_put_contents($sourceFile, '<?php');
+        touch($sourceFile, time());
+
+        $cacheFile = $this->tempDir . '/' . ClassNamePhpCache::FILENAME;
+        file_put_contents(
+            $cacheFile,
+            '<?php return ' . var_export(['SomeKey' => 'Some\\Class'], true) . ';',
+        );
+        touch($cacheFile, time() - 120);
+
+        $check = new CacheStalenessCheck(
+            $this->tempDir,
+            static fn (string $className): string => $sourceFile,
+        );
+
+        $result = $check->run();
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertNotEmpty($result->details);
+    }
+
+    public function test_unresolvable_source_is_reported(): void
+    {
+        $cacheFile = $this->tempDir . '/' . ClassNamePhpCache::FILENAME;
+        file_put_contents(
+            $cacheFile,
+            '<?php return ' . var_export(['SomeKey' => 'Ghost\\Class'], true) . ';',
+        );
+
+        $check = new CacheStalenessCheck(
+            $this->tempDir,
+            static fn (string $className): ?string => null,
+        );
+
+        $result = $check->run();
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('missing source', $result->details[0] ?? '');
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/SuffixMismatchCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/SuffixMismatchCheckTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use PHPUnit\Framework\TestCase;
+
+final class SuffixMismatchCheckTest extends TestCase
+{
+    public function test_no_modules_returns_ok(): void
+    {
+        $check = new SuffixMismatchCheck([], $this->defaultSuffixes());
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+    }
+
+    public function test_all_suffixes_match_defaults_returns_ok(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            'App\\Foo\\FooFactory',
+            'App\\Foo\\FooConfig',
+            'App\\Foo\\FooProvider',
+        );
+
+        $check = new SuffixMismatchCheck([$module], $this->defaultSuffixes());
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function test_facade_with_wrong_suffix_is_error(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFaced', // typo suffix
+        );
+
+        $check = new SuffixMismatchCheck([$module], $this->defaultSuffixes());
+
+        $result = $check->run();
+        self::assertSame(CheckStatus::Error, $result->status);
+        self::assertNotEmpty($result->details);
+    }
+
+    public function test_optional_factory_with_wrong_suffix_is_warning(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            'App\\Foo\\FooFactorio', // bad
+        );
+
+        $result = (new SuffixMismatchCheck([$module], $this->defaultSuffixes()))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+    }
+
+    public function test_custom_suffix_is_respected(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooPublicApi',
+        );
+
+        $suffixes = $this->defaultSuffixes();
+        $suffixes['Facade'][] = 'PublicApi';
+
+        self::assertSame(CheckStatus::Ok, (new SuffixMismatchCheck([$module], $suffixes))->run()->status);
+    }
+
+    /**
+     * @return array{Facade: list<string>, Factory: list<string>, Config: list<string>, Provider: list<string>}
+     */
+    private function defaultSuffixes(): array
+    {
+        return [
+            'Facade' => ['Facade'],
+            'Factory' => ['Factory'],
+            'Config' => ['Config'],
+            'Provider' => ['Provider'],
+        ];
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/CheckResultTest.php
+++ b/tests/Unit/Console/Application/Doctor/CheckResultTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use PHPUnit\Framework\TestCase;
+
+final class CheckResultTest extends TestCase
+{
+    public function test_ok_has_empty_details_when_no_detail_passed(): void
+    {
+        $result = CheckResult::ok('title');
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame('title', $result->title);
+        self::assertSame([], $result->details);
+        self::assertSame('', $result->remediation);
+    }
+
+    public function test_ok_wraps_detail_string_into_list(): void
+    {
+        $result = CheckResult::ok('title', 'single detail');
+
+        self::assertSame(['single detail'], $result->details);
+    }
+
+    public function test_warn_preserves_details_and_remediation(): void
+    {
+        $result = CheckResult::warn('title', ['a', 'b'], 'fix it');
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['a', 'b'], $result->details);
+        self::assertSame('fix it', $result->remediation);
+    }
+
+    public function test_error_preserves_details_and_remediation(): void
+    {
+        $result = CheckResult::error('title', ['bad'], 'do this');
+
+        self::assertSame(CheckStatus::Error, $result->status);
+        self::assertSame(['bad'], $result->details);
+        self::assertSame('do this', $result->remediation);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Introduces `bin/gacela doctor`, a single aggregated health-check command that surfaces wiring/environmental issues which today only fail at runtime with opaque stack traces. Complements `validate:config` (correctness of bindings) by focusing on end-to-end "does this project work right now".

## 🔖 Changes

- Add `HealthCheck` contract + `CheckResult` / `CheckStatus` value types under `src/Console/Application/Doctor/`
- Add `CacheStalenessCheck` — flags cached class-name entries whose source files are newer than the cache write
- Add `SuffixMismatchCheck` — verifies discovered modules use suffixes present in the configured `SuffixTypesBuilder` lists
- Add `DoctorCommand` with optional namespace filter argument and `ok/warn/error` exit codes
- Register `DoctorCommand` in `ConsoleProvider`
- 14 unit tests; structured to easily accept further checks (env, namespaces, opcache)