### PR TITLE
perf+dx: low-hanging runtime and DX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,15 @@
 ### Changed
 
 - Exception messages now include did-you-mean suggestions and actionable examples via `ErrorSuggestionHelper`
+- `Locator::getRequired()` now passes the container's registered services and bindings to `ServiceNotFoundException`, so the existing did-you-mean suggestions are produced when a typo'd service is requested
+- `validate:config` reports binding-mismatch warnings with the expected interface/class, the actual type chain of the bound value, and a fix hint; interface-keyed bindings are now also checked (previously skipped)
 
 ### Performance
 
 - Persist the merged file-based config to disk via `MergedConfigCache` so bootstraps skip globbing and parsing configuration files; produced by `cache:warm`, removed by `cache:clear`, keyed per `APP_ENV`
 - `cache:warm` now pre-populates the `ClassNamePhpCache` by running Gacela's resolvers against each module's Facade, so first requests skip the cold `namespaces × rules × types × class_exists` lookup in `ClassNameFinder`
+- `ClassValidator` memoizes `class_exists()` results so repeated candidate lookups across `namespaces × rules × types` reuse the autoloader probe within a request
+- Share `ReflectionClass` instances between `DocBlockResolver` and `CacheWarmService` via a `ReflectionClassPool` to avoid re-reflecting the same class
 
 ## [1.12.0](https://github.com/gacela-project/gacela/compare/1.11.0...1.12.0) - 2025-11-09
 

--- a/src/Console/Application/CacheWarm/CacheWarmService.php
+++ b/src/Console/Application/CacheWarm/CacheWarmService.php
@@ -12,7 +12,7 @@ use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 use Gacela\Framework\ClassResolver\Provider\DependencyProviderResolver;
 use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
 use Gacela\Framework\ServiceResolver\DocBlockResolver;
-use ReflectionClass;
+use Gacela\Framework\ServiceResolver\ReflectionClassPool;
 use ReflectionMethod;
 use Throwable;
 
@@ -126,7 +126,7 @@ final class CacheWarmService
         }
 
         try {
-            $reflectionClass = new ReflectionClass($className);
+            $reflectionClass = ReflectionClassPool::get($className);
             $methods = $reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC);
 
             // Create a DocBlockResolver instance to cache attribute resolutions

--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -128,8 +128,18 @@ final class ValidateConfigCommand extends Command
                     }
 
                     // Check if value is assignable to key (basic check)
-                    if (class_exists($key) && !is_subclass_of($value, $key) && $value !== $key) {
-                        $output->writeln(sprintf('  <fg=yellow>⚠ Warning: Binding value may not be compatible with key:</> %s -> %s', $key, $value));
+                    if (!is_subclass_of($value, $key) && $value !== $key) {
+                        $expectedKind = interface_exists($key) ? 'interface' : 'class';
+                        $valueParents = $this->describeTypeChain($value);
+
+                        $output->writeln(sprintf(
+                            '  <fg=yellow>⚠ Warning: Binding value may not be compatible with key:</> %s -> %s',
+                            $key,
+                            $value,
+                        ));
+                        $output->writeln(sprintf('      expected %s: %s', $expectedKind, $key));
+                        $output->writeln(sprintf('      actual:       %s', $valueParents));
+                        $output->writeln(sprintf('      hint:         make %s extend or implement %s', $value, $key));
                         $hasWarnings = true;
                     }
                 } elseif (is_object($value)) {
@@ -217,6 +227,26 @@ final class ValidateConfigCommand extends Command
         $output->writeln('');
 
         return ['errors' => $hasErrors, 'warnings' => $hasWarnings];
+    }
+
+    private function describeTypeChain(string $className): string
+    {
+        if (!class_exists($className) && !interface_exists($className)) {
+            return $className;
+        }
+
+        $parents = class_parents($className) ?: [];
+        $interfaces = class_implements($className) ?: [];
+
+        $parts = [$className];
+        if ($parents !== []) {
+            $parts[] = 'extends ' . implode(' -> ', $parents);
+        }
+        if ($interfaces !== []) {
+            $parts[] = 'implements ' . implode(', ', $interfaces);
+        }
+
+        return implode(' | ', $parts);
     }
 
     private function getHelpText(): string

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassValidator.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassValidator.php
@@ -6,8 +6,20 @@ namespace Gacela\Framework\ClassResolver\ClassNameFinder;
 
 final class ClassValidator implements ClassValidatorInterface
 {
+    /** @var array<string,bool> */
+    private static array $existsCache = [];
+
     public function isClassNameValid(string $className): bool
     {
-        return class_exists($className);
+        if (isset(self::$existsCache[$className])) {
+            return self::$existsCache[$className];
+        }
+
+        return self::$existsCache[$className] = class_exists($className);
+    }
+
+    public static function resetCache(): void
+    {
+        self::$existsCache = [];
     }
 }

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -115,10 +115,26 @@ final class Locator implements LocatorInterface
         $instance = $this->get($className);
 
         if ($instance === null) {
-            throw new ServiceNotFoundException($className);
+            throw new ServiceNotFoundException($className, $this->knownServiceNames());
         }
 
         return $instance;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function knownServiceNames(): array
+    {
+        $names = $this->container->getRegisteredServices();
+
+        if ($this->container instanceof Container) {
+            foreach (array_keys($this->container->getBindings()) as $binding) {
+                $names[] = $binding;
+            }
+        }
+
+        return array_values(array_unique($names));
     }
 
     /**

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -71,7 +71,7 @@ final class DocBlockResolver
      */
     private function getClassFromDoc(string $method): string
     {
-        $reflectionClass = new ReflectionClass($this->callerClass);
+        $reflectionClass = ReflectionClassPool::get($this->callerClass);
 
         $className = $this->searchClassOverAttributes($reflectionClass, $method);
         if ($className !== null) {

--- a/src/Framework/ServiceResolver/ReflectionClassPool.php
+++ b/src/Framework/ServiceResolver/ReflectionClassPool.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ServiceResolver;
+
+use ReflectionClass;
+
+/**
+ * @internal
+ */
+final class ReflectionClassPool
+{
+    /** @var array<class-string, ReflectionClass<object>> */
+    private static array $cache = [];
+
+    /**
+     * @param class-string $className
+     *
+     * @return ReflectionClass<object>
+     */
+    public static function get(string $className): ReflectionClass
+    {
+        return self::$cache[$className] ??= new ReflectionClass($className);
+    }
+
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/tests/Feature/Console/ValidateConfig/Fixtures/SomeContract.php
+++ b/tests/Feature/Console/ValidateConfig/Fixtures/SomeContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ValidateConfig\Fixtures;
+
+interface SomeContract
+{
+}

--- a/tests/Feature/Console/ValidateConfig/Fixtures/UnrelatedImplementation.php
+++ b/tests/Feature/Console/ValidateConfig/Fixtures/UnrelatedImplementation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ValidateConfig\Fixtures;
+
+final class UnrelatedImplementation
+{
+}

--- a/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
+++ b/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
@@ -7,6 +7,8 @@ namespace GacelaTest\Feature\Console\ValidateConfig;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\ValidateConfig\Fixtures\SomeContract;
+use GacelaTest\Feature\Console\ValidateConfig\Fixtures\UnrelatedImplementation;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -67,5 +69,24 @@ final class ValidateConfigCommandTest extends TestCase
         $output = $this->command->getDisplay();
 
         self::assertStringContainsString('Checking configuration paths...', $output);
+    }
+
+    public function test_validate_config_explains_binding_mismatch(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(SomeContract::class, UnrelatedImplementation::class);
+        });
+
+        $command = new CommandTester(new ValidateConfigCommand());
+        $command->execute([]);
+
+        $output = $command->getDisplay();
+
+        self::assertStringContainsString('Binding value may not be compatible with key', $output);
+        self::assertStringContainsString('expected interface: ' . SomeContract::class, $output);
+        self::assertStringContainsString('actual:', $output);
+        self::assertStringContainsString('hint:', $output);
+        self::assertStringContainsString('extend or implement ' . SomeContract::class, $output);
     }
 }

--- a/tests/Unit/Framework/ClassResolver/ClassNameFinder/ClassValidatorTest.php
+++ b/tests/Unit/Framework/ClassResolver/ClassNameFinder/ClassValidatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\ClassNameFinder;
+
+use Gacela\Framework\ClassResolver\ClassNameFinder\ClassValidator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class ClassValidatorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ClassValidator::resetCache();
+    }
+
+    public function test_returns_true_for_existing_class(): void
+    {
+        $validator = new ClassValidator();
+
+        self::assertTrue($validator->isClassNameValid(stdClass::class));
+    }
+
+    public function test_returns_false_for_missing_class(): void
+    {
+        $validator = new ClassValidator();
+
+        self::assertFalse($validator->isClassNameValid('GacelaTest\\Does\\Not\\Exist'));
+    }
+
+    public function test_repeated_lookups_are_memoized(): void
+    {
+        $validator = new ClassValidator();
+
+        $first = $validator->isClassNameValid('GacelaTest\\Memoized\\Missing');
+        $second = $validator->isClassNameValid('GacelaTest\\Memoized\\Missing');
+
+        self::assertFalse($first);
+        self::assertSame($first, $second);
+    }
+}

--- a/tests/Unit/Framework/Container/LocatorTest.php
+++ b/tests/Unit/Framework/Container/LocatorTest.php
@@ -101,4 +101,22 @@ final class LocatorTest extends TestCase
 
         self::assertEquals(new StringValue('from-container'), $singleton);
     }
+
+    public function test_get_required_suggests_similar_service_when_typo(): void
+    {
+        $container = new Container(bindings: [
+            StringValue::class => new StringValue('registered'),
+        ]);
+
+        /** @var class-string $typo */
+        $typo = 'GacelaTest\\Fixtures\\StringValu';
+
+        try {
+            Locator::getInstance($container)->getRequired($typo);
+            self::fail('Expected ServiceNotFoundException');
+        } catch (ServiceNotFoundException $e) {
+            self::assertStringContainsString('Did you mean?', $e->getMessage());
+            self::assertStringContainsString(StringValue::class, $e->getMessage());
+        }
+    }
 }

--- a/tests/Unit/Framework/ServiceResolver/ReflectionClassPoolTest.php
+++ b/tests/Unit/Framework/ServiceResolver/ReflectionClassPoolTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ServiceResolver;
+
+use Gacela\Framework\ServiceResolver\ReflectionClassPool;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class ReflectionClassPoolTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ReflectionClassPool::reset();
+    }
+
+    public function test_returns_same_instance_for_same_class(): void
+    {
+        $first = ReflectionClassPool::get(stdClass::class);
+        $second = ReflectionClassPool::get(stdClass::class);
+
+        self::assertSame($first, $second);
+    }
+
+    public function test_reset_clears_the_cache(): void
+    {
+        $first = ReflectionClassPool::get(stdClass::class);
+        ReflectionClassPool::reset();
+        $second = ReflectionClassPool::get(stdClass::class);
+
+        self::assertNotSame($first, $second);
+    }
+}


### PR DESCRIPTION
## 📚 Description

A small batch of low-hanging runtime perf and developer-experience improvements that came out of an audit of resolver hot paths and error sites. Each commit is independent and testable in isolation.

## 🔖 Changes

- **`perf(class-resolver)`**: `ClassValidator` memoizes `class_exists()`. Class resolution probes the autoloader for `namespaces × rules × types` candidates per cache key; repeating the same probes on every miss is wasteful within a request.
- **`perf(service-resolver)`**: Shared `ReflectionClassPool` between `DocBlockResolver` (cache-miss path) and `CacheWarmService`. Both used to construct fresh `ReflectionClass` objects for the same class.
- **`feat(dx)`**: `Locator::getRequired()` now passes the container's registered services and bindings to `ServiceNotFoundException` so the existing `ErrorSuggestionHelper::suggestSimilar()` actually has candidates to match against. Previously the helper was wired into the exception class but the only caller passed an empty list, so the "Did you mean?" hint never showed.
- **`feat(dx)`**: `validate:config` binding-mismatch warning now prints the expected interface/class, the actual type chain (`extends ... | implements ...`), and a concrete fix hint. Also drops a redundant `class_exists($key)` guard so interface-keyed bindings are checked too — they were silently skipped before.

## Test plan

- [x] `composer test-unit` (259 tests)
- [x] `composer test-integration` (62 tests)
- [x] `composer test-feature` (92 tests, includes new `test_validate_config_explains_binding_mismatch`)
- [x] `composer quality` (cs-fixer + psalm + phpstan all clean)
- [x] New unit tests: `ClassValidatorTest`, `ReflectionClassPoolTest`, `LocatorTest::test_get_required_suggests_similar_service_when_typo`