### PR TITLE
feat: ContainerFixture trait for test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `#[Provides('ID')]` attribute for declarative container registration in providers. Annotated methods are wrapped in a lazy closure and registered under the given id; `Container` is auto-injected when declared in the signature. `AbstractProvider::provideModuleDependencies()` is no longer abstract, so providers can go attribute-only or mix both styles
+- `ContainerFixture` trait under `Gacela\Framework\Testing` that gives PHPUnit tests a one-liner (`$this->resetContainer()`) to reset Gacela's container and singletons between test methods, plus `captureContainerState()` / `restoreContainerState()` helpers around the new immutable `ContainerSnapshot` value object, and `containerTempDir()` for auto-cleaned scratch directories
 
 ### Changed
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -45,3 +45,8 @@ parameters:
 			count: 1
 			path: src/Framework/Attribute/CacheableTrait.php
 
+		-
+			message: "#^Trait Gacela\\\\Framework\\\\Testing\\\\ContainerFixture is used zero times and is not analysed\\.$#"
+			count: 1
+			path: src/Framework/Testing/ContainerFixture.php
+

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -137,6 +137,27 @@ final class Gacela
     }
 
     /**
+     * Reset every singleton + in-memory cache registered by Gacela.
+     *
+     * Exposed publicly so test fixtures (see {@see Testing\ContainerFixture})
+     * can share this exact sequence instead of duplicating the list.
+     */
+    public static function resetCache(): void
+    {
+        AnonymousGlobal::resetCache();
+        AbstractFacade::resetCache();
+        AbstractFactory::resetCache();
+        AbstractClassResolver::resetCache();
+        InMemoryCache::resetCache();
+        GacelaFileCache::resetCache();
+        DocBlockResolverCache::resetCache();
+        ClassResolverCache::resetCache();
+        ConfigFactory::resetCache();
+        Config::resetInstance();
+        Locator::resetInstance();
+    }
+
+    /**
      * @param  null|Closure(GacelaConfig):void  $configFn
      */
     private static function processConfigFnIntoSetup(?Closure $configFn = null): SetupGacelaInterface
@@ -157,21 +178,6 @@ final class Gacela
         }
 
         return new SetupGacela();
-    }
-
-    private static function resetCache(): void
-    {
-        AnonymousGlobal::resetCache();
-        AbstractFacade::resetCache();
-        AbstractFactory::resetCache();
-        AbstractClassResolver::resetCache();
-        InMemoryCache::resetCache();
-        GacelaFileCache::resetCache();
-        DocBlockResolverCache::resetCache();
-        ClassResolverCache::resetCache();
-        ConfigFactory::resetCache();
-        Config::resetInstance();
-        Locator::resetInstance();
     }
 
     private static function runPlugins(Config $config): void

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Testing;
+
+use FilesystemIterator;
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\ClassResolver\ClassResolverCache;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\ConfigFactory;
+use Gacela\Framework\Container\Locator;
+use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use RuntimeException;
+use SplFileInfo;
+
+use function is_dir;
+use function register_shutdown_function;
+use function sprintf;
+
+/**
+ * PHPUnit trait that provides a one-liner helper to reset Gacela's
+ * container, config, and in-memory caches between test methods.
+ *
+ * The typical usage pattern combines this trait with PHPUnit's
+ * `#[Before]` attribute so the reset runs before every test method:
+ *
+ * ```php
+ * use Gacela\Framework\Testing\ContainerFixture;
+ * use PHPUnit\Framework\Attributes\Before;
+ * use PHPUnit\Framework\TestCase;
+ *
+ * final class MyTest extends TestCase
+ * {
+ *     use ContainerFixture;
+ *
+ *     #[Before]
+ *     protected function setUpContainer(): void
+ *     {
+ *         $this->resetContainer();
+ *     }
+ *
+ *     public function test_it_works(): void
+ *     {
+ *         // Gacela state is guaranteed fresh here.
+ *     }
+ * }
+ * ```
+ *
+ * The trait also offers {@see captureContainerState()} and
+ * {@see restoreContainerState()} for tests that need to swap state in
+ * and out explicitly, plus {@see containerTempDir()} for a unique
+ * auto-cleaned scratch directory.
+ */
+trait ContainerFixture
+{
+    /** @var list<string> */
+    private array $containerTempDirs = [];
+
+    private bool $containerTempDirsCleanupRegistered = false;
+
+    /**
+     * Reset all Gacela singletons and in-memory caches.
+     *
+     * Runs the same sequence as `Gacela::bootstrap()` does when
+     * `shouldResetInMemoryCache` is enabled. This is the drop-in
+     * replacement for the ad-hoc reset idiom in `setUp()`:
+     *
+     * ```php
+     * Config::resetInstance();
+     * AbstractClassResolver::resetCache();
+     * AnonymousGlobal::resetCache();
+     * InMemoryCache::resetCache();
+     * // ...and so on
+     * ```
+     *
+     * The call is side-effect free beyond clearing static state and
+     * completes in well under 10ms on a medium app — it does not
+     * rescan the filesystem or reinitialize any resolvers.
+     */
+    protected function resetContainer(): void
+    {
+        AnonymousGlobal::resetCache();
+        AbstractFacade::resetCache();
+        AbstractFactory::resetCache();
+        AbstractClassResolver::resetCache();
+        InMemoryCache::resetCache();
+        GacelaFileCache::resetCache();
+        DocBlockResolverCache::resetCache();
+        ClassResolverCache::resetCache();
+        ConfigFactory::resetCache();
+        Config::resetInstance();
+        Locator::resetInstance();
+    }
+
+    /**
+     * Alias for {@see resetContainer()}. Useful when the test wants to
+     * emphasise that the reset is about Gacela's singletons specifically
+     * rather than a user-owned container.
+     */
+    protected function resetGacelaSingletons(): void
+    {
+        $this->resetContainer();
+    }
+
+    /**
+     * Capture a snapshot of the current Gacela state.
+     *
+     * The snapshot covers the in-memory class-name cache, the active
+     * config values, the configured application root directory and the
+     * cache directory. It does not capture resolved service instances
+     * because those may hold non-serializable resources.
+     */
+    protected function captureContainerState(): ContainerSnapshot
+    {
+        $config = self::readStaticProperty(Config::class, 'instance');
+
+        $configValues = [];
+        $appRootDir = null;
+        $cacheDir = null;
+
+        if ($config instanceof Config) {
+            $configValues = self::readPrivateProperty($config, 'config') ?? [];
+            $appRootDir = self::readPrivateProperty($config, 'appRootDir');
+            $cacheDir = self::readPrivateProperty($config, 'cacheDir');
+        }
+
+        /** @var array<string, mixed> $configValues */
+        /** @var ?string $appRootDir */
+        /** @var ?string $cacheDir */
+        return new ContainerSnapshot(
+            inMemoryCache: InMemoryCache::all(),
+            config: $configValues,
+            appRootDir: $appRootDir,
+            cacheDir: $cacheDir,
+        );
+    }
+
+    /**
+     * Restore a previously captured snapshot of the container state.
+     *
+     * This resets the current singletons first and then re-applies the
+     * captured in-memory cache. It does not rerun the bootstrap cycle,
+     * so any derived caches (e.g. DocBlockResolverCache) stay empty and
+     * will be lazily rebuilt.
+     */
+    protected function restoreContainerState(ContainerSnapshot $snapshot): void
+    {
+        $this->resetContainer();
+
+        foreach ($snapshot->inMemoryCache() as $key => $entries) {
+            $cache = new InMemoryCache($key);
+            foreach ($entries as $cacheKey => $className) {
+                $cache->put($cacheKey, $className);
+            }
+        }
+    }
+
+    /**
+     * Create (on first access) and return a unique temporary directory
+     * for the current test method. The directory is automatically
+     * removed at the end of the PHP process via a shutdown function,
+     * so tests do not need to clean up manually.
+     */
+    protected function containerTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR
+            . 'gacela-container-fixture-' . bin2hex(random_bytes(8));
+
+        if (!is_dir($dir) && !mkdir($dir, 0777, true) && !is_dir($dir)) {
+            throw new RuntimeException(sprintf('Failed to create temp dir: %s', $dir));
+        }
+
+        $this->containerTempDirs[] = $dir;
+        $this->registerContainerTempDirsCleanup();
+
+        return $dir;
+    }
+
+    /**
+     * Remove all temporary directories created via {@see containerTempDir()}
+     * during the current test method. Called automatically from a shutdown
+     * function and callable as a PHPUnit `#[After]` hook when the user
+     * wants synchronous cleanup between methods.
+     */
+    protected function cleanupContainerTempDirs(): void
+    {
+        foreach ($this->containerTempDirs as $dir) {
+            self::removeDirectoryRecursively($dir);
+        }
+
+        $this->containerTempDirs = [];
+    }
+
+    private function registerContainerTempDirsCleanup(): void
+    {
+        if ($this->containerTempDirsCleanupRegistered) {
+            return;
+        }
+
+        $this->containerTempDirsCleanupRegistered = true;
+
+        /** @psalm-suppress UnusedFunctionCall */
+        register_shutdown_function(function (): void {
+            $this->cleanupContainerTempDirs();
+        });
+    }
+
+    private static function removeDirectoryRecursively(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $entry) {
+            /** @var SplFileInfo $entry */
+            $path = $entry->getPathname();
+            if ($entry->isDir()) {
+                @rmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+
+    private static function readPrivateProperty(object $object, string $property): mixed
+    {
+        $reflection = new ReflectionClass($object);
+        if (!$reflection->hasProperty($property)) {
+            return null;
+        }
+
+        $prop = $reflection->getProperty($property);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($object);
+    }
+
+    /**
+     * @param  class-string  $className
+     */
+    private static function readStaticProperty(string $className, string $property): mixed
+    {
+        $reflection = new ReflectionClass($className);
+        if (!$reflection->hasProperty($property)) {
+            return null;
+        }
+
+        $prop = $reflection->getProperty($property);
+        $prop->setAccessible(true);
+
+        return $prop->getValue();
+    }
+}

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -5,18 +5,9 @@ declare(strict_types=1);
 namespace Gacela\Framework\Testing;
 
 use FilesystemIterator;
-use Gacela\Framework\AbstractFacade;
-use Gacela\Framework\AbstractFactory;
-use Gacela\Framework\ClassResolver\AbstractClassResolver;
-use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
-use Gacela\Framework\ClassResolver\ClassResolverCache;
-use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config\Config;
-use Gacela\Framework\Config\ConfigFactory;
-use Gacela\Framework\Container\Locator;
-use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
-
+use Gacela\Framework\Gacela;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -69,37 +60,13 @@ trait ContainerFixture
     private bool $containerTempDirsCleanupRegistered = false;
 
     /**
-     * Reset all Gacela singletons and in-memory caches.
-     *
-     * Runs the same sequence as `Gacela::bootstrap()` does when
-     * `shouldResetInMemoryCache` is enabled. This is the drop-in
-     * replacement for the ad-hoc reset idiom in `setUp()`:
-     *
-     * ```php
-     * Config::resetInstance();
-     * AbstractClassResolver::resetCache();
-     * AnonymousGlobal::resetCache();
-     * InMemoryCache::resetCache();
-     * // ...and so on
-     * ```
-     *
-     * The call is side-effect free beyond clearing static state and
-     * completes in well under 10ms on a medium app — it does not
-     * rescan the filesystem or reinitialize any resolvers.
+     * Reset every Gacela singleton + in-memory cache. Drop-in replacement
+     * for the ad-hoc `::resetCache()` / `::resetInstance()` sequence in
+     * `setUp()`; runs in well under 10ms on a medium app.
      */
     protected function resetContainer(): void
     {
-        AnonymousGlobal::resetCache();
-        AbstractFacade::resetCache();
-        AbstractFactory::resetCache();
-        AbstractClassResolver::resetCache();
-        InMemoryCache::resetCache();
-        GacelaFileCache::resetCache();
-        DocBlockResolverCache::resetCache();
-        ClassResolverCache::resetCache();
-        ConfigFactory::resetCache();
-        Config::resetInstance();
-        Locator::resetInstance();
+        Gacela::resetCache();
     }
 
     /**

--- a/src/Framework/Testing/ContainerSnapshot.php
+++ b/src/Framework/Testing/ContainerSnapshot.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Testing;
+
+/**
+ * Immutable value object capturing a snapshot of Gacela container-related
+ * singletons and caches so tests can restore state between methods.
+ *
+ * The snapshot is intentionally restricted to data that is safe to serialize
+ * (scalars, arrays, and cache-dir roots). It does not attempt to capture
+ * object instances from the container because those may hold non-serializable
+ * resources (closures, file handles, PDO connections, etc.).
+ */
+final class ContainerSnapshot
+{
+    /**
+     * @param  array<string, array<string, string>>  $inMemoryCache
+     * @param  array<string, mixed>                  $config
+     * @param  array<string, mixed>                  $extras
+     */
+    public function __construct(
+        private readonly array $inMemoryCache = [],
+        private readonly array $config = [],
+        private readonly ?string $appRootDir = null,
+        private readonly ?string $cacheDir = null,
+        private readonly array $extras = [],
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     inMemoryCache: array<string, array<string, string>>,
+     *     config: array<string, mixed>,
+     *     appRootDir: ?string,
+     *     cacheDir: ?string,
+     *     extras: array<string, mixed>,
+     * }
+     */
+    public function __serialize(): array
+    {
+        return [
+            'inMemoryCache' => $this->inMemoryCache,
+            'config' => $this->config,
+            'appRootDir' => $this->appRootDir,
+            'cacheDir' => $this->cacheDir,
+            'extras' => $this->extras,
+        ];
+    }
+
+    /**
+     * @param  array{
+     *     inMemoryCache?: array<string, array<string, string>>,
+     *     config?: array<string, mixed>,
+     *     appRootDir?: ?string,
+     *     cacheDir?: ?string,
+     *     extras?: array<string, mixed>,
+     * }  $data
+     */
+    public function __unserialize(array $data): void
+    {
+        /** @psalm-suppress InaccessibleProperty */
+        $this->inMemoryCache = $data['inMemoryCache'] ?? [];
+        /** @psalm-suppress InaccessibleProperty */
+        $this->config = $data['config'] ?? [];
+        /** @psalm-suppress InaccessibleProperty */
+        $this->appRootDir = $data['appRootDir'] ?? null;
+        /** @psalm-suppress InaccessibleProperty */
+        $this->cacheDir = $data['cacheDir'] ?? null;
+        /** @psalm-suppress InaccessibleProperty */
+        $this->extras = $data['extras'] ?? [];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public function inMemoryCache(): array
+    {
+        return $this->inMemoryCache;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function config(): array
+    {
+        return $this->config;
+    }
+
+    public function appRootDir(): ?string
+    {
+        return $this->appRootDir;
+    }
+
+    public function cacheDir(): ?string
+    {
+        return $this->cacheDir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function extras(): array
+    {
+        return $this->extras;
+    }
+}

--- a/tests/Unit/Framework/Testing/ContainerFixtureTest.php
+++ b/tests/Unit/Framework/Testing/ContainerFixtureTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Testing;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Locator;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Testing\ContainerFixture;
+use Gacela\Framework\Testing\ContainerSnapshot;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use stdClass;
+
+use function sprintf;
+
+final class ContainerFixtureTest extends TestCase
+{
+    use ContainerFixture;
+
+    protected function tearDown(): void
+    {
+        $this->cleanupContainerTempDirs();
+        $this->resetContainer();
+    }
+
+    public function test_reset_container_clears_in_memory_cache(): void
+    {
+        $cache = new InMemoryCache('some-key');
+        $cache->put('SomeClass', 'ResolvedClass');
+
+        self::assertNotSame([], InMemoryCache::all(), 'cache should be populated before reset');
+
+        $this->resetContainer();
+
+        self::assertSame([], InMemoryCache::all());
+    }
+
+    public function test_reset_container_clears_anonymous_globals(): void
+    {
+        $anonFactory = new class() extends \Gacela\Framework\AbstractFactory {
+        };
+
+        Gacela::addGlobal($anonFactory, 'FixtureContext');
+
+        self::assertNotNull(
+            AnonymousGlobal::getByKey(AnonymousGlobal::createCacheKey('FixtureContext', 'Factory')),
+        );
+
+        $this->resetContainer();
+
+        self::assertNull(
+            AnonymousGlobal::getByKey(AnonymousGlobal::createCacheKey('FixtureContext', 'Factory')),
+        );
+    }
+
+    public function test_reset_container_clears_config_singleton(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+
+        self::assertInstanceOf(Config::class, $this->readConfigSingleton());
+
+        $this->resetContainer();
+
+        self::assertNull($this->readConfigSingleton());
+    }
+
+    public function test_reset_container_clears_class_resolver_cache(): void
+    {
+        $reflection = new ReflectionClass(AbstractClassResolver::class);
+        $prop = $reflection->getProperty('cachedInstances');
+        $prop->setAccessible(true);
+        $prop->setValue(null, ['some-key' => new stdClass()]);
+
+        /** @var array<string, mixed> $before */
+        $before = $prop->getValue();
+        self::assertNotSame([], $before);
+
+        $this->resetContainer();
+
+        /** @var array<string, mixed> $after */
+        $after = $prop->getValue();
+        self::assertSame([], $after);
+    }
+
+    public function test_reset_container_clears_locator_instance(): void
+    {
+        Locator::getInstance();
+        $reflection = new ReflectionClass(Locator::class);
+        $prop = $reflection->getProperty('instance');
+        $prop->setAccessible(true);
+
+        self::assertNotNull($prop->getValue());
+
+        $this->resetContainer();
+
+        self::assertNull($prop->getValue());
+    }
+
+    public function test_reset_container_clears_abstract_facade_factories(): void
+    {
+        $reflection = new ReflectionClass(AbstractFacade::class);
+        $prop = $reflection->getProperty('factories');
+        $prop->setAccessible(true);
+        $prop->setValue(null, [AbstractFacade::class => new class() extends \Gacela\Framework\AbstractFactory {
+        }]);
+
+        /** @var array<string, mixed> $before */
+        $before = $prop->getValue();
+        self::assertNotSame([], $before);
+
+        $this->resetContainer();
+
+        /** @var array<string, mixed> $after */
+        $after = $prop->getValue();
+        self::assertSame([], $after);
+    }
+
+    public function test_reset_gacela_singletons_is_an_alias_for_reset_container(): void
+    {
+        (new InMemoryCache('alias-test'))->put('K', 'V');
+
+        $this->resetGacelaSingletons();
+
+        self::assertSame([], InMemoryCache::all());
+    }
+
+    public function test_reset_container_runs_in_under_ten_milliseconds(): void
+    {
+        // Populate some state so reset has real work to do.
+        (new InMemoryCache('perf'))->put('A', 'B');
+        Gacela::addGlobal(new class() extends \Gacela\Framework\AbstractFactory {
+        }, 'PerfContext');
+
+        $start = hrtime(true);
+        $this->resetContainer();
+        $elapsedMs = (hrtime(true) - $start) / 1_000_000;
+
+        self::assertLessThan(10.0, $elapsedMs, sprintf('resetContainer took %.2fms', $elapsedMs));
+    }
+
+    public function test_capture_container_state_returns_snapshot_with_current_caches(): void
+    {
+        (new InMemoryCache('captured'))->put('Class', 'Resolved');
+
+        $snapshot = $this->captureContainerState();
+
+        self::assertInstanceOf(ContainerSnapshot::class, $snapshot);
+        self::assertSame(['captured' => ['Class' => 'Resolved']], $snapshot->inMemoryCache());
+    }
+
+    public function test_capture_container_state_without_bootstrap_yields_empty_config(): void
+    {
+        $snapshot = $this->captureContainerState();
+
+        self::assertSame([], $snapshot->config());
+        self::assertNull($snapshot->appRootDir());
+        self::assertNull($snapshot->cacheDir());
+    }
+
+    public function test_restore_container_state_reinstates_in_memory_cache(): void
+    {
+        (new InMemoryCache('to-restore'))->put('Foo', 'Bar');
+        $snapshot = $this->captureContainerState();
+
+        $this->resetContainer();
+        self::assertSame([], InMemoryCache::all());
+
+        $this->restoreContainerState($snapshot);
+
+        self::assertSame(['to-restore' => ['Foo' => 'Bar']], InMemoryCache::all());
+    }
+
+    public function test_container_temp_dir_returns_unique_existing_directory(): void
+    {
+        $dir1 = $this->containerTempDir();
+        $dir2 = $this->containerTempDir();
+
+        self::assertDirectoryExists($dir1);
+        self::assertDirectoryExists($dir2);
+        self::assertNotSame($dir1, $dir2);
+    }
+
+    public function test_cleanup_container_temp_dirs_removes_created_directories(): void
+    {
+        $dir = $this->containerTempDir();
+        self::assertDirectoryExists($dir);
+
+        $this->cleanupContainerTempDirs();
+
+        self::assertDirectoryDoesNotExist($dir);
+    }
+
+    public function test_cleanup_removes_nested_files_and_subdirectories(): void
+    {
+        $dir = $this->containerTempDir();
+        $nested = $dir . DIRECTORY_SEPARATOR . 'nested';
+        mkdir($nested, 0777, true);
+        file_put_contents($nested . DIRECTORY_SEPARATOR . 'file.txt', 'payload');
+
+        $this->cleanupContainerTempDirs();
+
+        self::assertDirectoryDoesNotExist($dir);
+    }
+
+    #[Before]
+    protected function setUpContainer(): void
+    {
+        $this->resetContainer();
+    }
+
+    private function readConfigSingleton(): ?Config
+    {
+        $reflection = new ReflectionClass(Config::class);
+        $prop = $reflection->getProperty('instance');
+        $prop->setAccessible(true);
+
+        /** @var Config|null $value */
+        $value = $prop->getValue();
+
+        return $value;
+    }
+}

--- a/tests/Unit/Framework/Testing/ContainerSnapshotTest.php
+++ b/tests/Unit/Framework/Testing/ContainerSnapshotTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Testing;
+
+use Gacela\Framework\Testing\ContainerSnapshot;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ContainerSnapshotTest extends TestCase
+{
+    public function test_it_exposes_constructor_arguments(): void
+    {
+        $snapshot = new ContainerSnapshot(
+            inMemoryCache: ['key' => ['ClassA' => 'ResolvedA']],
+            config: ['db.dsn' => 'sqlite::memory:'],
+            appRootDir: '/var/app',
+            cacheDir: '/var/app/cache',
+            extras: ['custom' => 'value'],
+        );
+
+        self::assertSame(['key' => ['ClassA' => 'ResolvedA']], $snapshot->inMemoryCache());
+        self::assertSame(['db.dsn' => 'sqlite::memory:'], $snapshot->config());
+        self::assertSame('/var/app', $snapshot->appRootDir());
+        self::assertSame('/var/app/cache', $snapshot->cacheDir());
+        self::assertSame(['custom' => 'value'], $snapshot->extras());
+    }
+
+    public function test_it_defaults_to_empty_state(): void
+    {
+        $snapshot = new ContainerSnapshot();
+
+        self::assertSame([], $snapshot->inMemoryCache());
+        self::assertSame([], $snapshot->config());
+        self::assertNull($snapshot->appRootDir());
+        self::assertNull($snapshot->cacheDir());
+        self::assertSame([], $snapshot->extras());
+    }
+
+    public function test_it_round_trips_through_serialize_and_unserialize(): void
+    {
+        $original = new ContainerSnapshot(
+            inMemoryCache: ['cacheKey' => ['Foo' => 'Bar']],
+            config: ['nested' => ['flag' => true]],
+            appRootDir: '/tmp/app',
+            cacheDir: '/tmp/app/cache',
+            extras: ['version' => 42],
+        );
+
+        /** @var ContainerSnapshot $restored */
+        $restored = unserialize(serialize($original));
+
+        self::assertInstanceOf(ContainerSnapshot::class, $restored);
+        self::assertSame($original->inMemoryCache(), $restored->inMemoryCache());
+        self::assertSame($original->config(), $restored->config());
+        self::assertSame($original->appRootDir(), $restored->appRootDir());
+        self::assertSame($original->cacheDir(), $restored->cacheDir());
+        self::assertSame($original->extras(), $restored->extras());
+    }
+
+    public function test_serialize_returns_the_full_state_array(): void
+    {
+        $snapshot = new ContainerSnapshot(
+            inMemoryCache: ['k' => ['A' => 'B']],
+            config: ['x' => 1],
+            appRootDir: '/app',
+            cacheDir: '/app/cache',
+            extras: ['e' => 'v'],
+        );
+
+        self::assertSame([
+            'inMemoryCache' => ['k' => ['A' => 'B']],
+            'config' => ['x' => 1],
+            'appRootDir' => '/app',
+            'cacheDir' => '/app/cache',
+            'extras' => ['e' => 'v'],
+        ], $snapshot->__serialize());
+    }
+
+    public function test_unserialize_restores_partial_payload_with_defaults(): void
+    {
+        $reflection = new ReflectionClass(ContainerSnapshot::class);
+        /** @var ContainerSnapshot $snapshot */
+        $snapshot = $reflection->newInstanceWithoutConstructor();
+        $snapshot->__unserialize([]);
+
+        self::assertSame([], $snapshot->inMemoryCache());
+        self::assertSame([], $snapshot->config());
+        self::assertNull($snapshot->appRootDir());
+        self::assertNull($snapshot->cacheDir());
+        self::assertSame([], $snapshot->extras());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds a PHPUnit-friendly trait that collapses the current ad-hoc `setUp` / `tearDown` reset incantation (10+ individual `::resetCache()` / `::resetInstance()` calls) into a single `$this->resetContainer()`. Users opt-in via `use ContainerFixture; #[Before] fn() => $this->resetContainer();`.

Explicitly **not** in this PR: the `#[IsolatedContainer]` attribute. That would need a PHPUnit extension (`Runner\Extension\Extension` hook) to actually gate per-test reset — ship the trait first; add the extension if users ask.

## 🔖 Changes

- `Gacela\Framework\Testing\ContainerFixture` — trait with `resetContainer()`, `resetGacelaSingletons()` alias, `captureContainerState()`, `restoreContainerState()`, `containerTempDir()`, and `cleanupContainerTempDirs()` for `#[After]` wiring
- `Gacela\Framework\Testing\ContainerSnapshot` — immutable value object with `__serialize` / `__unserialize`; captures in-memory class-name cache, config scalar bag, `appRootDir`, `cacheDir` via `ReflectionClass` (does NOT snapshot closures / file handles / PDO)
- 14 unit tests in `ContainerFixtureTest` (reset behavior, snapshot round-trip, temp-dir lifecycle, sub-10ms performance, alias method, `#[Before]` idiom)
- 5 unit tests in `ContainerSnapshotTest` (getters, defaults, serialize round-trip)
- Verified pass under `phpunit --process-isolation` as well
- `phpstan-baseline.neon` — same "trait used zero times" entry already present for `CacheableTrait`
- `CHANGELOG.md` — `## Unreleased > ### Added`