### PR TITLE
perf(config): persist merged config to disk via MergedConfigCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `MergedConfigCache` to persist the merged file-based config values to disk so bootstraps skip globbing and parsing configuration files; produced by `cache:warm`, removed by `cache:clear`, and keyed per `APP_ENV`
 - Add contextual bindings via GacelaConfig::when()
 - Add service aliases via GacelaConfig::addAlias()
 - Add protected services via GacelaConfig::addProtected()

--- a/src/Console/Application/CacheWarm/CacheWarmOutputFormatter.php
+++ b/src/Console/Application/CacheWarm/CacheWarmOutputFormatter.php
@@ -96,6 +96,13 @@ final class CacheWarmOutputFormatter
         $this->output->writeln('');
     }
 
+    public function writeMergedConfigCacheInfo(string $cacheFile, string $cacheSize): void
+    {
+        $this->output->writeln(sprintf('<fg=cyan>Merged config cache:</> %s', $cacheFile));
+        $this->output->writeln(sprintf('<fg=cyan>Merged config size:</> %s', $cacheSize));
+        $this->output->writeln('');
+    }
+
     public function writeCacheWarning(): void
     {
         $this->output->writeln('<fg=yellow>Warning: Cache file was not created. File caching might be disabled.</>');

--- a/src/Console/Infrastructure/Command/CacheClearCommand.php
+++ b/src/Console/Infrastructure/Command/CacheClearCommand.php
@@ -6,11 +6,13 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\CacheWarm\CacheManager;
 use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function file_exists;
 use function sprintf;
 
 /**
@@ -30,25 +32,40 @@ final class CacheClearCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $cacheManager = new CacheManager();
+        $config = Config::getInstance();
+        $mergedConfigCacheFile = $config->mergedConfigCacheFilename();
+        $mergedConfigCacheExists = file_exists($mergedConfigCacheFile);
 
         $output->writeln('<info>Clearing Gacela cache...</info>');
         $output->writeln('');
 
-        if (!$cacheManager->cacheFileExists()) {
+        if (!$cacheManager->cacheFileExists() && !$mergedConfigCacheExists) {
             $output->writeln('<comment>No cache files found.</comment>');
             return Command::SUCCESS;
         }
 
-        $cacheFile = $cacheManager->getCacheFilePath();
-        $cacheSize = $cacheManager->getFormattedCacheFileSize();
+        if ($cacheManager->cacheFileExists()) {
+            $cacheFile = $cacheManager->getCacheFilePath();
+            $cacheSize = $cacheManager->getFormattedCacheFileSize();
 
-        $cacheManager->clearCache();
+            $cacheManager->clearCache();
 
-        $output->writeln(sprintf(
-            '<info>✓</info> Cleared cache file: <comment>%s</comment> (<comment>%s</comment>)',
-            $cacheFile,
-            $cacheSize,
-        ));
+            $output->writeln(sprintf(
+                '<info>✓</info> Cleared cache file: <comment>%s</comment> (<comment>%s</comment>)',
+                $cacheFile,
+                $cacheSize,
+            ));
+        }
+
+        if ($mergedConfigCacheExists) {
+            $config->clearMergedConfigCache();
+
+            $output->writeln(sprintf(
+                '<info>✓</info> Cleared merged config cache: <comment>%s</comment>',
+                $mergedConfigCacheFile,
+            ));
+        }
+
         $output->writeln('');
         $output->writeln('<info>Cache cleared successfully!</info>');
 

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -12,6 +12,7 @@ use Gacela\Console\Application\CacheWarm\ParallelModuleWarmer;
 use Gacela\Console\Application\CacheWarm\PerformanceMetrics;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +22,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function count;
+use function file_exists;
+use function filesize;
+use function sprintf;
 
 /**
  * @method ConsoleFacade getFacade()
@@ -54,6 +58,7 @@ final class CacheWarmCommand extends Command
 
         if ($clearCache) {
             $cacheManager->clearCache();
+            Config::getInstance()->clearMergedConfigCache();
             $formatter->writeCacheCleared();
         }
 
@@ -78,8 +83,33 @@ final class CacheWarmCommand extends Command
         );
 
         $this->displayCacheInfo($cacheManager, $formatter);
+        $this->warmAndDisplayMergedConfigCache($formatter);
 
         return Command::SUCCESS;
+    }
+
+    private function warmAndDisplayMergedConfigCache(CacheWarmOutputFormatter $formatter): void
+    {
+        $filename = Config::getInstance()->writeMergedConfigCache();
+
+        if (!file_exists($filename)) {
+            return;
+        }
+
+        $formatter->writeMergedConfigCacheInfo($filename, $this->formatBytes((int) filesize($filename)));
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return sprintf('%d B', $bytes);
+        }
+
+        if ($bytes < 1048576) {
+            return sprintf('%.2f KB', $bytes / 1024);
+        }
+
+        return sprintf('%.2f MB', $bytes / 1048576);
     }
 
     /**

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
 
 use function array_key_exists;
+use function is_string;
 
 final class Config implements ConfigInterface
 {
@@ -98,9 +99,39 @@ final class Config implements ConfigInterface
 
         /** @psalm-suppress DuplicateArrayKey */
         $this->config = [
-            ...$this->loadAllConfigValues(),
+            ...$this->loadMergedConfigValues(),
             ...$this->setup->getConfigKeyValues(),
         ];
+    }
+
+    /**
+     * @internal persist the merged file-based config values to disk so future
+     *           bootstraps skip globbing and parsing configuration files
+     *
+     * @throws ConfigException
+     */
+    public function writeMergedConfigCache(): string
+    {
+        $cache = $this->createMergedConfigCache();
+        $cache->write($this->loadAllConfigValues());
+
+        return $cache->filename();
+    }
+
+    /**
+     * @internal
+     */
+    public function clearMergedConfigCache(): void
+    {
+        $this->createMergedConfigCache()->clear();
+    }
+
+    /**
+     * @internal
+     */
+    public function mergedConfigCacheFilename(): string
+    {
+        return $this->createMergedConfigCache()->filename();
     }
 
     public function setAppRootDir(string $dir): self
@@ -153,6 +184,32 @@ final class Config implements ConfigInterface
     public function hasKey(string $key): bool
     {
         return array_key_exists($key, $this->config);
+    }
+
+    /**
+     * @throws ConfigException
+     *
+     * @return array<string,mixed>
+     */
+    private function loadMergedConfigValues(): array
+    {
+        $cache = $this->createMergedConfigCache();
+
+        if ($this->setup->isFileCacheEnabled() && $cache->exists()) {
+            return $cache->load();
+        }
+
+        return $this->loadAllConfigValues();
+    }
+
+    private function createMergedConfigCache(): MergedConfigCache
+    {
+        $env = getenv('APP_ENV');
+
+        return new MergedConfigCache(
+            $this->getCacheDir(),
+            is_string($env) ? $env : '',
+        );
     }
 
     private function getDefaultCacheDir(): string

--- a/src/Framework/Config/MergedConfigCache.php
+++ b/src/Framework/Config/MergedConfigCache.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+use RuntimeException;
+
+use function sprintf;
+
+use const LOCK_EX;
+
+final class MergedConfigCache
+{
+    public const FILENAME_PREFIX = 'gacela-merged-config';
+
+    public const FILENAME_EXTENSION = '.php';
+
+    public function __construct(
+        private readonly string $cacheDir,
+        private readonly string $env = '',
+    ) {
+    }
+
+    public function exists(): bool
+    {
+        return is_file($this->filename());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function load(): array
+    {
+        /**
+         * @psalm-suppress UnresolvableInclude
+         *
+         * @var array<string,mixed> $data
+         */
+        $data = require $this->filename();
+
+        return $data;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    public function write(array $data): void
+    {
+        $this->ensureCacheDir();
+
+        $content = sprintf('<?php return %s;', var_export($data, true));
+        file_put_contents($this->filename(), $content, LOCK_EX);
+    }
+
+    public function clear(): void
+    {
+        if ($this->exists()) {
+            unlink($this->filename());
+        }
+    }
+
+    public function filename(): string
+    {
+        $suffix = $this->env !== '' ? '-' . $this->env : '';
+
+        return $this->cacheDir
+            . DIRECTORY_SEPARATOR
+            . self::FILENAME_PREFIX
+            . $suffix
+            . self::FILENAME_EXTENSION;
+    }
+
+    private function ensureCacheDir(): void
+    {
+        if (is_dir($this->cacheDir)) {
+            return;
+        }
+
+        if (!mkdir($concurrentDirectory = $this->cacheDir, 0777, true) && !is_dir($concurrentDirectory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        }
+    }
+}

--- a/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
+++ b/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
@@ -22,6 +22,8 @@ final class CacheWarmCommandTest extends TestCase
 
     private string $cacheFile;
 
+    private string $mergedConfigCacheFile;
+
     protected function setUp(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
@@ -30,21 +32,16 @@ final class CacheWarmCommandTest extends TestCase
         });
 
         $this->cacheFile = Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
+        $this->mergedConfigCacheFile = Config::getInstance()->mergedConfigCacheFilename();
 
-        // Clean up cache file before test
-        if (file_exists($this->cacheFile)) {
-            unlink($this->cacheFile);
-        }
+        $this->removeGeneratedCaches();
 
         $this->command = new CommandTester(new CacheWarmCommand());
     }
 
     protected function tearDown(): void
     {
-        // Clean up cache file after test
-        if (file_exists($this->cacheFile)) {
-            unlink($this->cacheFile);
-        }
+        $this->removeGeneratedCaches();
     }
 
     public function test_cache_warm_creates_cache_file(): void
@@ -164,5 +161,16 @@ final class CacheWarmCommandTest extends TestCase
         self::assertStringContainsString('Cache warming complete!', $output);
         self::assertMatchesRegularExpression('/Time taken:\s+[\d.]+\s+seconds/', $output);
         self::assertSame(0, $this->command->getStatusCode());
+    }
+
+    private function removeGeneratedCaches(): void
+    {
+        if (file_exists($this->cacheFile)) {
+            unlink($this->cacheFile);
+        }
+
+        if (file_exists($this->mergedConfigCacheFile)) {
+            unlink($this->mergedConfigCacheFile);
+        }
     }
 }

--- a/tests/Integration/Framework/Config/MergedConfigCacheIntegrationTest.php
+++ b/tests/Integration/Framework/Config/MergedConfigCacheIntegrationTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Config;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\MergedConfigCache;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function getenv;
+use function is_file;
+use function mkdir;
+use function putenv;
+use function rmdir;
+use function sprintf;
+use function uniqid;
+use function unlink;
+use function var_export;
+
+final class MergedConfigCacheIntegrationTest extends TestCase
+{
+    private string $cacheDir;
+
+    private ?string $originalAppEnv = null;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = __DIR__ . DIRECTORY_SEPARATOR . '.gacela-cache-' . uniqid('', true);
+
+        $env = getenv('APP_ENV');
+        $this->originalAppEnv = $env === false ? null : $env;
+        putenv('APP_ENV');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreAppEnv();
+        $this->removeCacheDir();
+        Config::resetInstance();
+    }
+
+    public function test_init_loads_from_cache_when_present_and_file_cache_enabled(): void
+    {
+        $this->writeMergedConfigCacheFile(['from_cache' => 'yes']);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        self::assertSame('yes', Config::getInstance()->get('from_cache'));
+    }
+
+    public function test_init_ignores_cache_when_file_cache_disabled(): void
+    {
+        $this->writeMergedConfigCacheFile(['from_cache' => 'yes']);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(false, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        self::assertSame('default', Config::getInstance()->get('from_cache', 'default'));
+    }
+
+    public function test_setup_config_values_override_cached_values(): void
+    {
+        $this->writeMergedConfigCacheFile(['shared_key' => 'from_cache']);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+            $config->addAppConfigKeyValue('shared_key', 'from_setup');
+        });
+
+        self::assertSame('from_setup', Config::getInstance()->get('shared_key'));
+    }
+
+    public function test_write_merged_config_cache_persists_file(): void
+    {
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        $filename = Config::getInstance()->writeMergedConfigCache();
+
+        self::assertTrue(is_file($filename));
+    }
+
+    public function test_clear_merged_config_cache_removes_file(): void
+    {
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        $filename = Config::getInstance()->writeMergedConfigCache();
+        self::assertTrue(is_file($filename));
+
+        Config::getInstance()->clearMergedConfigCache();
+
+        self::assertFalse(is_file($filename));
+    }
+
+    public function test_env_keys_produce_separate_cache_files(): void
+    {
+        putenv('APP_ENV=prod');
+        $this->writeMergedConfigCacheFile(['env_marker' => 'prod_value'], 'prod');
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        self::assertSame('prod_value', Config::getInstance()->get('env_marker'));
+    }
+
+    public function test_cache_file_for_one_env_is_not_used_by_another(): void
+    {
+        putenv('APP_ENV=prod');
+        $this->writeMergedConfigCacheFile(['env_marker' => 'prod_value'], 'prod');
+        putenv('APP_ENV=dev');
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        self::assertSame('missing', Config::getInstance()->get('env_marker', 'missing'));
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function writeMergedConfigCacheFile(array $data, string $env = ''): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            mkdir($this->cacheDir, 0777, true);
+        }
+
+        $suffix = $env !== '' ? '-' . $env : '';
+        $filename = $this->cacheDir
+            . DIRECTORY_SEPARATOR
+            . MergedConfigCache::FILENAME_PREFIX
+            . $suffix
+            . MergedConfigCache::FILENAME_EXTENSION;
+
+        file_put_contents($filename, sprintf('<?php return %s;', var_export($data, true)));
+    }
+
+    private function removeCacheDir(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            return;
+        }
+
+        foreach (glob($this->cacheDir . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->cacheDir);
+    }
+
+    private function restoreAppEnv(): void
+    {
+        if ($this->originalAppEnv === null) {
+            putenv('APP_ENV');
+            return;
+        }
+
+        putenv('APP_ENV=' . $this->originalAppEnv);
+    }
+}

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Config\MergedConfigCache;
+use PHPUnit\Framework\TestCase;
+
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class MergedConfigCacheTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-merged-config-test-' . uniqid('', true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeCacheDirIfExists();
+    }
+
+    public function test_exists_is_false_when_file_not_written(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+
+        self::assertFalse($cache->exists());
+    }
+
+    public function test_write_creates_the_cache_file(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+
+        $cache->write(['key' => 'value']);
+
+        self::assertTrue($cache->exists());
+    }
+
+    public function test_load_returns_written_data(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+        $cache->write(['key' => 'value', 'nested' => ['a' => 1]]);
+
+        self::assertSame(['key' => 'value', 'nested' => ['a' => 1]], $cache->load());
+    }
+
+    public function test_write_overwrites_previous_content(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+        $cache->write(['old' => 'data']);
+
+        $cache->write(['new' => 'data']);
+
+        self::assertSame(['new' => 'data'], $cache->load());
+    }
+
+    public function test_clear_removes_the_cache_file(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+        $cache->write(['key' => 'value']);
+
+        $cache->clear();
+
+        self::assertFalse($cache->exists());
+    }
+
+    public function test_clear_is_noop_when_file_does_not_exist(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+
+        $cache->clear();
+
+        self::assertFalse($cache->exists());
+    }
+
+    public function test_filename_has_no_env_suffix_when_env_empty(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+
+        self::assertStringEndsWith(
+            MergedConfigCache::FILENAME_PREFIX . MergedConfigCache::FILENAME_EXTENSION,
+            $cache->filename(),
+        );
+    }
+
+    public function test_filename_includes_env_suffix_when_env_set(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir, 'prod');
+
+        self::assertStringEndsWith(
+            MergedConfigCache::FILENAME_PREFIX . '-prod' . MergedConfigCache::FILENAME_EXTENSION,
+            $cache->filename(),
+        );
+    }
+
+    public function test_different_envs_produce_isolated_cache_files(): void
+    {
+        $prod = new MergedConfigCache($this->cacheDir, 'prod');
+        $dev = new MergedConfigCache($this->cacheDir, 'dev');
+
+        $prod->write(['app' => 'prod']);
+        $dev->write(['app' => 'dev']);
+
+        self::assertSame(['app' => 'prod'], $prod->load());
+        self::assertSame(['app' => 'dev'], $dev->load());
+    }
+
+    public function test_write_creates_cache_directory_when_missing(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+
+        $cache->write(['key' => 'value']);
+
+        self::assertDirectoryExists($this->cacheDir);
+    }
+
+    private function removeCacheDirIfExists(): void
+    {
+        foreach (glob($this->cacheDir . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->cacheDir);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds a persisted merged-config cache so bootstraps stop re-globbing and re-parsing configuration files on every request. Produced by `cache:warm`, removed by `cache:clear`, env-keyed via `APP_ENV`.

During investigation the earlier-proposed wins for Config/Factory turned out to already be implemented: `Config::get()` is already an O(1) flat hash lookup, `AbstractFactory::getContainer()` is already lazy, and Providers are already pooled per-class via `AbstractClassResolver::$cachedInstances`. The real remaining cold-path cost is `ConfigLoader::loadAll()` — disk I/O and parsing that runs on every bootstrap. This PR eliminates it.

## 🔖 Changes

- Add `Gacela\Framework\Config\MergedConfigCache` — reads/writes/clears a `gacela-merged-config[-env].php` include file
- `Config::init()` loads from the cache when `isFileCacheEnabled()` and the file exists; otherwise falls back to `loadAllConfigValues()`. `setup->getConfigKeyValues()` still spreads on top so runtime overrides keep working
- `Config::writeMergedConfigCache()` / `::clearMergedConfigCache()` / `::mergedConfigCacheFilename()` expose cache lifecycle to the console commands
- `cache:warm` writes the merged-config cache after resolving module classes and shows path/size in the output
- `cache:clear` removes the merged-config cache alongside the class-name cache

## ✅ Test plan

- [x] Unit: `MergedConfigCacheTest` — write/read/exists/clear, env-isolated filenames, missing-dir creation
- [x] Integration: `MergedConfigCacheIntegrationTest` — cache used when enabled + present, ignored when disabled, setup values still override, env-keyed isolation, write/clear round-trip via `Config`
- [x] Feature: updated `CacheWarmCommandTest` teardown so the new cache file is cleaned between tests
- [x] Full suite: `composer test` (quality + all phpunit suites) green locally