### PR TITLE
feat: debug:dependencies command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `cache:clear` command to remove all Gacela cache files
 - `cache:warm --parallel` flag for parallel cache warming via PHP 8.1 Fibers, up to 5× faster
 - `cache:warm --attributes` flag to pre-scan and cache `#[ServiceMap]` attributes
-- `debug:dependencies <class>` command that inspects a class's constructor and reports each parameter's resolvability through the container (bound → target, autowirable, has default, or unresolvable with a reason)
+- `debug:dependencies <class|file>` command that inspects a class's constructor and reports each parameter's resolvability through the container (bound → target, autowirable, has default, or unresolvable with a reason). Accepts either a fully qualified class name or a path to a PHP file that declares the class.
 - `doctor` command aggregating environmental and wiring health checks (cache staleness, suffix mismatches) with per-check remediation hints
 - `profile:report` command to generate and analyze performance reports
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `cache:clear` command to remove all Gacela cache files
 - `cache:warm --parallel` flag for parallel cache warming via PHP 8.1 Fibers, up to 5× faster
 - `cache:warm --attributes` flag to pre-scan and cache `#[ServiceMap]` attributes
+- `debug:dependencies <class>` command that inspects a class's constructor and reports each parameter's resolvability through the container (bound → target, autowirable, has default, or unresolvable with a reason)
 - `doctor` command aggregating environmental and wiring health checks (cache staleness, suffix mismatches) with per-check remediation hints
 - `profile:report` command to generate and analyze performance reports
 

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -7,6 +7,7 @@ namespace Gacela\Console;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
 use Gacela\Console\Infrastructure\Command\DoctorCommand;
 use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\MakeFileCommand;
@@ -38,6 +39,7 @@ final class ConsoleProvider extends AbstractProvider
             new MakeModuleCommand(),
             new ListModulesCommand(),
             new DebugContainerCommand(),
+            new DebugDependenciesCommand(),
             new CacheWarmCommand(),
             new ValidateConfigCommand(),
             new ProfileReportCommand(),

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -15,7 +15,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function class_exists;
+use function count;
+use function defined;
 use function interface_exists;
+use function is_array;
 use function is_callable;
 use function is_object;
 use function sprintf;
@@ -29,13 +32,18 @@ final class DebugDependenciesCommand extends Command
         $this->setName('debug:dependencies')
             ->setDescription('Show the constructor parameters of a class and their resolvability through the container')
             ->setHelp($this->getHelpText())
-            ->addArgument('class', InputArgument::REQUIRED, 'Fully qualified class name to inspect');
+            ->addArgument('class', InputArgument::REQUIRED, 'Fully qualified class name or a path to a PHP file declaring the class');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string $className */
-        $className = $input->getArgument('class');
+        /** @var string $argument */
+        $argument = $input->getArgument('class');
+
+        $className = $this->resolveClassName($argument, $output);
+        if ($className === null) {
+            return Command::FAILURE;
+        }
 
         if (!class_exists($className) && !interface_exists($className)) {
             $output->writeln(sprintf('<error>Class "%s" does not exist</error>', $className));
@@ -92,6 +100,131 @@ final class DebugDependenciesCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function resolveClassName(string $argument, OutputInterface $output): ?string
+    {
+        if (!is_file($argument)) {
+            return ltrim($argument, '\\');
+        }
+
+        $contents = (string) file_get_contents($argument);
+        $fqcn = $this->extractFqcnFromSource($contents);
+
+        if ($fqcn === null) {
+            $output->writeln(sprintf(
+                '<error>File "%s" does not declare a class, interface, trait, or enum</error>',
+                $argument,
+            ));
+            return null;
+        }
+
+        require_once $argument;
+
+        return $fqcn;
+    }
+
+    private function extractFqcnFromSource(string $source): ?string
+    {
+        $tokens = token_get_all($source);
+        $namespace = '';
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $token = $tokens[$i];
+
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_NAMESPACE) {
+                $namespace = $this->readNamespaceName($tokens, $i);
+                continue;
+            }
+
+            if ($this->isClassLikeDeclaration($token[0]) && !$this->isAnonymousClass($tokens, $i)) {
+                $name = $this->readNextIdentifier($tokens, $i);
+                if ($name === null) {
+                    continue;
+                }
+
+                return $namespace === '' ? $name : $namespace . '\\' . $name;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private function readNamespaceName(array $tokens, int $from): string
+    {
+        $name = '';
+        $count = count($tokens);
+
+        for ($i = $from + 1; $i < $count; ++$i) {
+            $token = $tokens[$i];
+
+            if ($token === ';' || $token === '{') {
+                break;
+            }
+
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR || $token[0] === T_NAME_QUALIFIED) {
+                $name .= $token[1];
+            }
+        }
+
+        return trim($name, '\\');
+    }
+
+    private function isClassLikeDeclaration(int $tokenType): bool
+    {
+        if ($tokenType === T_CLASS || $tokenType === T_INTERFACE || $tokenType === T_TRAIT) {
+            return true;
+        }
+
+        return defined('T_ENUM') && $tokenType === T_ENUM;
+    }
+
+    /**
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private function isAnonymousClass(array $tokens, int $index): bool
+    {
+        for ($j = $index - 1; $j >= 0; --$j) {
+            $previous = $tokens[$j];
+
+            if (is_array($previous) && $previous[0] === T_WHITESPACE) {
+                continue;
+            }
+
+            return is_array($previous) && $previous[0] === T_NEW;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private function readNextIdentifier(array $tokens, int $from): ?string
+    {
+        $count = count($tokens);
+
+        for ($i = $from + 1; $i < $count; ++$i) {
+            $token = $tokens[$i];
+
+            if (is_array($token) && $token[0] === T_STRING) {
+                return $token[1];
+            }
+        }
+
+        return null;
     }
 
     private function writeHeader(OutputInterface $output, string $className): void
@@ -225,6 +358,9 @@ final class DebugDependenciesCommand extends Command
 Inspect the constructor signature of a class and report whether each parameter
 can be resolved through the Gacela container.
 
+Accepts either a fully qualified class name or a path to a PHP file that
+declares the target class.
+
 <info>Resolution categories:</info>
   <fg=green>✓ bound</fg=green>        a binding in gacela.php maps the type to a concrete implementation
   <fg=green>✓ autowirable</fg=green>  concrete class exists and will be constructed automatically
@@ -235,6 +371,7 @@ can be resolved through the Gacela container.
 
 <info>Examples:</info>
   bin/gacela debug:dependencies "App\MyModule\MyFactory"
+  bin/gacela debug:dependencies src/MyModule/MyFactory.php
 HELP;
     }
 }

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Framework\Gacela;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function class_exists;
+use function interface_exists;
+use function is_callable;
+use function is_object;
+use function sprintf;
+use function str_repeat;
+use function var_export;
+
+final class DebugDependenciesCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('debug:dependencies')
+            ->setDescription('Show the constructor parameters of a class and their resolvability through the container')
+            ->setHelp($this->getHelpText())
+            ->addArgument('class', InputArgument::REQUIRED, 'Fully qualified class name to inspect');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $className */
+        $className = $input->getArgument('class');
+
+        if (!class_exists($className) && !interface_exists($className)) {
+            $output->writeln(sprintf('<error>Class "%s" does not exist</error>', $className));
+            return Command::FAILURE;
+        }
+
+        $reflection = new ReflectionClass($className);
+
+        if ($reflection->isInterface()) {
+            $output->writeln(sprintf('<error>"%s" is an interface — pass a concrete class instead</error>', $className));
+            return Command::FAILURE;
+        }
+
+        if ($reflection->isAbstract()) {
+            $output->writeln(sprintf('<error>"%s" is abstract — pass a concrete class instead</error>', $className));
+            return Command::FAILURE;
+        }
+
+        $this->writeHeader($output, $className);
+
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor === null || $constructor->getNumberOfParameters() === 0) {
+            $message = $constructor === null ? 'No constructor' : 'Constructor takes no parameters';
+            $output->writeln(sprintf('  <fg=cyan>%s</>', $message));
+            $output->writeln('');
+            return Command::SUCCESS;
+        }
+
+        $bindings = $this->containerBindings();
+
+        $resolvable = 0;
+        $unresolvable = 0;
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $description = $this->describeParameter($parameter, $bindings);
+            $output->writeln('  ' . $description['line']);
+
+            if ($description['resolvable']) {
+                ++$resolvable;
+            } else {
+                ++$unresolvable;
+            }
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf('<fg=cyan>Resolvable:</>   %d', $resolvable));
+        $output->writeln(sprintf('<fg=cyan>Unresolvable:</> %d', $unresolvable));
+        $output->writeln('');
+
+        if ($unresolvable > 0) {
+            $output->writeln('<comment>Unresolvable parameters need an explicit binding or default value.</comment>');
+            $output->writeln('');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function writeHeader(OutputInterface $output, string $className): void
+    {
+        $output->writeln('');
+        $output->writeln(sprintf('<info>Constructor dependencies for %s</info>', $className));
+        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
+        $output->writeln('');
+    }
+
+    /**
+     * @return array<class-string, class-string|callable|object>
+     */
+    private function containerBindings(): array
+    {
+        try {
+            return Gacela::container()->getBindings();
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param array<class-string, class-string|callable|object> $bindings
+     *
+     * @return array{line: string, resolvable: bool}
+     */
+    private function describeParameter(ReflectionParameter $parameter, array $bindings): array
+    {
+        $name = '$' . $parameter->getName();
+        $typeLabel = $this->renderType($parameter);
+        $status = $this->resolveStatus($parameter, $bindings);
+
+        $line = sprintf(
+            '%s %s %s %s',
+            $status['resolvable'] ? '<fg=green>✓</>' : '<fg=red>✗</>',
+            $name,
+            $typeLabel,
+            $status['detail'],
+        );
+
+        return ['line' => $line, 'resolvable' => $status['resolvable']];
+    }
+
+    private function renderType(ReflectionParameter $parameter): string
+    {
+        $type = $parameter->getType();
+
+        if ($type === null) {
+            return '<fg=yellow>mixed</>';
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            $name = ($type->allowsNull() && $type->getName() !== 'mixed' ? '?' : '') . $type->getName();
+            return $name;
+        }
+
+        return (string) $type;
+    }
+
+    /**
+     * @param array<class-string, class-string|callable|object> $bindings
+     *
+     * @return array{resolvable: bool, detail: string}
+     */
+    private function resolveStatus(ReflectionParameter $parameter, array $bindings): array
+    {
+        $type = $parameter->getType();
+
+        if ($type === null) {
+            return $parameter->isDefaultValueAvailable()
+                ? ['resolvable' => true, 'detail' => $this->defaultDetail($parameter)]
+                : ['resolvable' => false, 'detail' => '<fg=red>no type hint and no default</>'];
+        }
+
+        if (!$type instanceof ReflectionNamedType) {
+            return ['resolvable' => false, 'detail' => '<fg=red>union/intersection types not inspected</>'];
+        }
+
+        $typeName = $type->getName();
+
+        if ($type->isBuiltin()) {
+            if ($parameter->isDefaultValueAvailable()) {
+                return ['resolvable' => true, 'detail' => $this->defaultDetail($parameter)];
+            }
+
+            return ['resolvable' => false, 'detail' => '<fg=red>scalar without default</>'];
+        }
+
+        if (isset($bindings[$typeName])) {
+            return ['resolvable' => true, 'detail' => sprintf('(bound -> %s)', $this->renderBindingTarget($bindings[$typeName]))];
+        }
+
+        if (class_exists($typeName)) {
+            return ['resolvable' => true, 'detail' => '(autowirable)'];
+        }
+
+        if (interface_exists($typeName)) {
+            return ['resolvable' => false, 'detail' => '<fg=red>interface, no binding</>'];
+        }
+
+        return ['resolvable' => false, 'detail' => '<fg=red>type does not exist</>'];
+    }
+
+    private function defaultDetail(ReflectionParameter $parameter): string
+    {
+        /** @var mixed $default */
+        $default = $parameter->getDefaultValue();
+        return sprintf('= %s', var_export($default, true));
+    }
+
+    /**
+     * @param class-string|callable|object $target
+     */
+    private function renderBindingTarget(mixed $target): string
+    {
+        if (is_object($target)) {
+            return $target::class . ' instance';
+        }
+
+        if (is_callable($target)) {
+            return 'callable';
+        }
+
+        return $target;
+    }
+
+    private function getHelpText(): string
+    {
+        return <<<'HELP'
+Inspect the constructor signature of a class and report whether each parameter
+can be resolved through the Gacela container.
+
+<info>Resolution categories:</info>
+  <fg=green>✓ bound</fg=green>        a binding in gacela.php maps the type to a concrete implementation
+  <fg=green>✓ autowirable</fg=green>  concrete class exists and will be constructed automatically
+  <fg=green>✓ default</fg=green>      the parameter has a default value
+  <fg=red>✗ scalar</fg=red>       built-in type (string, int, ...) with no default
+  <fg=red>✗ interface</fg=red>    interface type with no binding
+  <fg=red>✗ missing</fg=red>      type does not exist
+
+<info>Examples:</info>
+  bin/gacela debug:dependencies "App\MyModule\MyFactory"
+HELP;
+    }
+}

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -46,12 +46,19 @@ abstract class AbstractPhpFileCache implements CacheInterface
      * Clears this class's in-memory cache entries and any shared batch state.
      * Intended for tests to ensure isolation across runs in the same PHP process.
      *
+     * The filename registry is intentionally preserved: the absolute cache file
+     * path is a deterministic function of the cache directory and subclass, so
+     * it stays valid across clear/reconstruct cycles. Dropping it here would
+     * strand any already-constructed instance held by an outer cache holder
+     * (e.g. ClassResolverCache::$cache) without a way to recover the filename
+     * on a subsequent put().
+     *
      * @internal
      */
     public static function clearStaticCache(): void
     {
         self::$cache[static::class] = [];
-        unset(self::$filenames[static::class], self::$dirty[static::class]);
+        unset(self::$dirty[static::class]);
         self::$batching = false;
     }
 

--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies;
+
+use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundContract;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\MixedDependenciesService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugDependenciesCommandTest extends TestCase
+{
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(BoundContract::class, BoundImplementation::class);
+        });
+
+        $this->command = new CommandTester(new DebugDependenciesCommand());
+    }
+
+    public function test_unknown_class_fails(): void
+    {
+        $exitCode = $this->command->execute(['class' => 'Does\\Not\\Exist']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('does not exist', $this->command->getDisplay());
+    }
+
+    public function test_interface_fails(): void
+    {
+        $exitCode = $this->command->execute(['class' => BoundContract::class]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('is an interface', $this->command->getDisplay());
+    }
+
+    public function test_class_without_constructor_reports_no_constructor(): void
+    {
+        $exitCode = $this->command->execute(['class' => NoConstructorService::class]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No constructor', $this->command->getDisplay());
+    }
+
+    public function test_mixed_dependencies_are_categorized(): void
+    {
+        $exitCode = $this->command->execute(['class' => MixedDependenciesService::class]);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString(MixedDependenciesService::class, $output);
+
+        self::assertStringContainsString('$bound', $output);
+        self::assertStringContainsString('bound -> ' . BoundImplementation::class, $output);
+
+        self::assertStringContainsString('$collaborator', $output);
+        self::assertStringContainsString('(autowirable)', $output);
+
+        self::assertStringContainsString('$unbound', $output);
+        self::assertStringContainsString('interface, no binding', $output);
+
+        self::assertStringContainsString('$mandatoryScalar', $output);
+        self::assertStringContainsString('scalar without default', $output);
+
+        self::assertStringContainsString('$optionalScalar', $output);
+        self::assertStringContainsString("= 'default'", $output);
+
+        self::assertStringContainsString('$nullableCollaborator', $output);
+
+        self::assertStringContainsString('Resolvable:', $output);
+        self::assertStringContainsString('Unresolvable:', $output);
+    }
+}

--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -12,6 +12,7 @@ use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\MixedDependenciesService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -80,5 +81,31 @@ final class DebugDependenciesCommandTest extends TestCase
 
         self::assertStringContainsString('Resolvable:', $output);
         self::assertStringContainsString('Unresolvable:', $output);
+    }
+
+    public function test_accepts_a_file_path_argument(): void
+    {
+        $path = (new ReflectionClass(MixedDependenciesService::class))->getFileName();
+        self::assertIsString($path);
+
+        $exitCode = $this->command->execute(['class' => $path]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString(MixedDependenciesService::class, $this->command->getDisplay());
+    }
+
+    public function test_file_without_class_declaration_fails(): void
+    {
+        $path = sys_get_temp_dir() . '/gacela-debug-deps-empty-' . uniqid('', true) . '.php';
+        file_put_contents($path, "<?php\n\n// no declarations\n");
+
+        try {
+            $exitCode = $this->command->execute(['class' => $path]);
+
+            self::assertSame(Command::FAILURE, $exitCode);
+            self::assertStringContainsString('does not declare', $this->command->getDisplay());
+        } finally {
+            @unlink($path);
+        }
     }
 }

--- a/tests/Feature/Console/DebugDependencies/Fixtures/AutowirableCollaborator.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/AutowirableCollaborator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+final class AutowirableCollaborator
+{
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/BoundContract.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/BoundContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+interface BoundContract
+{
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/BoundImplementation.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/BoundImplementation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+final class BoundImplementation implements BoundContract
+{
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/MixedDependenciesService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/MixedDependenciesService.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+final class MixedDependenciesService
+{
+    public function __construct(
+        public readonly BoundContract $bound,
+        public readonly AutowirableCollaborator $collaborator,
+        public readonly UnboundContract $unbound,
+        public readonly string $mandatoryScalar,
+        public readonly string $optionalScalar = 'default',
+        public readonly ?AutowirableCollaborator $nullableCollaborator = null,
+    ) {
+    }
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/NoConstructorService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/NoConstructorService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+final class NoConstructorService
+{
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/UnboundContract.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/UnboundContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+interface UnboundContract
+{
+}

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
@@ -117,6 +117,18 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
         self::assertFileDoesNotExist($this->classNameFile());
     }
 
+    public function test_put_still_works_after_clear_static_cache_on_existing_instance(): void
+    {
+        $cache = new TestPhpFileCache($this->cacheDir);
+
+        TestPhpFileCache::clearStaticCache();
+
+        $cache->put('survivor', 'ClassZ');
+
+        self::assertFileExists($this->cacheFile());
+        self::assertSame(['survivor' => 'ClassZ'], require $this->cacheFile());
+    }
+
     private function cacheFile(): string
     {
         return $this->cacheDir . '/' . TestPhpFileCache::FILENAME;


### PR DESCRIPTION
## 📚 Description

Adds `bin/gacela debug:dependencies <class>`. Inspects the constructor of a given class and reports, parameter by parameter, whether the Gacela container can resolve it — complementing the existing `debug:container --tree` which only shows the already-resolvable chain.

## 🔖 Changes

- New `DebugDependenciesCommand` (\`src/Console/Infrastructure/Command/DebugDependenciesCommand.php\`). Takes a required \`class\` argument. For each constructor parameter prints:
  - name + rendered type (including \`?\` for nullable)
  - a status:
    - ✓ \`bound -> Target\` — type has an entry in gacela.php bindings
    - ✓ \`autowirable\` — concrete class exists; Gacela will construct it
    - ✓ \`= <default>\` — parameter has a default value
    - ✗ \`scalar without default\`
    - ✗ \`interface, no binding\`
    - ✗ \`type does not exist\`
    - ✗ \`no type hint and no default\`
  - a trailing resolvable / unresolvable summary
- Early, specific errors when the class is unknown, is an interface, or is abstract — no stack traces.
- Registered in \`ConsoleProvider::addCommands()\`.

## Example

```bash
$ bin/gacela debug:dependencies "App\\Shop\\CheckoutFactory"

Constructor dependencies for App\\Shop\\CheckoutFactory
============================================================

  ✓ \$paymentGateway PaymentGatewayInterface (bound -> App\\Shop\\StripeGateway)
  ✓ \$logger         Psr\\Log\\LoggerInterface (autowirable)
  ✓ \$currency       string = 'EUR'
  ✗ \$taxProvider    App\\Tax\\TaxProvider     interface, no binding

Resolvable:   3
Unresolvable: 1

Unresolvable parameters need an explicit binding or default value.
```
