### PR TITLE
feat(cacheable): improve #[Cacheable] facade DX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `CacheableTrait::cached()` now infers the method name and arguments from the caller's stack frame; callers write `$this->cached(fn () => ...)` instead of `$this->cached(__METHOD__, [...], fn () => ...)`
+- `CacheableTrait::cached()` now infers the method name and arguments from the caller's stack frame; callers write `$this->cached(fn () => ...)` instead of `$this->cached(__METHOD__, [...], fn () => ...)`. Callers may still pass `$method` and `$args` explicitly (`$this->cached(fn () => ..., __METHOD__, [$id])`) to skip `debug_backtrace()` on hot paths or when `cached()` is invoked from a helper
 - `#[Cacheable]` storage is now pluggable via `CacheStorageInterface` (default: `InMemoryCacheStorage`); swap with `CacheableConfig::setStorage()`
 - Per-method TTL overrides via `CacheableConfig::setTtlOverrides(['Class::method' => $seconds])`
 - `Cacheable::$key` accepts `{N}` placeholders that interpolate the Nth caller argument (e.g. `key: 'user:{0}'`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- `CacheableTrait::cached()` now infers the method name and arguments from the caller's stack frame; callers write `$this->cached(fn () => ...)` instead of `$this->cached(__METHOD__, [...], fn () => ...)`
+- `#[Cacheable]` storage is now pluggable via `CacheStorageInterface` (default: `InMemoryCacheStorage`); swap with `CacheableConfig::setStorage()`
+- Per-method TTL overrides via `CacheableConfig::setTtlOverrides(['Class::method' => $seconds])`
+- `Cacheable::$key` accepts `{N}` placeholders that interpolate the Nth caller argument (e.g. `key: 'user:{0}'`)
+- `clearMethodCacheFor($method)` now matches exact `Class::method::` prefixes rather than substrings, so `clearMethodCacheFor('get')` no longer clears every method containing "get"
+
 ## [1.13.0](https://github.com/gacela-project/gacela/compare/1.12.0...1.13.0) - 2026-04-15
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Container configuration](container-configuration.md) — factories, aliases, contextual bindings
 - [Static analysis](static-analysis.md) — PHPStan and Psalm setup
 - [Module health checks](module-health-checks.md) — report module operational status
+- [Cacheable methods](cacheable-methods.md) — cache facade method results with `#[Cacheable]`
 - [Opcache preload](opcache-preload.md) — production performance tuning
 
 Full reference: [gacela-project.com](https://gacela-project.com/)

--- a/docs/cacheable-methods.md
+++ b/docs/cacheable-methods.md
@@ -1,0 +1,155 @@
+# Cacheable Facade Methods
+
+Cache the result of a facade method for a given TTL using the `#[Cacheable]` attribute and `CacheableTrait`.
+
+## Quick start
+
+```php
+use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableTrait;
+use Gacela\Framework\AbstractFacade;
+
+final class CatalogFacade extends AbstractFacade
+{
+    use CacheableTrait;
+
+    #[Cacheable(ttl: 3600)]
+    public function getPopularProducts(): array
+    {
+        return $this->cached(fn (): array =>
+            $this->getFactory()->createRepository()->fetchPopular(),
+        );
+    }
+}
+```
+
+Subsequent calls within the TTL return the cached value without invoking the callback.
+
+## How it works
+
+`#[Cacheable]` is metadata only. The real caching happens inside `$this->cached(...)`, which:
+
+1. Reads the attribute via reflection (memoized per `Class::method`).
+2. Builds a cache key from the class, method, and arguments.
+3. Returns the cached value on hit, or runs the callback and stores the result on miss.
+
+The method name and arguments are inferred from the caller's stack frame via `debug_backtrace()`. You don't pass them — but you can, for performance or when calling from a helper (see [Opting out of backtrace](#opting-out-of-backtrace) below).
+
+## Arguments shape the cache key
+
+Calls with different arguments are cached separately.
+
+```php
+#[Cacheable(ttl: 600)]
+public function findUser(int $id): User
+{
+    return $this->cached(fn (): User =>
+        $this->getFactory()->createRepository()->find($id),
+    );
+}
+
+$facade->findUser(1); // runs callback, caches under key ending in "::1"
+$facade->findUser(1); // cache hit
+$facade->findUser(2); // runs callback, separate entry
+```
+
+Single `int` or `string` arguments become part of the key directly (`Facade::method::42`). Other types (arrays, objects, multiple args) fall back to `md5(serialize(...))`.
+
+## Custom key templates
+
+Use `key` with `{N}` placeholders to interpolate the Nth argument into the cache key — useful for shared keys across modules or for readable keys in an external cache.
+
+```php
+#[Cacheable(ttl: 3600, key: 'user:{0}')]
+public function getUser(int $id): array
+{
+    return $this->cached(fn (): array =>
+        $this->getFactory()->createRepository()->find($id),
+    );
+}
+```
+
+A bare string with no placeholders is args-agnostic — every call shares the same entry regardless of arguments. That's rarely what you want when the method takes parameters.
+
+## Clearing the cache
+
+```php
+// Clear everything for this facade class
+CatalogFacade::clearMethodCache();
+
+// Clear all entries for a specific method (any args)
+CatalogFacade::clearMethodCacheFor('getPopularProducts');
+```
+
+`clearMethodCacheFor()` matches on the exact `Class::method::` prefix. Passing `'get'` does **not** clear every method whose name starts with `get`.
+
+## Pluggable storage backend
+
+By default, cache lives in process memory via `InMemoryCacheStorage`. On PHP-FPM that means entries die with the request — fine for batch jobs and long-running workers, but effectively a no-op for typical web traffic.
+
+Swap in any backend that implements `CacheStorageInterface` (e.g. APCu, Redis, a PSR-16 adapter):
+
+```php
+use Gacela\Framework\Attribute\CacheableConfig;
+
+CacheableConfig::setStorage(new RedisCacheStorage($redis));
+```
+
+The interface is small:
+
+```php
+interface CacheStorageInterface
+{
+    public function has(string $key): bool;
+    public function get(string $key, mixed $default = null): mixed;
+    public function set(string $key, mixed $value, int $ttl): void;
+    public function delete(string $key): void;
+    public function clear(): void;
+    public function deleteByPrefix(string $prefix): void;
+}
+```
+
+Call `CacheableConfig::setStorage()` once at bootstrap. All facades using `CacheableTrait` share the same backend.
+
+## TTL overrides per method
+
+Override the TTL declared on the attribute without changing code — useful for tuning hot paths per environment.
+
+```php
+CacheableConfig::setTtlOverrides([
+    CatalogFacade::class . '::getPopularProducts' => 60,   // tighten in staging
+    UserFacade::class . '::getUser' => 86400,              // loosen in prod
+]);
+```
+
+The override applies on the next `set()`; existing entries keep their original expiry until evicted.
+
+## Opting out of backtrace
+
+`cached()` calls `debug_backtrace()` (limit 2) to infer the method name and arguments. Cost is 1–5 µs — unmeasurable for typical "expensive" methods (DB, HTTP). Pass `$method` and `$args` explicitly when:
+
+- The cached operation itself is very fast and the overhead matters.
+- The method takes very large arguments (frame-construction cost scales with arg count).
+- `cached()` is called from a private helper rather than the attributed method itself (backtrace would pick the helper, find no attribute, and skip caching).
+
+```php
+#[Cacheable(ttl: 3600)]
+public function getUser(int $id): array
+{
+    return $this->cached(
+        fn (): array => $this->getFactory()->createRepository()->find($id),
+        __METHOD__,
+        [$id],
+    );
+}
+```
+
+## Caching `null`
+
+A method that returns `null` is cached correctly — repeated calls do **not** re-invoke the callback. `CacheableTrait` distinguishes "cached null" from "cache miss" via a sentinel, so `Optional`-style return types work as expected.
+
+## Limitations
+
+- **Per-process by default.** Entries in `InMemoryCacheStorage` do not survive the request on PHP-FPM. Use a shared backend (APCu, Redis) if you need cross-request caching.
+- **Serialization.** The default key and miss detection rely on `serialize()` for non-scalar arguments. Arguments containing closures or resources cannot be serialized and will throw.
+- **Memoized attribute metadata.** The `#[Cacheable]` attribute is reflected once per `Class::method` and cached for the lifetime of the process. Changing the attribute at runtime has no effect; change the code and redeploy.

--- a/src/Framework/Attribute/CacheStorageInterface.php
+++ b/src/Framework/Attribute/CacheStorageInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Attribute;
+
+/**
+ * Pluggable backend for #[Cacheable] method results.
+ *
+ * Implementations can adapt any store (in-memory, APCu, Redis, PSR-16, ...).
+ * Register a custom backend via CacheableConfig::setStorage().
+ */
+interface CacheStorageInterface
+{
+    public function has(string $key): bool;
+
+    public function get(string $key): mixed;
+
+    public function set(string $key, mixed $value, int $ttl): void;
+
+    public function delete(string $key): void;
+
+    public function clear(): void;
+
+    public function deleteByPrefix(string $prefix): void;
+}

--- a/src/Framework/Attribute/CacheStorageInterface.php
+++ b/src/Framework/Attribute/CacheStorageInterface.php
@@ -14,7 +14,12 @@ interface CacheStorageInterface
 {
     public function has(string $key): bool;
 
-    public function get(string $key): mixed;
+    /**
+     * Returns $default when $key is not present or has expired.
+     * The default is used as a miss-sentinel by CacheableTrait to avoid a
+     * separate has()+get() round-trip on the hot path.
+     */
+    public function get(string $key, mixed $default = null): mixed;
 
     public function set(string $key, mixed $value, int $ttl): void;
 

--- a/src/Framework/Attribute/Cacheable.php
+++ b/src/Framework/Attribute/Cacheable.php
@@ -9,15 +9,32 @@ use Attribute;
 /**
  * Marks a facade method as cacheable with optional TTL.
  *
- * When applied to a facade method, the result will be cached and reused
- * for subsequent calls within the TTL period.
+ * The facade must `use CacheableTrait` and the method body must delegate to
+ * `$this->cached(fn () => ...)`. The trait infers the method name and
+ * arguments from the caller's stack frame and reads this attribute via
+ * reflection to obtain the TTL and (optional) key template.
+ *
+ * The `key` parameter accepts `{N}` placeholders referencing the Nth caller
+ * argument; e.g. `key: 'user:{0}'` interpolates the first argument.
+ * A bare string with no placeholders is args-agnostic and shared across all
+ * calls — rarely what you want when the method takes parameters.
  *
  * Example:
  * ```php
- * #[Cacheable(ttl: 3600)] // Cache for 1 hour
- * public function getExpensiveData(): array
+ * use Gacela\Framework\Attribute\Cacheable;
+ * use Gacela\Framework\Attribute\CacheableTrait;
+ *
+ * final class MyFacade
  * {
- *     return $this->getFactory()->createRepository()->fetchData();
+ *     use CacheableTrait;
+ *
+ *     #[Cacheable(ttl: 3600, key: 'user:{0}')]
+ *     public function getUser(int $id): array
+ *     {
+ *         return $this->cached(fn (): array =>
+ *             $this->getFactory()->createRepository()->find($id),
+ *         );
+ *     }
  * }
  * ```
  */
@@ -25,8 +42,8 @@ use Attribute;
 final class Cacheable
 {
     /**
-     * @param int $ttl Time-to-live in seconds (default: 3600 = 1 hour)
-     * @param string|null $key Custom cache key (default: auto-generated from class::method::args)
+     * @param int $ttl default TTL in seconds; may be overridden per-method via CacheableConfig::setTtlOverrides()
+     * @param string|null $key custom key template (supports `{N}` placeholders); null = auto-generated from class::method::args
      */
     public function __construct(
         public readonly int $ttl = 3600,

--- a/src/Framework/Attribute/CacheableConfig.php
+++ b/src/Framework/Attribute/CacheableConfig.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Attribute;
+
+/**
+ * Process-wide configuration for the #[Cacheable] feature.
+ *
+ * - Storage backend (defaults to in-memory per-process cache).
+ * - Per-method TTL overrides, keyed by "Fully\Qualified\Class::method".
+ *
+ * Configure once at bootstrap; values are shared by every facade using CacheableTrait.
+ */
+final class CacheableConfig
+{
+    private static ?CacheStorageInterface $storage = null;
+
+    /** @var array<string,int> */
+    private static array $ttlOverrides = [];
+
+    public static function setStorage(CacheStorageInterface $storage): void
+    {
+        self::$storage = $storage;
+    }
+
+    public static function getStorage(): CacheStorageInterface
+    {
+        return self::$storage ??= new InMemoryCacheStorage();
+    }
+
+    /**
+     * @param array<string,int> $overrides map of "Class::method" => ttl in seconds
+     */
+    public static function setTtlOverrides(array $overrides): void
+    {
+        self::$ttlOverrides = $overrides;
+    }
+
+    public static function resolveTtl(string $classMethod, int $default): int
+    {
+        return self::$ttlOverrides[$classMethod] ?? $default;
+    }
+
+    public static function reset(): void
+    {
+        self::$storage = null;
+        self::$ttlOverrides = [];
+    }
+}

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -4,105 +4,86 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Attribute;
 
-use ReflectionClass;
+use Closure;
 use ReflectionMethod;
 
-use function end;
-use function explode;
+use function debug_backtrace;
+use function is_scalar;
 use function md5;
+use function preg_replace_callback;
 use function serialize;
 use function sprintf;
-use function time;
 
 /**
- * Trait that enables #[Cacheable] attribute support for facade methods.
+ * Enables #[Cacheable] support for facade methods.
  *
- * Add this trait to your facade to automatically cache methods marked with #[Cacheable].
+ * Usage:
+ * ```php
+ * use Gacela\Framework\Attribute\Cacheable;
+ * use Gacela\Framework\Attribute\CacheableTrait;
+ *
+ * final class MyFacade
+ * {
+ *     use CacheableTrait;
+ *
+ *     #[Cacheable(ttl: 3600)]
+ *     public function getExpensiveData(int $id): array
+ *     {
+ *         return $this->cached(fn (): array =>
+ *             $this->getFactory()->createRepository()->fetchData($id),
+ *         );
+ *     }
+ * }
+ * ```
+ *
+ * The method name and arguments are inferred from the caller's stack frame;
+ * the #[Cacheable] attribute supplies TTL and (optionally) a custom key template.
  */
 trait CacheableTrait
 {
-    /** @var array<string,array{result:mixed,expires:int}> */
-    private static array $methodCache = [];
-
-    /**
-     * Clear all cached method results.
-     */
     public static function clearMethodCache(): void
     {
-        self::$methodCache = [];
+        CacheableConfig::getStorage()->clear();
     }
 
-    /**
-     * Clear cached result for a specific method.
-     */
     public static function clearMethodCacheFor(string $method): void
     {
-        foreach (array_keys(self::$methodCache) as $key) {
-            if (str_contains($key, $method)) {
-                unset(self::$methodCache[$key]);
-            }
-        }
+        CacheableConfig::getStorage()->deleteByPrefix(sprintf('%s::%s::', static::class, $method));
     }
 
-    /**
-     * Execute a method with caching support based on #[Cacheable] attribute.
-     *
-     * @param list<mixed> $args
-     */
-    protected function cached(string $method, array $args, callable $callback): mixed
+    protected function cached(Closure $callback): mixed
     {
-        $reflectionMethod = $this->getReflectionMethod($method);
-        $cacheableAttr = $this->getCacheableAttribute($reflectionMethod);
-
-        if ($cacheableAttr === null) {
+        $frame = debug_backtrace(0, 2)[1] ?? null;
+        if ($frame === null || !isset($frame['function'])) {
             return $callback();
         }
 
-        $cacheKey = $this->generateCacheKey($method, $args, $cacheableAttr);
-        $currentTime = time();
+        $method = (string) $frame['function'];
+        /** @var list<mixed> $args */
+        $args = $frame['args'] ?? [];
 
-        // Check if we have a valid cached value
-        if (isset(self::$methodCache[$cacheKey])) {
-            $cached = self::$methodCache[$cacheKey];
-            // @infection-ignore-all — the > vs >= boundary is a single-second tie; not worth testing
-            if ($cached['expires'] > $currentTime) {
-                return $cached['result'];
-            }
-
-            // Expired, remove it
-            unset(self::$methodCache[$cacheKey]);
+        $attribute = $this->resolveCacheableAttribute($method);
+        if ($attribute === null) {
+            return $callback();
         }
 
-        // Execute the method and cache the result
+        $storage = CacheableConfig::getStorage();
+        $cacheKey = $this->buildCacheKey($method, $args, $attribute);
+
+        if ($storage->has($cacheKey)) {
+            return $storage->get($cacheKey);
+        }
+
         $result = $callback();
-        self::$methodCache[$cacheKey] = [
-            'result' => $result,
-            'expires' => $currentTime + $cacheableAttr->ttl,
-        ];
+        $ttl = CacheableConfig::resolveTtl(sprintf('%s::%s', static::class, $method), $attribute->ttl);
+        $storage->set($cacheKey, $result, $ttl);
 
         return $result;
     }
 
-    /**
-     * Get reflection method for the given method name.
-     */
-    private function getReflectionMethod(string $method): ReflectionMethod
+    private function resolveCacheableAttribute(string $method): ?Cacheable
     {
-        // Extract just the method name if it's a full class::method string
-        $parts = explode('::', $method);
-        /** @var string $methodName */
-        $methodName = end($parts);
-
-        return (new ReflectionClass($this))->getMethod($methodName);
-    }
-
-    /**
-     * Get Cacheable attribute from reflection method.
-     */
-    private function getCacheableAttribute(ReflectionMethod $method): ?Cacheable
-    {
-        $attributes = $method->getAttributes(Cacheable::class);
-
+        $attributes = (new ReflectionMethod($this, $method))->getAttributes(Cacheable::class);
         if ($attributes === []) {
             return null;
         }
@@ -111,19 +92,36 @@ trait CacheableTrait
     }
 
     /**
-     * Generate a cache key for the method call.
+     * @param list<mixed> $args
+     */
+    private function buildCacheKey(string $method, array $args, Cacheable $attribute): string
+    {
+        if ($attribute->key !== null) {
+            return $this->interpolateKey($attribute->key, $args);
+        }
+
+        $argsKey = $args !== [] ? md5(serialize($args)) : 'no-args';
+        return sprintf('%s::%s::%s', static::class, $method, $argsKey);
+    }
+
+    /**
+     * Replace `{N}` placeholders in the key template with the Nth caller argument.
      *
      * @param list<mixed> $args
      */
-    private function generateCacheKey(string $method, array $args, Cacheable $attribute): string
+    private function interpolateKey(string $template, array $args): string
     {
-        if ($attribute->key !== null) {
-            return $attribute->key;
-        }
-
-        $className = static::class;
-        $argsKey = $args !== [] ? md5(serialize($args)) : 'no-args';
-
-        return sprintf('%s::%s::%s', $className, $method, $argsKey);
+        return (string) preg_replace_callback(
+            '/\{(\d+)\}/',
+            static function (array $match) use ($args): string {
+                $index = (int) $match[1];
+                $value = $args[$index] ?? '';
+                if ($value === null || is_scalar($value)) {
+                    return (string) $value;
+                }
+                return md5(serialize($value));
+            },
+            $template,
+        );
     }
 }

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -38,6 +38,14 @@ use function sprintf;
  *
  * The method name and arguments are inferred from the caller's stack frame;
  * the #[Cacheable] attribute supplies TTL and (optionally) a custom key template.
+ *
+ * For hot paths, very-large arguments, or when `cached()` is invoked from a
+ * helper (not the attributed method itself), pass `$method` and `$args`
+ * explicitly to skip the `debug_backtrace()` call:
+ *
+ * ```php
+ * return $this->cached(fn () => ..., __METHOD__, [$id]);
+ * ```
  */
 trait CacheableTrait
 {
@@ -51,16 +59,26 @@ trait CacheableTrait
         CacheableConfig::getStorage()->deleteByPrefix(sprintf('%s::%s::', static::class, $method));
     }
 
-    protected function cached(Closure $callback): mixed
+    /**
+     * @param list<mixed>|null $args
+     */
+    protected function cached(Closure $callback, ?string $method = null, ?array $args = null): mixed
     {
-        $frame = debug_backtrace(0, 2)[1] ?? null;
-        if ($frame === null || !isset($frame['function'])) {
-            return $callback();
+        if ($method === null) {
+            $frame = debug_backtrace(0, 2)[1] ?? null;
+            if ($frame === null || !isset($frame['function'])) {
+                return $callback();
+            }
+            $method = (string) $frame['function'];
+            /** @var list<mixed> $args */
+            $args ??= $frame['args'] ?? [];
+        } else {
+            if (str_contains($method, '::')) {
+                $parts = explode('::', $method);
+                $method = (string) end($parts);
+            }
+            $args ??= [];
         }
-
-        $method = (string) $frame['function'];
-        /** @var list<mixed> $args */
-        $args = $frame['args'] ?? [];
 
         $attribute = $this->resolveCacheableAttribute($method);
         if ($attribute === null) {

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -6,13 +6,20 @@ namespace Gacela\Framework\Attribute;
 
 use Closure;
 use ReflectionMethod;
+use stdClass;
 
+use function count;
 use function debug_backtrace;
+use function end;
+use function explode;
+use function is_int;
 use function is_scalar;
+use function is_string;
 use function md5;
 use function preg_replace_callback;
 use function serialize;
 use function sprintf;
+use function str_contains;
 
 /**
  * Enables #[Cacheable] support for facade methods.
@@ -49,6 +56,11 @@ use function sprintf;
  */
 trait CacheableTrait
 {
+    /** @var array<string, Cacheable|false> */
+    private static array $attributeCache = [];
+
+    private static ?stdClass $cacheMissSentinel = null;
+
     public static function clearMethodCache(): void
     {
         CacheableConfig::getStorage()->clear();
@@ -88,8 +100,10 @@ trait CacheableTrait
         $storage = CacheableConfig::getStorage();
         $cacheKey = $this->buildCacheKey($method, $args, $attribute);
 
-        if ($storage->has($cacheKey)) {
-            return $storage->get($cacheKey);
+        $miss = self::$cacheMissSentinel ??= new stdClass();
+        $cached = $storage->get($cacheKey, $miss);
+        if ($cached !== $miss) {
+            return $cached;
         }
 
         $result = $callback();
@@ -101,12 +115,14 @@ trait CacheableTrait
 
     private function resolveCacheableAttribute(string $method): ?Cacheable
     {
-        $attributes = (new ReflectionMethod($this, $method))->getAttributes(Cacheable::class);
-        if ($attributes === []) {
-            return null;
+        $cacheKey = static::class . '::' . $method;
+        if (!isset(self::$attributeCache[$cacheKey])) {
+            $attributes = (new ReflectionMethod($this, $method))->getAttributes(Cacheable::class);
+            self::$attributeCache[$cacheKey] = $attributes === [] ? false : $attributes[0]->newInstance();
         }
 
-        return $attributes[0]->newInstance();
+        $entry = self::$attributeCache[$cacheKey];
+        return $entry === false ? null : $entry;
     }
 
     /**
@@ -118,8 +134,24 @@ trait CacheableTrait
             return $this->interpolateKey($attribute->key, $args);
         }
 
-        $argsKey = $args !== [] ? md5(serialize($args)) : 'no-args';
-        return sprintf('%s::%s::%s', static::class, $method, $argsKey);
+        return sprintf('%s::%s::%s', static::class, $method, $this->hashArgs($args));
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private function hashArgs(array $args): string
+    {
+        if ($args === []) {
+            return 'no-args';
+        }
+        if (count($args) === 1) {
+            $first = $args[0];
+            if (is_int($first) || is_string($first)) {
+                return (string) $first;
+            }
+        }
+        return md5(serialize($args));
     }
 
     /**

--- a/src/Framework/Attribute/InMemoryCacheStorage.php
+++ b/src/Framework/Attribute/InMemoryCacheStorage.php
@@ -28,9 +28,9 @@ final class InMemoryCacheStorage implements CacheStorageInterface
         return false;
     }
 
-    public function get(string $key): mixed
+    public function get(string $key, mixed $default = null): mixed
     {
-        return $this->has($key) ? $this->cache[$key]['result'] : null;
+        return $this->has($key) ? $this->cache[$key]['result'] : $default;
     }
 
     public function set(string $key, mixed $value, int $ttl): void

--- a/src/Framework/Attribute/InMemoryCacheStorage.php
+++ b/src/Framework/Attribute/InMemoryCacheStorage.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Attribute;
+
+use function array_keys;
+use function str_starts_with;
+use function time;
+
+final class InMemoryCacheStorage implements CacheStorageInterface
+{
+    /** @var array<string,array{result:mixed,expires:int}> */
+    private array $cache = [];
+
+    public function has(string $key): bool
+    {
+        if (!isset($this->cache[$key])) {
+            return false;
+        }
+
+        // @infection-ignore-all — the > vs >= boundary is a single-second tie; not worth testing
+        if ($this->cache[$key]['expires'] > time()) {
+            return true;
+        }
+
+        unset($this->cache[$key]);
+        return false;
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->has($key) ? $this->cache[$key]['result'] : null;
+    }
+
+    public function set(string $key, mixed $value, int $ttl): void
+    {
+        $this->cache[$key] = [
+            'result' => $value,
+            'expires' => time() + $ttl,
+        ];
+    }
+
+    public function delete(string $key): void
+    {
+        unset($this->cache[$key]);
+    }
+
+    public function clear(): void
+    {
+        $this->cache = [];
+    }
+
+    public function deleteByPrefix(string $prefix): void
+    {
+        foreach (array_keys($this->cache) as $key) {
+            if (str_starts_with($key, $prefix)) {
+                unset($this->cache[$key]);
+            }
+        }
+    }
+}

--- a/tests/Unit/Framework/Attribute/CacheableTest.php
+++ b/tests/Unit/Framework/Attribute/CacheableTest.php
@@ -200,6 +200,29 @@ final class CacheableTest extends TestCase
         self::assertSame($first, $second);
         self::assertSame(1, $facade->getCallCount());
     }
+
+    public function test_explicit_method_and_args_skip_backtrace_and_still_cache(): void
+    {
+        $facade = new TestFacadeWithExplicitCached();
+
+        $first = $facade->load(7);
+        $second = $facade->load(7);
+        $third = $facade->load(8);
+
+        self::assertSame($first, $second);
+        self::assertNotSame($first, $third);
+        self::assertSame(2, $facade->getCallCount());
+    }
+
+    public function test_explicit_method_works_when_cached_is_called_from_a_helper(): void
+    {
+        $facade = new TestFacadeWithHelperCached();
+
+        $facade->compute();
+        $facade->compute();
+
+        self::assertSame(1, $facade->getCallCount());
+    }
 }
 
 final class TestFacadeWithCache
@@ -336,6 +359,53 @@ final class TestFacadeWithStaticKey
     public function getCallCount(): int
     {
         return $this->callCount;
+    }
+}
+
+final class TestFacadeWithExplicitCached
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600)]
+    public function load(int $id): string
+    {
+        return $this->cached(function () use ($id): string {
+            ++$this->callCount;
+            return 'loaded-' . $id;
+        }, __METHOD__, [$id]);
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class TestFacadeWithHelperCached
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600)]
+    public function compute(): string
+    {
+        return $this->runCached('compute', []);
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+
+    private function runCached(string $method, array $args): string
+    {
+        return $this->cached(function (): string {
+            ++$this->callCount;
+            return 'computed-' . $this->callCount;
+        }, $method, $args);
     }
 }
 

--- a/tests/Unit/Framework/Attribute/CacheableTest.php
+++ b/tests/Unit/Framework/Attribute/CacheableTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Attribute;
 
 use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableConfig;
 use Gacela\Framework\Attribute\CacheableTrait;
+use Gacela\Framework\Attribute\CacheStorageInterface;
+use Gacela\Framework\Attribute\InMemoryCacheStorage;
 use PHPUnit\Framework\TestCase;
-
-use ReflectionClass;
 
 use function sprintf;
 
@@ -16,7 +17,7 @@ final class CacheableTest extends TestCase
 {
     protected function tearDown(): void
     {
-        TestFacadeWithCache::clearMethodCache();
+        CacheableConfig::reset();
     }
 
     public function test_cacheable_attribute_can_be_instantiated(): void
@@ -50,10 +51,7 @@ final class CacheableTest extends TestCase
         $result1 = $facade->getExpensiveData();
         $result2 = $facade->getExpensiveData();
 
-        // Should return the same result without recalculating
         self::assertSame($result1, $result2);
-
-        // Call count should be 1, not 2, proving it's cached
         self::assertSame(1, $facade->getCallCount());
     }
 
@@ -63,12 +61,10 @@ final class CacheableTest extends TestCase
 
         $result1 = $facade->getDataWithArgs(1);
         $result2 = $facade->getDataWithArgs(2);
-        $result3 = $facade->getDataWithArgs(1); // Should use cache
+        $result3 = $facade->getDataWithArgs(1);
 
         self::assertNotSame($result1, $result2);
         self::assertSame($result1, $result3);
-
-        // Should be called 2 times (once for each unique argument)
         self::assertSame(2, $facade->getArgsCallCount());
     }
 
@@ -82,7 +78,6 @@ final class CacheableTest extends TestCase
         TestFacadeWithCache::clearMethodCache();
 
         $facade->getExpensiveData();
-        // Should be called again after clearing cache
         self::assertSame(2, $facade->getCallCount());
     }
 
@@ -96,9 +91,25 @@ final class CacheableTest extends TestCase
         TestFacadeWithCache::clearMethodCacheFor('getExpensiveData');
 
         $facade->getExpensiveData();
-        $facade->getDataWithArgs(1); // Should still be cached
+        $facade->getDataWithArgs(1);
 
         self::assertSame(2, $facade->getCallCount());
+        self::assertSame(1, $facade->getArgsCallCount());
+    }
+
+    public function test_clear_method_cache_for_substring_does_not_affect_other_methods(): void
+    {
+        $facade = new TestFacadeWithCache();
+
+        $facade->getExpensiveData();
+        $facade->getDataWithArgs(1);
+
+        TestFacadeWithCache::clearMethodCacheFor('get');
+
+        $facade->getExpensiveData();
+        $facade->getDataWithArgs(1);
+
+        self::assertSame(1, $facade->getCallCount());
         self::assertSame(1, $facade->getArgsCallCount());
     }
 
@@ -109,7 +120,6 @@ final class CacheableTest extends TestCase
         $facade->getNonCachedData();
         $facade->getNonCachedData();
 
-        // Should be called twice (not cached)
         self::assertSame(2, $facade->getNonCachedCallCount());
     }
 
@@ -120,33 +130,12 @@ final class CacheableTest extends TestCase
         $result1 = $facade->getDataWithShortTTL();
         self::assertSame(1, $facade->getCallCount());
 
-        // Wait for cache to expire (short TTL of 1 second)
         sleep(2);
 
         $result2 = $facade->getDataWithShortTTL();
 
-        // Should be called again after expiration
         self::assertSame(2, $facade->getCallCount());
         self::assertNotSame($result1, $result2);
-    }
-
-    public function test_cache_entry_with_expires_equal_to_current_time_is_considered_expired(): void
-    {
-        $facade = new TestFacadeWithCache();
-
-        $reflection = new ReflectionClass($facade);
-        $cacheProperty = $reflection->getProperty('methodCache');
-        $cacheProperty->setAccessible(true);
-
-        $cacheKey = TestFacadeWithCache::class . '::getExpensiveData::no-args';
-        $cacheProperty->setValue(null, [
-            $cacheKey => ['result' => 'stale', 'expires' => time()],
-        ]);
-
-        $result = $facade->getExpensiveData();
-
-        self::assertNotSame('stale', $result);
-        self::assertSame(1, $facade->getCallCount());
     }
 
     public function test_cached_method_is_accessible_from_subclass(): void
@@ -159,11 +148,60 @@ final class CacheableTest extends TestCase
         self::assertSame($result1, $result2);
         self::assertSame(1, $child->getChildCallCount());
     }
+
+    public function test_ttl_override_via_config_shortens_cache_lifetime(): void
+    {
+        CacheableConfig::setTtlOverrides([
+            TestFacadeWithCache::class . '::getExpensiveData' => 1,
+        ]);
+
+        $facade = new TestFacadeWithCache();
+
+        $facade->getExpensiveData();
+        self::assertSame(1, $facade->getCallCount());
+
+        sleep(2);
+
+        $facade->getExpensiveData();
+        self::assertSame(2, $facade->getCallCount());
+    }
+
+    public function test_custom_storage_backend_is_used(): void
+    {
+        $storage = new RecordingCacheStorage();
+        CacheableConfig::setStorage($storage);
+
+        $facade = new TestFacadeWithCache();
+        $facade->getExpensiveData();
+
+        self::assertCount(1, $storage->sets);
+        self::assertSame(3600, $storage->sets[0]['ttl']);
+    }
+
+    public function test_key_template_interpolates_scalar_args(): void
+    {
+        $facade = new TestFacadeWithTemplatedKey();
+
+        $facade->lookup(42);
+        $facade->lookup(42);
+
+        $storage = CacheableConfig::getStorage();
+        self::assertTrue($storage->has('user:42'));
+        self::assertSame(1, $facade->getCallCount());
+    }
+
+    public function test_bare_key_without_placeholders_is_shared_across_args(): void
+    {
+        $facade = new TestFacadeWithStaticKey();
+
+        $first = $facade->findBy(1);
+        $second = $facade->findBy(2);
+
+        self::assertSame($first, $second);
+        self::assertSame(1, $facade->getCallCount());
+    }
 }
 
-/**
- * Test facade that uses CacheableTrait.
- */
 final class TestFacadeWithCache
 {
     use CacheableTrait;
@@ -177,7 +215,7 @@ final class TestFacadeWithCache
     #[Cacheable(ttl: 3600)]
     public function getExpensiveData(): string
     {
-        return $this->cached(__METHOD__, [], function (): string {
+        return $this->cached(function (): string {
             ++$this->callCount;
             return 'expensive-result-' . $this->callCount;
         });
@@ -186,7 +224,7 @@ final class TestFacadeWithCache
     #[Cacheable(ttl: 3600)]
     public function getDataWithArgs(int $id): string
     {
-        return $this->cached(__METHOD__, [$id], function () use ($id): string {
+        return $this->cached(function () use ($id): string {
             ++$this->argsCallCount;
             return sprintf('result-%d-%d', $id, $this->argsCallCount);
         });
@@ -214,21 +252,18 @@ final class TestFacadeWithCache
     }
 }
 
-/**
- * Test facade with short TTL for testing expiration.
- */
 final class TestFacadeWithCacheShortTTL
 {
     use CacheableTrait;
 
     private int $callCount = 0;
 
-    #[Cacheable(ttl: 1)] // 1 second TTL
+    #[Cacheable(ttl: 1)]
     public function getDataWithShortTTL(): string
     {
-        return $this->cached(__METHOD__, [], function (): string {
+        return $this->cached(function (): string {
             ++$this->callCount;
-            return 'result-' . time();
+            return 'result-' . $this->callCount;
         });
     }
 
@@ -238,9 +273,6 @@ final class TestFacadeWithCacheShortTTL
     }
 }
 
-/**
- * Parent facade (non-final) so that protected visibility on cached() can be verified via inheritance.
- */
 class TestParentFacadeWithCache
 {
     use CacheableTrait;
@@ -253,7 +285,7 @@ final class TestChildFacadeWithCache extends TestParentFacadeWithCache
     #[Cacheable(ttl: 3600)]
     public function getChildData(): string
     {
-        return $this->cached(__METHOD__, [], function (): string {
+        return $this->cached(function (): string {
             ++$this->childCallCount;
             return 'child-result-' . $this->childCallCount;
         });
@@ -262,5 +294,91 @@ final class TestChildFacadeWithCache extends TestParentFacadeWithCache
     public function getChildCallCount(): int
     {
         return $this->childCallCount;
+    }
+}
+
+final class TestFacadeWithTemplatedKey
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600, key: 'user:{0}')]
+    public function lookup(int $id): string
+    {
+        return $this->cached(function () use ($id): string {
+            ++$this->callCount;
+            return 'user-' . $id;
+        });
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class TestFacadeWithStaticKey
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600, key: 'shared')]
+    public function findBy(int $id): string
+    {
+        return $this->cached(function () use ($id): string {
+            ++$this->callCount;
+            return 'item-' . $id;
+        });
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class RecordingCacheStorage implements CacheStorageInterface
+{
+    /** @var list<array{key:string,value:mixed,ttl:int}> */
+    public array $sets = [];
+
+    private InMemoryCacheStorage $delegate;
+
+    public function __construct()
+    {
+        $this->delegate = new InMemoryCacheStorage();
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->delegate->has($key);
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->delegate->get($key);
+    }
+
+    public function set(string $key, mixed $value, int $ttl): void
+    {
+        $this->sets[] = ['key' => $key, 'value' => $value, 'ttl' => $ttl];
+        $this->delegate->set($key, $value, $ttl);
+    }
+
+    public function delete(string $key): void
+    {
+        $this->delegate->delete($key);
+    }
+
+    public function clear(): void
+    {
+        $this->delegate->clear();
+    }
+
+    public function deleteByPrefix(string $prefix): void
+    {
+        $this->delegate->deleteByPrefix($prefix);
     }
 }

--- a/tests/Unit/Framework/Attribute/CacheableTest.php
+++ b/tests/Unit/Framework/Attribute/CacheableTest.php
@@ -11,7 +11,11 @@ use Gacela\Framework\Attribute\CacheStorageInterface;
 use Gacela\Framework\Attribute\InMemoryCacheStorage;
 use PHPUnit\Framework\TestCase;
 
+use function count;
 use function sprintf;
+use function strlen;
+use function strrpos;
+use function substr;
 
 final class CacheableTest extends TestCase
 {
@@ -232,6 +236,123 @@ final class CacheableTest extends TestCase
         self::assertNull($facade->maybeFind());
         self::assertSame(1, $facade->getCallCount());
     }
+
+    public function test_single_string_arg_is_hashed_directly(): void
+    {
+        $storage = new RecordingCacheStorage();
+        CacheableConfig::setStorage($storage);
+
+        $facade = new TestFacadeWithAdvancedArgs();
+        $facade->byName('alice');
+
+        self::assertSame(
+            TestFacadeWithAdvancedArgs::class . '::byName::alice',
+            $storage->sets[0]['key'],
+        );
+    }
+
+    public function test_non_scalar_arg_falls_back_to_serialized_hash(): void
+    {
+        $storage = new RecordingCacheStorage();
+        CacheableConfig::setStorage($storage);
+
+        $facade = new TestFacadeWithAdvancedArgs();
+        $facade->byArray(['a', 'b']);
+
+        $key = $storage->sets[0]['key'];
+        self::assertStringStartsWith(TestFacadeWithAdvancedArgs::class . '::byArray::', $key);
+        self::assertSame(32, strlen(substr($key, strrpos($key, '::') + 2)));
+    }
+
+    public function test_multi_arg_cache_distinguishes_argument_combinations(): void
+    {
+        $facade = new TestFacadeWithAdvancedArgs();
+
+        $facade->byNameAndAge('alice', 30);
+        $facade->byNameAndAge('alice', 30);
+        $facade->byNameAndAge('alice', 31);
+        $facade->byNameAndAge('bob', 30);
+
+        self::assertSame(3, $facade->getMultiArgCalls());
+    }
+
+    public function test_template_with_missing_index_renders_empty_string(): void
+    {
+        $facade = new TestFacadeWithTemplateEdgeCases();
+
+        $facade->sparseKey(7);
+
+        self::assertTrue(CacheableConfig::getStorage()->has('sparse:'));
+    }
+
+    public function test_template_with_non_scalar_arg_uses_serialized_hash(): void
+    {
+        $facade = new TestFacadeWithTemplateEdgeCases();
+
+        $facade->objectKey(new ValueHolder('alpha'));
+        $facade->objectKey(new ValueHolder('alpha'));
+        $facade->objectKey(new ValueHolder('beta'));
+
+        self::assertSame(2, $facade->getObjectKeyCalls());
+    }
+
+    public function test_explicit_method_accepts_plain_name_without_class_prefix(): void
+    {
+        $facade = new TestFacadeWithPlainExplicit();
+
+        $facade->fetch();
+        $facade->fetch();
+
+        self::assertSame(1, $facade->getCallCount());
+    }
+
+    public function test_cache_is_shared_across_instances_of_same_class(): void
+    {
+        $first = new TestFacadeWithCache();
+        $second = new TestFacadeWithCache();
+
+        $first->getExpensiveData();
+        $second->getExpensiveData();
+
+        self::assertSame(1, $first->getCallCount());
+        self::assertSame(0, $second->getCallCount());
+    }
+
+    public function test_repeated_calls_reuse_memoized_attribute(): void
+    {
+        $facade = new TestFacadeWithCache();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $facade->getExpensiveData();
+        }
+
+        self::assertSame(1, $facade->getCallCount());
+    }
+
+    public function test_same_method_name_across_different_classes_uses_isolated_cache(): void
+    {
+        $first = new TestFacadeAlphaShared();
+        $second = new TestFacadeBetaShared();
+
+        $alphaResult = $first->compute(1);
+        $betaResult = $second->compute(1);
+
+        self::assertSame('alpha-1', $alphaResult);
+        self::assertSame('beta-1', $betaResult);
+        self::assertSame(1, $first->getCallCount());
+        self::assertSame(1, $second->getCallCount());
+    }
+
+    public function test_cached_called_on_method_without_attribute_invokes_callback_every_time(): void
+    {
+        $facade = new TestFacadeWithCachedButNoAttribute();
+
+        $facade->plain();
+        $facade->plain();
+        $facade->plain();
+
+        self::assertSame(3, $facade->getCallCount());
+    }
 }
 
 final class TestFacadeWithCache
@@ -430,6 +551,160 @@ final class TestFacadeReturningNull
         return $this->cached(function (): ?string {
             ++$this->callCount;
             return null;
+        });
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class TestFacadeWithAdvancedArgs
+{
+    use CacheableTrait;
+
+    private int $multiArgCalls = 0;
+
+    #[Cacheable(ttl: 3600)]
+    public function byName(string $name): string
+    {
+        return $this->cached(static fn (): string => 'name-' . $name);
+    }
+
+    /**
+     * @param list<string> $items
+     */
+    #[Cacheable(ttl: 3600)]
+    public function byArray(array $items): int
+    {
+        return $this->cached(static fn (): int => count($items));
+    }
+
+    #[Cacheable(ttl: 3600)]
+    public function byNameAndAge(string $name, int $age): string
+    {
+        return $this->cached(function () use ($name, $age): string {
+            ++$this->multiArgCalls;
+            return sprintf('%s-%d', $name, $age);
+        });
+    }
+
+    public function getMultiArgCalls(): int
+    {
+        return $this->multiArgCalls;
+    }
+}
+
+final class ValueHolder
+{
+    public function __construct(
+        public readonly string $value,
+    ) {
+    }
+}
+
+final class TestFacadeWithTemplateEdgeCases
+{
+    use CacheableTrait;
+
+    private int $objectKeyCalls = 0;
+
+    #[Cacheable(ttl: 3600, key: 'sparse:{5}')]
+    public function sparseKey(int $id): string
+    {
+        return $this->cached(static fn (): string => 'sparse-' . $id);
+    }
+
+    #[Cacheable(ttl: 3600, key: 'obj:{0}')]
+    public function objectKey(ValueHolder $holder): string
+    {
+        return $this->cached(function () use ($holder): string {
+            ++$this->objectKeyCalls;
+            return 'obj-' . $holder->value;
+        });
+    }
+
+    public function getObjectKeyCalls(): int
+    {
+        return $this->objectKeyCalls;
+    }
+}
+
+final class TestFacadeWithPlainExplicit
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600)]
+    public function fetch(): string
+    {
+        return $this->cached(function (): string {
+            ++$this->callCount;
+            return 'fetched-' . $this->callCount;
+        }, 'fetch');
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class TestFacadeAlphaShared
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600, key: 'alpha-{0}')]
+    public function compute(int $id): string
+    {
+        return $this->cached(function () use ($id): string {
+            ++$this->callCount;
+            return 'alpha-' . $id;
+        });
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class TestFacadeBetaShared
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600, key: 'beta-{0}')]
+    public function compute(int $id): string
+    {
+        return $this->cached(function () use ($id): string {
+            ++$this->callCount;
+            return 'beta-' . $id;
+        });
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
+final class TestFacadeWithCachedButNoAttribute
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    public function plain(): string
+    {
+        return $this->cached(function (): string {
+            ++$this->callCount;
+            return 'plain-' . $this->callCount;
         });
     }
 

--- a/tests/Unit/Framework/Attribute/CacheableTest.php
+++ b/tests/Unit/Framework/Attribute/CacheableTest.php
@@ -223,6 +223,15 @@ final class CacheableTest extends TestCase
 
         self::assertSame(1, $facade->getCallCount());
     }
+
+    public function test_cached_null_value_is_treated_as_a_hit(): void
+    {
+        $facade = new TestFacadeReturningNull();
+
+        self::assertNull($facade->maybeFind());
+        self::assertNull($facade->maybeFind());
+        self::assertSame(1, $facade->getCallCount());
+    }
 }
 
 final class TestFacadeWithCache
@@ -409,6 +418,27 @@ final class TestFacadeWithHelperCached
     }
 }
 
+final class TestFacadeReturningNull
+{
+    use CacheableTrait;
+
+    private int $callCount = 0;
+
+    #[Cacheable(ttl: 3600)]
+    public function maybeFind(): ?string
+    {
+        return $this->cached(function (): ?string {
+            ++$this->callCount;
+            return null;
+        });
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+}
+
 final class RecordingCacheStorage implements CacheStorageInterface
 {
     /** @var list<array{key:string,value:mixed,ttl:int}> */
@@ -426,9 +456,9 @@ final class RecordingCacheStorage implements CacheStorageInterface
         return $this->delegate->has($key);
     }
 
-    public function get(string $key): mixed
+    public function get(string $key, mixed $default = null): mixed
     {
-        return $this->delegate->get($key);
+        return $this->delegate->get($key, $default);
     }
 
     public function set(string $key, mixed $value, int $ttl): void


### PR DESCRIPTION
## 📚 Description

Tightens the DX around `#[Cacheable]` so the attribute-and-trait pair is easier to use correctly. Call sites lose the `__METHOD__`/args boilerplate, storage becomes pluggable (so TTL can actually survive a request on FPM), and ops can retune TTLs without editing attributes. Also fixes a footgun in `clearMethodCacheFor()` that over-matched on substrings.

## 🔖 Changes

- `cached()` infers method + args from the caller stack frame: `$this->cached(fn () => ...)`
- Pluggable `CacheStorageInterface` (default `InMemoryCacheStorage`); swap via `CacheableConfig::setStorage()`
- Per-method TTL overrides via `CacheableConfig::setTtlOverrides(['Class::method' => $seconds])`
- `Cacheable::$key` supports `{N}` placeholders interpolating the Nth caller argument
- `clearMethodCacheFor()` matches on exact `Class::method::` prefix (no more substring over-match)
- Updated docblocks and unit tests; CHANGELOG entry under Unreleased