### PR TITLE
🐛 fix(ci): switch mutation tests to pcov to stop flaky coverage failures

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -19,8 +19,9 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          coverage: xdebug
+          coverage: pcov
           tools: composer
+          ini-values: opcache.enable_cli=0
 
       - name: Install dependencies
         run: composer install --prefer-dist


### PR DESCRIPTION
## 📚 Description

The **Mutation Tests** workflow on `main` has been flaking intermittently since April 12 with:

```
Message:  Undefined constant PhpParser\Node\Expr\List_::KIND_ARRAY
Location: vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:1025
```

Example failing run: https://github.com/gacela-project/gacela/actions/runs/24415999881/job/71325177778

Some runs on the same lockfile passed, others failed — classic infra flake.

### Investigation

- The constant **is defined** in `PhpParser\Node\Expr\List_` (both v5.6.x and v5.7.0), so it is not a real missing-constant issue.
- **Pinning `nikic/php-parser` to `~5.6.0`** (the previous known-good) did **not** fix it — the same flake reproduced on the first CI run after the downgrade.
- The failure only appears on **PHP 8.1 + Xdebug 3.5 during coverage tracking**. It does not reproduce on PHP 8.4 locally, and the regular Tests workflow (no coverage) is green across 8.1–8.4.
- Pattern matches the known PHP 8.1 + OPcache + Xdebug-coverage interaction where class-constant lookups can be perturbed under load.

### Fix

- Switch the Mutation Tests workflow from `coverage: xdebug` to `coverage: pcov` — pcov is purpose-built for coverage, no OPcache coupling, and is fully supported by Infection.
- Explicitly set `opcache.enable_cli=0` to remove any residual interaction.

### Verification

- ✅ Mutation Tests green on this PR (2m02s): https://github.com/gacela-project/gacela/actions/runs/24417487315/job/71330502316
- ✅ `composer quality` locally
- ✅ full `phpunit` suite (579 tests) locally

## 🔖 Changes

- `.github/workflows/mutation-testing.yml`
  - `coverage: xdebug` → `coverage: pcov`
  - add `ini-values: opcache.enable_cli=0`