### PR TITLE
perf(cache-warm): pre-populate ClassNamePhpCache via Gacela resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `cache:warm` now eagerly resolves each module's Factory, Config, and Provider through Gacela's class resolvers so the `ClassNamePhpCache` is populated at warm time — first requests skip the cold `namespaces × rules × types × class_exists` lookup
 - Add contextual bindings via GacelaConfig::when()
 - Add service aliases via GacelaConfig::addAlias()
 - Add protected services via GacelaConfig::addProtected()

--- a/src/Console/Application/CacheWarm/CacheWarmService.php
+++ b/src/Console/Application/CacheWarm/CacheWarmService.php
@@ -6,6 +6,11 @@ namespace Gacela\Console\Application\CacheWarm;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\Config\ConfigResolver;
+use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
+use Gacela\Framework\ClassResolver\Provider\DependencyProviderResolver;
+use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
 use Gacela\Framework\ServiceResolver\DocBlockResolver;
 use ReflectionClass;
 use ReflectionMethod;
@@ -17,9 +22,36 @@ use function str_contains;
 
 final class CacheWarmService
 {
+    /** @var list<AbstractClassResolver>|null */
+    private ?array $classResolvers = null;
+
     public function __construct(
         private readonly ConsoleFacade $facade,
     ) {
+    }
+
+    /**
+     * Eagerly resolve a module's Factory, Config, and Provider through Gacela's
+     * class resolvers so the on-disk ClassNamePhpCache is populated at warm time
+     * rather than paying the namespaces x rules x types x class_exists lookup
+     * on the first request to each module.
+     *
+     * @param class-string $facadeClass
+     */
+    public function warmClassResolution(string $facadeClass): void
+    {
+        if (!class_exists($facadeClass)) {
+            return;
+        }
+
+        foreach ($this->classResolvers() as $resolver) {
+            try {
+                $resolver->resolve($facadeClass);
+            } catch (Throwable) {
+                // A module may legitimately lack a Factory/Config/Provider, or
+                // its dependencies may not be constructible during warm; skip.
+            }
+        }
     }
 
     /**
@@ -123,5 +155,18 @@ final class CacheWarmService
         } catch (Throwable) {
             // Silently skip classes that can't be reflected or resolved
         }
+    }
+
+    /**
+     * @return list<AbstractClassResolver>
+     */
+    private function classResolvers(): array
+    {
+        return $this->classResolvers ??= [
+            new FactoryResolver(),
+            new ConfigResolver(),
+            new ProviderResolver(),
+            new DependencyProviderResolver(),
+        ];
     }
 }

--- a/src/Console/Application/CacheWarm/ParallelModuleWarmer.php
+++ b/src/Console/Application/CacheWarm/ParallelModuleWarmer.php
@@ -135,6 +135,8 @@ final class ParallelModuleWarmer
             }
         }
 
+        $this->cacheWarmService->warmClassResolution($module->facadeClass());
+
         $this->formatter->writeEmptyLine();
 
         return [$resolvedCount, $skippedCount];

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -135,6 +135,8 @@ final class CacheWarmCommand extends Command
                 }
             }
 
+            $cacheWarmService->warmClassResolution($module->facadeClass());
+
             $formatter->writeEmptyLine();
         }
 

--- a/tests/Integration/Console/CacheWarm/CacheWarmServiceTest.php
+++ b/tests/Integration/Console/CacheWarm/CacheWarmServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm;
+
+use Gacela\Console\Application\CacheWarm\CacheWarmService;
+use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Console\AllAppModules\Domain\Module1\Module1Facade;
+use PHPUnit\Framework\TestCase;
+
+use function array_values;
+use function implode;
+use function rmdir;
+use function uniqid;
+use function unlink;
+
+final class CacheWarmServiceTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = __DIR__ . DIRECTORY_SEPARATOR . '.gacela-cache-' . uniqid('', true);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(true, $cacheDir);
+            $config->setProjectNamespaces(['GacelaTest\\Integration\\Console\\AllAppModules\\Domain']);
+        });
+
+        ClassNamePhpCache::clearStaticCache();
+    }
+
+    protected function tearDown(): void
+    {
+        ClassNamePhpCache::clearStaticCache();
+        $this->removeCacheDir();
+    }
+
+    public function test_warm_class_resolution_populates_factory_config_and_provider_entries(): void
+    {
+        $service = new CacheWarmService(new ConsoleFacade());
+
+        $service->warmClassResolution(Module1Facade::class);
+
+        $resolved = implode('|', array_values(ClassNamePhpCache::all()));
+
+        self::assertStringContainsString('Module1Factory', $resolved);
+        self::assertStringContainsString('Module1Config', $resolved);
+        self::assertStringContainsString('Module1Provider', $resolved);
+    }
+
+    public function test_warm_class_resolution_is_idempotent(): void
+    {
+        $service = new CacheWarmService(new ConsoleFacade());
+
+        $service->warmClassResolution(Module1Facade::class);
+        $firstRun = ClassNamePhpCache::all();
+
+        $service->warmClassResolution(Module1Facade::class);
+        $secondRun = ClassNamePhpCache::all();
+
+        self::assertSame($firstRun, $secondRun);
+    }
+
+    public function test_warm_class_resolution_skips_when_facade_class_missing(): void
+    {
+        $service = new CacheWarmService(new ConsoleFacade());
+
+        /** @var class-string $fake */
+        $fake = 'Non\\Existing\\MissingFacade';
+        $service->warmClassResolution($fake);
+
+        self::assertSame([], ClassNamePhpCache::all());
+    }
+
+    private function removeCacheDir(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            return;
+        }
+
+        foreach (glob($this->cacheDir . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->cacheDir);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`cache:warm` previously autoloaded each module's classes via `class_exists()` but did not exercise Gacela's ClassResolver pipeline. The on-disk `ClassNamePhpCache` therefore stayed empty after warming, and the first runtime call to each module paid the cold `namespaces × rules × types × class_exists` lookup in `ClassNameFinder::findClassName()` before caching the result. This PR eliminates that cold cost.

## 🔖 Changes

- Add `CacheWarmService::warmClassResolution(string $facadeClass)` — runs `FactoryResolver`, `ConfigResolver`, `ProviderResolver`, and `DependencyProviderResolver` (kept for BC) against the module's Facade class so the persistent `ClassNamePhpCache` gets populated at warm time
- Wire the new call into both the sequential path (`CacheWarmCommand::warmModulesCache`) and the parallel path (`ParallelModuleWarmer::warmModule`), once per module after class autoloading
- Resolver failures are swallowed so modules that legitimately lack a concept (or have hard-to-construct dependencies at warm time) don't abort the warming run

## ✅ Test plan

- [x] Integration: `CacheWarmServiceTest` — verifies `ClassNamePhpCache::all()` contains Factory/Config/Provider entries after warming, idempotent on repeat calls, and gracefully skips missing Facade classes
- [x] Full suite: `composer test` (quality + all phpunit suites) green locally