### PR TITLE
feat: debug:modules command (audit pillar dependencies across all modules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `cache:warm --parallel` flag for parallel cache warming via PHP 8.1 Fibers, up to 5× faster
 - `cache:warm --attributes` flag to pre-scan and cache `#[ServiceMap]` attributes
 - `debug:dependencies <class|file>` command that inspects a class's constructor and reports each parameter's resolvability through the container (bound → target, autowirable, has default, or unresolvable with a reason). Accepts either a fully qualified class name or a path to a PHP file that declares the class.
+- `debug:modules [filter]` command that walks every discovered Gacela module and inspects the constructor of each pillar (Facade, Factory, Config, Provider). Default output groups by module with per-pillar resolvable/unresolvable counts; `--detail` shows every parameter. Complements `list:modules` (structural view) and `debug:dependencies` (single-class deep dive).
 - `doctor` command aggregating environmental and wiring health checks (cache staleness, suffix mismatches) with per-check remediation hints
 - `profile:report` command to generate and analyze performance reports
 

--- a/src/Console/Application/Debug/ConstructorInspection.php
+++ b/src/Console/Application/Debug/ConstructorInspection.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+use function count;
+
+final class ConstructorInspection
+{
+    /**
+     * @param class-string $className
+     * @param list<ParameterInspection> $parameters
+     */
+    public function __construct(
+        public readonly string $className,
+        public readonly bool $hasConstructor,
+        public readonly array $parameters,
+    ) {
+    }
+
+    public function resolvableCount(): int
+    {
+        return count($this->filterByResolvable(true));
+    }
+
+    public function unresolvableCount(): int
+    {
+        return count($this->filterByResolvable(false));
+    }
+
+    public function isFullyResolvable(): bool
+    {
+        return $this->unresolvableCount() === 0;
+    }
+
+    /**
+     * @return list<ParameterInspection>
+     */
+    public function unresolvableParameters(): array
+    {
+        return $this->filterByResolvable(false);
+    }
+
+    /**
+     * @return list<ParameterInspection>
+     */
+    private function filterByResolvable(bool $resolvable): array
+    {
+        $result = [];
+        foreach ($this->parameters as $parameter) {
+            if ($parameter->isResolvable() === $resolvable) {
+                $result[] = $parameter;
+            }
+        }
+        return $result;
+    }
+}

--- a/src/Console/Application/Debug/ConstructorInspector.php
+++ b/src/Console/Application/Debug/ConstructorInspector.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+use Gacela\Framework\Gacela;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionType;
+
+use Throwable;
+
+use function class_exists;
+use function interface_exists;
+use function is_callable;
+use function is_object;
+use function sprintf;
+use function var_export;
+
+final class ConstructorInspector
+{
+    /**
+     * @param class-string $className
+     */
+    public function inspect(string $className): ConstructorInspection
+    {
+        $reflection = new ReflectionClass($className);
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor === null) {
+            return new ConstructorInspection($className, false, []);
+        }
+
+        $bindings = $this->containerBindings();
+        $parameters = [];
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $parameters[] = $this->inspectParameter($parameter, $bindings);
+        }
+
+        return new ConstructorInspection($className, true, $parameters);
+    }
+
+    /**
+     * @param array<class-string, class-string|callable|object> $bindings
+     */
+    private function inspectParameter(ReflectionParameter $parameter, array $bindings): ParameterInspection
+    {
+        $type = $parameter->getType();
+        $name = '$' . $parameter->getName();
+        $renderedType = $this->renderType($type);
+
+        if ($type === null) {
+            return $parameter->isDefaultValueAvailable()
+                ? new ParameterInspection($name, $renderedType, ParameterStatus::HasDefault, $this->defaultDetail($parameter))
+                : new ParameterInspection($name, $renderedType, ParameterStatus::NoTypeHint, 'no type hint and no default');
+        }
+
+        if (!$type instanceof ReflectionNamedType) {
+            return new ParameterInspection($name, $renderedType, ParameterStatus::UnsupportedType, 'union/intersection types not inspected');
+        }
+
+        $typeName = $type->getName();
+
+        if ($type->isBuiltin()) {
+            if ($parameter->isDefaultValueAvailable()) {
+                return new ParameterInspection($name, $renderedType, ParameterStatus::HasDefault, $this->defaultDetail($parameter));
+            }
+
+            return new ParameterInspection($name, $renderedType, ParameterStatus::ScalarWithoutDefault, 'scalar without default');
+        }
+
+        if (isset($bindings[$typeName])) {
+            return new ParameterInspection(
+                $name,
+                $renderedType,
+                ParameterStatus::Bound,
+                sprintf('bound -> %s', $this->renderBindingTarget($bindings[$typeName])),
+            );
+        }
+
+        if (class_exists($typeName)) {
+            return new ParameterInspection($name, $renderedType, ParameterStatus::Autowirable, 'autowirable');
+        }
+
+        if (interface_exists($typeName)) {
+            return new ParameterInspection($name, $renderedType, ParameterStatus::UnboundInterface, 'interface, no binding');
+        }
+
+        return new ParameterInspection($name, $renderedType, ParameterStatus::MissingType, 'type does not exist');
+    }
+
+    private function renderType(?ReflectionType $type): string
+    {
+        if ($type === null) {
+            return 'mixed';
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            return ($type->allowsNull() && $type->getName() !== 'mixed' ? '?' : '') . $type->getName();
+        }
+
+        return (string) $type;
+    }
+
+    private function defaultDetail(ReflectionParameter $parameter): string
+    {
+        /** @var mixed $default */
+        $default = $parameter->getDefaultValue();
+        return sprintf('= %s', var_export($default, true));
+    }
+
+    /**
+     * @param class-string|callable|object $target
+     */
+    private function renderBindingTarget(mixed $target): string
+    {
+        if (is_object($target)) {
+            return $target::class . ' instance';
+        }
+
+        if (is_callable($target)) {
+            return 'callable';
+        }
+
+        return $target;
+    }
+
+    /**
+     * @return array<class-string, class-string|callable|object>
+     */
+    private function containerBindings(): array
+    {
+        try {
+            return Gacela::container()->getBindings();
+        } catch (Throwable) {
+            return [];
+        }
+    }
+}

--- a/src/Console/Application/Debug/ParameterInspection.php
+++ b/src/Console/Application/Debug/ParameterInspection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+final class ParameterInspection
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $renderedType,
+        public readonly ParameterStatus $status,
+        public readonly string $detail,
+    ) {
+    }
+
+    public function isResolvable(): bool
+    {
+        return $this->status->isResolvable();
+    }
+}

--- a/src/Console/Application/Debug/ParameterStatus.php
+++ b/src/Console/Application/Debug/ParameterStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+enum ParameterStatus: string
+{
+    case Bound = 'bound';
+    case Autowirable = 'autowirable';
+    case HasDefault = 'default';
+    case NoTypeHint = 'no-type-hint';
+    case ScalarWithoutDefault = 'scalar-without-default';
+    case UnboundInterface = 'unbound-interface';
+    case MissingType = 'missing-type';
+    case UnsupportedType = 'unsupported-type';
+
+    public function isResolvable(): bool
+    {
+        return match ($this) {
+            self::Bound, self::Autowirable, self::HasDefault => true,
+            default => false,
+        };
+    }
+}

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -8,6 +8,7 @@ use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
 use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
 use Gacela\Console\Infrastructure\Command\DoctorCommand;
 use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\MakeFileCommand;
@@ -40,6 +41,7 @@ final class ConsoleProvider extends AbstractProvider
             new ListModulesCommand(),
             new DebugContainerCommand(),
             new DebugDependenciesCommand(),
+            new DebugModulesCommand(),
             new CacheWarmCommand(),
             new ValidateConfigCommand(),
             new ProfileReportCommand(),

--- a/src/Console/Domain/AllAppModules/AppModuleCreator.php
+++ b/src/Console/Domain/AllAppModules/AppModuleCreator.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ClassResolver\Config\ConfigResolver;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
 use ReflectionClass;
+use Throwable;
 
 use function strlen;
 
@@ -63,7 +64,11 @@ final class AppModuleCreator
      */
     private function findFactory(string $facadeClass): ?string
     {
-        $resolver = $this->factoryResolver->resolve($facadeClass);
+        try {
+            $resolver = $this->factoryResolver->resolve($facadeClass);
+        } catch (Throwable) {
+            return null;
+        }
 
         if ((new ReflectionClass($resolver))->isAnonymous()) {
             return null;
@@ -77,7 +82,11 @@ final class AppModuleCreator
      */
     private function findConfig(string $facadeClass): ?string
     {
-        $resolver = $this->configResolver->resolve($facadeClass);
+        try {
+            $resolver = $this->configResolver->resolve($facadeClass);
+        } catch (Throwable) {
+            return null;
+        }
 
         if ((new ReflectionClass($resolver))->isAnonymous()) {
             return null;
@@ -91,7 +100,12 @@ final class AppModuleCreator
      */
     private function findProvider(string $facadeClass): ?string
     {
-        $resolver = $this->providerResolver->resolve($facadeClass);
+        try {
+            $resolver = $this->providerResolver->resolve($facadeClass);
+        } catch (Throwable) {
+            return null;
+        }
+
         if (!$resolver instanceof AbstractProvider) {
             return null;
         }

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -4,26 +4,24 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Infrastructure\Command;
 
-use Gacela\Framework\Gacela;
+use Gacela\Console\Application\Debug\ConstructorInspection;
+use Gacela\Console\Application\Debug\ConstructorInspector;
+use Gacela\Console\Application\Debug\ParameterInspection;
+use Gacela\Console\Application\Debug\ParameterStatus;
 use ReflectionClass;
-use ReflectionNamedType;
-use ReflectionParameter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 
 use function class_exists;
 use function count;
 use function defined;
 use function interface_exists;
 use function is_array;
-use function is_callable;
-use function is_object;
+use function ltrim;
 use function sprintf;
 use function str_repeat;
-use function var_export;
 
 final class DebugDependenciesCommand extends Command
 {
@@ -62,44 +60,64 @@ final class DebugDependenciesCommand extends Command
             return Command::FAILURE;
         }
 
-        $this->writeHeader($output, $className);
+        $inspection = (new ConstructorInspector())->inspect($className);
 
-        $constructor = $reflection->getConstructor();
+        $this->renderInspection($output, $inspection);
 
-        if ($constructor === null || $constructor->getNumberOfParameters() === 0) {
-            $message = $constructor === null ? 'No constructor' : 'Constructor takes no parameters';
-            $output->writeln(sprintf('  <fg=cyan>%s</>', $message));
+        return Command::SUCCESS;
+    }
+
+    private function renderInspection(OutputInterface $output, ConstructorInspection $inspection): void
+    {
+        $output->writeln('');
+        $output->writeln(sprintf('<info>Constructor dependencies for %s</info>', $inspection->className));
+        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
+        $output->writeln('');
+
+        if (!$inspection->hasConstructor) {
+            $output->writeln('  <fg=cyan>No constructor</>');
             $output->writeln('');
-            return Command::SUCCESS;
+            return;
         }
 
-        $bindings = $this->containerBindings();
+        if ($inspection->parameters === []) {
+            $output->writeln('  <fg=cyan>Constructor takes no parameters</>');
+            $output->writeln('');
+            return;
+        }
 
-        $resolvable = 0;
-        $unresolvable = 0;
-
-        foreach ($constructor->getParameters() as $parameter) {
-            $description = $this->describeParameter($parameter, $bindings);
-            $output->writeln('  ' . $description['line']);
-
-            if ($description['resolvable']) {
-                ++$resolvable;
-            } else {
-                ++$unresolvable;
-            }
+        foreach ($inspection->parameters as $parameter) {
+            $output->writeln('  ' . $this->formatParameter($parameter));
         }
 
         $output->writeln('');
-        $output->writeln(sprintf('<fg=cyan>Resolvable:</>   %d', $resolvable));
-        $output->writeln(sprintf('<fg=cyan>Unresolvable:</> %d', $unresolvable));
+        $output->writeln(sprintf('<fg=cyan>Resolvable:</>   %d', $inspection->resolvableCount()));
+        $output->writeln(sprintf('<fg=cyan>Unresolvable:</> %d', $inspection->unresolvableCount()));
         $output->writeln('');
 
-        if ($unresolvable > 0) {
+        if (!$inspection->isFullyResolvable()) {
             $output->writeln('<comment>Unresolvable parameters need an explicit binding or default value.</comment>');
             $output->writeln('');
         }
+    }
 
-        return Command::SUCCESS;
+    private function formatParameter(ParameterInspection $parameter): string
+    {
+        $marker = $parameter->isResolvable() ? '<fg=green>✓</>' : '<fg=red>✗</>';
+        $detail = $parameter->isResolvable()
+            ? $this->parenthesize($parameter)
+            : sprintf('<fg=red>%s</>', $parameter->detail);
+
+        return sprintf('%s %s %s %s', $marker, $parameter->name, $parameter->renderedType, $detail);
+    }
+
+    private function parenthesize(ParameterInspection $parameter): string
+    {
+        if ($parameter->status === ParameterStatus::HasDefault) {
+            return $parameter->detail;
+        }
+
+        return '(' . $parameter->detail . ')';
     }
 
     private function resolveClassName(string $argument, OutputInterface $output): ?string
@@ -225,131 +243,6 @@ final class DebugDependenciesCommand extends Command
         }
 
         return null;
-    }
-
-    private function writeHeader(OutputInterface $output, string $className): void
-    {
-        $output->writeln('');
-        $output->writeln(sprintf('<info>Constructor dependencies for %s</info>', $className));
-        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
-        $output->writeln('');
-    }
-
-    /**
-     * @return array<class-string, class-string|callable|object>
-     */
-    private function containerBindings(): array
-    {
-        try {
-            return Gacela::container()->getBindings();
-        } catch (Throwable) {
-            return [];
-        }
-    }
-
-    /**
-     * @param array<class-string, class-string|callable|object> $bindings
-     *
-     * @return array{line: string, resolvable: bool}
-     */
-    private function describeParameter(ReflectionParameter $parameter, array $bindings): array
-    {
-        $name = '$' . $parameter->getName();
-        $typeLabel = $this->renderType($parameter);
-        $status = $this->resolveStatus($parameter, $bindings);
-
-        $line = sprintf(
-            '%s %s %s %s',
-            $status['resolvable'] ? '<fg=green>✓</>' : '<fg=red>✗</>',
-            $name,
-            $typeLabel,
-            $status['detail'],
-        );
-
-        return ['line' => $line, 'resolvable' => $status['resolvable']];
-    }
-
-    private function renderType(ReflectionParameter $parameter): string
-    {
-        $type = $parameter->getType();
-
-        if ($type === null) {
-            return '<fg=yellow>mixed</>';
-        }
-
-        if ($type instanceof ReflectionNamedType) {
-            $name = ($type->allowsNull() && $type->getName() !== 'mixed' ? '?' : '') . $type->getName();
-            return $name;
-        }
-
-        return (string) $type;
-    }
-
-    /**
-     * @param array<class-string, class-string|callable|object> $bindings
-     *
-     * @return array{resolvable: bool, detail: string}
-     */
-    private function resolveStatus(ReflectionParameter $parameter, array $bindings): array
-    {
-        $type = $parameter->getType();
-
-        if ($type === null) {
-            return $parameter->isDefaultValueAvailable()
-                ? ['resolvable' => true, 'detail' => $this->defaultDetail($parameter)]
-                : ['resolvable' => false, 'detail' => '<fg=red>no type hint and no default</>'];
-        }
-
-        if (!$type instanceof ReflectionNamedType) {
-            return ['resolvable' => false, 'detail' => '<fg=red>union/intersection types not inspected</>'];
-        }
-
-        $typeName = $type->getName();
-
-        if ($type->isBuiltin()) {
-            if ($parameter->isDefaultValueAvailable()) {
-                return ['resolvable' => true, 'detail' => $this->defaultDetail($parameter)];
-            }
-
-            return ['resolvable' => false, 'detail' => '<fg=red>scalar without default</>'];
-        }
-
-        if (isset($bindings[$typeName])) {
-            return ['resolvable' => true, 'detail' => sprintf('(bound -> %s)', $this->renderBindingTarget($bindings[$typeName]))];
-        }
-
-        if (class_exists($typeName)) {
-            return ['resolvable' => true, 'detail' => '(autowirable)'];
-        }
-
-        if (interface_exists($typeName)) {
-            return ['resolvable' => false, 'detail' => '<fg=red>interface, no binding</>'];
-        }
-
-        return ['resolvable' => false, 'detail' => '<fg=red>type does not exist</>'];
-    }
-
-    private function defaultDetail(ReflectionParameter $parameter): string
-    {
-        /** @var mixed $default */
-        $default = $parameter->getDefaultValue();
-        return sprintf('= %s', var_export($default, true));
-    }
-
-    /**
-     * @param class-string|callable|object $target
-     */
-    private function renderBindingTarget(mixed $target): string
-    {
-        if (is_object($target)) {
-            return $target::class . ' instance';
-        }
-
-        if (is_callable($target)) {
-            return 'callable';
-        }
-
-        return $target;
     }
 
     private function getHelpText(): string

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\Application\Debug\ConstructorInspection;
+use Gacela\Console\Application\Debug\ConstructorInspector;
+use Gacela\Console\Application\Debug\ParameterInspection;
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function array_filter;
+use function class_exists;
+use function sprintf;
+use function str_repeat;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+final class DebugModulesCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('debug:modules')
+            ->setDescription('Show dependency resolvability of every Gacela module pillar (Facade, Factory, Config, Provider)')
+            ->setHelp($this->getHelpText())
+            ->addArgument('filter', InputArgument::OPTIONAL, 'Restrict output to modules whose name matches this substring', '')
+            ->addOption('detail', 'd', InputOption::VALUE_NONE, 'Include every parameter, not just unresolvable ones');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $filter */
+        $filter = $input->getArgument('filter');
+        $detail = (bool) $input->getOption('detail');
+
+        try {
+            $modules = $this->getFacade()->findAllAppModules($filter);
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>Could not discover modules: %s</error>', $throwable->getMessage()));
+            return Command::FAILURE;
+        }
+
+        $this->writeHeader($output, $filter);
+
+        if ($modules === []) {
+            $output->writeln($filter === ''
+                ? '  <comment>No modules discovered.</comment>'
+                : sprintf('  <comment>No modules match filter "%s".</comment>', $filter));
+            $output->writeln('');
+            return Command::SUCCESS;
+        }
+
+        $inspector = new ConstructorInspector();
+        $moduleCount = 0;
+        $pillarCount = 0;
+        $unresolvableTotal = 0;
+
+        foreach ($modules as $module) {
+            $pillars = $this->existingPillarClasses($module);
+            if ($pillars === []) {
+                continue;
+            }
+
+            ++$moduleCount;
+            $output->writeln(sprintf('  <fg=green>%s</>', $module->fullModuleName()));
+
+            foreach ($pillars as $pillarClass) {
+                ++$pillarCount;
+                $inspection = $inspector->inspect($pillarClass);
+                $unresolvableTotal += $inspection->unresolvableCount();
+
+                $this->writePillar($output, $inspection, $detail);
+            }
+
+            $output->writeln('');
+        }
+
+        $this->writeSummary($output, $moduleCount, $pillarCount, $unresolvableTotal);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function existingPillarClasses(AppModule $module): array
+    {
+        $candidates = [
+            $module->facadeClass(),
+            $module->factoryClass(),
+            $module->configClass(),
+            $module->providerClass(),
+        ];
+
+        $pillars = array_filter(
+            $candidates,
+            static fn (?string $class): bool => $class !== null && class_exists($class),
+        );
+
+        return array_values($pillars);
+    }
+
+    private function writeHeader(OutputInterface $output, string $filter): void
+    {
+        $title = $filter === ''
+            ? 'Gacela modules: constructor resolvability'
+            : sprintf('Gacela modules matching "%s"', $filter);
+
+        $output->writeln('');
+        $output->writeln(sprintf('<info>%s</info>', $title));
+        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
+        $output->writeln('');
+    }
+
+    private function writePillar(OutputInterface $output, ConstructorInspection $inspection, bool $detail): void
+    {
+        if (!$inspection->hasConstructor) {
+            $output->writeln(sprintf('    <fg=green>✓</> %s <fg=cyan>(no constructor)</>', $inspection->className));
+            return;
+        }
+
+        if ($inspection->parameters === []) {
+            $output->writeln(sprintf('    <fg=green>✓</> %s <fg=cyan>(constructor takes no parameters)</>', $inspection->className));
+            return;
+        }
+
+        $marker = $inspection->isFullyResolvable() ? '<fg=green>✓</>' : '<fg=red>✗</>';
+
+        $output->writeln(sprintf(
+            '    %s %s <fg=cyan>(%d resolvable, %d unresolvable)</>',
+            $marker,
+            $inspection->className,
+            $inspection->resolvableCount(),
+            $inspection->unresolvableCount(),
+        ));
+
+        $parametersToList = $detail
+            ? $inspection->parameters
+            : $inspection->unresolvableParameters();
+
+        foreach ($parametersToList as $parameter) {
+            $output->writeln('       ' . $this->formatParameter($parameter));
+        }
+    }
+
+    private function formatParameter(ParameterInspection $parameter): string
+    {
+        $marker = $parameter->isResolvable() ? '<fg=green>✓</>' : '<fg=red>✗</>';
+        $detail = $parameter->isResolvable()
+            ? $parameter->detail
+            : sprintf('<fg=red>%s</>', $parameter->detail);
+
+        return sprintf('%s %s %s (%s)', $marker, $parameter->name, $parameter->renderedType, $detail);
+    }
+
+    private function writeSummary(
+        OutputInterface $output,
+        int $moduleCount,
+        int $pillarCount,
+        int $unresolvableTotal,
+    ): void {
+        $output->writeln(sprintf(
+            '<fg=cyan>Summary:</> %d %s, %d %s inspected, %d unresolvable %s',
+            $moduleCount,
+            $moduleCount === 1 ? 'module' : 'modules',
+            $pillarCount,
+            $pillarCount === 1 ? 'pillar' : 'pillars',
+            $unresolvableTotal,
+            $unresolvableTotal === 1 ? 'parameter' : 'parameters',
+        ));
+
+        if ($unresolvableTotal > 0) {
+            $output->writeln('<comment>Run bin/gacela debug:dependencies &lt;class&gt; for a per-class view.</comment>');
+        }
+
+        $output->writeln('');
+    }
+
+    private function getHelpText(): string
+    {
+        return <<<'HELP'
+Walks every discovered Gacela module and inspects the constructor of each
+pillar (Facade, Factory, Config, Provider) through the container, flagging
+any parameter that cannot be resolved.
+
+<info>Examples:</info>
+  # Inspect every module
+  bin/gacela debug:modules
+
+  # Limit to modules whose name contains "Checkout"
+  bin/gacela debug:modules Checkout
+
+  # Show every parameter, not just the unresolvable ones
+  bin/gacela debug:modules --detail
+
+<comment>Complements:</comment>
+  bin/gacela list:modules          list modules and their pillars
+  bin/gacela debug:dependencies    deep-dive into one class
+HELP;
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -10,6 +10,7 @@ use Gacela\Console\Application\Debug\ParameterInspection;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use ReflectionClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,7 +35,7 @@ final class DebugModulesCommand extends Command
         $this->setName('debug:modules')
             ->setDescription('Show dependency resolvability of every Gacela module pillar (Facade, Factory, Config, Provider)')
             ->setHelp($this->getHelpText())
-            ->addArgument('filter', InputArgument::OPTIONAL, 'Restrict output to modules whose name matches this substring', '')
+            ->addArgument('filter', InputArgument::OPTIONAL, 'Restrict output to a namespace substring (e.g. "App\\\\Shop") or a directory on disk (e.g. "src/")', '')
             ->addOption('detail', 'd', InputOption::VALUE_NONE, 'Include every parameter, not just unresolvable ones');
     }
 
@@ -44,11 +45,18 @@ final class DebugModulesCommand extends Command
         $filter = $input->getArgument('filter');
         $detail = (bool) $input->getOption('detail');
 
+        $pathFilter = $this->asPathFilter($filter);
+        $namespaceFilter = $pathFilter === null ? $filter : '';
+
         try {
-            $modules = $this->getFacade()->findAllAppModules($filter);
+            $modules = $this->getFacade()->findAllAppModules($namespaceFilter);
         } catch (Throwable $throwable) {
             $output->writeln(sprintf('<error>Could not discover modules: %s</error>', $throwable->getMessage()));
             return Command::FAILURE;
+        }
+
+        if ($pathFilter !== null) {
+            $modules = $this->filterModulesByPath($modules, $pathFilter);
         }
 
         $this->writeHeader($output, $filter);
@@ -89,6 +97,50 @@ final class DebugModulesCommand extends Command
         $this->writeSummary($output, $moduleCount, $pillarCount, $unresolvableTotal);
 
         return Command::SUCCESS;
+    }
+
+    private function asPathFilter(string $filter): ?string
+    {
+        if ($filter === '' || !is_dir($filter)) {
+            return null;
+        }
+
+        $real = realpath($filter);
+        return $real === false ? null : $real;
+    }
+
+    /**
+     * @param list<AppModule> $modules
+     *
+     * @return list<AppModule>
+     */
+    private function filterModulesByPath(array $modules, string $path): array
+    {
+        $prefix = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $matching = [];
+
+        foreach ($modules as $module) {
+            $file = $this->facadeFilename($module->facadeClass());
+            if ($file !== null && str_starts_with($file, $prefix)) {
+                $matching[] = $module;
+            }
+        }
+
+        return $matching;
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function facadeFilename(string $className): ?string
+    {
+        try {
+            $file = (new ReflectionClass($className))->getFileName();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $file === false ? null : $file;
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -17,10 +17,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
-use function array_filter;
 use function class_exists;
 use function sprintf;
 use function str_repeat;
+use function strlen;
 
 /**
  * @method ConsoleFacade getFacade()
@@ -92,23 +92,50 @@ final class DebugModulesCommand extends Command
     }
 
     /**
+     * Combine what discovery reported with conventional-name probes so that a
+     * pillar class present on disk is still inspected even when its resolver
+     * would fail to instantiate it (e.g. a factory whose ctor takes an unbound
+     * dependency — exactly the failure mode we want to surface).
+     *
      * @return list<class-string>
      */
     private function existingPillarClasses(AppModule $module): array
     {
-        $candidates = [
-            $module->facadeClass(),
-            $module->factoryClass(),
-            $module->configClass(),
-            $module->providerClass(),
+        $pillars = [$module->facadeClass()];
+
+        foreach ($this->pillarsBySuffix($module) as $pillar) {
+            if ($pillar === null || !class_exists($pillar)) {
+                continue;
+            }
+            $pillars[] = $pillar;
+        }
+
+        return array_values(array_unique($pillars));
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    private function pillarsBySuffix(AppModule $module): array
+    {
+        $facade = $module->facadeClass();
+
+        return [
+            'Factory' => $module->factoryClass() ?? $this->classByConvention($facade, 'Factory'),
+            'Config' => $module->configClass() ?? $this->classByConvention($facade, 'Config'),
+            'Provider' => $module->providerClass() ?? $this->classByConvention($facade, 'Provider'),
         ];
+    }
 
-        $pillars = array_filter(
-            $candidates,
-            static fn (?string $class): bool => $class !== null && class_exists($class),
-        );
+    private function classByConvention(string $facadeClass, string $suffix): ?string
+    {
+        if (!str_ends_with($facadeClass, 'Facade')) {
+            return null;
+        }
 
-        return array_values($pillars);
+        $candidate = substr($facadeClass, 0, -strlen('Facade')) . $suffix;
+
+        return class_exists($candidate) ? $candidate : null;
     }
 
     private function writeHeader(OutputInterface $output, string $filter): void
@@ -181,7 +208,7 @@ final class DebugModulesCommand extends Command
         ));
 
         if ($unresolvableTotal > 0) {
-            $output->writeln('<comment>Run bin/gacela debug:dependencies &lt;class&gt; for a per-class view.</comment>');
+            $output->writeln('<comment>Run bin/gacela debug:dependencies \<class> for a per-class view.</comment>');
         }
 
         $output->writeln('');

--- a/tests/Feature/Console/DebugModules/BrokenFixtures/BrokenModule/BrokenModuleFacade.php
+++ b/tests/Feature/Console/DebugModules/BrokenFixtures/BrokenModule/BrokenModuleFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\BrokenFixtures\BrokenModule;
+
+use Gacela\Framework\AbstractFacade;
+
+final class BrokenModuleFacade extends AbstractFacade
+{
+}

--- a/tests/Feature/Console/DebugModules/BrokenFixtures/BrokenModule/BrokenModuleFactory.php
+++ b/tests/Feature/Console/DebugModules/BrokenFixtures/BrokenModule/BrokenModuleFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\BrokenFixtures\BrokenModule;
+
+use Gacela\Framework\AbstractFactory;
+
+final class BrokenModuleFactory extends AbstractFactory
+{
+    public function __construct(
+        public readonly UnboundDependency $dependency,
+    ) {
+    }
+}

--- a/tests/Feature/Console/DebugModules/BrokenFixtures/BrokenModule/UnboundDependency.php
+++ b/tests/Feature/Console/DebugModules/BrokenFixtures/BrokenModule/UnboundDependency.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\BrokenFixtures\BrokenModule;
+
+interface UnboundDependency
+{
+}

--- a/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
+++ b/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
@@ -69,6 +69,15 @@ final class DebugModulesCommandTest extends TestCase
         self::assertStringContainsString('No modules match filter', $output);
     }
 
+    public function test_filter_accepts_a_directory_path(): void
+    {
+        $this->command->execute(['filter' => __DIR__ . '/Fixtures/WidgetModule']);
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString(WidgetModuleFacade::class, $output);
+        self::assertStringNotContainsString(GizmoModuleFacade::class, $output);
+    }
+
     public function test_surfaces_factory_whose_resolver_would_fail(): void
     {
         Gacela::bootstrap(__DIR__ . '/BrokenFixtures', static function (GacelaConfig $config): void {

--- a/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
+++ b/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules;
+
+use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugModules\Fixtures\GizmoModule\GizmoModuleFacade;
+use GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule\WidgetModuleFacade;
+use GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule\WidgetModuleFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugModulesCommandTest extends TestCase
+{
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__ . '/Fixtures', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $this->command = new CommandTester(new DebugModulesCommand());
+    }
+
+    public function test_lists_every_discovered_module(): void
+    {
+        $exitCode = $this->command->execute([]);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString(WidgetModuleFacade::class, $output);
+        self::assertStringContainsString(WidgetModuleFactory::class, $output);
+        self::assertStringContainsString(GizmoModuleFacade::class, $output);
+    }
+
+    public function test_reports_pillars_without_constructor_as_resolvable(): void
+    {
+        $this->command->execute([]);
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('no constructor', $output);
+        self::assertStringContainsString('Summary:', $output);
+        self::assertStringContainsString('0 unresolvable', $output);
+    }
+
+    public function test_filter_argument_narrows_modules(): void
+    {
+        $this->command->execute(['filter' => 'WidgetModule']);
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString(WidgetModuleFacade::class, $output);
+        self::assertStringNotContainsString(GizmoModuleFacade::class, $output);
+    }
+
+    public function test_unknown_filter_reports_no_matches(): void
+    {
+        $exitCode = $this->command->execute(['filter' => 'DoesNotExist']);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No modules match filter', $output);
+    }
+}

--- a/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
+++ b/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
@@ -7,6 +7,9 @@ namespace GacelaTest\Feature\Console\DebugModules;
 use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugModules\BrokenFixtures\BrokenModule\BrokenModuleFacade;
+use GacelaTest\Feature\Console\DebugModules\BrokenFixtures\BrokenModule\BrokenModuleFactory;
+use GacelaTest\Feature\Console\DebugModules\BrokenFixtures\BrokenModule\UnboundDependency;
 use GacelaTest\Feature\Console\DebugModules\Fixtures\GizmoModule\GizmoModuleFacade;
 use GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule\WidgetModuleFacade;
 use GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule\WidgetModuleFactory;
@@ -64,5 +67,24 @@ final class DebugModulesCommandTest extends TestCase
 
         self::assertSame(Command::SUCCESS, $exitCode);
         self::assertStringContainsString('No modules match filter', $output);
+    }
+
+    public function test_surfaces_factory_whose_resolver_would_fail(): void
+    {
+        Gacela::bootstrap(__DIR__ . '/BrokenFixtures', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $command = new CommandTester(new DebugModulesCommand());
+        $exitCode = $command->execute([]);
+        $output = $command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString(BrokenModuleFacade::class, $output);
+        self::assertStringContainsString(BrokenModuleFactory::class, $output);
+        self::assertStringContainsString('$dependency', $output);
+        self::assertStringContainsString(UnboundDependency::class, $output);
+        self::assertStringContainsString('interface, no binding', $output);
+        self::assertStringContainsString('1 unresolvable', $output);
     }
 }

--- a/tests/Feature/Console/DebugModules/Fixtures/GizmoModule/GizmoModuleFacade.php
+++ b/tests/Feature/Console/DebugModules/Fixtures/GizmoModule/GizmoModuleFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\Fixtures\GizmoModule;
+
+use Gacela\Framework\AbstractFacade;
+
+final class GizmoModuleFacade extends AbstractFacade
+{
+}

--- a/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleConfig.php
+++ b/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleConfig.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule;
+
+use Gacela\Framework\AbstractConfig;
+
+final class WidgetModuleConfig extends AbstractConfig
+{
+}

--- a/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleFacade.php
+++ b/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule;
+
+use Gacela\Framework\AbstractFacade;
+
+final class WidgetModuleFacade extends AbstractFacade
+{
+}

--- a/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleFactory.php
+++ b/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule;
+
+use Gacela\Framework\AbstractFactory;
+
+final class WidgetModuleFactory extends AbstractFactory
+{
+}

--- a/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleProvider.php
+++ b/tests/Feature/Console/DebugModules/Fixtures/WidgetModule/WidgetModuleProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\Fixtures\WidgetModule;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class WidgetModuleProvider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Debug;
+
+use Gacela\Console\Application\Debug\ConstructorInspector;
+use Gacela\Console\Application\Debug\ParameterStatus;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\AutowirableCollaborator;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundContract;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\MixedDependenciesService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
+use PHPUnit\Framework\TestCase;
+
+final class ConstructorInspectorTest extends TestCase
+{
+    private ConstructorInspector $inspector;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(BoundContract::class, BoundImplementation::class);
+        });
+
+        $this->inspector = new ConstructorInspector();
+    }
+
+    public function test_class_without_constructor(): void
+    {
+        $inspection = $this->inspector->inspect(NoConstructorService::class);
+
+        self::assertFalse($inspection->hasConstructor);
+        self::assertSame([], $inspection->parameters);
+        self::assertTrue($inspection->isFullyResolvable());
+    }
+
+    public function test_mixed_dependencies_are_categorized(): void
+    {
+        $inspection = $this->inspector->inspect(MixedDependenciesService::class);
+
+        self::assertTrue($inspection->hasConstructor);
+        self::assertCount(6, $inspection->parameters);
+
+        $statuses = [];
+        foreach ($inspection->parameters as $parameter) {
+            $statuses[$parameter->name] = $parameter->status;
+        }
+
+        self::assertSame(ParameterStatus::Bound, $statuses['$bound']);
+        self::assertSame(ParameterStatus::Autowirable, $statuses['$collaborator']);
+        self::assertSame(ParameterStatus::UnboundInterface, $statuses['$unbound']);
+        self::assertSame(ParameterStatus::ScalarWithoutDefault, $statuses['$mandatoryScalar']);
+        self::assertSame(ParameterStatus::HasDefault, $statuses['$optionalScalar']);
+        self::assertSame(ParameterStatus::Autowirable, $statuses['$nullableCollaborator']);
+
+        self::assertSame(4, $inspection->resolvableCount());
+        self::assertSame(2, $inspection->unresolvableCount());
+        self::assertFalse($inspection->isFullyResolvable());
+    }
+
+    public function test_bound_parameter_includes_target(): void
+    {
+        $inspection = $this->inspector->inspect(MixedDependenciesService::class);
+
+        $bound = $inspection->parameters[0];
+        self::assertSame('$bound', $bound->name);
+        self::assertSame('bound -> ' . BoundImplementation::class, $bound->detail);
+    }
+
+    public function test_autowirable_parameter_details(): void
+    {
+        $inspection = $this->inspector->inspect(MixedDependenciesService::class);
+
+        $collaborator = $inspection->parameters[1];
+        self::assertSame('$collaborator', $collaborator->name);
+        self::assertSame(AutowirableCollaborator::class, $collaborator->renderedType);
+        self::assertSame('autowirable', $collaborator->detail);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds `bin/gacela debug:modules [filter]` — walks every discovered Gacela module and inspects each pillar's (Facade / Factory / Config / Provider) constructor against the container. Answers "which modules have unresolvable dependencies?" in one shot, where `list:modules` only shows structure and `debug:dependencies` is single-class.

Built on an inspection service extracted from the existing `debug:dependencies` command — both now share the same resolution rules.

## 🔖 Changes

- **`ref(console)` — first commit**: extracted from `DebugDependenciesCommand` into reusable pieces so the new command doesn't duplicate the classification logic.
  - `ConstructorInspector` — reflection + container lookup
  - `ConstructorInspection` — value object: className, hasConstructor, parameters, counts
  - `ParameterInspection` — per-parameter name / type / status / detail
  - `ParameterStatus` (enum) — Bound / Autowirable / HasDefault / ScalarWithoutDefault / UnboundInterface / MissingType / NoTypeHint / UnsupportedType
  - `DebugDependenciesCommand` is now thin: argument parsing + formatting only
- **`feat(console)` — second commit**: `DebugModulesCommand`
  - Discovers modules via `ConsoleFacade::findAllAppModules($filter)` (same source as `list:modules` and `doctor`)
  - Iterates pillars declared on each `AppModule` (facade / factory / config / provider), skipping anonymous/unresolved classes
  - Output groups per module; per-pillar line shows ✓/✗ with resolvable/unresolvable counts; unresolvable params detailed inline
  - `--detail` flag expands to every parameter; `filter` argument narrows modules
  - Graceful failure when module discovery throws (mirrors how `doctor` handles the same path)

## Example

```
$ bin/gacela debug:modules

Gacela modules: constructor resolvability
============================================================

  App\Shop\Checkout
    ✓ App\Shop\Checkout\CheckoutFacade (no constructor)
    ✗ App\Shop\Checkout\CheckoutFactory (2 resolvable, 1 unresolvable)
       ✗ $taxProvider App\Tax\TaxProvider (interface, no binding)
    ✓ App\Shop\Checkout\CheckoutConfig (no constructor)

  App\Shop\Cart
    ✓ App\Shop\Cart\CartFacade (no constructor)
    ✓ App\Shop\Cart\CartFactory (1 resolvable, 0 unresolvable)

Summary: 2 modules, 5 pillars inspected, 1 unresolvable parameter
Run bin/gacela debug:dependencies <class> for a per-class view.
```

## Test plan

- [x] `composer test-unit` — 270 tests (4 new in `ConstructorInspectorTest`)
- [x] `composer test-integration` — 62 tests
- [x] `composer test-feature` — 102 tests (4 new in `DebugModulesCommandTest`, existing 6 in `DebugDependenciesCommandTest` still green after the refactor)
- [x] `composer quality` — cs-fixer + psalm + phpstan, clean