### PR TITLE
test(framework): raise mutation score from 80.3% to 91.9%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .gacela/
 .vscode/
 .phpbench/

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         "phpbench-base": "XDEBUG_MODE=off ./vendor/bin/phpbench run --tag=baseline --report=aggregate --progress=plain --ansi",
         "phpbench-ref": "XDEBUG_MODE=off ./vendor/bin/phpbench run --ref=baseline --report=aggregate --progress=plain --ansi",
         "phpstan": "XDEBUG_MODE=develop ./vendor/bin/phpstan analyze --no-progress --memory-limit=1G",
-        "phpstan-tests": "XDEBUG_MODE=off ./vendor/bin/phpstan analyze -c phpstan-tests.neon",
+        "phpstan-tests": "XDEBUG_MODE=off ./vendor/bin/phpstan analyze -c phpstan-tests.neon --memory-limit=1G",
         "phpunit": [
             "@test-unit",
             "@test-integration",

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -28,6 +28,11 @@ final class FileCacheFeatureTest extends TestCase
         DirectoryUtil::removeDir(__DIR__ . '/custom');
     }
 
+    protected function tearDown(): void
+    {
+        putenv('GACELA_CACHE_DIR');
+    }
+
     public function test_custom_cache_dir(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Framework\Config;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function getcwd;
+use function sys_get_temp_dir;
 
 final class ConfigTest extends TestCase
 {
@@ -42,5 +48,113 @@ final class ConfigTest extends TestCase
 
         $config->setAppRootDir(DIRECTORY_SEPARATOR . 'directory2' . DIRECTORY_SEPARATOR);
         self::assertSame(DIRECTORY_SEPARATOR . 'directory2', $config->getAppRootDir());
+    }
+
+    public function test_get_instance_throws_when_not_bootstrapped(): void
+    {
+        Config::resetInstance();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('bootstrap Gacela');
+
+        Config::getInstance();
+    }
+
+    public function test_get_returns_value_set_via_app_config_key_value(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+            $config->addAppConfigKeyValue('my_config_key', 'my_config_value');
+        });
+
+        self::assertSame('my_config_value', Config::getInstance()->get('my_config_key'));
+    }
+
+    public function test_set_app_root_dir_falls_back_to_cwd_when_given_empty_string(): void
+    {
+        $config = Config::getInstance();
+
+        $config->setAppRootDir('');
+
+        self::assertSame(getcwd(), $config->getAppRootDir());
+    }
+
+    public function test_set_app_root_dir_falls_back_to_cwd_when_given_zero_string(): void
+    {
+        $config = Config::getInstance();
+
+        $config->setAppRootDir('0');
+
+        self::assertSame(getcwd(), $config->getAppRootDir());
+    }
+
+    public function test_get_cache_dir_strips_trailing_directory_separator(): void
+    {
+        // Bootstrap eagerly calls init() which memoises the cache dir, so we
+        // drive Config directly here to observe the rtrim path on the first
+        // and only call.
+        Config::resetInstance();
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->setFileCache(true, sys_get_temp_dir() . '/trailing-sep/'),
+        );
+        $config = Config::createWithSetup($setup);
+        $config->setAppRootDir(sys_get_temp_dir());
+
+        self::assertSame(sys_get_temp_dir() . '/trailing-sep', $config->getCacheDir());
+    }
+
+    public function test_get_cache_dir_leaves_absolute_path_inside_app_root_unchanged(): void
+    {
+        $appRoot = Config::getInstance()->getAppRootDir();
+
+        Gacela::bootstrap($appRoot, static function (GacelaConfig $config) use ($appRoot): void {
+            $config->setFileCache(true, $appRoot . DIRECTORY_SEPARATOR . 'custom-cache');
+        });
+
+        self::assertSame(
+            $appRoot . DIRECTORY_SEPARATOR . 'custom-cache',
+            Config::getInstance()->getCacheDir(),
+        );
+    }
+
+    public function test_get_cache_dir_prefixes_relative_path_with_app_root_and_separator(): void
+    {
+        $appRoot = Config::getInstance()->getAppRootDir();
+
+        Gacela::bootstrap($appRoot, static function (GacelaConfig $config): void {
+            $config->setFileCache(true, 'relative/cache/path');
+        });
+
+        self::assertSame(
+            $appRoot . DIRECTORY_SEPARATOR . 'relative/cache/path',
+            Config::getInstance()->getCacheDir(),
+        );
+    }
+
+    public function test_get_cache_dir_strips_leading_separator_before_joining_relative_path(): void
+    {
+        // An input like `subdir/` with no absolute prefix is treated as relative,
+        // concatenated as `$appRoot . DIRECTORY_SEPARATOR . ltrim(input, DS)`.
+        $appRoot = Config::getInstance()->getAppRootDir();
+
+        Gacela::bootstrap($appRoot, static function (GacelaConfig $config): void {
+            $config->setFileCache(true, 'subdir');
+        });
+
+        self::assertSame(
+            $appRoot . DIRECTORY_SEPARATOR . 'subdir',
+            Config::getInstance()->getCacheDir(),
+        );
+    }
+
+    public function test_get_factory_returns_cached_instance_across_calls(): void
+    {
+        $config = Config::getInstance();
+
+        $factoryA = $config->getFactory();
+        $factoryB = $config->getFactory();
+
+        self::assertInstanceOf(ConfigFactory::class, $factoryA);
+        self::assertSame($factoryA, $factoryB);
     }
 }

--- a/tests/Integration/Framework/GacelaTest.php
+++ b/tests/Integration/Framework/GacelaTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework;
 
+use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
+use Gacela\Framework\Container\Container;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
@@ -33,5 +36,63 @@ final class GacelaTest extends TestCase
         });
 
         self::assertSame('any/root/directory', Gacela::rootDir());
+    }
+
+    public function test_container_throws_when_not_bootstrapped(): void
+    {
+        $gacelaProxy = new ReflectionClass(Gacela::class);
+        $mainContainerProp = $gacelaProxy->getProperty('mainContainer');
+        $mainContainerProp->setValue($gacelaProxy, value: null);
+
+        $this->expectException(GacelaNotBootstrappedException::class);
+
+        Gacela::container();
+    }
+
+    public function test_container_returns_the_main_container_when_bootstrapped(): void
+    {
+        Gacela::bootstrap('any/root/directory', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $gacelaProxy = new ReflectionClass(Gacela::class);
+        $mainContainerProp = $gacelaProxy->getProperty('mainContainer');
+        $mainContainerProp->setValue($gacelaProxy, value: new Container());
+
+        self::assertInstanceOf(Container::class, Gacela::container());
+    }
+
+    public function test_add_global_with_empty_context_resolves_caller_file_as_context(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $service = new class() extends AbstractConfig {};
+
+        Gacela::addGlobal($service);
+
+        // The caller of addGlobal() is this test file, so the resolved
+        // context should be this file's basename (without `.php`).
+        self::assertSame(
+            $service,
+            AnonymousGlobal::getByKey(AnonymousGlobal::createCacheKey('GacelaTest', 'Config')),
+        );
+    }
+
+    public function test_add_global_with_file_path_context_uses_its_basename(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $service = new class() extends AbstractConfig {};
+
+        Gacela::addGlobal($service, __FILE__);
+
+        self::assertSame(
+            $service,
+            AnonymousGlobal::getByKey(AnonymousGlobal::createCacheKey('GacelaTest', 'Config')),
+        );
     }
 }

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use PHPUnit\Framework\TestCase;
+
+final class GacelaConfigTest extends TestCase
+{
+    public function test_default_php_config_registers_default_paths(): void
+    {
+        $closure = GacelaConfig::defaultPhpConfig();
+        $config = new GacelaConfig();
+
+        $closure($config);
+
+        $dto = $config->toTransfer();
+
+        $paths = $dto->appConfigBuilder->build();
+        self::assertCount(1, $paths);
+        self::assertSame('config/*.php', $paths[0]->path());
+        self::assertSame('config/local.php', $paths[0]->pathLocal());
+    }
+
+    public function test_add_mapping_interface_is_an_alias_of_add_binding(): void
+    {
+        $a = new GacelaConfig();
+        $b = new GacelaConfig();
+
+        $a->addMappingInterface('App\\Port', 'App\\Adapter');
+        $b->addBinding('App\\Port', 'App\\Adapter');
+
+        self::assertEquals(
+            $a->toTransfer()->bindingsBuilder->build(),
+            $b->toTransfer()->bindingsBuilder->build(),
+        );
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
@@ -7,16 +7,22 @@ namespace GacelaTest\Unit\Framework\ClassResolver\Cache;
 use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 use function count;
+use function file_put_contents;
 use function glob;
 use function is_dir;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unlink;
 
 final class AbstractPhpFileCacheBatchTest extends TestCase
 {
     private string $cacheDir;
+
+    /** @var list<string> */
+    private array $blockerFiles = [];
 
     protected function setUp(): void
     {
@@ -30,6 +36,85 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
         TestPhpFileCache::clearStaticCache();
         ClassNamePhpCache::clearStaticCache();
         $this->removeDir($this->cacheDir);
+
+        foreach ($this->blockerFiles as $blocker) {
+            if (is_file($blocker)) {
+                unlink($blocker);
+            }
+        }
+        $this->blockerFiles = [];
+    }
+
+    public function test_is_batching_reflects_current_batch_state(): void
+    {
+        self::assertFalse(AbstractPhpFileCache::isBatching());
+
+        AbstractPhpFileCache::beginBatch();
+        self::assertTrue(AbstractPhpFileCache::isBatching());
+
+        AbstractPhpFileCache::commitBatch();
+        self::assertFalse(AbstractPhpFileCache::isBatching());
+    }
+
+    public function test_put_overwrites_existing_key_with_different_value(): void
+    {
+        $cache = new TestPhpFileCache($this->cacheDir);
+
+        $cache->put('key', 'Original');
+        $cache->put('key', 'Updated');
+
+        self::assertSame('Updated', $cache->get('key'));
+        self::assertSame(['key' => 'Updated'], require $this->cacheFile());
+    }
+
+    public function test_put_with_identical_value_does_not_rewrite_the_file(): void
+    {
+        $cache = new TestPhpFileCache($this->cacheDir);
+        $cache->put('key', 'A');
+        $firstContent = file_get_contents($this->cacheFile());
+        $firstMtime = filemtime($this->cacheFile());
+
+        // Force a detectable mtime gap on systems with second-resolution filesystems.
+        usleep(1_100_000);
+        clearstatcache(true, $this->cacheFile());
+
+        $cache->put('key', 'A');
+
+        clearstatcache(true, $this->cacheFile());
+        self::assertSame($firstContent, file_get_contents($this->cacheFile()));
+        self::assertSame($firstMtime, filemtime($this->cacheFile()));
+    }
+
+    public function test_constructor_loads_existing_cache_entries_from_disk(): void
+    {
+        $cache1 = new TestPhpFileCache($this->cacheDir);
+        $cache1->put('persisted', 'ClassP');
+        TestPhpFileCache::clearStaticCache();
+
+        $cache2 = new TestPhpFileCache($this->cacheDir);
+
+        self::assertSame(['persisted' => 'ClassP'], $cache2->getAll());
+    }
+
+    public function test_constructor_throws_when_cache_directory_cannot_be_created(): void
+    {
+        $blocker = sys_get_temp_dir() . '/gacela-blocker-' . uniqid('', true);
+        file_put_contents($blocker, 'blocked');
+        $this->blockerFiles[] = $blocker;
+
+        // mkdir() emits an E_WARNING when the parent exists as a file; PHPUnit
+        // turns that into a test warning. Suppress it so only the thrown
+        // RuntimeException reaches the assertions.
+        set_error_handler(static fn (): bool => true, E_WARNING);
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('was not created');
+
+            new TestPhpFileCache($blocker . '/subdir');
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function test_put_outside_batch_writes_immediately(): void

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockParserTest.php
@@ -34,4 +34,84 @@ TXT;
             $this->parser->getClassFromMethod($input, 'getClass()'),
         );
     }
+
+    public function test_get_factory_falls_back_to_abstract_factory_when_template_is_missing(): void
+    {
+        self::assertSame(
+            \Gacela\Framework\AbstractFactory::class,
+            $this->parser->getClassFromMethod('/** nothing relevant */', 'getFactory'),
+        );
+    }
+
+    public function test_get_factory_resolves_abstract_facade_template_parameter(): void
+    {
+        $docBlock = <<<'TXT'
+/**
+ * @extends \Gacela\Framework\AbstractFacade<\App\Module\CustomFactory>
+ */
+TXT;
+
+        self::assertSame(
+            '\App\Module\CustomFactory',
+            $this->parser->getClassFromMethod($docBlock, 'getFactory'),
+        );
+    }
+
+    public function test_get_factory_matches_abstract_facade_template_case_insensitively(): void
+    {
+        // Proves the /i flag on the extends regex — without it, `@EXTENDS`
+        // would not match and the parser would fall back to AbstractFactory.
+        $docBlock = <<<'TXT'
+/**
+ * @EXTENDS \Gacela\Framework\AbstractFacade<\App\Module\CaseFactory>
+ */
+TXT;
+
+        self::assertSame(
+            '\App\Module\CaseFactory',
+            $this->parser->getClassFromMethod($docBlock, 'getFactory'),
+        );
+    }
+
+    public function test_get_config_falls_back_to_abstract_config_when_template_is_missing(): void
+    {
+        self::assertSame(
+            \Gacela\Framework\AbstractConfig::class,
+            $this->parser->getClassFromMethod('/** nothing relevant */', 'getConfig'),
+        );
+    }
+
+    public function test_get_config_resolves_abstract_factory_template_parameter(): void
+    {
+        $docBlock = <<<'TXT'
+/**
+ * @extends \Gacela\Framework\AbstractFactory<\App\Module\CustomConfig>
+ */
+TXT;
+
+        self::assertSame(
+            '\App\Module\CustomConfig',
+            $this->parser->getClassFromMethod($docBlock, 'getConfig'),
+        );
+    }
+
+    public function test_get_config_matches_abstract_factory_template_case_insensitively(): void
+    {
+        // Same /i-flag proof as the facade variant.
+        $docBlock = <<<'TXT'
+/**
+ * @EXTENDS \Gacela\Framework\AbstractFactory<\App\Module\CaseConfig>
+ */
+TXT;
+
+        self::assertSame(
+            '\App\Module\CaseConfig',
+            $this->parser->getClassFromMethod($docBlock, 'getConfig'),
+        );
+    }
+
+    public function test_unknown_method_with_no_matching_doc_block_returns_empty_string(): void
+    {
+        self::assertSame('', $this->parser->getClassFromMethod('/** nothing */', 'somethingElse'));
+    }
 }

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
@@ -58,6 +58,66 @@ final class UseBlockParserTest extends TestCase
         self::assertSame('\Ns\Test\CommentedClassInAnotherNs', $actual);
     }
 
+    public function test_leading_backslash_in_use_statement_is_normalized_to_single_backslash(): void
+    {
+        // A fully-qualified `use \Foo\Bar;` must still resolve to `\Foo\Bar`,
+        // not `\\Foo\Bar`. The implementation relies on `ltrim($fqcn, '\\')`
+        // to strip the leading backslash before re-prefixing it.
+        $phpCode = <<<'PHP'
+<?php
+
+namespace Ns\Test;
+
+use \Fully\Qualified\LeadingBackslashClass;
+
+final class TestClass
+{
+}
+PHP;
+
+        $actual = $this->parser->getUseStatement('LeadingBackslashClass', $phpCode);
+
+        self::assertSame('\Fully\Qualified\LeadingBackslashClass', $actual);
+    }
+
+    public function test_use_statement_matches_on_semicolon_terminated_class_name(): void
+    {
+        // If the semicolon is dropped from the needle, any line whose class
+        // name is a prefix of the target would match first. This test proves
+        // the parser anchors on the terminating `;`, not on a bare substring.
+        $phpCode = <<<'PHP'
+<?php
+
+namespace Ns\Test;
+
+use Ns\Other\UserNameExtension;
+use Ns\Target\UserName;
+
+final class TestClass
+{
+}
+PHP;
+
+        $actual = $this->parser->getUseStatement('UserName', $phpCode);
+
+        self::assertSame('\Ns\Target\UserName', $actual);
+    }
+
+    public function test_falls_back_to_empty_namespace_when_php_code_has_no_namespace_line(): void
+    {
+        $phpCode = <<<'PHP'
+<?php
+
+final class TestClass
+{
+}
+PHP;
+
+        $actual = $this->parser->getUseStatement('TestClass', $phpCode);
+
+        self::assertSame('\\\\TestClass', $actual);
+    }
+
     private function phpCode(): string
     {
         return <<<'PHP'

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -6,7 +6,9 @@ namespace GacelaTest\Unit\Framework\Config;
 
 use Gacela\Framework\Config\MergedConfigCache;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
+use function file_put_contents;
 use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -16,6 +18,9 @@ final class MergedConfigCacheTest extends TestCase
 {
     private string $cacheDir;
 
+    /** @var list<string> */
+    private array $blockerFiles = [];
+
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-merged-config-test-' . uniqid('', true);
@@ -24,6 +29,33 @@ final class MergedConfigCacheTest extends TestCase
     protected function tearDown(): void
     {
         $this->removeCacheDirIfExists();
+
+        foreach ($this->blockerFiles as $blocker) {
+            if (is_file($blocker)) {
+                unlink($blocker);
+            }
+        }
+        $this->blockerFiles = [];
+    }
+
+    public function test_write_throws_when_the_cache_directory_cannot_be_created(): void
+    {
+        $blocker = sys_get_temp_dir() . '/gacela-merged-blocker-' . uniqid('', true);
+        file_put_contents($blocker, 'blocked');
+        $this->blockerFiles[] = $blocker;
+
+        $cache = new MergedConfigCache($blocker . '/subdir');
+
+        set_error_handler(static fn (): bool => true, E_WARNING);
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('was not created');
+
+            $cache->write(['key' => 'value']);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function test_exists_is_false_when_file_not_written(): void

--- a/tests/Unit/Framework/Exception/ErrorSuggestionHelperTest.php
+++ b/tests/Unit/Framework/Exception/ErrorSuggestionHelperTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Exception;
+
+use Gacela\Framework\Exception\ErrorSuggestionHelper;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorSuggestionHelperTest extends TestCase
+{
+    public function test_suggest_similar_returns_empty_string_when_no_options_available(): void
+    {
+        self::assertSame('', ErrorSuggestionHelper::suggestSimilar('anything', []));
+    }
+
+    public function test_suggest_similar_returns_empty_string_when_no_option_is_similar_enough(): void
+    {
+        self::assertSame('', ErrorSuggestionHelper::suggestSimilar('abc', ['xyz', 'qrs', 'uvw']));
+    }
+
+    public function test_suggest_similar_returns_exact_formatted_output_with_one_match(): void
+    {
+        $expected = "\n\nDid you mean?\n  - userName";
+
+        self::assertSame(
+            $expected,
+            ErrorSuggestionHelper::suggestSimilar('user_name', ['userName', 'xyz', 'qrs']),
+        );
+    }
+
+    public function test_suggest_similar_prefixes_each_match_with_bullet_dash(): void
+    {
+        $actual = ErrorSuggestionHelper::suggestSimilar('apple', ['apples', 'apply', 'appliance']);
+
+        self::assertStringStartsWith("\n\nDid you mean?\n  - ", $actual);
+        self::assertStringContainsString("\n  - ", $actual);
+    }
+
+    public function test_suggest_similar_sorts_by_highest_similarity_first(): void
+    {
+        $actual = ErrorSuggestionHelper::suggestSimilar(
+            'userName',
+            ['userNam', 'userNa', 'userN'],
+        );
+
+        self::assertSame(
+            "\n\nDid you mean?\n  - userNam\n  - userNa\n  - userN",
+            $actual,
+        );
+    }
+
+    public function test_suggest_similar_caps_results_at_three(): void
+    {
+        $actual = ErrorSuggestionHelper::suggestSimilar(
+            'userName',
+            ['userNam', 'userNa', 'userN', 'userNameX', 'userNameY'],
+        );
+
+        self::assertSame(3, substr_count($actual, "\n  - "));
+    }
+
+    public function test_suggest_similar_is_case_insensitive(): void
+    {
+        $actual = ErrorSuggestionHelper::suggestSimilar('USERNAME', ['username']);
+
+        self::assertSame("\n\nDid you mean?\n  - username", $actual);
+    }
+
+    public function test_suggest_similar_uses_strict_greater_than_threshold(): void
+    {
+        // similar_text('abc', 'xyz') returns 0 → below the 0.4 threshold → excluded
+        $actual = ErrorSuggestionHelper::suggestSimilar('abc', ['xyz']);
+
+        self::assertSame('', $actual);
+    }
+
+    public function test_suggest_similar_excludes_options_with_low_similarity_score(): void
+    {
+        // similar_text('hello', 'hel') ≈ 75% → included
+        // similar_text('hello', 'xy') → low → excluded
+        $actual = ErrorSuggestionHelper::suggestSimilar('hello', ['hel', 'xy']);
+
+        self::assertStringContainsString('  - hel', $actual);
+        self::assertStringNotContainsString('  - xy', $actual);
+    }
+
+    public function test_suggest_similar_treats_two_empty_strings_as_identical(): void
+    {
+        // Exercises the `$longer === 0 → return 1.0` branch in calculateSimilarity.
+        // With both searchTerm and option empty, the method short-circuits to 1.0
+        // (above threshold) so the empty option is reported as a suggestion.
+        $actual = ErrorSuggestionHelper::suggestSimilar('', ['']);
+
+        self::assertSame("\n\nDid you mean?\n  - ", $actual);
+    }
+
+    public function test_add_helpful_tip_for_class_not_found(): void
+    {
+        $expected = "\n\nTips:\n"
+            . "  • Check your class namespace\n"
+            . "  • Ensure the file exists in the correct location\n"
+            . "  • Run 'composer dump-autoload' to refresh autoloader\n"
+            . '  • Verify PSR-4 namespace mapping in composer.json';
+
+        self::assertSame($expected, ErrorSuggestionHelper::addHelpfulTip('class_not_found'));
+    }
+
+    public function test_add_helpful_tip_for_service_not_found(): void
+    {
+        $expected = "\n\nTips:\n"
+            . "  • Check if the service is registered in a Provider\n"
+            . "  • Verify the service binding in gacela.php\n"
+            . '  • Ensure the service class exists and is autoloadable';
+
+        self::assertSame($expected, ErrorSuggestionHelper::addHelpfulTip('service_not_found'));
+    }
+
+    public function test_add_helpful_tip_for_facade_not_found(): void
+    {
+        $expected = "\n\nTips:\n"
+            . "  • Ensure your Facade extends AbstractFacade\n"
+            . "  • Check the module namespace matches the directory structure\n"
+            . '  • Verify the Facade file name matches the class name';
+
+        self::assertSame($expected, ErrorSuggestionHelper::addHelpfulTip('facade_not_found'));
+    }
+
+    public function test_add_helpful_tip_for_config_error(): void
+    {
+        $expected = "\n\nTips:\n"
+            . "  • Check your gacela.php configuration file\n"
+            . "  • Ensure all configuration values are valid\n"
+            . '  • Review the documentation: https://gacela-project.com/docs/';
+
+        self::assertSame($expected, ErrorSuggestionHelper::addHelpfulTip('config_error'));
+    }
+
+    public function test_add_helpful_tip_for_unknown_context_returns_empty_string(): void
+    {
+        self::assertSame('', ErrorSuggestionHelper::addHelpfulTip('unknown'));
+        self::assertSame('', ErrorSuggestionHelper::addHelpfulTip(''));
+    }
+}

--- a/tests/Unit/Framework/Profiler/ProfilerTest.php
+++ b/tests/Unit/Framework/Profiler/ProfilerTest.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Profiler;
 
 use Gacela\Framework\Profiler\Profiler;
+use Gacela\Framework\Profiler\TProfileEntry;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function array_sum;
+use function round;
 
 final class ProfilerTest extends TestCase
 {
@@ -118,5 +123,153 @@ final class ProfilerTest extends TestCase
         $this->profiler->stop('operation2', 'subject2'); // Stop different operation
 
         self::assertCount(0, $this->profiler->getEntries());
+    }
+
+    public function test_get_stats_returns_zero_values_when_no_entries_are_recorded(): void
+    {
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(0, $stats['total_operations']);
+        self::assertSame(0.0, $stats['total_duration']);
+        self::assertSame(0.0, $stats['avg_duration']);
+        self::assertSame(0, $stats['peak_memory']);
+        self::assertSame([], $stats['by_operation']);
+    }
+
+    public function test_duration_equals_difference_between_end_and_start_time(): void
+    {
+        $this->profiler->start('op', 'subj');
+        usleep(1000);
+        $this->profiler->stop('op', 'subj');
+
+        $entry = $this->profiler->getEntries()[0];
+
+        self::assertSame($entry->endTime - $entry->startTime, $entry->duration);
+    }
+
+    public function test_current_time_is_in_seconds_so_measurable_durations_are_sub_second(): void
+    {
+        // Guards against mutating `hrtime(true) / 1e9` → keeps the value in the
+        // second-scale range for short operations. A wrong divisor would blow
+        // the duration up by many orders of magnitude.
+        $this->profiler->start('op', 'subj');
+        usleep(1000);
+        $this->profiler->stop('op', 'subj');
+
+        $entry = $this->profiler->getEntries()[0];
+
+        self::assertLessThan(1.0, $entry->duration);
+        self::assertGreaterThan(0.0, $entry->duration);
+    }
+
+    public function test_total_duration_is_the_sum_of_all_entry_durations(): void
+    {
+        $this->injectEntries([
+            $this->entry('op1', 's1', duration: 0.001),
+            $this->entry('op1', 's2', duration: 0.002),
+            $this->entry('op2', 's3', duration: 0.004),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(round(0.001 + 0.002 + 0.004, 6), $stats['total_duration']);
+    }
+
+    public function test_avg_duration_is_total_divided_by_count_rounded_to_six_decimals(): void
+    {
+        $this->injectEntries([
+            $this->entry('op', 's1', duration: 0.001),
+            $this->entry('op', 's2', duration: 0.002),
+            $this->entry('op', 's3', duration: 0.0035),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        $expected = round(array_sum([0.001, 0.002, 0.0035]) / 3.0, 6);
+        self::assertSame($expected, $stats['avg_duration']);
+    }
+
+    public function test_per_operation_total_duration_is_sum_of_that_operations_entries(): void
+    {
+        $this->injectEntries([
+            $this->entry('op1', 's1', duration: 0.001),
+            $this->entry('op1', 's2', duration: 0.002),
+            $this->entry('op2', 's3', duration: 0.004),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(0.001 + 0.002, $stats['by_operation']['op1']['total_duration']);
+        self::assertSame(0.004, $stats['by_operation']['op2']['total_duration']);
+    }
+
+    public function test_per_operation_avg_duration_is_that_operations_total_over_count(): void
+    {
+        $this->injectEntries([
+            $this->entry('op', 's1', duration: 0.001),
+            $this->entry('op', 's2', duration: 0.002),
+            $this->entry('op', 's3', duration: 0.003),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(round((0.001 + 0.002 + 0.003) / 3.0, 6), $stats['by_operation']['op']['avg_duration']);
+    }
+
+    public function test_peak_memory_is_the_max_memory_usage_across_entries(): void
+    {
+        $this->injectEntries([
+            $this->entry('op', 's1', memoryUsage: 1024),
+            $this->entry('op', 's2', memoryUsage: 4096),
+            $this->entry('op', 's3', memoryUsage: 2048),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(4096, $stats['peak_memory']);
+    }
+
+    public function test_get_stats_rounds_total_and_avg_to_six_decimal_places(): void
+    {
+        // Picks durations whose mean has a non-zero 7th decimal digit so that
+        // mutations flipping `round()` to `ceil()`/`floor()` or dropping the
+        // precision argument produce a visibly different value.
+        $this->injectEntries([
+            $this->entry('op', 's1', duration: 0.1234567),
+            $this->entry('op', 's2', duration: 0.7654321),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(round(0.1234567 + 0.7654321, 6), $stats['total_duration']);
+        self::assertSame(round((0.1234567 + 0.7654321) / 2.0, 6), $stats['avg_duration']);
+        self::assertSame(round((0.1234567 + 0.7654321) / 2.0, 6), $stats['by_operation']['op']['avg_duration']);
+    }
+
+    /**
+     * @param list<TProfileEntry> $entries
+     */
+    private function injectEntries(array $entries): void
+    {
+        $reflection = new ReflectionClass(Profiler::class);
+        $property = $reflection->getProperty('entries');
+        $property->setValue($this->profiler, $entries);
+    }
+
+    private function entry(
+        string $operation,
+        string $subject,
+        float $duration = 0.001,
+        int $memoryUsage = 0,
+        float $startTime = 0.0,
+    ): TProfileEntry {
+        return new TProfileEntry(
+            operation: $operation,
+            subject: $subject,
+            startTime: $startTime,
+            endTime: $startTime + $duration,
+            duration: $duration,
+            memoryUsage: $memoryUsage,
+        );
     }
 }

--- a/tests/Unit/PHPStan/Rules/SuffixExtendsRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/SuffixExtendsRuleTest.php
@@ -222,4 +222,48 @@ final class SuffixExtendsRuleTest extends TestCase
 
         self::assertSame(Class_::class, $rule->getNodeType());
     }
+
+    public function test_short_name_is_the_full_class_when_there_is_no_namespace_separator(): void
+    {
+        // Class name without any backslash takes the `$pos === false` branch.
+        // This specifically exercises the identity check and ternary direction
+        // in `$shortName = $pos === false ? $className : substr(...)`.
+        $rule = new SuffixExtendsRule('Facade', AbstractFacade::class);
+        $node = self::createStub(Class_::class);
+        $node->method('isAnonymous')->willReturn(false);
+
+        $classReflection = $this->createMock(ClassReflection::class);
+        $classReflection->method('getName')->willReturn('Facade');
+        $classReflection->method('isSubclassOf')->with(AbstractFacade::class)->willReturn(false);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn($classReflection);
+
+        $result = $rule->processNode($node, $scope);
+
+        self::assertCount(1, $result);
+        self::assertStringContainsString('Facade', $result[0]);
+    }
+
+    public function test_short_name_includes_first_character_after_the_namespace_separator(): void
+    {
+        // Class `App\Facade` must be short-named `Facade`, not `acade`. This
+        // guards against `+ 1` being mutated to `+ 2` (which would skip the
+        // `F` and make str_ends_with('acade', 'Facade') fail).
+        $rule = new SuffixExtendsRule('Facade', AbstractFacade::class);
+        $node = self::createStub(Class_::class);
+        $node->method('isAnonymous')->willReturn(false);
+
+        $classReflection = $this->createMock(ClassReflection::class);
+        $classReflection->method('getName')->willReturn('App\Facade');
+        $classReflection->method('isSubclassOf')->with(AbstractFacade::class)->willReturn(false);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn($classReflection);
+
+        $result = $rule->processNode($node, $scope);
+
+        self::assertCount(1, $result);
+        self::assertStringContainsString('App\Facade', $result[0]);
+    }
 }


### PR DESCRIPTION
## 📚 Description

Attacks issue #294 by adding targeted tests that kill **139 previously-escaped mutants**, lifting Infection's MSI from **80.3% → 91.9%** (killed 964 → 1103 / 1200). Also fixes a hidden test-order dependency that crashed `composer infection` before the mutation phase could even start.

## 🔖 Changes

- Stabilize random-order runs by unsetting `GACELA_CACHE_DIR` in `FileCacheFeatureTest::tearDown()`
- New tests: `ErrorSuggestionHelperTest`, `GacelaConfigTest`; expanded `ProfilerTest`, `AbstractPhpFileCacheBatchTest`, `ConfigTest`, `MergedConfigCacheTest`, `GacelaTest`, `UseBlockParserTest`, `DocBlockParserTest`, `SuffixExtendsRuleTest`
- Bump `composer phpstan-tests` memory limit to 1G (was OOM-crashing under parallel workers)
- Ignore `.claude/scheduled_tasks.lock`

Refs #294