### PR TITLE
ref: route MergedConfigCache write through FileCache::writeAtomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Per-method TTL overrides via `CacheableConfig::setTtlOverrides(['Class::method' => $seconds])`
 - `Cacheable::$key` accepts `{N}` placeholders that interpolate the Nth caller argument (e.g. `key: 'user:{0}'`)
 - `clearMethodCacheFor($method)` now matches exact `Class::method::` prefixes rather than substrings, so `clearMethodCacheFor('get')` no longer clears every method containing "get"
+- `MergedConfigCache` now routes its write through `FileCache::writeAtomically()`, picking up atomic rename + opcache invalidation (previously used direct `file_put_contents` with `LOCK_EX`, which could tear under concurrent writes)
 
 ## [1.13.0](https://github.com/gacela-project/gacela/compare/1.12.0...1.13.0) - 2026-04-15
 

--- a/src/Framework/Config/MergedConfigCache.php
+++ b/src/Framework/Config/MergedConfigCache.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
+use Gacela\Framework\Cache\FileCache;
 use RuntimeException;
 
 use function sprintf;
-
-use const LOCK_EX;
 
 final class MergedConfigCache
 {
@@ -48,9 +47,7 @@ final class MergedConfigCache
     public function write(array $data): void
     {
         $this->ensureCacheDir();
-
-        $content = sprintf('<?php return %s;', var_export($data, true));
-        file_put_contents($this->filename(), $content, LOCK_EX);
+        FileCache::writeAtomically($this->filename(), $data);
     }
 
     public function clear(): void
@@ -77,8 +74,8 @@ final class MergedConfigCache
             return;
         }
 
-        if (!mkdir($concurrentDirectory = $this->cacheDir, recursive: true) && !is_dir($concurrentDirectory)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        if (!mkdir($this->cacheDir, recursive: true) && !is_dir($this->cacheDir)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $this->cacheDir));
         }
     }
 }


### PR DESCRIPTION
## 📚 Description

Unblocked by #377 (FileCache primitive). Migrates `MergedConfigCache` to route its write through `FileCache::writeAtomically()` — the second gacela-internal consumer, after `AbstractPhpFileCache`. Completes the "dogfood before downstream adopts" goal of PR #2.

Incidentally fixes a subtle bug: the previous direct `file_put_contents($filename, $content, LOCK_EX)` was **not atomic** — `LOCK_EX` serializes concurrent writes to the same file but readers using `require` could still observe a half-written file between `fopen`/`fwrite` calls. `FileCache::writeAtomically()` uses the `.tmp` + `rename()` idiom which is truly atomic on POSIX.

Also picks up `opcache_invalidate()` on write for free.

## 🔖 Changes

- `MergedConfigCache::write()` now calls `FileCache::writeAtomically($this->filename(), $data)` instead of rolling its own `file_put_contents` path
- `ensureCacheDir()` cleanup — removed the IDE-generated `$concurrentDirectory` variable noise (same cleanup applied inside `FileCache` in #377)
- Removed the now-unused `LOCK_EX` / `sprintf`-for-var_export plumbing
- `CHANGELOG.md` entry under `## Unreleased > ### Changed`
- No test changes needed — existing `MergedConfigCacheTest` covers the public behaviour and all 111 feature tests + 461 unit tests still pass