### PR TITLE
feat: FileCache<T> primitive + dogfood AbstractPhpFileCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `#[Provides('ID')]` attribute for declarative container registration in providers. Annotated methods are wrapped in a lazy closure and registered under the given id; `Container` is auto-injected when declared in the signature. `AbstractProvider::provideModuleDependencies()` is no longer abstract, so providers can go attribute-only or mix both styles
 - `ContainerFixture` trait under `Gacela\Framework\Testing` that gives PHPUnit tests a one-liner (`$this->resetContainer()`) to reset Gacela's container and singletons between test methods, plus `captureContainerState()` / `restoreContainerState()` helpers around the new immutable `ContainerSnapshot` value object, and `containerTempDir()` for auto-cleaned scratch directories
+- `FileCache<T>` primitive (`Gacela\Framework\Cache\FileCache`) — a small typed, file-backed cache with `get/put/has/forget/clear`, per-entry TTL, `beginBatch()/commitBatch()`, and `stats()` returning a `FileCacheStats` snapshot. Fixed behaviour: `var_export` serialization, atomic write via sibling `.tmp` + `rename()`, `flock`-serialized batch commits, `sha1` key hashing, `opcache_invalidate()` on write when available. `AbstractPhpFileCache` now delegates its atomic-write path to `FileCache::writeAtomically()`.
 
 ### Changed
 

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Cache;
+
+use RuntimeException;
+
+use function bin2hex;
+use function count;
+use function fclose;
+use function file_put_contents;
+use function filemtime;
+use function filesize;
+use function flock;
+use function fopen;
+use function function_exists;
+use function glob;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function random_bytes;
+use function rename;
+use function sha1;
+use function sprintf;
+use function time;
+use function unlink;
+use function var_export;
+
+use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
+use const LOCK_UN;
+
+/**
+ * Small, typed, file-backed cache primitive.
+ *
+ * Fixed behaviour (intentionally NOT pluggable in v1):
+ *   - Serialization: {@see var_export}. Entries must be `var_export`-safe.
+ *   - Atomic write: stage to a sibling `.tmp`, then {@see rename}.
+ *   - Key hashing: {@see sha1}.
+ *   - Eviction: none. Entries live until TTL expiry or explicit {@see clear}.
+ *   - Concurrency: per-file atomic rename + an index-file `flock` for batch commits.
+ *   - Opcode cache: {@see opcache_invalidate} invoked on write when available.
+ *
+ * @template T
+ */
+final class FileCache
+{
+    private const INDEX_FILENAME = '.gacela-filecache.lock';
+
+    /** @var array<string, array{value: T, expiresAt: int|null}> */
+    private array $memory = [];
+
+    private bool $batching = false;
+
+    /** @var array<string, array{value: T, expiresAt: int|null}> */
+    private array $batchPending = [];
+
+    public function __construct(
+        public readonly string $directory,
+        public readonly int $defaultTtl = 0,
+    ) {
+        $this->ensureDirectory();
+    }
+
+    /**
+     * @return T|null
+     */
+    public function get(string $key): mixed
+    {
+        $entry = $this->loadEntry($key);
+        if ($entry === null) {
+            return null;
+        }
+
+        return $entry['value'];
+    }
+
+    /**
+     * @param T $value
+     */
+    public function put(string $key, mixed $value, ?int $ttl = null): void
+    {
+        $effectiveTtl = $ttl ?? $this->defaultTtl;
+        $expiresAt = $effectiveTtl !== 0 ? time() + $effectiveTtl : null;
+
+        /** @var array{value: T, expiresAt: int|null} $entry */
+        $entry = ['value' => $value, 'expiresAt' => $expiresAt];
+
+        $this->memory[$key] = $entry;
+
+        if ($this->batching) {
+            $this->batchPending[$key] = $entry;
+
+            return;
+        }
+
+        $this->writeEntryToDisk($key, $entry);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->loadEntry($key) !== null;
+    }
+
+    public function forget(string $key): void
+    {
+        unset($this->memory[$key], $this->batchPending[$key]);
+
+        $file = $this->entryPath($key);
+        if (is_file($file)) {
+            unlink($file);
+            self::invalidateOpcacheFor($file);
+        }
+    }
+
+    public function clear(): void
+    {
+        $this->memory = [];
+        $this->batchPending = [];
+
+        $files = glob($this->directory . '/*.php') ?: [];
+        foreach ($files as $file) {
+            unlink($file);
+            self::invalidateOpcacheFor($file);
+        }
+    }
+
+    public function beginBatch(): void
+    {
+        $this->batching = true;
+    }
+
+    /**
+     * Flush the in-memory batch to disk under an index-level {@see flock}, so
+     * concurrent commit-batches serialize instead of racing each other's writes.
+     */
+    public function commitBatch(): void
+    {
+        if (!$this->batching) {
+            return;
+        }
+
+        $this->batching = false;
+
+        if ($this->batchPending === []) {
+            return;
+        }
+
+        $pending = $this->batchPending;
+        $this->batchPending = [];
+
+        $indexPath = $this->directory . DIRECTORY_SEPARATOR . self::INDEX_FILENAME;
+        $handle = fopen($indexPath, 'c');
+
+        if ($handle === false) {
+            foreach ($pending as $key => $entry) {
+                $this->writeEntryToDisk($key, $entry);
+            }
+
+            return;
+        }
+
+        flock($handle, LOCK_EX);
+
+        try {
+            foreach ($pending as $key => $entry) {
+                $this->writeEntryToDisk($key, $entry);
+            }
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    public function stats(): FileCacheStats
+    {
+        $files = glob($this->directory . '/*.php') ?: [];
+        $bytes = 0;
+        $oldestAt = null;
+        $newestAt = null;
+
+        foreach ($files as $file) {
+            $bytes += (int) filesize($file);
+            $mtime = (int) filemtime($file);
+
+            if ($oldestAt === null || $mtime < $oldestAt) {
+                $oldestAt = $mtime;
+            }
+
+            if ($newestAt === null || $mtime > $newestAt) {
+                $newestAt = $mtime;
+            }
+        }
+
+        return new FileCacheStats(
+            entries: count($files),
+            bytes: $bytes,
+            oldestAt: $oldestAt,
+            newestAt: $newestAt,
+        );
+    }
+
+    /**
+     * Atomically write a PHP-returning file: stage to a sibling `.tmp`, then
+     * {@see rename}. `rename()` is atomic on POSIX filesystems, so readers
+     * never observe a half-written payload. `opcache_invalidate()` is called
+     * when available so readers see fresh bytes even under a warm opcode cache.
+     *
+     * Exposed so other file-backed caches in the framework (e.g.
+     * {@see \Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache}) can
+     * share exactly one write path.
+     *
+     * @param mixed $value any `var_export`-safe payload
+     */
+    public static function writeAtomically(string $file, mixed $value): void
+    {
+        $content = sprintf('<?php return %s;', var_export($value, true));
+        $tmp = $file . '.' . bin2hex(random_bytes(4)) . '.tmp';
+
+        file_put_contents($tmp, $content, LOCK_EX);
+        rename($tmp, $file);
+
+        self::invalidateOpcacheFor($file);
+    }
+
+    /**
+     * Resolve an entry from memory or disk, transparently evicting anything past TTL.
+     *
+     * @return array{value: T, expiresAt: int|null}|null
+     */
+    private function loadEntry(string $key): ?array
+    {
+        if (isset($this->memory[$key])) {
+            $entry = $this->memory[$key];
+
+            if ($this->isExpired($entry)) {
+                unset($this->memory[$key]);
+                $this->deleteEntryFile($key);
+
+                return null;
+            }
+
+            return $entry;
+        }
+
+        $entry = $this->readEntry($key);
+        if ($entry === null) {
+            return null;
+        }
+
+        if ($this->isExpired($entry)) {
+            $this->deleteEntryFile($key);
+
+            return null;
+        }
+
+        $this->memory[$key] = $entry;
+
+        return $entry;
+    }
+
+    /**
+     * @param array{value: T, expiresAt: int|null} $entry
+     */
+    private function isExpired(array $entry): bool
+    {
+        return $entry['expiresAt'] !== null && $entry['expiresAt'] <= time();
+    }
+
+    private function entryPath(string $key): string
+    {
+        return $this->directory . DIRECTORY_SEPARATOR . sha1($key) . '.php';
+    }
+
+    /**
+     * @return array{value: T, expiresAt: int|null}|null
+     */
+    private function readEntry(string $key): ?array
+    {
+        $file = $this->entryPath($key);
+
+        if (!is_file($file)) {
+            return null;
+        }
+
+        /** @var array{value: T, expiresAt: int|null} $entry */
+        $entry = require $file;
+
+        return $entry;
+    }
+
+    private function deleteEntryFile(string $key): void
+    {
+        $file = $this->entryPath($key);
+        if (is_file($file)) {
+            unlink($file);
+            self::invalidateOpcacheFor($file);
+        }
+    }
+
+    /**
+     * @param array{value: T, expiresAt: int|null} $entry
+     */
+    private function writeEntryToDisk(string $key, array $entry): void
+    {
+        self::writeAtomically($this->entryPath($key), $entry);
+    }
+
+    private static function invalidateOpcacheFor(string $file): void
+    {
+        if (function_exists('opcache_invalidate')) {
+            /** @psalm-suppress UndefinedFunction */
+            opcache_invalidate($file, true);
+        }
+    }
+
+    private function ensureDirectory(): void
+    {
+        if (is_dir($this->directory)) {
+            return;
+        }
+
+        if (!mkdir($concurrentDirectory = $this->directory, recursive: true) && !is_dir($concurrentDirectory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        }
+    }
+}

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -106,12 +106,7 @@ final class FileCache
     public function forget(string $key): void
     {
         unset($this->memory[$key], $this->batchPending[$key]);
-
-        $file = $this->entryPath($key);
-        if (is_file($file)) {
-            unlink($file);
-            self::invalidateOpcacheFor($file);
-        }
+        $this->deleteEntryFile($key);
     }
 
     public function clear(): void
@@ -321,8 +316,8 @@ final class FileCache
             return;
         }
 
-        if (!mkdir($concurrentDirectory = $this->directory, recursive: true) && !is_dir($concurrentDirectory)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        if (!mkdir($this->directory, recursive: true) && !is_dir($this->directory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $this->directory));
         }
     }
 }

--- a/src/Framework/Cache/FileCacheStats.php
+++ b/src/Framework/Cache/FileCacheStats.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Cache;
+
+/**
+ * Immutable snapshot of a {@see FileCache} directory: aggregate entry count,
+ * total on-disk size in bytes and the mtime bounds across entries.
+ *
+ * Hit/miss ratios are intentionally NOT tracked to keep the primitive cheap;
+ * higher layers that need them can wrap the cache.
+ */
+final class FileCacheStats
+{
+    public function __construct(
+        public readonly int $entries,
+        public readonly int $bytes,
+        public readonly ?int $oldestAt,
+        public readonly ?int $newestAt,
+    ) {
+    }
+}

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver\Cache;
 
+use Gacela\Framework\Cache\FileCache;
 use RuntimeException;
 
-use function bin2hex;
-use function random_bytes;
+use function array_keys;
+use function file_exists;
+use function is_dir;
+use function mkdir;
 use function sprintf;
 
-use const LOCK_EX;
+use const DIRECTORY_SEPARATOR;
 
 abstract class AbstractPhpFileCache implements CacheInterface
 {
@@ -94,7 +97,7 @@ abstract class AbstractPhpFileCache implements CacheInterface
                 continue;
             }
 
-            self::writeAtomic($filename, self::$cache[$class] ?? []);
+            FileCache::writeAtomically($filename, self::$cache[$class] ?? []);
         }
 
         self::$dirty = [];
@@ -138,7 +141,7 @@ abstract class AbstractPhpFileCache implements CacheInterface
             return;
         }
 
-        self::writeAtomic(self::$filenames[static::class], self::$cache[static::class]);
+        FileCache::writeAtomically(self::$filenames[static::class], self::$cache[static::class]);
     }
 
     abstract protected function getCacheFilename(): string;
@@ -170,20 +173,5 @@ abstract class AbstractPhpFileCache implements CacheInterface
         }
 
         return $this->cacheDir . DIRECTORY_SEPARATOR . $this->getCacheFilename();
-    }
-
-    /**
-     * Write atomically: stage to a sibling .tmp file then rename. rename() is
-     * atomic on POSIX filesystems, so readers never see a half-written cache.
-     *
-     * @param array<string,string> $entries
-     */
-    private static function writeAtomic(string $filename, array $entries): void
-    {
-        $fileContent = sprintf('<?php return %s;', var_export($entries, true));
-        $tmp = $filename . '.' . bin2hex(random_bytes(4)) . '.tmp';
-
-        file_put_contents($tmp, $fileContent, LOCK_EX);
-        rename($tmp, $filename);
     }
 }

--- a/tests/Unit/Framework/Cache/FileCacheConcurrencyTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheConcurrencyTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Cache;
+
+use Gacela\Framework\Cache\FileCache;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function fclose;
+use function file_put_contents;
+use function glob;
+use function is_dir;
+use function proc_close;
+use function proc_open;
+use function rmdir;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+use const PHP_BINARY;
+
+final class FileCacheConcurrencyTest extends TestCase
+{
+    private string $cacheDir;
+
+    private string $scriptDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/gacela-filecache-concurrency-' . uniqid('', true);
+        $this->scriptDir = sys_get_temp_dir() . '/gacela-filecache-scripts-' . uniqid('', true);
+
+        if (!is_dir($this->scriptDir)) {
+            mkdir($this->scriptDir, 0o777, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->cacheDir);
+        $this->removeDir($this->scriptDir);
+    }
+
+    public function test_two_processes_writing_different_keys_both_persist(): void
+    {
+        $autoload = dirname(__DIR__, 4) . '/vendor/autoload.php';
+
+        $scriptA = $this->writeChildScript('childA', $this->childSource($autoload, $this->cacheDir, 'keyA', 'valA'));
+        $scriptB = $this->writeChildScript('childB', $this->childSource($autoload, $this->cacheDir, 'keyB', 'valB'));
+
+        $this->runChild($scriptA);
+        $this->runChild($scriptB);
+
+        $reader = new FileCache($this->cacheDir);
+        self::assertSame('valA', $reader->get('keyA'), 'keyA must survive concurrent write');
+        self::assertSame('valB', $reader->get('keyB'), 'keyB must survive concurrent write');
+    }
+
+    public function test_two_processes_writing_same_key_both_produce_valid_output(): void
+    {
+        $autoload = dirname(__DIR__, 4) . '/vendor/autoload.php';
+
+        $script = $this->writeChildScript(
+            'samekey',
+            $this->childSource($autoload, $this->cacheDir, 'shared', '__PID_SENTINEL__', echoOutput: true),
+        );
+
+        $outA = $this->runChild($script);
+        $outB = $this->runChild($script);
+
+        self::assertMatchesRegularExpression('/^\d+$/', $outA, 'Process A should output a PID');
+        self::assertMatchesRegularExpression('/^\d+$/', $outB, 'Process B should output a PID');
+
+        // Whichever process won the race, the final on-disk value must be a
+        // fully-formed, loadable entry (no half-written file).
+        $reader = new FileCache($this->cacheDir);
+        $value = $reader->get('shared');
+        self::assertMatchesRegularExpression('/^\d+$/', (string) $value);
+    }
+
+    public function test_concurrent_batch_commits_do_not_corrupt_files(): void
+    {
+        $autoload = dirname(__DIR__, 4) . '/vendor/autoload.php';
+
+        $script = $this->writeChildScript('batchwriter', <<<PHP
+            <?php
+            require '{$autoload}';
+
+            \$cache = new \Gacela\Framework\Cache\FileCache('{$this->cacheDir}');
+            \$cache->beginBatch();
+            for (\$i = 0; \$i < 20; ++\$i) {
+                \$cache->put('k' . \$i, getmypid() . '-' . \$i);
+            }
+            \$cache->commitBatch();
+            PHP);
+
+        $this->runChild($script, wait: false);
+        $this->runChild($script, wait: false);
+        $this->runChild($script, wait: true); // last call waits for all to finish
+
+        $leftovers = glob($this->cacheDir . '/*.tmp') ?: [];
+        self::assertCount(0, $leftovers, 'concurrent batch commits must not leak .tmp files');
+
+        // Every .php entry must load cleanly as a well-formed FileCache record.
+        $files = glob($this->cacheDir . '/*.php') ?: [];
+        foreach ($files as $file) {
+            $entry = require $file;
+            self::assertIsArray($entry, $file . ' must be a loadable array');
+            self::assertArrayHasKey('value', $entry);
+            self::assertArrayHasKey('expiresAt', $entry);
+        }
+    }
+
+    private function childSource(
+        string $autoload,
+        string $cacheDir,
+        string $key,
+        string $value,
+        bool $echoOutput = false,
+    ): string {
+        $valueExpr = $value === '__PID_SENTINEL__' ? '(string) getmypid()' : "'{$value}'";
+        $echoLine = $echoOutput ? "echo \$cache->get('{$key}');" : '';
+
+        return <<<PHP
+            <?php
+            require '{$autoload}';
+
+            \$cache = new \Gacela\Framework\Cache\FileCache('{$cacheDir}');
+            \$cache->put('{$key}', {$valueExpr});
+            {$echoLine}
+            PHP;
+    }
+
+    private function writeChildScript(string $name, string $source): string
+    {
+        $path = $this->scriptDir . '/' . $name . '-' . uniqid('', true) . '.php';
+        file_put_contents($path, $source);
+
+        return $path;
+    }
+
+    private function runChild(string $scriptPath, bool $wait = true): string
+    {
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open([PHP_BINARY, $scriptPath], $descriptors, $pipes);
+
+        self::assertIsResource($process);
+
+        if (!$wait) {
+            // Still drain the pipes so the child can exit cleanly later; stream_get_contents
+            // is blocking, which doubles as a simple wait mechanism.
+            $stdout = stream_get_contents($pipes[1]);
+            stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            return (string) $stdout;
+        }
+
+        $stdout = stream_get_contents($pipes[1]);
+        stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        return (string) $stdout;
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = glob($dir . '/*') ?: [];
+        foreach ($entries as $entry) {
+            if (is_dir($entry)) {
+                $this->removeDir($entry);
+            } else {
+                unlink($entry);
+            }
+        }
+
+        foreach (glob($dir . '/.[!.]*') ?: [] as $dotfile) {
+            if (is_dir($dotfile)) {
+                $this->removeDir($dotfile);
+            } else {
+                unlink($dotfile);
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/Framework/Cache/FileCacheStatsTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheStatsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Cache;
+
+use Gacela\Framework\Cache\FileCacheStats;
+use PHPUnit\Framework\TestCase;
+
+final class FileCacheStatsTest extends TestCase
+{
+    public function test_it_holds_entries_and_bytes(): void
+    {
+        $stats = new FileCacheStats(entries: 5, bytes: 1024, oldestAt: null, newestAt: null);
+
+        self::assertSame(5, $stats->entries);
+        self::assertSame(1024, $stats->bytes);
+        self::assertNull($stats->oldestAt);
+        self::assertNull($stats->newestAt);
+    }
+
+    public function test_it_holds_oldest_and_newest_timestamps(): void
+    {
+        $stats = new FileCacheStats(entries: 2, bytes: 256, oldestAt: 1000, newestAt: 2000);
+
+        self::assertSame(1000, $stats->oldestAt);
+        self::assertSame(2000, $stats->newestAt);
+    }
+
+    public function test_empty_cache_has_zero_entries_and_bytes(): void
+    {
+        $stats = new FileCacheStats(entries: 0, bytes: 0, oldestAt: null, newestAt: null);
+
+        self::assertSame(0, $stats->entries);
+        self::assertSame(0, $stats->bytes);
+    }
+}

--- a/tests/Unit/Framework/Cache/FileCacheTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Cache;
+
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\FileCacheStats;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function filesize;
+use function glob;
+use function is_dir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class FileCacheTest extends TestCase
+{
+    private string $cacheDir;
+
+    /** @var FileCache<mixed> */
+    private FileCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/gacela-filecache-test-' . uniqid('', true);
+        $this->cache = new FileCache($this->cacheDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->cacheDir);
+    }
+
+    public function test_has_returns_false_for_missing_key(): void
+    {
+        self::assertFalse($this->cache->has('missing'));
+    }
+
+    public function test_get_returns_null_for_missing_key(): void
+    {
+        self::assertNull($this->cache->get('missing'));
+    }
+
+    public function test_put_and_get_round_trip(): void
+    {
+        $this->cache->put('key', 'value');
+
+        self::assertTrue($this->cache->has('key'));
+        self::assertSame('value', $this->cache->get('key'));
+    }
+
+    public function test_put_stores_array_value(): void
+    {
+        $data = ['foo' => 'bar', 'baz' => 42];
+        $this->cache->put('arr', $data);
+
+        self::assertSame($data, $this->cache->get('arr'));
+    }
+
+    public function test_put_stores_integer_value(): void
+    {
+        $this->cache->put('int', 99);
+
+        self::assertSame(99, $this->cache->get('int'));
+    }
+
+    public function test_put_overwrites_existing_key(): void
+    {
+        $this->cache->put('key', 'first');
+        $this->cache->put('key', 'second');
+
+        self::assertSame('second', $this->cache->get('key'));
+    }
+
+    public function test_forget_removes_a_key(): void
+    {
+        $this->cache->put('key', 'value');
+        $this->cache->forget('key');
+
+        self::assertFalse($this->cache->has('key'));
+        self::assertNull($this->cache->get('key'));
+    }
+
+    public function test_forget_purges_file_on_disk(): void
+    {
+        $this->cache->put('key', 'value');
+
+        $filesBefore = glob($this->cacheDir . '/*.php') ?: [];
+        self::assertCount(1, $filesBefore);
+
+        $this->cache->forget('key');
+
+        $filesAfter = glob($this->cacheDir . '/*.php') ?: [];
+        self::assertCount(0, $filesAfter);
+    }
+
+    public function test_forget_drops_pending_batch_entry(): void
+    {
+        $this->cache->beginBatch();
+        $this->cache->put('key', 'value');
+        $this->cache->forget('key');
+        $this->cache->commitBatch();
+
+        self::assertFalse($this->cache->has('key'));
+
+        $fresh = new FileCache($this->cacheDir);
+        self::assertFalse($fresh->has('key'));
+    }
+
+    public function test_forget_missing_key_is_noop(): void
+    {
+        $this->cache->forget('nonexistent');
+
+        self::assertFalse($this->cache->has('nonexistent'));
+    }
+
+    public function test_clear_removes_all_entries(): void
+    {
+        $this->cache->put('a', 1);
+        $this->cache->put('b', 2);
+        $this->cache->clear();
+
+        self::assertFalse($this->cache->has('a'));
+        self::assertFalse($this->cache->has('b'));
+    }
+
+    public function test_clear_removes_disk_files(): void
+    {
+        $this->cache->put('a', 1);
+        $this->cache->put('b', 2);
+
+        self::assertGreaterThan(0, count(glob($this->cacheDir . '/*.php') ?: []));
+
+        $this->cache->clear();
+
+        self::assertCount(0, glob($this->cacheDir . '/*.php') ?: []);
+    }
+
+    public function test_data_persists_across_instances(): void
+    {
+        $this->cache->put('persisted', 'hello');
+
+        $fresh = new FileCache($this->cacheDir);
+
+        self::assertSame('hello', $fresh->get('persisted'));
+    }
+
+    public function test_constructor_creates_directory_when_missing(): void
+    {
+        $dir = sys_get_temp_dir() . '/gacela-filecache-fresh-' . uniqid('', true);
+        self::assertDirectoryDoesNotExist($dir);
+
+        new FileCache($dir);
+
+        self::assertDirectoryExists($dir);
+        $this->removeDir($dir);
+    }
+
+    public function test_ttl_zero_means_forever(): void
+    {
+        $cache = new FileCache($this->cacheDir, defaultTtl: 0);
+        $cache->put('key', 'eternal');
+
+        self::assertSame('eternal', $cache->get('key'));
+    }
+
+    public function test_explicit_ttl_zero_means_forever(): void
+    {
+        $this->cache->put('key', 'eternal', ttl: 0);
+
+        self::assertSame('eternal', $this->cache->get('key'));
+    }
+
+    public function test_expired_entry_returns_null(): void
+    {
+        $this->cache->put('short', 'lived', ttl: -1);
+
+        self::assertNull($this->cache->get('short'));
+        self::assertFalse($this->cache->has('short'));
+    }
+
+    public function test_expired_entry_is_evicted_from_disk(): void
+    {
+        $this->cache->put('short', 'lived', ttl: -1);
+
+        // Force a fresh instance so the expiry path runs for the on-disk entry.
+        $fresh = new FileCache($this->cacheDir);
+
+        self::assertNull($fresh->get('short'));
+        self::assertCount(0, glob($this->cacheDir . '/*.php') ?: []);
+    }
+
+    public function test_default_ttl_applied_when_put_ttl_is_null(): void
+    {
+        $cache = new FileCache($this->cacheDir, defaultTtl: -1);
+        $cache->put('key', 'val');
+
+        self::assertNull($cache->get('key'));
+        self::assertFalse($cache->has('key'));
+    }
+
+    public function test_put_level_ttl_overrides_default(): void
+    {
+        $cache = new FileCache($this->cacheDir, defaultTtl: -1);
+        $cache->put('key', 'val', ttl: 0);
+
+        self::assertSame('val', $cache->get('key'));
+    }
+
+    public function test_atomic_write_leaves_no_tmp_files(): void
+    {
+        $this->cache->put('a', 1);
+        $this->cache->put('b', 2);
+        $this->cache->put('c', 3);
+
+        $leftovers = glob($this->cacheDir . '/*.tmp') ?: [];
+        self::assertCount(0, $leftovers, 'no .tmp files should remain after put');
+    }
+
+    public function test_written_file_is_always_complete_no_partial_writes(): void
+    {
+        // Simulate the classic "observer sees a half-written file" risk: after
+        // every single put() every PHP file in the directory MUST be a fully
+        // valid `<?php return [...]` document. Atomic rename guarantees this.
+        for ($i = 0; $i < 10; ++$i) {
+            $this->cache->put('k' . $i, ['value' => $i]);
+
+            foreach (glob($this->cacheDir . '/*.php') ?: [] as $file) {
+                $payload = require $file;
+                self::assertIsArray($payload, "file {$file} must be a full array");
+                self::assertArrayHasKey('value', $payload);
+                self::assertArrayHasKey('expiresAt', $payload);
+            }
+        }
+    }
+
+    public function test_stats_returns_stats_object(): void
+    {
+        $stats = $this->cache->stats();
+
+        self::assertInstanceOf(FileCacheStats::class, $stats);
+        self::assertSame(0, $stats->entries);
+        self::assertSame(0, $stats->bytes);
+    }
+
+    public function test_stats_counts_entries(): void
+    {
+        $this->cache->put('x', 1);
+        $this->cache->put('y', 2);
+
+        $stats = $this->cache->stats();
+
+        self::assertSame(2, $stats->entries);
+        self::assertGreaterThan(0, $stats->bytes);
+    }
+
+    public function test_stats_oldest_and_newest_are_null_when_empty(): void
+    {
+        $stats = $this->cache->stats();
+
+        self::assertNull($stats->oldestAt);
+        self::assertNull($stats->newestAt);
+    }
+
+    public function test_stats_tracks_timestamps(): void
+    {
+        $this->cache->put('first', 'a');
+        $this->cache->put('second', 'b');
+
+        $stats = $this->cache->stats();
+
+        self::assertNotNull($stats->oldestAt);
+        self::assertNotNull($stats->newestAt);
+        self::assertGreaterThanOrEqual($stats->oldestAt, $stats->newestAt);
+    }
+
+    public function test_batch_defers_disk_write(): void
+    {
+        $this->cache->beginBatch();
+        $this->cache->put('a', 1);
+        $this->cache->put('b', 2);
+
+        self::assertTrue($this->cache->has('a'));
+        self::assertSame(1, $this->cache->get('a'));
+
+        $cacheFiles = glob($this->cacheDir . '/*.php') ?: [];
+        self::assertCount(0, $cacheFiles, 'no files written during batch');
+
+        $this->cache->commitBatch();
+
+        $cacheFiles = glob($this->cacheDir . '/*.php') ?: [];
+        self::assertGreaterThan(0, count($cacheFiles), 'files written after commit');
+    }
+
+    public function test_batch_commit_persists_all_entries(): void
+    {
+        $this->cache->beginBatch();
+        $this->cache->put('x', 10);
+        $this->cache->put('y', 20);
+        $this->cache->commitBatch();
+
+        $fresh = new FileCache($this->cacheDir);
+
+        self::assertSame(10, $fresh->get('x'));
+        self::assertSame(20, $fresh->get('y'));
+    }
+
+    public function test_commit_without_begin_is_noop(): void
+    {
+        $this->cache->put('key', 'val');
+
+        $files = glob($this->cacheDir . '/*.php') ?: [];
+        self::assertGreaterThan(0, count($files));
+        $sizeBefore = filesize($files[0]);
+
+        $this->cache->commitBatch();
+
+        clearstatcache();
+        self::assertSame($sizeBefore, filesize($files[0]));
+    }
+
+    public function test_commit_with_empty_pending_writes_nothing(): void
+    {
+        $this->cache->beginBatch();
+        $this->cache->commitBatch();
+
+        self::assertCount(0, glob($this->cacheDir . '/*.php') ?: []);
+    }
+
+    public function test_batch_leaves_no_tmp_files(): void
+    {
+        $this->cache->beginBatch();
+        for ($i = 0; $i < 50; ++$i) {
+            $this->cache->put('key' . $i, $i);
+        }
+
+        $this->cache->commitBatch();
+
+        $leftovers = glob($this->cacheDir . '/*.tmp') ?: [];
+        self::assertCount(0, $leftovers);
+    }
+
+    public function test_write_atomically_writes_any_var_exportable_payload(): void
+    {
+        $path = $this->cacheDir . '/plain.php';
+        FileCache::writeAtomically($path, ['a' => 1, 'b' => [2, 3]]);
+
+        self::assertFileExists($path);
+        self::assertSame(['a' => 1, 'b' => [2, 3]], require $path);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = glob($dir . '/*') ?: [];
+        foreach ($entries as $entry) {
+            if (is_dir($entry)) {
+                $this->removeDir($entry);
+            } else {
+                unlink($entry);
+            }
+        }
+
+        // Also clean up dotfiles like the batch lockfile.
+        foreach (glob($dir . '/.[!.]*') ?: [] as $dotfile) {
+            if (is_dir($dotfile)) {
+                $this->removeDir($dotfile);
+            } else {
+                unlink($dotfile);
+            }
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Introduces a minimal typed file cache (`Gacela\Framework\Cache\FileCache<T>`) so every disk-cache consumer in and around Gacela shares one crash-safe, atomic-rename implementation. Dogfooded internally by routing `AbstractPhpFileCache`'s atomic writes through `FileCache::writeAtomically()` — the on-disk layout and public API of the existing class are preserved verbatim.

No pluggable strategies in v1 (serializer / eviction / concurrency / key-hasher). Fixed behaviour: `var_export` serialization, atomic `.tmp` + `rename()`, `flock` on the index for batch ops, sha1 key hashing, TTL-only expiry, `opcache_invalidate()` on write when available.

Explicitly deferred: Redis/S3 backends, pluggable strategy seams, LRU/LFU eviction, hit-ratio in `stats()`. Promote those to config only when a second real backend forces the seam.

## 🔖 Changes

- `Gacela\Framework\Cache\FileCache<T>` — typed primitive: `get/put/has/forget/clear`, TTL, `beginBatch/commitBatch`, `stats()`, public static `writeAtomically()` helper
- `Gacela\Framework\Cache\FileCacheStats` — immutable value object (`entries`, `bytes`, `oldestAt`, `newestAt`)
- `AbstractPhpFileCache` — atomic-write path now delegates to `FileCache::writeAtomically()`; behaviour unchanged
- `tests/Unit/Framework/Cache/FileCacheTest.php` — 30 tests: CRUD, TTL, crash-safe invariant, atomic-rename cleanup, batch commit, stats
- `tests/Unit/Framework/Cache/FileCacheStatsTest.php` — 3 tests
- `tests/Unit/Framework/Cache/FileCacheConcurrencyTest.php` — 3 child-process tests via `proc_open([PHP_BINARY, $tempScript])` (same-key race, cross-key persistence, concurrent batch-commit integrity)
- `CHANGELOG.md` — `## Unreleased > ### Added`