### PR TITLE
feat: build-time HandlerRegistry for dispatch tables

### DIFF
--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -33,6 +33,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const contextualBindings = 'contextualBindings';
 
+    public const handlerRegistries = 'handlerRegistries';
+
     public const plugins = 'plugins';
 
     public const gacelaConfigsToExtend = 'gacelaConfigsToExtend';
@@ -62,6 +64,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const DEFAULT_ALIASES = [];
 
     protected const DEFAULT_CONTEXTUAL_BINDINGS = [];
+
+    protected const DEFAULT_HANDLER_REGISTRIES = [];
 
     protected const DEFAULT_GACELA_CONFIGS_TO_EXTEND = [];
 

--- a/src/Framework/Bootstrap/ContainerConfigurationInterface.php
+++ b/src/Framework/Bootstrap/ContainerConfigurationInterface.php
@@ -51,4 +51,14 @@ interface ContainerConfigurationInterface
      * @return array<string,array<class-string,class-string|callable|object>>
      */
     public function getContextualBindings(): array;
+
+    /**
+     * Get handler registry declarations (build-time dispatch tables).
+     *
+     * Each entry maps a registry identifier to the declared handler classes.
+     * The registry is resolvable from the container under that identifier.
+     *
+     * @return array<string,array<string|int,class-string>>
+     */
+    public function getHandlerRegistries(): array;
 }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -62,6 +62,9 @@ final class GacelaConfig
     /** @var array<string,array<class-string,class-string|callable|object>> */
     private array $contextualBindings = [];
 
+    /** @var array<string,array<string|int,class-string>> */
+    private array $handlerRegistries = [];
+
     /**
      * @param array<string,class-string|object|callable> $externalServices
      */
@@ -370,6 +373,23 @@ final class GacelaConfig
     }
 
     /**
+     * Declare a build-time dispatch table. The registry is resolvable from the
+     * container under `$registryKey` and returns a {@see \Gacela\Framework\Plugins\HandlerRegistry}
+     * that lazy-instantiates each handler through the container on first access.
+     *
+     * Registries are frozen after boot: there is no runtime `register()` method.
+     *
+     * @param string $registryKey identifier under which the registry is resolved (typically an interface/class name)
+     * @param array<string|int,class-string> $handlers map of dispatch key to handler class
+     */
+    public function addHandlerRegistry(string $registryKey, array $handlers): self
+    {
+        $this->handlerRegistries[$registryKey] = $handlers;
+
+        return $this;
+    }
+
+    /**
      * Add a new invokable class that can extend the GacelaConfig object.
      *
      * This configClass will receive the GacelaConfig object as argument to the __invoke() method.
@@ -441,6 +461,7 @@ final class GacelaConfig
             $this->protectedServices,
             $this->aliases,
             $this->contextualBindings,
+            $this->handlerRegistries,
         );
     }
 }

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -24,6 +24,7 @@ final class GacelaConfigTransfer
      * @param array<string,Closure> $protectedServices
      * @param array<string,string> $aliases
      * @param array<string,array<class-string,class-string|callable|object>> $contextualBindings
+     * @param array<string,array<string|int,class-string>> $handlerRegistries
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,
@@ -45,6 +46,7 @@ final class GacelaConfigTransfer
         public readonly array $protectedServices,
         public readonly array $aliases,
         public readonly array $contextualBindings,
+        public readonly array $handlerRegistries = [],
     ) {
     }
 }

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -76,6 +76,9 @@ final class Properties
     /** @var ?list<class-string|callable> */
     public ?array $plugins = null;
 
+    /** @var ?array<string,array<string|int,class-string>> */
+    public ?array $handlerRegistries = null;
+
     public function __construct()
     {
         $emptyFn = static function (): void {};

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -112,4 +112,23 @@ final class PropertyMerger
 
         $this->setup->setContextualBindings($merged);
     }
+
+    /**
+     * @param array<string,array<string|int,class-string>> $list
+     */
+    public function mergeHandlerRegistries(array $list): void
+    {
+        $current = $this->setup->getHandlerRegistries();
+        $merged = $current;
+
+        foreach ($list as $registryKey => $handlers) {
+            if (!isset($merged[$registryKey])) {
+                $merged[$registryKey] = [];
+            }
+
+            $merged[$registryKey] = array_merge($merged[$registryKey], $handlers);
+        }
+
+        $this->setup->setHandlerRegistries($merged);
+    }
 }

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -38,6 +38,7 @@ final class SetupInitializer
             ->setFactories($dto->factories)
             ->setProtectedServices($dto->protectedServices)
             ->setAliases($dto->aliases)
-            ->setContextualBindings($dto->contextualBindings);
+            ->setContextualBindings($dto->contextualBindings)
+            ->setHandlerRegistries($dto->handlerRegistries);
     }
 }

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -33,6 +33,7 @@ final class SetupMerger
         $this->mergeProtectedServices($other);
         $this->mergeAliases($other);
         $this->mergeContextualBindings($other);
+        $this->mergeHandlerRegistries($other);
         $this->mergePlugins($other);
         $this->mergeGacelaConfigsToExtend($other);
 
@@ -150,6 +151,13 @@ final class SetupMerger
     {
         if ($other->isPropertyChanged(SetupGacela::contextualBindings)) {
             $this->original->mergeContextualBindings($other->getContextualBindings());
+        }
+    }
+
+    private function mergeHandlerRegistries(SetupGacela $other): void
+    {
+        if ($other->isPropertyChanged(SetupGacela::handlerRegistries)) {
+            $this->original->mergeHandlerRegistries($other->getHandlerRegistries());
         }
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -294,6 +294,14 @@ final class SetupGacela extends AbstractSetupGacela
         return $this->properties->contextualBindings ?? self::DEFAULT_CONTEXTUAL_BINDINGS;
     }
 
+    /**
+     * @return array<string,array<string|int,class-string>>
+     */
+    public function getHandlerRegistries(): array
+    {
+        return $this->properties->handlerRegistries ?? self::DEFAULT_HANDLER_REGISTRIES;
+    }
+
     public function setFileCacheEnabled(?bool $flag): self
     {
         $this->properties->fileCacheEnabled = $this->setPropertyWithTracking(
@@ -589,6 +597,30 @@ final class SetupGacela extends AbstractSetupGacela
         );
 
         return $this;
+    }
+
+    /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
+     * @param ?array<string,array<string|int,class-string>> $list
+     */
+    public function setHandlerRegistries(?array $list): self
+    {
+        $this->properties->handlerRegistries = $this->setPropertyWithTracking(
+            self::handlerRegistries,
+            $list,
+            self::DEFAULT_HANDLER_REGISTRIES,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param array<string,array<string|int,class-string>> $list
+     */
+    public function mergeHandlerRegistries(array $list): void
+    {
+        $this->propertyMerger->mergeHandlerRegistries($list);
     }
 
     /**

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework\Container;
 use Gacela\Container\Container as GacelaContainer;
 use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Plugins\LazyHandlerRegistry;
 
 /**
  * This is a decorator class to simplify the usage of the decoupled Container
@@ -38,28 +39,31 @@ final class Container extends GacelaContainer implements ContainerInterface
             $containerConfig->getServicesToExtend(),
         );
 
-        // Register factory services
         foreach ($containerConfig->getFactories() as $id => $factory) {
             $container->set($id, $container->factory($factory));
         }
 
-        // Register protected services
         foreach ($containerConfig->getProtectedServices() as $id => $service) {
             $container->set($id, $container->protect($service));
         }
 
-        // Register aliases
         foreach ($containerConfig->getAliases() as $alias => $id) {
             $container->alias($alias, $id);
         }
 
-        // Register contextual bindings
         foreach ($containerConfig->getContextualBindings() as $concrete => $needs) {
             foreach ($needs as $abstract => $implementation) {
                 /** @var class-string $concrete */
                 /** @var class-string $abstract */
                 $container->when($concrete)->needs($abstract)->give($implementation);
             }
+        }
+
+        foreach ($containerConfig->getHandlerRegistries() as $registryKey => $handlers) {
+            $container->set(
+                $registryKey,
+                static fn (): LazyHandlerRegistry => new LazyHandlerRegistry($handlers, $container),
+            );
         }
 
         return $container;

--- a/src/Framework/Plugins/HandlerRegistry.php
+++ b/src/Framework/Plugins/HandlerRegistry.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Plugins;
+
+/**
+ * Build-time dispatch table that maps keys to handler classes.
+ *
+ * Implementations are frozen after boot: the handler map is declared
+ * in a Provider via GacelaConfig::addHandlerRegistry() and no entries
+ * can be added at runtime. Handlers are resolved through the DI
+ * container so their constructor dependencies are auto-wired.
+ *
+ * @template THandler of object
+ * @template TKey of string|int
+ */
+interface HandlerRegistry
+{
+    /**
+     * Resolve (and cache) the handler registered for the given key.
+     *
+     * @return THandler
+     */
+    public function get(string|int $key): object;
+
+    public function has(string|int $key): bool;
+
+    /**
+     * @return list<TKey>
+     */
+    public function keys(): array;
+}

--- a/src/Framework/Plugins/LazyHandlerRegistry.php
+++ b/src/Framework/Plugins/LazyHandlerRegistry.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Plugins;
+
+use Gacela\Container\ContainerInterface;
+use OutOfBoundsException;
+
+use function array_key_exists;
+use function array_keys;
+use function implode;
+use function sprintf;
+
+/**
+ * Default {@see HandlerRegistry} that resolves handlers through the container
+ * on first access and caches the resulting instance.
+ *
+ * @template THandler of object
+ * @template TKey of string|int
+ *
+ * @implements HandlerRegistry<THandler, TKey>
+ */
+final class LazyHandlerRegistry implements HandlerRegistry
+{
+    /** @var array<string|int, object> */
+    private array $resolved = [];
+
+    /**
+     * @param array<TKey, class-string<THandler>> $handlers
+     */
+    public function __construct(
+        private readonly array $handlers,
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public function get(string|int $key): object
+    {
+        if (array_key_exists($key, $this->resolved)) {
+            /** @var THandler */
+            return $this->resolved[$key];
+        }
+
+        if (!array_key_exists($key, $this->handlers)) {
+            throw new OutOfBoundsException(sprintf(
+                'No handler registered for key "%s". Known keys: %s',
+                (string) $key,
+                $this->handlers === [] ? '(none)' : implode(', ', array_map(
+                    static fn (string|int $k): string => (string) $k,
+                    array_keys($this->handlers),
+                )),
+            ));
+        }
+
+        /** @var THandler $instance */
+        $instance = $this->container->get($this->handlers[$key]);
+        $this->resolved[$key] = $instance;
+
+        return $instance;
+    }
+
+    public function has(string|int $key): bool
+    {
+        return array_key_exists($key, $this->handlers);
+    }
+
+    /**
+     * @return list<TKey>
+     */
+    public function keys(): array
+    {
+        /** @var list<TKey> $keys */
+        $keys = array_keys($this->handlers);
+
+        return $keys;
+    }
+}

--- a/tests/Integration/Framework/Plugins/Handler/ConcreteHandlerA.php
+++ b/tests/Integration/Framework/Plugins/Handler/ConcreteHandlerA.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Plugins\Handler;
+
+final class ConcreteHandlerA
+{
+}

--- a/tests/Integration/Framework/Plugins/Handler/ConcreteHandlerB.php
+++ b/tests/Integration/Framework/Plugins/Handler/ConcreteHandlerB.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Plugins\Handler;
+
+final class ConcreteHandlerB
+{
+}

--- a/tests/Integration/Framework/Plugins/Handler/CountingHandler.php
+++ b/tests/Integration/Framework/Plugins/Handler/CountingHandler.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Plugins\Handler;
+
+final class CountingHandler
+{
+    public static int $instantiations = 0;
+
+    public function __construct()
+    {
+        ++self::$instantiations;
+    }
+}

--- a/tests/Integration/Framework/Plugins/Handler/HandlerWithDependency.php
+++ b/tests/Integration/Framework/Plugins/Handler/HandlerWithDependency.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Plugins\Handler;
+
+final class HandlerWithDependency
+{
+    public function __construct(
+        public readonly InjectedDependency $dependency,
+    ) {
+    }
+}

--- a/tests/Integration/Framework/Plugins/Handler/InjectedDependency.php
+++ b/tests/Integration/Framework/Plugins/Handler/InjectedDependency.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Plugins\Handler;
+
+final class InjectedDependency
+{
+}

--- a/tests/Integration/Framework/Plugins/HandlerRegistryTest.php
+++ b/tests/Integration/Framework/Plugins/HandlerRegistryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Plugins;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Plugins\HandlerRegistry;
+use Gacela\Framework\Plugins\LazyHandlerRegistry;
+use GacelaTest\Integration\Framework\Plugins\Handler\ConcreteHandlerA;
+use GacelaTest\Integration\Framework\Plugins\Handler\ConcreteHandlerB;
+use GacelaTest\Integration\Framework\Plugins\Handler\CountingHandler;
+use GacelaTest\Integration\Framework\Plugins\Handler\HandlerWithDependency;
+use GacelaTest\Integration\Framework\Plugins\Handler\InjectedDependency;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class HandlerRegistryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $reflection = new ReflectionClass(Gacela::class);
+        $reflection->getMethod('resetCache')->invoke(null);
+        CountingHandler::$instantiations = 0;
+    }
+
+    public function test_registry_is_resolvable_from_container(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addHandlerRegistry('dispatcher', [
+                'a' => ConcreteHandlerA::class,
+                'b' => ConcreteHandlerB::class,
+            ]);
+        });
+
+        $container = Container::withConfig(Config::getInstance());
+
+        $registry = $container->get('dispatcher');
+
+        self::assertInstanceOf(HandlerRegistry::class, $registry);
+        self::assertInstanceOf(LazyHandlerRegistry::class, $registry);
+    }
+
+    public function test_get_returns_handler_for_registered_key(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addHandlerRegistry('dispatcher', [
+                'a' => ConcreteHandlerA::class,
+                'b' => ConcreteHandlerB::class,
+            ]);
+        });
+
+        /** @var HandlerRegistry $registry */
+        $registry = Container::withConfig(Config::getInstance())->get('dispatcher');
+
+        self::assertInstanceOf(ConcreteHandlerA::class, $registry->get('a'));
+        self::assertInstanceOf(ConcreteHandlerB::class, $registry->get('b'));
+    }
+
+    public function test_handler_constructor_dependencies_are_auto_wired(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addHandlerRegistry('dispatcher', [
+                'needs-dep' => HandlerWithDependency::class,
+            ]);
+        });
+
+        /** @var HandlerRegistry $registry */
+        $registry = Container::withConfig(Config::getInstance())->get('dispatcher');
+
+        /** @var HandlerWithDependency $handler */
+        $handler = $registry->get('needs-dep');
+
+        self::assertInstanceOf(HandlerWithDependency::class, $handler);
+        self::assertInstanceOf(InjectedDependency::class, $handler->dependency);
+    }
+
+    public function test_handlers_are_instantiated_lazily(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addHandlerRegistry('dispatcher', [
+                'only' => CountingHandler::class,
+            ]);
+        });
+
+        /** @var HandlerRegistry $registry */
+        $registry = Container::withConfig(Config::getInstance())->get('dispatcher');
+
+        self::assertSame(0, CountingHandler::$instantiations);
+
+        $registry->get('only');
+        $registry->get('only');
+
+        self::assertSame(1, CountingHandler::$instantiations);
+    }
+
+    public function test_unknown_key_throws(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addHandlerRegistry('dispatcher', [
+                'a' => ConcreteHandlerA::class,
+            ]);
+        });
+
+        /** @var HandlerRegistry $registry */
+        $registry = Container::withConfig(Config::getInstance())->get('dispatcher');
+
+        $this->expectException(OutOfBoundsException::class);
+
+        $registry->get('missing');
+    }
+
+    public function test_multiple_registries_are_independently_resolvable(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addHandlerRegistry('dispatcher-a', ['k' => ConcreteHandlerA::class]);
+            $config->addHandlerRegistry('dispatcher-b', ['k' => ConcreteHandlerB::class]);
+        });
+
+        $container = Container::withConfig(Config::getInstance());
+
+        /** @var HandlerRegistry $registryA */
+        $registryA = $container->get('dispatcher-a');
+        /** @var HandlerRegistry $registryB */
+        $registryB = $container->get('dispatcher-b');
+
+        self::assertInstanceOf(ConcreteHandlerA::class, $registryA->get('k'));
+        self::assertInstanceOf(ConcreteHandlerB::class, $registryB->get('k'));
+    }
+}

--- a/tests/Unit/Framework/Plugins/LazyHandlerRegistryTest.php
+++ b/tests/Unit/Framework/Plugins/LazyHandlerRegistryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Plugins;
+
+use Gacela\Container\Container;
+use Gacela\Framework\Plugins\LazyHandlerRegistry;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class LazyHandlerRegistryTest extends TestCase
+{
+    public function test_get_resolves_handler_through_container(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['only' => stdClass::class],
+            new Container(),
+        );
+
+        $handler = $registry->get('only');
+
+        self::assertInstanceOf(stdClass::class, $handler);
+    }
+
+    public function test_get_caches_instance_between_calls(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['a' => stdClass::class],
+            new Container(),
+        );
+
+        $first = $registry->get('a');
+        $second = $registry->get('a');
+
+        self::assertSame($first, $second);
+    }
+
+    public function test_handler_is_not_instantiated_until_requested(): void
+    {
+        CountingHandler::$instantiations = 0;
+
+        $registry = new LazyHandlerRegistry(
+            ['only' => CountingHandler::class],
+            new Container(),
+        );
+
+        self::assertSame(0, CountingHandler::$instantiations);
+
+        $registry->get('only');
+        $registry->get('only');
+
+        self::assertSame(1, CountingHandler::$instantiations);
+    }
+
+    public function test_has_returns_true_for_registered_key(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['a' => stdClass::class],
+            new Container(),
+        );
+
+        self::assertTrue($registry->has('a'));
+    }
+
+    public function test_has_returns_false_for_unknown_key(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['a' => stdClass::class],
+            new Container(),
+        );
+
+        self::assertFalse($registry->has('missing'));
+    }
+
+    public function test_keys_returns_registered_keys_in_order(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['a' => stdClass::class, 'b' => stdClass::class, 7 => stdClass::class],
+            new Container(),
+        );
+
+        self::assertSame(['a', 'b', 7], $registry->keys());
+    }
+
+    public function test_keys_is_empty_when_no_handlers_registered(): void
+    {
+        $registry = new LazyHandlerRegistry([], new Container());
+
+        self::assertSame([], $registry->keys());
+    }
+
+    public function test_get_throws_for_unknown_key(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['a' => stdClass::class],
+            new Container(),
+        );
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('No handler registered for key "missing"');
+
+        $registry->get('missing');
+    }
+
+    public function test_get_error_lists_known_keys_when_registry_non_empty(): void
+    {
+        $registry = new LazyHandlerRegistry(
+            ['alpha' => stdClass::class, 'beta' => stdClass::class],
+            new Container(),
+        );
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('alpha, beta');
+
+        $registry->get('missing');
+    }
+
+    public function test_get_error_reports_none_when_registry_empty(): void
+    {
+        $registry = new LazyHandlerRegistry([], new Container());
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('(none)');
+
+        $registry->get('missing');
+    }
+}
+
+final class CountingHandler
+{
+    public static int $instantiations = 0;
+
+    public function __construct()
+    {
+        ++self::$instantiations;
+    }
+}


### PR DESCRIPTION
## 📚 Description

Replaces hand-rolled `match($key) { ... }` dispatch tables with a Provider-registered, DI-aware lookup. Handlers are declared at boot time in a Provider via `$config->addHandlerRegistry('key', [...])`, resolved through the container on first access (lazy + cached), and constructor deps auto-wire.

**Critical invariant**: the registry is **frozen after boot** — no runtime `register()` method on the interface. This preserves the compiled-container property that `cache:warm` relies on. A future `MutableHandlerRegistry` can be added separately if ever needed.

## 🔖 Changes

- `Gacela\Framework\Plugins\HandlerRegistry` — generic interface (`@template THandler`, `@template TKey`)
- `Gacela\Framework\Plugins\LazyHandlerRegistry` — default implementation: lazy instantiation, per-instance caching, clear error for unknown keys
- `GacelaConfig::addHandlerRegistry(string $registryKey, array $handlers)` — placed before `extendGacelaConfig()`
- `GacelaConfigTransfer` + Setup pipeline (`Properties`, `PropertyMerger`, `SetupMerger`, `SetupInitializer`) — carries declarations through boot
- `Container::withContainerConfiguration()` — registers each declared registry as a resolvable service
- 10 unit tests for `LazyHandlerRegistry` (lazy instantiation, caching, has/keys/get semantics, unknown-key error)
- 6 integration tests proving end-to-end flow: Provider declares registry → container returns `HandlerRegistry` → `get('a')` returns a handler with constructor deps auto-wired