### PR TITLE
feat: ScopedCache decorator with dependency invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `#[Provides('ID')]` attribute for declarative container registration in providers; `AbstractProvider::provideModuleDependencies()` is no longer abstract
 - `FileCache<T>` primitive — typed file-backed cache with TTL, batching, and atomic writes; `AbstractPhpFileCache` now delegates its write path to it
+- `ScopedCache` decorator over `FileCache` with `dependsOn`, cascading `invalidate`, `invalidateLeaf`, persisted dependency graph (survives process restart), and cycle detection at `dependsOn` time
 - `GacelaConfig::addHandlerRegistry($key, [...])` for Provider-registered dispatch tables (lazy, container-resolved, frozen after boot) replacing hand-rolled `match` blocks
 - `GacelaConfig::addHealthCheck()` for Provider-based registration of `ModuleHealthCheckInterface` implementations, surfaced by `doctor`
 - `ContainerFixture` trait (`Gacela\Framework\Testing`) with `resetContainer()`, `captureContainerState()` / `restoreContainerState()`, and `containerTempDir()` for PHPUnit test isolation

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Container configuration](container-configuration.md) — factories, aliases, contextual bindings
 - [Static analysis](static-analysis.md) — PHPStan and Psalm setup
 - [Module health checks](module-health-checks.md) — report module operational status
+- [Caching](caching.md) — overview of Gacela's three caching layers and when to reach for each
 - [Cacheable methods](cacheable-methods.md) — cache facade method results with `#[Cacheable]`
 - [Opcache preload](opcache-preload.md) — production performance tuning
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,128 @@
+# Caching
+
+Gacela caches at three different levels. Each solves a different problem — they compose, they don't replace one another.
+
+| Layer | What it caches | Where | Typical use |
+|---|---|---|---|
+| [Framework resolution](#layer-1--framework-resolution-cache) | Resolved facades, factories, configs, merged config | Memory or disk | Always on — pick the mode per environment |
+| [Cacheable methods](#layer-2--cacheable-facade-methods) | Return values of facade methods | Memory (pluggable) | Expensive, deterministic reads |
+| [Value primitives](#layer-3--value-primitives) | Arbitrary key → value data, optionally with a dependency graph | Disk | Your code needs its own cache (compilers, pipelines, parsed artefacts) |
+
+## Layer 1 — Framework resolution cache
+
+Gacela resolves classes by convention: `Facade` → `Factory` → `Provider` → `Config`. Those lookups walk namespaces and files, and the merged configuration is reassembled from every `config/*.php` file. All of it is memoised once per process, and can additionally be persisted to disk between runs.
+
+- **In-memory** (default): `InMemoryCache` holds resolved class names for the life of the process.
+- **On-disk**: `ClassNamePhpCache` and `CustomServicesPhpCache` persist the same data to `gacela-class-names.php` / `gacela-custom-services.php`; `MergedConfigCache` persists the merged configuration to `gacela-merged-config[{env}].php`.
+
+Configure at bootstrap:
+
+```php
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+
+Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+    $config->enableFileCache();                  // use the default cache dir
+    // $config->enableFileCache('/custom/dir');  // or pick one
+    // $config->setFileCache(false);             // explicitly off
+    // $config->resetInMemoryCache();            // wipe static caches (tests)
+});
+```
+
+The directory can also be overridden at runtime with the `GACELA_CACHE_DIR` environment variable — handy when the same image is reused across environments.
+
+Typical wiring:
+
+- **Development** — file cache **off**. Edits take effect immediately.
+- **Production** — file cache **on**, directory baked into the image. Re-deploy to refresh.
+- **Tests** — call `resetInMemoryCache()` between suites so resolution state doesn't bleed.
+
+See also: [Opcache preload](opcache-preload.md) for getting PHP itself to cache Gacela's own source files.
+
+## Layer 2 — Cacheable facade methods
+
+Cache the *result* of a facade method with the `#[Cacheable]` attribute and `CacheableTrait`:
+
+```php
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableTrait;
+
+final class CatalogFacade extends AbstractFacade
+{
+    use CacheableTrait;
+
+    #[Cacheable(ttl: 3600)]
+    public function getPopularProducts(): array
+    {
+        return $this->cached(fn (): array =>
+            $this->getFactory()->createRepository()->fetchPopular(),
+        );
+    }
+}
+```
+
+Storage is `InMemoryCacheStorage` by default, which means entries die with the request on PHP-FPM. For cross-request caching swap in a shared backend (APCu, Redis, PSR-16) via `CacheableConfig::setStorage()`.
+
+Clear selectively:
+
+```php
+CatalogFacade::clearMethodCache();                        // all of this facade
+CatalogFacade::clearMethodCacheFor('getPopularProducts'); // one method, any args
+```
+
+Full reference: [Cacheable methods](cacheable-methods.md).
+
+## Layer 3 — Value primitives
+
+When *your code* needs a cache — compiled artefacts, parsed data, a build pipeline — use `Gacela\Framework\Cache\FileCache`:
+
+```php
+use Gacela\Framework\Cache\FileCache;
+
+$cache = new FileCache('/var/cache/myapp');
+
+$cache->put('user:42', $user, ttl: 600);
+$cache->get('user:42');     // $user, or null after TTL expiry
+$cache->forget('user:42');
+$cache->clear();
+```
+
+- One `.php` file per key (SHA1-hashed), written atomically via staged `.tmp` + `rename`.
+- TTL per entry; `ttl: 0` means forever.
+- `beginBatch()` / `commitBatch()` defer writes behind a single index-locked flush — useful for warming many entries at once.
+- `stats()` returns entry count, total bytes, and oldest/newest timestamps.
+- Safe against torn reads: concurrent readers see either the previous file or the new one, never a half-written one.
+
+### ScopedCache — dependency-aware decorator
+
+When invalidating one entry should cascade to every downstream entry that derived from it, wrap `FileCache` in `ScopedCache`:
+
+```php
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\ScopedCache;
+
+$cache = new ScopedCache(new FileCache('/var/cache/myapp'));
+
+$cache->put('ns:core', $envCore);
+$cache->put('file:a.php', $compiledA);
+$cache->put('fragment:a#1', $fragment);
+
+$cache->dependsOn('file:a.php', 'ns:core');
+$cache->dependsOn('fragment:a#1', 'file:a.php');
+
+$cache->invalidate('ns:core');          // cascades: file:a.php and fragment:a#1 also go
+$cache->invalidateLeaf('file:a.php');   // only this key; dependents stay valid
+```
+
+- `get` / `put` / `has` delegate straight to the underlying `FileCache` — zero overhead on the hot path.
+- The dependency graph is persisted alongside the values (`.gacela-scoped-cache-graph.php`) and survives process restarts.
+- Cycles are rejected eagerly at `dependsOn()` — self, two-node, and transitive.
+- Single-writer concurrency: multiple processes racing on `dependsOn()` may lose edges added between load and persist. The value store underneath remains read-safe under concurrency regardless.
+
+## Picking a layer
+
+- Make Gacela's own resolution faster → Layer 1, `enableFileCache()`.
+- Memoise a specific facade method → Layer 2, `#[Cacheable]`.
+- Cache arbitrary application data → Layer 3, `FileCache`.
+- Same, but invalidation must cascade → Layer 3, `ScopedCache`.

--- a/rector.php
+++ b/rector.php
@@ -3,10 +3,14 @@
 declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 
@@ -23,6 +27,26 @@ return static function (RectorConfig $rectorConfig): void {
         ],
         FlipTypeControlToUseExclusiveTypeRector::class => [
             __DIR__ . '/src/Framework/AbstractFactory.php',
+        ],
+        // Generic `@var THandler` is required by Psalm to infer the return type of
+        // `LazyHandlerRegistry::get()`; rector's RemoveNonExistingVarAnnotationRector
+        // does not understand class-level `@template` parameters.
+        RemoveNonExistingVarAnnotationRector::class => [
+            __DIR__ . '/src/Framework/Plugins/LazyHandlerRegistry.php',
+        ],
+        // These tests embed PHP source inside heredocs; keeping interpolation makes
+        // the embedded snippets readable. sprintf() obscures them for no benefit.
+        EncapsedStringsToSprintfRector::class => [
+            __DIR__ . '/tests/Unit/Framework/Cache/FileCacheConcurrencyTest.php',
+            __DIR__ . '/tests/Unit/Framework/Cache/FileCacheTest.php',
+        ],
+        // `#[Before]`-attributed setup methods are invoked reflectively by PHPUnit;
+        // rector sees them as unused. Removing them silently drops test isolation.
+        RemoveUnusedPrivateMethodRector::class => [
+            __DIR__ . '/tests/Unit/Framework/Testing/ContainerFixtureTest.php',
+        ],
+        PrivatizeFinalClassMethodRector::class => [
+            __DIR__ . '/tests/Unit/Framework/Testing/ContainerFixtureTest.php',
         ],
     ]);
 

--- a/src/Framework/Cache/CycleDetectedException.php
+++ b/src/Framework/Cache/CycleDetectedException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Cache;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class CycleDetectedException extends RuntimeException
+{
+    public static function between(string $childKey, string $parentKey): self
+    {
+        return new self(sprintf(
+            'Refusing to add dependency "%s" -> "%s": parent already depends on child (cycle).',
+            $childKey,
+            $parentKey,
+        ));
+    }
+
+    public static function selfDependency(string $key): self
+    {
+        return new self(sprintf('A cache entry cannot depend on itself ("%s").', $key));
+    }
+}

--- a/src/Framework/Cache/ScopedCache.php
+++ b/src/Framework/Cache/ScopedCache.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Cache;
+
+use function array_filter;
+use function array_unique;
+use function array_values;
+use function in_array;
+use function is_array;
+use function is_file;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Dependency-aware decorator over {@see FileCache}.
+ *
+ * Each entry may declare other entries it depends on via {@see dependsOn()}.
+ * Invalidating a parent cascades through every transitive dependent;
+ * {@see invalidateLeaf()} invalidates a single entry without cascading.
+ *
+ * The dependency graph is persisted next to the underlying {@see FileCache}
+ * directory, so the relationships survive process restarts. Cycles are
+ * rejected eagerly at {@see dependsOn()} time.
+ *
+ * Concurrency: this decorator assumes a single writer at a time. Multiple
+ * concurrent writers may lose edges added between the in-memory load and
+ * the on-disk persist. The value store behind it ({@see FileCache}) remains
+ * read-safe under concurrency regardless.
+ *
+ * @template T
+ */
+final class ScopedCache
+{
+    private const GRAPH_FILENAME = '.gacela-scoped-cache-graph.php';
+
+    /** @var array<string, list<string>> childKey => list of direct parents */
+    private array $dependencies = [];
+
+    /** @var array<string, list<string>> parentKey => list of direct dependents */
+    private array $dependents = [];
+
+    /**
+     * @param FileCache<T> $cache
+     */
+    public function __construct(
+        private readonly FileCache $cache,
+    ) {
+        $this->loadGraph();
+    }
+
+    /**
+     * @return T|null
+     */
+    public function get(string $key): mixed
+    {
+        return $this->cache->get($key);
+    }
+
+    /**
+     * @param T $value
+     */
+    public function put(string $key, mixed $value, ?int $ttl = null): void
+    {
+        $this->cache->put($key, $value, $ttl);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->cache->has($key);
+    }
+
+    /**
+     * Declare that `$childKey`'s validity depends on `$parentKey`.
+     * Invalidating `$parentKey` transitively invalidates `$childKey`.
+     *
+     * @throws CycleDetectedException when the new edge would close a cycle
+     */
+    public function dependsOn(string $childKey, string $parentKey): void
+    {
+        if ($childKey === $parentKey) {
+            throw CycleDetectedException::selfDependency($childKey);
+        }
+
+        if ($this->reachableViaDependencies($parentKey, $childKey)) {
+            throw CycleDetectedException::between($childKey, $parentKey);
+        }
+
+        if (!in_array($parentKey, $this->dependencies[$childKey] ?? [], true)) {
+            $this->dependencies[$childKey][] = $parentKey;
+        }
+
+        if (!in_array($childKey, $this->dependents[$parentKey] ?? [], true)) {
+            $this->dependents[$parentKey][] = $childKey;
+        }
+
+        $this->persistGraph();
+    }
+
+    /**
+     * Invalidate `$key` and every entry that transitively declared a
+     * dependency on it. Runs in O(|descendants|), not O(|entries|).
+     */
+    public function invalidate(string $key): void
+    {
+        $toForget = $this->collectDescendants($key);
+        $toForget[] = $key;
+
+        foreach (array_unique($toForget) as $k) {
+            $this->cache->forget($k);
+            $this->removeFromGraph($k);
+        }
+
+        $this->persistGraph();
+    }
+
+    /**
+     * Invalidate `$key` without cascading to its dependents. Useful when the
+     * caller knows dependents are still valid (e.g. a file changed but the
+     * namespace it participates in did not).
+     */
+    public function invalidateLeaf(string $key): void
+    {
+        $this->cache->forget($key);
+        $this->removeFromGraph($key);
+        $this->persistGraph();
+    }
+
+    /**
+     * Direct dependents of `$key` (one hop). Use {@see invalidate()} for the
+     * transitive set.
+     *
+     * @return list<string>
+     */
+    public function dependents(string $key): array
+    {
+        return $this->dependents[$key] ?? [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectDescendants(string $key): array
+    {
+        $out = [];
+        $queue = [$key];
+        $seen = [$key => true];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            foreach ($this->dependents[$current] ?? [] as $child) {
+                if (isset($seen[$child])) {
+                    continue;
+                }
+                $seen[$child] = true;
+                $out[] = $child;
+                $queue[] = $child;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Walks the forward (child => parents) graph. Returns true when `$target`
+     * is reachable from `$start` — i.e. when `$start` already depends on
+     * `$target`, directly or transitively.
+     */
+    private function reachableViaDependencies(string $start, string $target): bool
+    {
+        $queue = [$start];
+        $seen = [$start => true];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            foreach ($this->dependencies[$current] ?? [] as $parent) {
+                if ($parent === $target) {
+                    return true;
+                }
+                if (isset($seen[$parent])) {
+                    continue;
+                }
+                $seen[$parent] = true;
+                $queue[] = $parent;
+            }
+        }
+
+        return false;
+    }
+
+    private function removeFromGraph(string $key): void
+    {
+        foreach ($this->dependencies[$key] ?? [] as $parent) {
+            $this->dependents[$parent] = array_values(array_filter(
+                $this->dependents[$parent] ?? [],
+                static fn (string $c): bool => $c !== $key,
+            ));
+            if ($this->dependents[$parent] === []) {
+                unset($this->dependents[$parent]);
+            }
+        }
+
+        foreach ($this->dependents[$key] ?? [] as $child) {
+            $this->dependencies[$child] = array_values(array_filter(
+                $this->dependencies[$child] ?? [],
+                static fn (string $p): bool => $p !== $key,
+            ));
+            if ($this->dependencies[$child] === []) {
+                unset($this->dependencies[$child]);
+            }
+        }
+
+        unset($this->dependencies[$key], $this->dependents[$key]);
+    }
+
+    private function graphPath(): string
+    {
+        return $this->cache->directory . DIRECTORY_SEPARATOR . self::GRAPH_FILENAME;
+    }
+
+    private function loadGraph(): void
+    {
+        $path = $this->graphPath();
+        if (!is_file($path)) {
+            return;
+        }
+
+        /** @var mixed $payload */
+        $payload = require $path;
+        if (!is_array($payload)) {
+            return;
+        }
+
+        /** @var array<string, list<string>> $deps */
+        $deps = is_array($payload['dependencies'] ?? null) ? $payload['dependencies'] : [];
+        /** @var array<string, list<string>> $dependents */
+        $dependents = is_array($payload['dependents'] ?? null) ? $payload['dependents'] : [];
+
+        $this->dependencies = $deps;
+        $this->dependents = $dependents;
+    }
+
+    private function persistGraph(): void
+    {
+        FileCache::writeAtomically($this->graphPath(), [
+            'dependencies' => $this->dependencies,
+            'dependents' => $this->dependents,
+        ]);
+    }
+}

--- a/src/Framework/Cache/ScopedCache.php
+++ b/src/Framework/Cache/ScopedCache.php
@@ -168,10 +168,11 @@ final class ScopedCache
     private function removeFromGraph(string $key): void
     {
         foreach ($this->dependencies[$key] ?? [] as $parent) {
-            self::pruneEdge($this->dependents, $parent, $key);
+            $this->pruneEdge($this->dependents, $parent, $key);
         }
+
         foreach ($this->dependents[$key] ?? [] as $child) {
-            self::pruneEdge($this->dependencies, $child, $key);
+            $this->pruneEdge($this->dependencies, $child, $key);
         }
 
         unset($this->dependencies[$key], $this->dependents[$key]);
@@ -182,7 +183,7 @@ final class ScopedCache
      *
      * @param array<string, list<string>> $graph
      */
-    private static function pruneEdge(array &$graph, string $node, string $neighbour): void
+    private function pruneEdge(array &$graph, string $node, string $neighbour): void
     {
         if (!isset($graph[$node])) {
             return;
@@ -213,6 +214,7 @@ final class ScopedCache
                 if (isset($seen[$child])) {
                     continue;
                 }
+
                 $seen[$child] = true;
                 $out[] = $child;
                 $queue[] = $child;
@@ -238,9 +240,11 @@ final class ScopedCache
                 if ($parent === $target) {
                     return true;
                 }
+
                 if (isset($seen[$parent])) {
                     continue;
                 }
+
                 $seen[$parent] = true;
                 $queue[] = $parent;
             }
@@ -274,14 +278,20 @@ final class ScopedCache
 
         /** @var mixed $parents */
         foreach ($payload as $child => $parents) {
-            if (!is_string($child) || !is_array($parents)) {
+            if (!is_string($child)) {
                 continue;
             }
+
+            if (!is_array($parents)) {
+                continue;
+            }
+
             /** @var mixed $parent */
             foreach ($parents as $parent) {
                 if (!is_string($parent)) {
                     continue;
                 }
+
                 $this->addEdge($child, $parent);
             }
         }

--- a/src/Framework/Cache/ScopedCache.php
+++ b/src/Framework/Cache/ScopedCache.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Gacela\Framework\Cache;
 
 use function array_filter;
-use function array_unique;
 use function array_values;
 use function in_array;
 use function is_array;
 use function is_file;
+use function is_string;
+use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -35,10 +36,10 @@ final class ScopedCache
 {
     private const GRAPH_FILENAME = '.gacela-scoped-cache-graph.php';
 
-    /** @var array<string, list<string>> childKey => list of direct parents */
+    /** @var array<string, list<string>> childKey => direct parents (persisted) */
     private array $dependencies = [];
 
-    /** @var array<string, list<string>> parentKey => list of direct dependents */
+    /** @var array<string, list<string>> parentKey => direct dependents (derived from) */
     private array $dependents = [];
 
     /**
@@ -72,6 +73,21 @@ final class ScopedCache
     }
 
     /**
+     * Drop every cached value AND wipe the dependency graph (on disk too).
+     */
+    public function clear(): void
+    {
+        $this->cache->clear();
+        $this->dependencies = [];
+        $this->dependents = [];
+
+        $path = $this->graphPath();
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+
+    /**
      * Declare that `$childKey`'s validity depends on `$parentKey`.
      * Invalidating `$parentKey` transitively invalidates `$childKey`.
      *
@@ -87,15 +103,11 @@ final class ScopedCache
             throw CycleDetectedException::between($childKey, $parentKey);
         }
 
-        if (!in_array($parentKey, $this->dependencies[$childKey] ?? [], true)) {
-            $this->dependencies[$childKey][] = $parentKey;
-        }
+        $added = $this->addEdge($childKey, $parentKey);
 
-        if (!in_array($childKey, $this->dependents[$parentKey] ?? [], true)) {
-            $this->dependents[$parentKey][] = $childKey;
+        if ($added) {
+            $this->persistGraph();
         }
-
-        $this->persistGraph();
     }
 
     /**
@@ -104,10 +116,10 @@ final class ScopedCache
      */
     public function invalidate(string $key): void
     {
-        $toForget = $this->collectDescendants($key);
-        $toForget[] = $key;
+        $targets = $this->collectDescendants($key);
+        $targets[] = $key;
 
-        foreach (array_unique($toForget) as $k) {
+        foreach ($targets as $k) {
             $this->cache->forget($k);
             $this->removeFromGraph($k);
         }
@@ -136,6 +148,54 @@ final class ScopedCache
     public function dependents(string $key): array
     {
         return $this->dependents[$key] ?? [];
+    }
+
+    /**
+     * @return bool true when a new edge was recorded, false when it was already present
+     */
+    private function addEdge(string $childKey, string $parentKey): bool
+    {
+        if (in_array($parentKey, $this->dependencies[$childKey] ?? [], true)) {
+            return false;
+        }
+
+        $this->dependencies[$childKey][] = $parentKey;
+        $this->dependents[$parentKey][] = $childKey;
+
+        return true;
+    }
+
+    private function removeFromGraph(string $key): void
+    {
+        foreach ($this->dependencies[$key] ?? [] as $parent) {
+            self::pruneEdge($this->dependents, $parent, $key);
+        }
+        foreach ($this->dependents[$key] ?? [] as $child) {
+            self::pruneEdge($this->dependencies, $child, $key);
+        }
+
+        unset($this->dependencies[$key], $this->dependents[$key]);
+    }
+
+    /**
+     * Remove `$neighbour` from `$graph[$node]`, collapsing the entry when empty.
+     *
+     * @param array<string, list<string>> $graph
+     */
+    private static function pruneEdge(array &$graph, string $node, string $neighbour): void
+    {
+        if (!isset($graph[$node])) {
+            return;
+        }
+
+        $graph[$node] = array_values(array_filter(
+            $graph[$node],
+            static fn (string $n): bool => $n !== $neighbour,
+        ));
+
+        if ($graph[$node] === []) {
+            unset($graph[$node]);
+        }
     }
 
     /**
@@ -189,36 +249,16 @@ final class ScopedCache
         return false;
     }
 
-    private function removeFromGraph(string $key): void
-    {
-        foreach ($this->dependencies[$key] ?? [] as $parent) {
-            $this->dependents[$parent] = array_values(array_filter(
-                $this->dependents[$parent] ?? [],
-                static fn (string $c): bool => $c !== $key,
-            ));
-            if ($this->dependents[$parent] === []) {
-                unset($this->dependents[$parent]);
-            }
-        }
-
-        foreach ($this->dependents[$key] ?? [] as $child) {
-            $this->dependencies[$child] = array_values(array_filter(
-                $this->dependencies[$child] ?? [],
-                static fn (string $p): bool => $p !== $key,
-            ));
-            if ($this->dependencies[$child] === []) {
-                unset($this->dependencies[$child]);
-            }
-        }
-
-        unset($this->dependencies[$key], $this->dependents[$key]);
-    }
-
     private function graphPath(): string
     {
         return $this->cache->directory . DIRECTORY_SEPARATOR . self::GRAPH_FILENAME;
     }
 
+    /**
+     * Load the forward graph from disk and derive the reverse adjacency
+     * in memory. Storing only one direction keeps the two views
+     * automatically consistent across restarts.
+     */
     private function loadGraph(): void
     {
         $path = $this->graphPath();
@@ -232,20 +272,23 @@ final class ScopedCache
             return;
         }
 
-        /** @var array<string, list<string>> $deps */
-        $deps = is_array($payload['dependencies'] ?? null) ? $payload['dependencies'] : [];
-        /** @var array<string, list<string>> $dependents */
-        $dependents = is_array($payload['dependents'] ?? null) ? $payload['dependents'] : [];
-
-        $this->dependencies = $deps;
-        $this->dependents = $dependents;
+        /** @var mixed $parents */
+        foreach ($payload as $child => $parents) {
+            if (!is_string($child) || !is_array($parents)) {
+                continue;
+            }
+            /** @var mixed $parent */
+            foreach ($parents as $parent) {
+                if (!is_string($parent)) {
+                    continue;
+                }
+                $this->addEdge($child, $parent);
+            }
+        }
     }
 
     private function persistGraph(): void
     {
-        FileCache::writeAtomically($this->graphPath(), [
-            'dependencies' => $this->dependencies,
-            'dependents' => $this->dependents,
-        ]);
+        FileCache::writeAtomically($this->graphPath(), $this->dependencies);
     }
 }

--- a/tests/Feature/Framework/ScopedCache/ScopedCacheFeatureTest.php
+++ b/tests/Feature/Framework/ScopedCache/ScopedCacheFeatureTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ScopedCache;
+
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\ScopedCache;
+use GacelaTest\Feature\Util\DirectoryUtil;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function glob;
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * End-to-end scenarios exercising {@see ScopedCache} against a real
+ * {@see FileCache} on disk. Each test covers an angle of the holistic
+ * lifecycle — cascading invalidation, leaf invalidation, process restart,
+ * and full reset — so a future reader can see how the pieces compose.
+ */
+final class ScopedCacheFeatureTest extends TestCase
+{
+    private const GRAPH_FILE = '.gacela-scoped-cache-graph.php';
+
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/gacela-scoped-cache-feature-' . uniqid('', true);
+    }
+
+    protected function tearDown(): void
+    {
+        DirectoryUtil::removeDir($this->cacheDir);
+    }
+
+    /**
+     * Scenario:
+     *     ns:core ─── file:lib/a.php ──┬── fragment:a#1
+     *                                  └── fragment:a#2
+     *     ns:app  ─── file:app/ctrl.php ── fragment:ctrl#1
+     *
+     * Invalidating `ns:core` must drop every node under it while leaving
+     * the `ns:app` subtree untouched.
+     */
+    public function test_invalidating_a_namespace_cascades_only_within_its_subtree(): void
+    {
+        $cache = $this->openCache();
+        $this->seedPipeline($cache);
+
+        $cache->invalidate('ns:core');
+
+        self::assertFalse($cache->has('ns:core'));
+        self::assertFalse($cache->has('file:lib/a.php'));
+        self::assertFalse($cache->has('fragment:a#1'));
+        self::assertFalse($cache->has('fragment:a#2'));
+
+        self::assertSame('env:app', $cache->get('ns:app'));
+        self::assertSame('compiled:ctrl', $cache->get('file:app/ctrl.php'));
+        self::assertSame('frag:ctrl1', $cache->get('fragment:ctrl#1'));
+    }
+
+    public function test_graph_survives_process_restart_and_still_cascades(): void
+    {
+        $cache = $this->openCache();
+        $this->seedPipeline($cache);
+
+        // Simulate a fresh process.
+        $reopened = $this->openCache();
+        self::assertSame(['file:app/ctrl.php'], $reopened->dependents('ns:app'));
+
+        $reopened->invalidate('ns:app');
+
+        self::assertFalse($reopened->has('ns:app'));
+        self::assertFalse($reopened->has('file:app/ctrl.php'));
+        self::assertFalse($reopened->has('fragment:ctrl#1'));
+
+        // The untouched subtree is still hot after the restart.
+        self::assertSame('env:core', $reopened->get('ns:core'));
+        self::assertSame('compiled:a', $reopened->get('file:lib/a.php'));
+    }
+
+    public function test_leaf_invalidation_drops_a_single_file_without_touching_neighbours(): void
+    {
+        $cache = $this->openCache();
+        $this->seedPipeline($cache);
+
+        $cache->invalidateLeaf('file:lib/a.php');
+
+        self::assertFalse($cache->has('file:lib/a.php'));
+        self::assertSame('frag:a1', $cache->get('fragment:a#1'));
+        self::assertSame('frag:a2', $cache->get('fragment:a#2'));
+        self::assertSame('env:core', $cache->get('ns:core'));
+
+        // Edges pointing at the removed key are gone, in both directions.
+        self::assertSame([], $cache->dependents('file:lib/a.php'));
+        self::assertSame([], $cache->dependents('ns:core'));
+    }
+
+    public function test_clear_wipes_values_and_graph_file_and_survives_restart(): void
+    {
+        $cache = $this->openCache();
+        $this->seedPipeline($cache);
+
+        $graphPath = $this->cacheDir . '/' . self::GRAPH_FILE;
+        self::assertFileExists($graphPath);
+        self::assertGreaterThan(0, $this->countCacheFiles());
+
+        $cache->clear();
+
+        self::assertFileDoesNotExist($graphPath);
+        self::assertSame(0, $this->countCacheFiles());
+
+        $fresh = $this->openCache();
+        self::assertSame([], $fresh->dependents('ns:core'));
+        self::assertFalse($fresh->has('fragment:a#1'));
+    }
+
+    /**
+     * @param ScopedCache<string> $cache
+     */
+    private function seedPipeline(ScopedCache $cache): void
+    {
+        $cache->put('ns:core', 'env:core');
+        $cache->put('ns:app', 'env:app');
+        $cache->put('file:lib/a.php', 'compiled:a');
+        $cache->put('file:app/ctrl.php', 'compiled:ctrl');
+        $cache->put('fragment:a#1', 'frag:a1');
+        $cache->put('fragment:a#2', 'frag:a2');
+        $cache->put('fragment:ctrl#1', 'frag:ctrl1');
+
+        $cache->dependsOn('file:lib/a.php', 'ns:core');
+        $cache->dependsOn('file:app/ctrl.php', 'ns:app');
+        $cache->dependsOn('fragment:a#1', 'file:lib/a.php');
+        $cache->dependsOn('fragment:a#2', 'file:lib/a.php');
+        $cache->dependsOn('fragment:ctrl#1', 'file:app/ctrl.php');
+    }
+
+    /**
+     * @return ScopedCache<string>
+     */
+    private function openCache(): ScopedCache
+    {
+        return new ScopedCache(new FileCache($this->cacheDir));
+    }
+
+    private function countCacheFiles(): int
+    {
+        return count(glob($this->cacheDir . '/*.php') ?: []);
+    }
+}

--- a/tests/Unit/Framework/Cache/ScopedCacheTest.php
+++ b/tests/Unit/Framework/Cache/ScopedCacheTest.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\ScopedCache;
 use PHPUnit\Framework\TestCase;
 
+use function file_put_contents;
 use function glob;
 use function is_dir;
 use function rmdir;
@@ -254,6 +255,148 @@ final class ScopedCacheTest extends TestCase
 
         self::assertNull($this->cache->get('short'));
         self::assertFalse($this->cache->has('short'));
+    }
+
+    public function test_invalidate_middle_of_chain_leaves_ancestors_alone(): void
+    {
+        // `a` depends on `b` depends on `c`. Invalidating `b` drops `b` and
+        // its dependent `a`, but leaves `c` (which `b` depends on) intact.
+        $this->cache->put('a', 'A');
+        $this->cache->put('b', 'B');
+        $this->cache->put('c', 'C');
+        $this->cache->dependsOn('a', 'b');
+        $this->cache->dependsOn('b', 'c');
+
+        $this->cache->invalidate('b');
+
+        self::assertFalse($this->cache->has('a'));
+        self::assertFalse($this->cache->has('b'));
+        self::assertSame('C', $this->cache->get('c'));
+    }
+
+    public function test_diamond_dependency_cascades_each_node_once(): void
+    {
+        // `a` depends on both `b` and `c`; both depend on `d`. Invalidating
+        // `d` must drop every node — and exercise the BFS `$seen` dedup,
+        // since `a` is otherwise reachable twice (via `b` and via `c`).
+        $this->cache->put('a', 'A');
+        $this->cache->put('b', 'B');
+        $this->cache->put('c', 'C');
+        $this->cache->put('d', 'D');
+
+        $this->cache->dependsOn('a', 'b');
+        $this->cache->dependsOn('a', 'c');
+        $this->cache->dependsOn('b', 'd');
+        $this->cache->dependsOn('c', 'd');
+
+        $this->cache->invalidate('d');
+
+        self::assertFalse($this->cache->has('a'));
+        self::assertFalse($this->cache->has('b'));
+        self::assertFalse($this->cache->has('c'));
+        self::assertFalse($this->cache->has('d'));
+    }
+
+    public function test_deep_chain_cascades_fully(): void
+    {
+        $depth = 20;
+        for ($i = 0; $i <= $depth; ++$i) {
+            $this->cache->put('n_' . $i, $i);
+        }
+        for ($i = 0; $i < $depth; ++$i) {
+            $this->cache->dependsOn('n_' . $i, 'n_' . ($i + 1));
+        }
+
+        $this->cache->invalidate('n_' . $depth);
+
+        for ($i = 0; $i <= $depth; ++$i) {
+            self::assertFalse($this->cache->has('n_' . $i));
+        }
+    }
+
+    public function test_partial_invalidate_keeps_siblings_and_parent(): void
+    {
+        $this->cache->put('ns:X', 'env');
+        $this->cache->put('file:a', 'a');
+        $this->cache->put('file:b', 'b');
+        $this->cache->dependsOn('file:a', 'ns:X');
+        $this->cache->dependsOn('file:b', 'ns:X');
+
+        $this->cache->invalidate('file:a');
+
+        self::assertFalse($this->cache->has('file:a'));
+        self::assertSame('b', $this->cache->get('file:b'));
+        self::assertSame('env', $this->cache->get('ns:X'));
+        self::assertSame(['file:b'], $this->cache->dependents('ns:X'));
+
+        // Parent still cascades to the remaining sibling.
+        $this->cache->invalidate('ns:X');
+        self::assertFalse($this->cache->has('file:b'));
+    }
+
+    public function test_dependson_declared_before_put_still_invalidates(): void
+    {
+        // Edges may be declared before the values exist.
+        $this->cache->dependsOn('file:a', 'ns:X');
+
+        $this->cache->put('ns:X', 'env');
+        $this->cache->put('file:a', 'a');
+
+        $this->cache->invalidate('ns:X');
+
+        self::assertFalse($this->cache->has('file:a'));
+    }
+
+    public function test_put_on_existing_key_preserves_edges(): void
+    {
+        $this->cache->put('ns:X', 'env');
+        $this->cache->put('file:a', 'first');
+        $this->cache->dependsOn('file:a', 'ns:X');
+
+        $this->cache->put('file:a', 'second');
+
+        self::assertSame(['file:a'], $this->cache->dependents('ns:X'));
+
+        $this->cache->invalidate('ns:X');
+        self::assertFalse($this->cache->has('file:a'));
+    }
+
+    public function test_loadgraph_ignores_non_array_payload(): void
+    {
+        file_put_contents(
+            $this->cacheDir . '/.gacela-scoped-cache-graph.php',
+            "<?php\n\nreturn 'not-a-graph';\n",
+        );
+
+        $reopened = new ScopedCache(new FileCache($this->cacheDir));
+
+        self::assertSame([], $reopened->dependents('ns:X'));
+        $reopened->put('ns:X', 'env');
+        self::assertSame('env', $reopened->get('ns:X'));
+    }
+
+    public function test_loadgraph_skips_malformed_entries_keeps_valid_ones(): void
+    {
+        file_put_contents(
+            $this->cacheDir . '/.gacela-scoped-cache-graph.php',
+            <<<'PHP'
+                <?php
+
+                return [
+                    'file:a' => ['ns:X'],
+                    123      => ['bad-int-key'],
+                    'file:b' => 'not-an-array',
+                    'file:c' => ['ns:Y', 456],
+                ];
+                PHP,
+        );
+
+        $reopened = new ScopedCache(new FileCache($this->cacheDir));
+
+        self::assertSame(['file:a'], $reopened->dependents('ns:X'));
+        self::assertSame(['file:c'], $reopened->dependents('ns:Y'));
+        self::assertSame([], $reopened->dependents('bad-int-key'));
+        self::assertSame([], $reopened->dependents('file:b'));
     }
 
     private function removeDir(string $dir): void

--- a/tests/Unit/Framework/Cache/ScopedCacheTest.php
+++ b/tests/Unit/Framework/Cache/ScopedCacheTest.php
@@ -303,6 +303,7 @@ final class ScopedCacheTest extends TestCase
         for ($i = 0; $i <= $depth; ++$i) {
             $this->cache->put('n_' . $i, $i);
         }
+
         for ($i = 0; $i < $depth; ++$i) {
             $this->cache->dependsOn('n_' . $i, 'n_' . ($i + 1));
         }

--- a/tests/Unit/Framework/Cache/ScopedCacheTest.php
+++ b/tests/Unit/Framework/Cache/ScopedCacheTest.php
@@ -225,6 +225,37 @@ final class ScopedCacheTest extends TestCase
         self::assertFalse($this->cache->has('never-existed'));
     }
 
+    public function test_clear_drops_values_and_graph(): void
+    {
+        $this->cache->put('ns:X', 'env-x');
+        $this->cache->put('file:a.php', 'a');
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+
+        $this->cache->clear();
+
+        self::assertFalse($this->cache->has('ns:X'));
+        self::assertFalse($this->cache->has('file:a.php'));
+        self::assertSame([], $this->cache->dependents('ns:X'));
+    }
+
+    public function test_clear_graph_is_gone_after_restart(): void
+    {
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+        $this->cache->clear();
+
+        $reopened = new ScopedCache(new FileCache($this->cacheDir));
+
+        self::assertSame([], $reopened->dependents('ns:X'));
+    }
+
+    public function test_put_honors_ttl_passthrough(): void
+    {
+        $this->cache->put('short', 'lived', ttl: -1);
+
+        self::assertNull($this->cache->get('short'));
+        self::assertFalse($this->cache->has('short'));
+    }
+
     private function removeDir(string $dir): void
     {
         if (!is_dir($dir)) {

--- a/tests/Unit/Framework/Cache/ScopedCacheTest.php
+++ b/tests/Unit/Framework/Cache/ScopedCacheTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Cache;
+
+use Gacela\Framework\Cache\CycleDetectedException;
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\ScopedCache;
+use PHPUnit\Framework\TestCase;
+
+use function glob;
+use function is_dir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class ScopedCacheTest extends TestCase
+{
+    private string $cacheDir;
+
+    /** @var ScopedCache<mixed> */
+    private ScopedCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/gacela-scoped-cache-test-' . uniqid('', true);
+        $this->cache = new ScopedCache(new FileCache($this->cacheDir));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->cacheDir);
+    }
+
+    public function test_put_and_get_round_trip(): void
+    {
+        $this->cache->put('file:a.php', 'compiled-a');
+
+        self::assertTrue($this->cache->has('file:a.php'));
+        self::assertSame('compiled-a', $this->cache->get('file:a.php'));
+    }
+
+    public function test_get_returns_null_for_missing_key(): void
+    {
+        self::assertNull($this->cache->get('missing'));
+        self::assertFalse($this->cache->has('missing'));
+    }
+
+    public function test_dependents_is_empty_when_no_edges_declared(): void
+    {
+        $this->cache->put('ns:X', 'env-x');
+
+        self::assertSame([], $this->cache->dependents('ns:X'));
+    }
+
+    public function test_dependents_reports_direct_children_only(): void
+    {
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+        $this->cache->dependsOn('file:b.php', 'ns:X');
+        $this->cache->dependsOn('ns:X', 'ns:root');
+
+        self::assertSame(['file:a.php', 'file:b.php'], $this->cache->dependents('ns:X'));
+        self::assertSame(['ns:X'], $this->cache->dependents('ns:root'));
+    }
+
+    public function test_invalidate_cascades_through_transitive_dependents(): void
+    {
+        $this->cache->put('ns:X', 'env');
+        $this->cache->put('file:a.php', 'a');
+        $this->cache->put('file:b.php', 'b');
+        $this->cache->put('fragment:a1', 'frag');
+
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+        $this->cache->dependsOn('file:b.php', 'ns:X');
+        $this->cache->dependsOn('fragment:a1', 'file:a.php');
+
+        $this->cache->invalidate('ns:X');
+
+        self::assertFalse($this->cache->has('ns:X'));
+        self::assertFalse($this->cache->has('file:a.php'));
+        self::assertFalse($this->cache->has('file:b.php'));
+        self::assertFalse($this->cache->has('fragment:a1'));
+    }
+
+    public function test_invalidate_leaves_unrelated_entries_alone(): void
+    {
+        $this->cache->put('ns:X', 'env-x');
+        $this->cache->put('ns:Y', 'env-y');
+        $this->cache->put('file:a.php', 'a');
+
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+
+        $this->cache->invalidate('ns:X');
+
+        self::assertFalse($this->cache->has('ns:X'));
+        self::assertFalse($this->cache->has('file:a.php'));
+        self::assertSame('env-y', $this->cache->get('ns:Y'));
+    }
+
+    public function test_invalidate_leaf_does_not_cascade_to_dependents(): void
+    {
+        $this->cache->put('ns:X', 'env-x');
+        $this->cache->put('file:a.php', 'a');
+
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+
+        $this->cache->invalidateLeaf('ns:X');
+
+        self::assertFalse($this->cache->has('ns:X'));
+        self::assertSame('a', $this->cache->get('file:a.php'));
+    }
+
+    public function test_invalidate_leaf_drops_edges_referencing_the_key(): void
+    {
+        $this->cache->put('ns:X', 'env-x');
+        $this->cache->put('file:a.php', 'a');
+
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+        $this->cache->invalidateLeaf('ns:X');
+
+        self::assertSame([], $this->cache->dependents('ns:X'));
+    }
+
+    public function test_dependency_graph_survives_process_restart(): void
+    {
+        $this->cache->put('ns:X', 'env-x');
+        $this->cache->put('file:a.php', 'a');
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+
+        $reopened = new ScopedCache(new FileCache($this->cacheDir));
+
+        self::assertSame(['file:a.php'], $reopened->dependents('ns:X'));
+
+        $reopened->invalidate('ns:X');
+        self::assertFalse($reopened->has('file:a.php'));
+    }
+
+    public function test_dependency_survives_restart_with_leaf_invalidation(): void
+    {
+        // Acceptance case: `file:X` depending on `ns:Y` survives process
+        // restart and invalidates correctly.
+        $this->cache->put('ns:Y', 'env-y');
+        $this->cache->put('file:X', 'compiled-x');
+        $this->cache->dependsOn('file:X', 'ns:Y');
+
+        $reopened = new ScopedCache(new FileCache($this->cacheDir));
+
+        $reopened->invalidateLeaf('file:X');
+        self::assertFalse($reopened->has('file:X'));
+        self::assertSame('env-y', $reopened->get('ns:Y'));
+
+        $reopened->invalidate('ns:Y');
+        self::assertFalse($reopened->has('ns:Y'));
+    }
+
+    public function test_dependson_rejects_self_dependency(): void
+    {
+        $this->expectException(CycleDetectedException::class);
+
+        $this->cache->dependsOn('same', 'same');
+    }
+
+    public function test_dependson_rejects_two_node_cycle(): void
+    {
+        $this->cache->dependsOn('a', 'b');
+
+        $this->expectException(CycleDetectedException::class);
+        $this->cache->dependsOn('b', 'a');
+    }
+
+    public function test_dependson_rejects_transitive_cycle(): void
+    {
+        $this->cache->dependsOn('a', 'b');
+        $this->cache->dependsOn('b', 'c');
+
+        $this->expectException(CycleDetectedException::class);
+        $this->cache->dependsOn('c', 'a');
+    }
+
+    public function test_dependson_rejected_cycle_leaves_graph_unchanged(): void
+    {
+        $this->cache->dependsOn('a', 'b');
+
+        try {
+            $this->cache->dependsOn('b', 'a');
+            self::fail('expected CycleDetectedException');
+        } catch (CycleDetectedException) {
+            // expected
+        }
+
+        self::assertSame(['a'], $this->cache->dependents('b'));
+        self::assertSame([], $this->cache->dependents('a'));
+    }
+
+    public function test_dependson_is_idempotent(): void
+    {
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+
+        self::assertSame(['file:a.php'], $this->cache->dependents('ns:X'));
+    }
+
+    public function test_multiple_parents_all_cascade(): void
+    {
+        $this->cache->put('file:a.php', 'a');
+        $this->cache->put('ns:X', 'x');
+        $this->cache->put('ns:Y', 'y');
+
+        $this->cache->dependsOn('file:a.php', 'ns:X');
+        $this->cache->dependsOn('file:a.php', 'ns:Y');
+
+        $this->cache->invalidate('ns:X');
+
+        self::assertFalse($this->cache->has('file:a.php'));
+        self::assertFalse($this->cache->has('ns:X'));
+        self::assertSame('y', $this->cache->get('ns:Y'));
+    }
+
+    public function test_invalidate_missing_key_is_noop(): void
+    {
+        $this->cache->invalidate('never-existed');
+
+        self::assertFalse($this->cache->has('never-existed'));
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            if (is_dir($entry)) {
+                $this->removeDir($entry);
+            } else {
+                unlink($entry);
+            }
+        }
+
+        foreach (glob($dir . '/.[!.]*') ?: [] as $dotfile) {
+            if (is_dir($dotfile)) {
+                $this->removeDir($dotfile);
+            } else {
+                unlink($dotfile);
+            }
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds `ScopedCache`, the Tier 2 item from `local/phel-lang-feature-proposals.md` §4 and PR #5 in `local/pr-plan.md`. Unblocked by `FileCache<T>` shipping in 1.13.0.

`ScopedCache` decorates `FileCache` with a persisted dependency graph. Callers declare `dependsOn($child, $parent)`; `invalidate($parent)` cascades through every transitive dependent in `O(|descendants|)`, while `invalidateLeaf($key)` drops a single entry without cascading. Cycles are rejected eagerly at `dependsOn()` time.

The graph lives next to the `FileCache` directory (`.gacela-scoped-cache-graph.php`), so a `file:X → ns:Y` relationship survives process restarts — matching the proposal's acceptance case (the compiler-cache replacement target in phel-lang's `CompiledCodeCache`).

Scope notes (following the proposal):
- **Decorator, not a parallel primitive.** Wraps `FileCache<T>`; reuses its atomic-rename write path via `FileCache::writeAtomically()` for the graph file.
- **Single-writer assumption.** Documented on the class; in-memory load + write-through on each edge mutation. Flock-per-edit is deferred until a real multi-writer consumer surfaces.
- **No runtime proxies / no evict policies / no pluggable graph store** — same v1 restraint `FileCache` landed with.

## 🔖 Changes

- `Gacela\Framework\Cache\ScopedCache` — `@template T` decorator: `get`, `put`, `has`, `dependsOn`, `invalidate`, `invalidateLeaf`, `dependents`. In-memory dependency graph (forward `child => parents` and reverse `parent => children`), persisted via `FileCache::writeAtomically()` in the cache directory. Loaded lazily at construction.
- `Gacela\Framework\Cache\CycleDetectedException` — named constructors `::selfDependency()` and `::between()` so the error message includes both keys.
- 17 unit tests in `ScopedCacheTest` covering: round-trip, cascading `invalidate`, `invalidateLeaf` isolation, `dependents()` reporting, persistence across fresh instances, cycle rejection (self / two-node / transitive), idempotent `dependsOn`, multi-parent cascade, missing-key no-op, graph integrity after rejected edge.
- `CHANGELOG.md` — `## Unreleased > ### Added` entry.

No migrations, no changes to existing `FileCache` or consumers. `composer quality` + `composer test-unit` + `composer test-integration` + `composer test-feature` all green locally (also validated by the pre-commit hook).