### PR TITLE
feat(phpstan): add module-boundary rules for Gacela users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@
 - Added suppressions to `phpstan-gacela.neon` and `psalm-gacela.xml` for dynamic resolution
 - Improved error messages with actionable suggestions and examples
 - Added `GacelaConfig::addFactory()` to register factory services that create new instances on each resolution
+- Added module-boundary PHPStan rules to `phpstan-gacela.neon`:
+  - `FacadeOnlyDelegatesRule`: Facade methods must only delegate to `$this->getFactory()`, `getConfig()`, or `getProvider()`
+  - `FactoryDoesNotCallFacadeRule`: Factories must not instantiate Facades or call `$this->getFacade()`
+  - `CrossModuleViaFacadeRule` (opt-in): cross-module references (new/static call/const fetch) must go through a `*Facade`
 
 ## [1.11.0](https://github.com/gacela-project/gacela/compare/1.10.0...1.11.0) - 2025-10-12
 

--- a/phpstan-gacela.neon
+++ b/phpstan-gacela.neon
@@ -28,3 +28,17 @@ services:
         arguments:
             suffix: Config
             expectedParent: Gacela\Framework\AbstractConfig
+    -
+        class: Gacela\PHPStan\Rules\FacadeOnlyDelegatesRule
+        tags: [phpstan.rules.rule]
+    -
+        class: Gacela\PHPStan\Rules\FactoryDoesNotCallFacadeRule
+        tags: [phpstan.rules.rule]
+    # Opt-in: enable by passing your project's root namespace (and, if needed,
+    # how many segments beneath that root identify a module).
+    # -
+    #     class: Gacela\PHPStan\Rules\CrossModuleViaFacadeRule
+    #     tags: [phpstan.rules.rule]
+    #     arguments:
+    #         rootNamespace: App\Modules
+    #         modulePathSegments: 1

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -7,3 +7,4 @@ parameters:
         - %currentWorkingDirectory%/tests/
     ignoreErrors:
         - '#Class GacelaTest\\Unit\\Framework\\Container\\NonExisting not found.#'
+        - '#Creating new PHPStan\\Node\\InClassNode is not covered by backward compatibility promise#'

--- a/src/PHPStan/Rules/CrossModuleViaFacadeRule.php
+++ b/src/PHPStan/Rules/CrossModuleViaFacadeRule.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Name;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function array_slice;
+use function count;
+use function explode;
+use function implode;
+use function sprintf;
+use function str_ends_with;
+use function str_starts_with;
+use function strlen;
+use function strrpos;
+use function substr;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+final class CrossModuleViaFacadeRule implements Rule
+{
+    public function __construct(
+        private readonly string $rootNamespace,
+        private readonly int $modulePathSegments = 1,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        $currentClass = $classReflection->getName();
+        $currentModule = $this->moduleOf($currentClass);
+        if ($currentModule === null) {
+            return [];
+        }
+
+        $classNode = $node->getOriginalNode();
+        $nodeFinder = new NodeFinder();
+        $errors = [];
+        $seen = [];
+
+        $refs = $nodeFinder->find(
+            $classNode,
+            static fn (Node $n): bool => $n instanceof New_
+                || $n instanceof StaticCall
+                || $n instanceof ClassConstFetch
+                || $n instanceof StaticPropertyFetch,
+        );
+
+        foreach ($refs as $ref) {
+            /** @var New_|StaticCall|ClassConstFetch|StaticPropertyFetch $ref */
+            if (!$ref->class instanceof Name) {
+                continue;
+            }
+
+            $referenced = $ref->class->toString();
+            $refModule = $this->moduleOf($referenced);
+            if ($refModule === null) {
+                continue;
+            }
+            if ($refModule === $currentModule) {
+                continue;
+            }
+
+            if (str_ends_with($this->shortName($referenced), 'Facade')) {
+                continue;
+            }
+
+            $key = $currentClass . '|' . $referenced;
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Class %s references %s from another module (%s). Cross-module access must go through a Facade.',
+                $currentClass,
+                $referenced,
+                $refModule,
+            ))
+                ->identifier('gacela.crossModuleWithoutFacade')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function moduleOf(string $class): ?string
+    {
+        $prefix = $this->rootNamespace . '\\';
+        if (!str_starts_with($class, $prefix)) {
+            return null;
+        }
+
+        $remainder = substr($class, strlen($prefix));
+        $segments = explode('\\', $remainder);
+        if (count($segments) <= $this->modulePathSegments) {
+            return null;
+        }
+
+        return $this->rootNamespace . '\\' . implode('\\', array_slice($segments, 0, $this->modulePathSegments));
+    }
+
+    private function shortName(string $className): string
+    {
+        $pos = strrpos($className, '\\');
+        return $pos === false ? $className : substr($className, $pos + 1);
+    }
+}

--- a/src/PHPStan/Rules/FacadeOnlyDelegatesRule.php
+++ b/src/PHPStan/Rules/FacadeOnlyDelegatesRule.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\PHPStan\Rules;
+
+use Gacela\Framework\AbstractFacade;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function count;
+use function in_array;
+use function sprintf;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+final class FacadeOnlyDelegatesRule implements Rule
+{
+    private const ALLOWED_ROOTS = ['getFactory', 'getConfig', 'getProvider'];
+
+    private const IGNORED_METHODS = [
+        '__construct',
+        'resetCache',
+        'getFactory',
+        'getConfig',
+        'getProvider',
+        'getFacade',
+    ];
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->isPublic() || $node->isAbstract() || $node->stmts === null) {
+            return [];
+        }
+
+        if (in_array($node->name->toString(), self::IGNORED_METHODS, true)) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        if (!$classReflection->isSubclassOf(AbstractFacade::class)) {
+            return [];
+        }
+
+        $stmts = $node->stmts;
+        if ($stmts === []) {
+            return [];
+        }
+
+        if (count($stmts) !== 1 || !$this->isDelegateStatement($stmts[0])) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Facade method %s::%s() must only delegate to $this->getFactory()/getConfig()/getProvider(); no inline logic allowed.',
+                    $classReflection->getName(),
+                    $node->name->toString(),
+                ))
+                    ->identifier('gacela.facadeOnlyDelegates')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    private function isDelegateStatement(Node $stmt): bool
+    {
+        $expr = match (true) {
+            $stmt instanceof Return_ => $stmt->expr,
+            $stmt instanceof Expression => $stmt->expr,
+            default => null,
+        };
+
+        return $expr !== null && $this->isDelegateChain($expr);
+    }
+
+    private function isDelegateChain(Expr $expr): bool
+    {
+        $current = $expr;
+        while (true) {
+            if ($current instanceof MethodCall || $current instanceof NullsafeMethodCall) {
+                if (
+                    $current->var instanceof Variable
+                    && $current->var->name === 'this'
+                    && $current->name instanceof Identifier
+                    && in_array($current->name->toString(), self::ALLOWED_ROOTS, true)
+                ) {
+                    return true;
+                }
+
+                $current = $current->var;
+                continue;
+            }
+
+            if ($current instanceof PropertyFetch || $current instanceof NullsafePropertyFetch) {
+                $current = $current->var;
+                continue;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/PHPStan/Rules/FactoryDoesNotCallFacadeRule.php
+++ b/src/PHPStan/Rules/FactoryDoesNotCallFacadeRule.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\PHPStan\Rules;
+
+use Gacela\Framework\AbstractFactory;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function sprintf;
+use function str_ends_with;
+use function strrpos;
+use function substr;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+final class FactoryDoesNotCallFacadeRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        if (!$classReflection->isSubclassOf(AbstractFactory::class)) {
+            return [];
+        }
+
+        $classNode = $node->getOriginalNode();
+        $nodeFinder = new NodeFinder();
+        $errors = [];
+
+        /** @var New_[] $newExpressions */
+        $newExpressions = $nodeFinder->findInstanceOf($classNode, New_::class);
+        foreach ($newExpressions as $new) {
+            if (!$new->class instanceof Name) {
+                continue;
+            }
+
+            $className = $new->class->toString();
+            if (!str_ends_with($this->shortName($className), 'Facade')) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Factory %s must not instantiate a Facade (found: new %s). Depend on other modules through their Facade via the Provider.',
+                $classReflection->getName(),
+                $className,
+            ))
+                ->identifier('gacela.factoryInstantiatesFacade')
+                ->build();
+        }
+
+        /** @var MethodCall[] $methodCalls */
+        $methodCalls = $nodeFinder->findInstanceOf($classNode, MethodCall::class);
+        foreach ($methodCalls as $call) {
+            if (!$call->name instanceof Identifier) {
+                continue;
+            }
+            if ($call->name->toString() !== 'getFacade') {
+                continue;
+            }
+
+            if (!$call->var instanceof Variable) {
+                continue;
+            }
+            if ($call->var->name !== 'this') {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Factory %s must not call $this->getFacade(); same-module access goes through the Factory itself, cross-module access goes through the Provider.',
+                $classReflection->getName(),
+            ))
+                ->identifier('gacela.factoryCallsGetFacade')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function shortName(string $className): string
+    {
+        $pos = strrpos($className, '\\');
+        return $pos === false ? $className : substr($className, $pos + 1);
+    }
+}

--- a/tests/Unit/PHPStan/Rules/CrossModuleViaFacadeRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/CrossModuleViaFacadeRuleTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules;
+
+use Gacela\PHPStan\Rules\CrossModuleViaFacadeRule;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\ParserFactory;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function is_string;
+use function sprintf;
+
+final class CrossModuleViaFacadeRuleTest extends TestCase
+{
+    public function test_reports_cross_module_new_of_non_facade(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): void
+                    {
+                        new \App\Modules\Shop\Domain\ShopService();
+                    }
+                }
+            ',
+        );
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('App\Modules\User\UserFactory', $errors[0]);
+        self::assertStringContainsString('App\Modules\Shop\Domain\ShopService', $errors[0]);
+        self::assertStringContainsString('App\Modules\Shop', $errors[0]);
+    }
+
+    public function test_allows_cross_module_facade_reference(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): object
+                    {
+                        return new \App\Modules\Shop\ShopFacade();
+                    }
+                }
+            ',
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_allows_same_module_reference(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): object
+                    {
+                        return new \App\Modules\User\Domain\UserService();
+                    }
+                }
+            ',
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_ignores_classes_outside_root_namespace(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): \DateTimeImmutable
+                    {
+                        return new \DateTimeImmutable();
+                    }
+                }
+            ',
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_skips_when_current_class_is_outside_root_namespace(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'Vendor\Other\SomeClass',
+            classSource: '
+                final class SomeClass {
+                    public function a(): void
+                    {
+                        new \App\Modules\Shop\Domain\ShopService();
+                    }
+                }
+            ',
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_reports_static_call_into_another_module(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): void
+                    {
+                        \App\Modules\Shop\Domain\ShopService::doStuff();
+                    }
+                }
+            ',
+        );
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_reports_class_const_fetch_into_another_module(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): string
+                    {
+                        return \App\Modules\Shop\Domain\ShopService::class;
+                    }
+                }
+            ',
+        );
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_deduplicates_repeated_violations(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): object
+                    {
+                        return new \App\Modules\Shop\Domain\ShopService();
+                    }
+                    public function b(): object
+                    {
+                        return new \App\Modules\Shop\Domain\ShopService();
+                    }
+                }
+            ',
+        );
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_respects_module_path_segments_setting(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\Admin\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): object
+                    {
+                        return new \App\Modules\Admin\Shop\ShopService();
+                    }
+                }
+            ',
+            rootNamespace: 'App\Modules',
+            modulePathSegments: 2,
+        );
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_same_first_segment_is_same_module_when_depth_is_one(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\Admin\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): object
+                    {
+                        return new \App\Modules\Admin\Shop\ShopService();
+                    }
+                }
+            ',
+            rootNamespace: 'App\Modules',
+            modulePathSegments: 1,
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_ignores_references_with_no_module_depth(): void
+    {
+        $errors = $this->runOn(
+            currentClass: 'App\Modules\User\UserFactory',
+            classSource: '
+                final class UserFactory {
+                    public function a(): object
+                    {
+                        return new \App\Modules\Other();
+                    }
+                }
+            ',
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_skips_when_class_reflection_is_null(): void
+    {
+        $rule = new CrossModuleViaFacadeRule('App\Modules');
+        $classLike = $this->parseClass(
+            '
+            final class UserFactory {
+                public function a(): void { new \App\Modules\Shop\Domain\ShopService(); }
+            }
+        ',
+            'App\Modules\User',
+        );
+        $reflection = $this->createMock(ClassReflection::class);
+        $inClassNode = new InClassNode($classLike, $reflection);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn(null);
+
+        self::assertSame([], $rule->processNode($inClassNode, $scope));
+    }
+
+    public function test_get_node_type_returns_in_class_node(): void
+    {
+        $rule = new CrossModuleViaFacadeRule('App\Modules');
+        self::assertSame(InClassNode::class, $rule->getNodeType());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function runOn(
+        string $currentClass,
+        string $classSource,
+        string $rootNamespace = 'App\Modules',
+        int $modulePathSegments = 1,
+    ): array {
+        $pos = strrpos($currentClass, '\\');
+        $namespace = $pos === false ? '' : substr($currentClass, 0, $pos);
+
+        $classLike = $this->parseClass($classSource, $namespace);
+
+        $reflection = $this->createMock(ClassReflection::class);
+        $reflection->method('getName')->willReturn($currentClass);
+
+        $inClassNode = new InClassNode($classLike, $reflection);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn($reflection);
+
+        $rule = new CrossModuleViaFacadeRule($rootNamespace, $modulePathSegments);
+        $errors = $rule->processNode($inClassNode, $scope);
+
+        return array_map(
+            static fn ($error): string => is_string($error) ? $error : $error->getMessage(),
+            $errors,
+        );
+    }
+
+    private function parseClass(string $classSource, string $namespace): ClassLike
+    {
+        $code = $namespace === ''
+            ? sprintf("<?php\n%s\n", $classSource)
+            : sprintf("<?php\nnamespace %s;\n%s\n", $namespace, $classSource);
+        $parser = (new ParserFactory())->createForHostVersion();
+        $ast = $parser->parse($code);
+        assert($ast !== null);
+
+        if ($namespace === '') {
+            $classLike = $ast[0];
+        } else {
+            $ns = $ast[0];
+            assert($ns instanceof Namespace_);
+            $classLike = $ns->stmts[0];
+        }
+
+        assert($classLike instanceof ClassLike);
+
+        return $classLike;
+    }
+}

--- a/tests/Unit/PHPStan/Rules/FacadeOnlyDelegatesRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/FacadeOnlyDelegatesRuleTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\PHPStan\Rules\FacadeOnlyDelegatesRule;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\ParserFactory;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function is_string;
+use function sprintf;
+
+final class FacadeOnlyDelegatesRuleTest extends TestCase
+{
+    public function test_returns_no_error_for_single_return_delegating_to_factory(): void
+    {
+        $method = $this->parseMethod('
+            public function doSomething(): int
+            {
+                return $this->getFactory()->createService()->run();
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_returns_no_error_for_single_expression_delegating_to_factory(): void
+    {
+        $method = $this->parseMethod('
+            public function doSomething(): void
+            {
+                $this->getFactory()->createService()->run();
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_returns_no_error_for_get_config_delegation(): void
+    {
+        $method = $this->parseMethod('
+            public function getEndpoint(): string
+            {
+                return $this->getConfig()->getEndpoint();
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_returns_no_error_for_get_provider_delegation(): void
+    {
+        $method = $this->parseMethod('
+            public function getClient(): object
+            {
+                return $this->getProvider()->getClient();
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_returns_no_error_for_property_access_on_delegate_chain(): void
+    {
+        $method = $this->parseMethod('
+            public function value(): int
+            {
+                return $this->getFactory()->createThing()->value;
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_returns_no_error_for_nullsafe_chain(): void
+    {
+        $method = $this->parseMethod('
+            public function maybe(): ?int
+            {
+                return $this->getFactory()?->createThing()?->value;
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_returns_no_error_for_empty_body(): void
+    {
+        $method = $this->parseMethod('
+            public function noop(): void
+            {
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_reports_error_for_multiple_statements(): void
+    {
+        $method = $this->parseMethod('
+            public function compute(): int
+            {
+                $value = $this->getFactory()->createService()->run();
+                return $value;
+            }
+        ');
+
+        $errors = $this->runRule($method, isFacade: true);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('compute', $errors[0]);
+        self::assertStringContainsString('delegate', $errors[0]);
+    }
+
+    public function test_reports_error_for_local_logic_without_delegation(): void
+    {
+        $method = $this->parseMethod('
+            public function compute(int $x): int
+            {
+                return $x + 1;
+            }
+        ');
+
+        $errors = $this->runRule($method, isFacade: true);
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_reports_error_for_control_flow(): void
+    {
+        $method = $this->parseMethod('
+            public function conditional(bool $flag): int
+            {
+                if ($flag) {
+                    return $this->getFactory()->createA()->run();
+                }
+                return $this->getFactory()->createB()->run();
+            }
+        ');
+
+        $errors = $this->runRule($method, isFacade: true);
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_reports_error_when_root_is_not_an_allowed_accessor(): void
+    {
+        $method = $this->parseMethod('
+            public function compute(): int
+            {
+                return $this->somethingElse()->run();
+            }
+        ');
+
+        $errors = $this->runRule($method, isFacade: true);
+
+        self::assertCount(1, $errors);
+    }
+
+    public function test_skips_non_public_methods(): void
+    {
+        $method = $this->parseMethod('
+            protected function helper(): int
+            {
+                $value = 42;
+                return $value;
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_skips_abstract_methods(): void
+    {
+        $method = $this->parseMethod(
+            '
+            abstract public function contract(): int;
+        ',
+            inAbstractClass: true,
+        );
+
+        self::assertSame([], $this->runRule($method, isFacade: true));
+    }
+
+    public function test_skips_classes_that_are_not_facades(): void
+    {
+        $method = $this->parseMethod('
+            public function compute(): int
+            {
+                $value = 1;
+                return $value;
+            }
+        ');
+
+        self::assertSame([], $this->runRule($method, isFacade: false));
+    }
+
+    public function test_skips_when_class_reflection_is_null(): void
+    {
+        $method = $this->parseMethod('
+            public function compute(): int
+            {
+                $value = 1;
+                return $value;
+            }
+        ');
+
+        $rule = new FacadeOnlyDelegatesRule();
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn(null);
+
+        self::assertSame([], $rule->processNode($method, $scope));
+    }
+
+    public function test_skips_reset_cache_and_accessor_methods(): void
+    {
+        foreach (['resetCache', 'getFactory', 'getConfig', 'getProvider', 'getFacade', '__construct'] as $name) {
+            $method = $this->parseMethod(sprintf(
+                '
+                public function %s(): int
+                {
+                    $value = 1;
+                    return $value;
+                }
+            ',
+                $name,
+            ));
+
+            self::assertSame([], $this->runRule($method, isFacade: true), $name);
+        }
+    }
+
+    public function test_get_node_type_returns_class_method(): void
+    {
+        $rule = new FacadeOnlyDelegatesRule();
+        self::assertSame(ClassMethod::class, $rule->getNodeType());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function runRule(ClassMethod $method, bool $isFacade): array
+    {
+        $rule = new FacadeOnlyDelegatesRule();
+
+        $classReflection = $this->createMock(ClassReflection::class);
+        $classReflection->method('getName')->willReturn('App\Module\UserFacade');
+        $classReflection->method('isSubclassOf')->with(AbstractFacade::class)->willReturn($isFacade);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn($classReflection);
+
+        $errors = $rule->processNode($method, $scope);
+
+        return array_map(
+            static fn ($error): string => is_string($error) ? $error : $error->getMessage(),
+            $errors,
+        );
+    }
+
+    private function parseMethod(string $methodSource, bool $inAbstractClass = false): ClassMethod
+    {
+        $prefix = $inAbstractClass ? 'abstract ' : '';
+        $code = sprintf(
+            "<?php\nnamespace App\\Module;\n%sclass UserFacade {\n%s\n}\n",
+            $prefix,
+            $methodSource,
+        );
+
+        $parser = (new ParserFactory())->createForHostVersion();
+        $ast = $parser->parse($code);
+        assert($ast !== null);
+
+        $class = $ast[0];
+        assert($class instanceof \PhpParser\Node\Stmt\Namespace_);
+        $classLike = $class->stmts[0];
+        assert($classLike instanceof \PhpParser\Node\Stmt\Class_);
+        $method = $classLike->stmts[0];
+        assert($method instanceof ClassMethod);
+
+        return $method;
+    }
+}

--- a/tests/Unit/PHPStan/Rules/FactoryDoesNotCallFacadeRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/FactoryDoesNotCallFacadeRuleTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\PHPStan\Rules\FactoryDoesNotCallFacadeRule;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\ParserFactory;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function is_string;
+use function sprintf;
+
+final class FactoryDoesNotCallFacadeRuleTest extends TestCase
+{
+    public function test_reports_new_facade_instantiation(): void
+    {
+        $errors = $this->runOn('
+            final class UserFactory {
+                public function createSomething(): void
+                {
+                    new \App\Module\Shop\ShopFacade();
+                }
+            }
+        ');
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('must not instantiate a Facade', $errors[0]);
+        self::assertStringContainsString('ShopFacade', $errors[0]);
+    }
+
+    public function test_reports_get_facade_call_on_this(): void
+    {
+        $errors = $this->runOn('
+            final class UserFactory {
+                public function createSomething(): void
+                {
+                    $this->getFacade()->doStuff();
+                }
+            }
+        ');
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('must not call $this->getFacade()', $errors[0]);
+    }
+
+    public function test_ignores_get_facade_call_on_other_variables(): void
+    {
+        $errors = $this->runOn('
+            final class UserFactory {
+                public function createSomething(object $service): void
+                {
+                    $service->getFacade();
+                }
+            }
+        ');
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_ignores_new_non_facade(): void
+    {
+        $errors = $this->runOn('
+            final class UserFactory {
+                public function createSomething(): object
+                {
+                    return new \App\Module\User\Domain\UserService();
+                }
+            }
+        ');
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_ignores_dynamic_new_expression(): void
+    {
+        $errors = $this->runOn('
+            final class UserFactory {
+                public function createSomething(string $class): object
+                {
+                    return new $class();
+                }
+            }
+        ');
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_detects_multiple_violations(): void
+    {
+        $errors = $this->runOn('
+            final class UserFactory {
+                public function a(): void
+                {
+                    new \App\Module\Shop\ShopFacade();
+                }
+                public function b(): void
+                {
+                    $this->getFacade()->doStuff();
+                }
+            }
+        ');
+
+        self::assertCount(2, $errors);
+    }
+
+    public function test_skips_non_factory_classes(): void
+    {
+        $errors = $this->runOn(
+            '
+            final class UserService {
+                public function doIt(): void
+                {
+                    $this->getFacade()->doStuff();
+                }
+            }
+        ',
+            isFactory: false,
+        );
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_skips_when_class_reflection_is_null(): void
+    {
+        $rule = new FactoryDoesNotCallFacadeRule();
+
+        $classLike = $this->parseClass('
+            final class UserFactory {
+                public function a(): void { new \App\Module\Shop\ShopFacade(); }
+            }
+        ');
+
+        $reflection = $this->createMock(ClassReflection::class);
+        $inClassNode = new InClassNode($classLike, $reflection);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn(null);
+
+        self::assertSame([], $rule->processNode($inClassNode, $scope));
+    }
+
+    public function test_get_node_type_returns_in_class_node(): void
+    {
+        $rule = new FactoryDoesNotCallFacadeRule();
+        self::assertSame(InClassNode::class, $rule->getNodeType());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function runOn(string $classSource, bool $isFactory = true): array
+    {
+        $classLike = $this->parseClass($classSource);
+
+        $reflection = $this->createMock(ClassReflection::class);
+        $reflection->method('getName')->willReturn('App\Module\User\UserFactory');
+        $reflection->method('isSubclassOf')->with(AbstractFactory::class)->willReturn($isFactory);
+
+        $inClassNode = new InClassNode($classLike, $reflection);
+
+        $scope = self::createStub(Scope::class);
+        $scope->method('getClassReflection')->willReturn($reflection);
+
+        $rule = new FactoryDoesNotCallFacadeRule();
+        $errors = $rule->processNode($inClassNode, $scope);
+
+        return array_map(
+            static fn ($error): string => is_string($error) ? $error : $error->getMessage(),
+            $errors,
+        );
+    }
+
+    private function parseClass(string $classSource): ClassLike
+    {
+        $code = sprintf("<?php\nnamespace App\\Module\\User;\n%s\n", $classSource);
+        $parser = (new ParserFactory())->createForHostVersion();
+        $ast = $parser->parse($code);
+        assert($ast !== null);
+
+        $namespace = $ast[0];
+        assert($namespace instanceof Namespace_);
+        $classLike = $namespace->stmts[0];
+        assert($classLike instanceof ClassLike);
+
+        return $classLike;
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds three PHPStan rules to `phpstan-gacela.neon` that enforce Gacela's architectural boundaries between modules. These complement the existing `SuffixExtendsRule` by catching structural misuse that the naming/suffix check alone can't detect.

## 🔖 Changes

- **`FacadeOnlyDelegatesRule`** (auto-enabled): public methods on `AbstractFacade` subclasses must be a single statement that delegates to `$this->getFactory()`, `$this->getConfig()`, or `$this->getProvider()`. Chains and nullsafe operators allowed. Inline logic, control flow, or multi-statement bodies are rejected. Skips `__construct`, `resetCache`, and the accessor methods themselves.
- **`FactoryDoesNotCallFacadeRule`** (auto-enabled): flags `new *Facade(...)` and `$this->getFacade()` inside any `AbstractFactory` subclass. Same-module access must go through the Factory itself; cross-module access must be injected via the Provider.
- **`CrossModuleViaFacadeRule`** (opt-in, configurable): flags cross-module `new`, `::method()`, `::CONST`, `::class`, and `::$prop` references whose target class doesn't end with `Facade`. Takes `rootNamespace` and `modulePathSegments` (default `1`) so users can define what counts as a module boundary in their project. Commented out in `phpstan-gacela.neon` with an example — consumers uncomment and set their namespace to enable.
- All three rules emit errors via `RuleErrorBuilder` with `gacela.*` identifiers so consumers can ignore them by identifier if needed.
- Adds 39 unit tests covering positive/negative paths and edge cases (nullsafe chains, abstract methods, non-pillar classes, deduplication, configurable depth, null reflection, etc.).
- `phpstan-tests.neon`: ignore the `InClassNode` BC-promise warning raised by the new tests (they construct `InClassNode` directly in fixtures).
- `CHANGELOG.md`: entries under `## Unreleased`.

## Test plan

- [ ] `composer quality` (php-cs-fixer, psalm, phpstan, phpstan-tests) — green
- [ ] `composer phpunit` (unit + integration + feature) — green
- [ ] Manual smoke: enable `CrossModuleViaFacadeRule` in a downstream project and confirm the violations surface