### PR TITLE
feat: Provider-based module health-check registration

### DIFF
--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -11,12 +11,16 @@ use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Health\HealthCheckRegistry;
+use Gacela\Framework\Health\HealthLevel;
+use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function is_scalar;
 use function sprintf;
 
 /**
@@ -69,10 +73,59 @@ final class DoctorCommand extends Command
         $modules = $this->getFacade()->findAllAppModules($filter);
         $suffixTypes = $config->getFactory()->createGacelaFileConfig()->getSuffixTypes();
 
-        return [
+        $checks = [
             new CacheStalenessCheck($config->getCacheDir()),
             new SuffixMismatchCheck($modules, $suffixTypes),
         ];
+
+        foreach (HealthCheckRegistry::createHealthChecker()->checkAll()->getResults() as $moduleName => $status) {
+            $checks[] = $this->toHealthCheck($moduleName, $status);
+        }
+
+        return $checks;
+    }
+
+    private function toHealthCheck(string $moduleName, HealthStatus $status): HealthCheck
+    {
+        return new class($moduleName, $status) implements HealthCheck {
+            public function __construct(
+                private readonly string $moduleName,
+                private readonly HealthStatus $status,
+            ) {
+            }
+
+            public function name(): string
+            {
+                return $this->moduleName;
+            }
+
+            public function run(): CheckResult
+            {
+                $title = sprintf('module health: %s', $this->moduleName);
+                $detail = $this->status->message;
+                $metadata = $this->formatMetadata();
+
+                return match ($this->status->level) {
+                    HealthLevel::HEALTHY => CheckResult::ok($title, $detail),
+                    HealthLevel::DEGRADED => CheckResult::warn($title, $metadata === [] ? [$detail] : [$detail, ...$metadata]),
+                    HealthLevel::UNHEALTHY => CheckResult::error($title, $metadata === [] ? [$detail] : [$detail, ...$metadata]),
+                };
+            }
+
+            /**
+             * @return list<string>
+             */
+            private function formatMetadata(): array
+            {
+                $lines = [];
+                /** @var mixed $value */
+                foreach ($this->status->metadata as $key => $value) {
+                    $lines[] = sprintf('%s: %s', $key, is_scalar($value) ? (string) $value : get_debug_type($value));
+                }
+
+                return $lines;
+            }
+        };
     }
 
     private function renderResult(CheckResult $result, OutputInterface $output): void

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -67,9 +67,6 @@ final class GacelaConfig
     /** @var array<string,array<string|int,class-string>> */
     private array $handlerRegistries = [];
 
-    /** @var list<class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface> */
-    private array $healthChecks = [];
-
     /**
      * @param array<string,class-string|object|callable> $externalServices
      */
@@ -449,7 +446,6 @@ final class GacelaConfig
      */
     public function addHealthCheck(string|ModuleHealthCheckInterface $check): self
     {
-        $this->healthChecks[] = $check;
         HealthCheckRegistry::register($check);
 
         return $this;
@@ -481,7 +477,6 @@ final class GacelaConfig
             $this->aliases,
             $this->contextualBindings,
             $this->handlerRegistries,
-            $this->healthChecks,
         );
     }
 }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -12,6 +12,8 @@ use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Health\HealthCheckRegistry;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 
 final class GacelaConfig
 {
@@ -65,6 +67,9 @@ final class GacelaConfig
     /** @var array<string,array<string|int,class-string>> */
     private array $handlerRegistries = [];
 
+    /** @var list<class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface> */
+    private array $healthChecks = [];
+
     /**
      * @param array<string,class-string|object|callable> $externalServices
      */
@@ -73,6 +78,7 @@ final class GacelaConfig
         $this->appConfigBuilder = new AppConfigBuilder();
         $this->suffixTypesBuilder = new SuffixTypesBuilder();
         $this->bindingsBuilder = new BindingsBuilder();
+        HealthCheckRegistry::reset();
     }
 
     /**
@@ -437,6 +443,19 @@ final class GacelaConfig
     }
 
     /**
+     * Register a module health check to be executed by the Doctor command.
+     *
+     * @param class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface $check
+     */
+    public function addHealthCheck(string|ModuleHealthCheckInterface $check): self
+    {
+        $this->healthChecks[] = $check;
+        HealthCheckRegistry::register($check);
+
+        return $this;
+    }
+
+    /**
      * @internal
      */
     public function toTransfer(): GacelaConfigTransfer
@@ -462,6 +481,7 @@ final class GacelaConfig
             $this->aliases,
             $this->contextualBindings,
             $this->handlerRegistries,
+            $this->healthChecks,
         );
     }
 }

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -8,6 +8,7 @@ use Closure;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 
 final class GacelaConfigTransfer
 {
@@ -25,6 +26,7 @@ final class GacelaConfigTransfer
      * @param array<string,string> $aliases
      * @param array<string,array<class-string,class-string|callable|object>> $contextualBindings
      * @param array<string,array<string|int,class-string>> $handlerRegistries
+     * @param list<class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface> $healthChecks
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,
@@ -47,6 +49,7 @@ final class GacelaConfigTransfer
         public readonly array $aliases,
         public readonly array $contextualBindings,
         public readonly array $handlerRegistries = [],
+        public readonly array $healthChecks = [],
     ) {
     }
 }

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -8,7 +8,6 @@ use Closure;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
-use Gacela\Framework\Health\ModuleHealthCheckInterface;
 
 final class GacelaConfigTransfer
 {
@@ -26,7 +25,6 @@ final class GacelaConfigTransfer
      * @param array<string,string> $aliases
      * @param array<string,array<class-string,class-string|callable|object>> $contextualBindings
      * @param array<string,array<string|int,class-string>> $handlerRegistries
-     * @param list<class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface> $healthChecks
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,
@@ -49,7 +47,6 @@ final class GacelaConfigTransfer
         public readonly array $aliases,
         public readonly array $contextualBindings,
         public readonly array $handlerRegistries = [],
-        public readonly array $healthChecks = [],
     ) {
     }
 }

--- a/src/Framework/Health/HealthCheckRegistry.php
+++ b/src/Framework/Health/HealthCheckRegistry.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Health;
+
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Exception\GacelaNotBootstrappedException;
+use Gacela\Framework\Gacela;
+use Throwable;
+
+/**
+ * Tracks health checks registered through GacelaConfig::addHealthCheck()
+ * so they can be resolved into a HealthChecker at runtime.
+ */
+final class HealthCheckRegistry
+{
+    /** @var list<class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface> */
+    private static array $checks = [];
+
+    /**
+     * @param class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface $check
+     */
+    public static function register(string|ModuleHealthCheckInterface $check): void
+    {
+        self::$checks[] = $check;
+    }
+
+    public static function reset(): void
+    {
+        self::$checks = [];
+    }
+
+    /**
+     * @return list<class-string<ModuleHealthCheckInterface>|ModuleHealthCheckInterface>
+     */
+    public static function all(): array
+    {
+        return self::$checks;
+    }
+
+    public static function createHealthChecker(): HealthChecker
+    {
+        return new HealthChecker(self::resolveAll());
+    }
+
+    /**
+     * @return list<ModuleHealthCheckInterface>
+     */
+    private static function resolveAll(): array
+    {
+        $container = self::resolveContainer();
+        $resolved = [];
+
+        foreach (self::$checks as $check) {
+            if ($check instanceof ModuleHealthCheckInterface) {
+                $resolved[] = $check;
+                continue;
+            }
+
+            $instance = self::instantiate($check, $container);
+            if ($instance instanceof ModuleHealthCheckInterface) {
+                $resolved[] = $instance;
+            }
+        }
+
+        return $resolved;
+    }
+
+    private static function resolveContainer(): ?Container
+    {
+        try {
+            return Gacela::container();
+        } catch (GacelaNotBootstrappedException) {
+            return null;
+        }
+    }
+
+    /**
+     * @param class-string<ModuleHealthCheckInterface> $className
+     */
+    private static function instantiate(string $className, ?Container $container): ?ModuleHealthCheckInterface
+    {
+        if ($container instanceof Container) {
+            try {
+                /** @var mixed $instance */
+                $instance = $container->get($className);
+                if ($instance instanceof ModuleHealthCheckInterface) {
+                    return $instance;
+                }
+            } catch (Throwable) {
+                // fall through to direct instantiation
+            }
+        }
+
+        if (!class_exists($className)) {
+            return null;
+        }
+
+        return new $className();
+    }
+}

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\Doctor;
+
+use Gacela\Console\Infrastructure\Command\DoctorCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\Doctor\Fixtures\FakeHealthCheck;
+use GacelaTest\Feature\Console\Doctor\Fixtures\UnhealthyHealthCheck;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DoctorCommandTest extends TestCase
+{
+    public function test_doctor_runs_registered_health_check_class_string(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addHealthCheck(FakeHealthCheck::class);
+        });
+
+        $command = new CommandTester(new DoctorCommand());
+        $exitCode = $command->execute([]);
+
+        $output = $command->getDisplay();
+
+        self::assertStringContainsString('FakeModule', $output);
+        self::assertStringContainsString('FakeHealthCheck ran', $output);
+        self::assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    public function test_doctor_runs_registered_health_check_instance(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addHealthCheck(new FakeHealthCheck());
+        });
+
+        $command = new CommandTester(new DoctorCommand());
+        $command->execute([]);
+
+        $output = $command->getDisplay();
+
+        self::assertStringContainsString('FakeModule', $output);
+    }
+
+    public function test_doctor_fails_when_registered_check_is_unhealthy(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addHealthCheck(UnhealthyHealthCheck::class);
+        });
+
+        $command = new CommandTester(new DoctorCommand());
+        $exitCode = $command->execute([]);
+
+        $output = $command->getDisplay();
+
+        self::assertStringContainsString('UnhealthyModule', $output);
+        self::assertStringContainsString('Service is down', $output);
+        self::assertSame(Command::FAILURE, $exitCode);
+    }
+
+    public function test_doctor_without_registered_checks_still_succeeds(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $command = new CommandTester(new DoctorCommand());
+        $exitCode = $command->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+    }
+}

--- a/tests/Feature/Console/Doctor/Fixtures/FakeHealthCheck.php
+++ b/tests/Feature/Console/Doctor/Fixtures/FakeHealthCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\Doctor\Fixtures;
+
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+
+final class FakeHealthCheck implements ModuleHealthCheckInterface
+{
+    public function checkHealth(): HealthStatus
+    {
+        return HealthStatus::healthy('FakeHealthCheck ran');
+    }
+
+    public function getModuleName(): string
+    {
+        return 'FakeModule';
+    }
+}

--- a/tests/Feature/Console/Doctor/Fixtures/UnhealthyHealthCheck.php
+++ b/tests/Feature/Console/Doctor/Fixtures/UnhealthyHealthCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\Doctor\Fixtures;
+
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+
+final class UnhealthyHealthCheck implements ModuleHealthCheckInterface
+{
+    public function checkHealth(): HealthStatus
+    {
+        return HealthStatus::unhealthy('Service is down');
+    }
+
+    public function getModuleName(): string
+    {
+        return 'UnhealthyModule';
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Bootstrap;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigTest extends TestCase
@@ -36,5 +38,71 @@ final class GacelaConfigTest extends TestCase
             $a->toTransfer()->bindingsBuilder->build(),
             $b->toTransfer()->bindingsBuilder->build(),
         );
+    }
+
+    public function test_add_health_check_collects_class_string(): void
+    {
+        $config = new GacelaConfig();
+
+        $config->addHealthCheck(GacelaConfigTestFakeHealthCheck::class);
+
+        self::assertSame(
+            [GacelaConfigTestFakeHealthCheck::class],
+            $config->toTransfer()->healthChecks,
+        );
+    }
+
+    public function test_add_health_check_collects_instance(): void
+    {
+        $config = new GacelaConfig();
+        $instance = new GacelaConfigTestFakeHealthCheck();
+
+        $config->addHealthCheck($instance);
+
+        self::assertSame([$instance], $config->toTransfer()->healthChecks);
+    }
+
+    public function test_add_health_check_is_fluent(): void
+    {
+        $config = new GacelaConfig();
+
+        $result = $config->addHealthCheck(GacelaConfigTestFakeHealthCheck::class);
+
+        self::assertSame($config, $result);
+    }
+
+    public function test_add_health_check_preserves_registration_order(): void
+    {
+        $config = new GacelaConfig();
+        $instance = new GacelaConfigTestFakeHealthCheck();
+
+        $config
+            ->addHealthCheck(GacelaConfigTestFakeHealthCheck::class)
+            ->addHealthCheck($instance);
+
+        self::assertSame(
+            [GacelaConfigTestFakeHealthCheck::class, $instance],
+            $config->toTransfer()->healthChecks,
+        );
+    }
+
+    public function test_add_health_check_defaults_to_empty_list(): void
+    {
+        $config = new GacelaConfig();
+
+        self::assertSame([], $config->toTransfer()->healthChecks);
+    }
+}
+
+final class GacelaConfigTestFakeHealthCheck implements ModuleHealthCheckInterface
+{
+    public function checkHealth(): HealthStatus
+    {
+        return HealthStatus::healthy();
+    }
+
+    public function getModuleName(): string
+    {
+        return 'GacelaConfigTestFake';
     }
 }

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Bootstrap;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use PHPUnit\Framework\TestCase;
@@ -48,7 +49,7 @@ final class GacelaConfigTest extends TestCase
 
         self::assertSame(
             [GacelaConfigTestFakeHealthCheck::class],
-            $config->toTransfer()->healthChecks,
+            HealthCheckRegistry::all(),
         );
     }
 
@@ -59,7 +60,7 @@ final class GacelaConfigTest extends TestCase
 
         $config->addHealthCheck($instance);
 
-        self::assertSame([$instance], $config->toTransfer()->healthChecks);
+        self::assertSame([$instance], HealthCheckRegistry::all());
     }
 
     public function test_add_health_check_is_fluent(): void
@@ -82,15 +83,15 @@ final class GacelaConfigTest extends TestCase
 
         self::assertSame(
             [GacelaConfigTestFakeHealthCheck::class, $instance],
-            $config->toTransfer()->healthChecks,
+            HealthCheckRegistry::all(),
         );
     }
 
     public function test_add_health_check_defaults_to_empty_list(): void
     {
-        $config = new GacelaConfig();
+        new GacelaConfig();
 
-        self::assertSame([], $config->toTransfer()->healthChecks);
+        self::assertSame([], HealthCheckRegistry::all());
     }
 }
 

--- a/tests/Unit/Framework/Health/HealthCheckRegistryTest.php
+++ b/tests/Unit/Framework/Health/HealthCheckRegistryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Health;
+
+use Gacela\Framework\Health\HealthCheckRegistry;
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use PHPUnit\Framework\TestCase;
+
+final class HealthCheckRegistryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        HealthCheckRegistry::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        HealthCheckRegistry::reset();
+    }
+
+    public function test_reset_clears_all_registered_checks(): void
+    {
+        HealthCheckRegistry::register(HealthCheckRegistryTestFake::class);
+
+        HealthCheckRegistry::reset();
+
+        self::assertSame([], HealthCheckRegistry::all());
+    }
+
+    public function test_all_returns_registered_checks_in_order(): void
+    {
+        $instance = new HealthCheckRegistryTestFake();
+
+        HealthCheckRegistry::register(HealthCheckRegistryTestFake::class);
+        HealthCheckRegistry::register($instance);
+
+        self::assertSame(
+            [HealthCheckRegistryTestFake::class, $instance],
+            HealthCheckRegistry::all(),
+        );
+    }
+
+    public function test_create_health_checker_resolves_class_strings_into_instances(): void
+    {
+        HealthCheckRegistry::register(HealthCheckRegistryTestFake::class);
+
+        $checker = HealthCheckRegistry::createHealthChecker();
+        $report = $checker->checkAll();
+
+        self::assertArrayHasKey('Fake', $report->getResults());
+        self::assertTrue($report->isHealthy());
+    }
+
+    public function test_create_health_checker_passes_instances_through(): void
+    {
+        $instance = new HealthCheckRegistryTestFake();
+        HealthCheckRegistry::register($instance);
+
+        $checker = HealthCheckRegistry::createHealthChecker();
+        $report = $checker->checkAll();
+
+        self::assertArrayHasKey('Fake', $report->getResults());
+    }
+
+    public function test_create_health_checker_returns_empty_when_nothing_registered(): void
+    {
+        $checker = HealthCheckRegistry::createHealthChecker();
+
+        self::assertSame(0, $checker->count());
+    }
+}
+
+final class HealthCheckRegistryTestFake implements ModuleHealthCheckInterface
+{
+    public function checkHealth(): HealthStatus
+    {
+        return HealthStatus::healthy();
+    }
+
+    public function getModuleName(): string
+    {
+        return 'Fake';
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds `GacelaConfig::addHealthCheck()` so modules can contribute health checks via Provider config. `DoctorCommand` now aggregates Provider-registered checks alongside its existing built-in ones — zero changes required at the `doctor` call site.

Previously every new module-level check required editing `DoctorCommand` directly (or in downstream consumers like phel-lang, their wrapper command). This unblocks auto-discovery without filesystem scanning.

## 🔖 Changes

- `GacelaConfig::addHealthCheck(class-string|ModuleHealthCheckInterface)` — Provider-registered entries resolve through the container (class-strings get constructor deps; instances pass through)
- `HealthCheckRegistry` — static registry; reset on each bootstrap for test isolation
- `GacelaConfigTransfer::$healthChecks` — carries registered checks through Setup
- `DoctorCommand::buildChecks()` — extended to merge Provider-registered results via a `HealthLevel → CheckResult` adapter
- Unit tests for `addHealthCheck()` and the registry (10 tests)
- Feature tests for `DoctorCommand` covering class-string + instance registration, unhealthy exit code, and no-op baseline