### PR TITLE
docs(rfc): revise RFC-0001 to accepted status with firm decisions

### DIFF
--- a/docs/rfc/0001-inject-symfony-di-interop.md
+++ b/docs/rfc/0001-inject-symfony-di-interop.md
@@ -1,200 +1,377 @@
-# RFC-0001: `#[Inject]` and `#[ServiceMapTyped]` — Symfony DI interop
+# RFC-0001: `#[Inject]` and Symfony DI interop
 
-- Status: **Proposed** — not yet approved. Implementation is gated on this RFC.
-- Supersedes: —
-- Blocks: `feat/inject-attribute` (PR #8 in `local/pr-plan.md`)
+- Status: **Accepted** (2026-04-15). Supersedes the prior `Proposed` draft.
+- Blocks: `feat/inject-attribute` (PR #8 in `local/pr-plan.md`).
+- Revision note: the prior draft misrepresented `#[Inject]` as new and
+  described a property-level `#[ServiceMap]` that does not exist. Both
+  issues are corrected here; see §1.2 for existing-state facts.
 
 ## 1. Context
 
-Consumers of Gacela facades frequently see one of three patterns in their code:
+### 1.1 Pain points
+
+Gacela consumers today use one of three patterns to reach services from
+outside a facade or factory:
 
 ```php
-// Pattern A — verbose typed lookup
+// Pattern A — verbose typed lookup at the call site
 $fs = Gacela::getRequired(FilesystemFacade::class);
 
-// Pattern B — service map attribute, loses interface typing
+// Pattern B — class-level dispatch map (current `#[ServiceMap]`)
+#[ServiceMap(method: 'getFs', className: FilesystemFacade::class)]
 final class MyClass
 {
-    #[ServiceMap(FilesystemFacade::class)]
-    private FilesystemFacade $fs;
+    use ServiceResolverAwareTrait;
+    // $this->getFs() works via __call magic
 }
 
-// Pattern C — direct facade access with suppressions
+// Pattern C — direct facade access with Psalm suppressions
 /** @psalm-suppress InternalMethod */
 $fs = $this->getFacade()->clearCache();
 ```
 
-All three work, but none reads as natural constructor injection. Downstream
-projects (phel-lang is the reference case) have dozens of Symfony `Command`
-classes that could drop `ServiceResolverAwareTrait` and `getFacade()` calls
-in favour of a single constructor-injected interface.
+None of these reads as natural constructor injection. Phel's Symfony
+commands (~10 `Command` classes under
+`src/php/*/Infrastructure/Command/`) carry `ServiceResolverAwareTrait`
+boilerplate and `@psalm-suppress` comments that `#[Inject]` can delete.
 
-The proposal is to add `#[Inject]` on constructor parameters and
-`#[ServiceMapTyped]` on properties, both targeting interfaces, and have
-the container resolve them automatically. Psalm and PHPStan then infer
-types without `@psalm-suppress` or manual docblocks.
+### 1.2 What already exists
+
+- `Gacela\Container\Attribute\Inject` is defined in the vendor container
+  package (`vendor/gacela-project/container/src/Container/Attribute/Inject.php`)
+  with target `Attribute::TARGET_PARAMETER` and an optional
+  `?string $implementation` parameter for interface → concrete override.
+- `DependencyResolver::resolveDependenciesRecursively()` (same package)
+  already honors it: if `#[Inject($concrete)]` is present, it resolves
+  `$concrete`; otherwise it falls through to the parameter's type-hint
+  (autowire) or a default value.
+- Constructor autowiring-by-type-hint works today for any Gacela-managed
+  construction path — `#[Inject]` is an optional override, not a switch
+  to turn injection on.
+- `Gacela\Framework\` contains **zero** references to `Inject`. The
+  attribute is effectively undocumented and undiscoverable.
+- `#[ServiceMap(method, className)]` (`src/Framework/ServiceResolver/ServiceMap.php`)
+  targets `TARGET_CLASS`, is repeatable, and declares class-level
+  dispatch-map entries consumed by `ServiceResolverAwareTrait::__call()`.
+  It is **not** a property attribute and has no interface-typing mode.
+
+The prior RFC draft conflated these two attributes and proposed a new
+`#[ServiceMapTyped]`. Given `#[Inject]` already exists and already
+supports interface → concrete override, no second attribute is needed.
+
+### 1.3 Existing DI infrastructure referenced below
+
+| Concern | Today |
+| --- | --- |
+| Bindings | `GacelaConfig::addBinding(Interface, Impl)` → `BindingResolver` |
+| Contextual bindings | `GacelaConfig::when(Consumer)->needs(Interface)->give(Impl)` |
+| Protected services | `GacelaConfig::addProtected(id, Closure)` — stored raw, not instantiated |
+| Not-found error | `ServiceNotFoundException` (thrown by `Gacela::getRequired()`) |
+| Wrong-param-shape error | `DependencyInvalidArgumentException` (thrown at reflection time) |
+| `debug:dependencies` | `src/Console/Infrastructure/Command/DebugDependenciesCommand.php` — renders constructor params with a `ParameterStatus` enum tag per row |
+| Reflection caching | `DependencyResolver::constructorCache` (per-process); `AbstractPhpFileCache` (cross-process) |
 
 ## 2. Problem
 
-Three open questions must be resolved before implementation. Each one
-has ergonomic and runtime consequences; the cost of picking the wrong
-answer is BC breakage or a silently-wrong DI wiring.
+Three questions must be resolved before PR #8 opens. Each has a
+committed decision in §3.
 
 ### Q1. Who wires Symfony `Command` constructors?
 
 Phel's commands live inside a Symfony `Application`. Symfony autowires
-`Command` constructors through its own container. If Gacela's `#[Inject]`
-attribute also wires them, the two containers race — last-writer wins,
-and the user gets silent mis-wiring that only surfaces at runtime.
+`Command` constructors through its own container. If Gacela's
+`#[Inject]` also wires them, the two containers race — last-writer
+wins, and the user gets silent mis-wiring that surfaces only at runtime.
 
-**Option A.** Gacela owns the commands. Ship a Symfony compiler pass
-(`GacelaInjectCompilerPass`) that inspects each `Command` service
-definition: if any parameter has `#[Inject]`, route that parameter's
-resolution to Gacela's container. Fail the build when both containers
-bind the same parameter.
-- Pros: clean consumer story (`#[Inject]` just works in Symfony classes).
-- Cons: adds a hard dep on Symfony DI (at least in the interop package);
-  compiler passes are the right extension point but raise the learning
-  curve for debugging wiring issues.
+- **Option A.** Gacela core owns commands via a built-in Symfony
+  compiler pass. Hard dep on `symfony/dependency-injection`.
+- **Option B.** `#[Inject]` skips Symfony-owned classes; commands keep
+  using `Gacela::getRequired()` in `execute()`.
+- **Option C.** Separate `gacela/symfony-bridge` package that ships the
+  compiler pass. Core stays decoupled; Symfony coupling is explicit and
+  optional.
 
-**Option B.** `#[Inject]` only applies to non-Symfony classes. Symfony
-commands keep using `Gacela::getRequired()` in `configure()` /
-`execute()`. Document the boundary explicitly.
-- Pros: no Symfony dep; two containers stay decoupled.
-- Cons: the biggest target audience (phel's commands) doesn't benefit —
-  the whole feature becomes much smaller in impact.
+### Q2. One attribute or two?
 
-**Option C.** Ship a separate `gacela/symfony-bridge` package that
-provides the compiler pass, and keep `#[Inject]` container-agnostic in
-the core. Users opt-in by requiring the bridge.
-- Pros: core stays thin; Symfony coupling is explicit and optional;
-  other frameworks (Laravel, Slim, Mezzio) can ship their own bridges.
-- Cons: one more package to publish and version; users must discover it.
+The prior draft proposed `#[Inject]` for constructor parameters and
+`#[ServiceMapTyped]` for properties. With `#[Inject]` already
+implemented in the container and constructor injection the modern-PHP
+norm, a second property attribute doubles the surface area for a use
+case we have no concrete consumer for.
 
-**Recommended**: C. It keeps the core decoupled and gives phel a
-narrow bridge they can adopt or fork. If the bridge footprint is small
-enough (< ~200 LOC), it could be a subfolder inside gacela that ships
-as a separate composer package via path-based autoload.
+- **Option A.** Ship only `#[Inject]` (constructor, targeting
+  parameters). Defer property injection until a consumer asks for it.
+- **Option B.** Extend `#[Inject]` to target both parameters and
+  properties; property injection happens in a post-construct pass.
+- **Option C.** Introduce `#[ServiceMapTyped]` as a property-only
+  attribute orthogonal to `#[Inject]`.
 
-### Q2. What does `#[ServiceMapTyped]` return — proxy, binding, or hint?
+### Q3. `debug:dependencies` output
 
-`#[ServiceMapTyped(interface: FilesystemFacadeInterface::class)]` needs
-to hand back a value that satisfies the interface *and* routes internal
-method calls through the container's existing facade dispatch.
+`DebugDependenciesCommand` already prints constructor parameters with
+per-row `ParameterStatus` (bound / autowirable / default / scalar /
+missing). After #8, some rows are `#[Inject]`-annotated (possibly with
+an override).
 
-**Option A — Runtime proxy.** Generate an `$ interface`-implementing
-proxy class on first resolution that forwards every method call to
-`Gacela::getRequired($concrete)`. Psalm/PHPStan see the interface
-type; internal `@internal` methods go through Gacela normally.
-- Pros: zero call-site awareness of the proxy.
-- Cons: generated code adds a file-cache entry per interface; reflection
-  cost on boot; debugging traces show proxy methods.
+- **Option A.** Add a new section for injected parameters.
+- **Option B.** Add a `kind` column to the existing rows: `inject`,
+  `contextual`, `bound`, `autowirable`, `default`, `scalar`, `missing`.
+- **Option C.** New `debug:injected` command.
 
-**Option B — Binding.** Register the interface → concrete mapping in
-the container at Provider time, so `Gacela::getRequired(Interface)`
-returns the concrete. `#[ServiceMapTyped]` becomes a typed alias on
-top of existing `addBinding()`.
-- Pros: no code generation; same runtime cost as today's `getRequired`.
-- Cons: doesn't address the `@psalm-suppress InternalMethod` pattern —
-  callers still pierce `@internal` when they call concrete methods
-  directly. Requires users to call only interface methods.
+## 3. Decision
 
-**Option C — Static-analysis hint only.** `#[ServiceMapTyped]` does
-nothing at runtime — it's purely a marker for Psalm/PHPStan extensions
-to upgrade the inferred type of `Gacela::getRequired($interface)` to
-the concrete class.
-- Pros: no runtime cost; no proxy; no new wiring.
-- Cons: requires shipping a Psalm plugin and a PHPStan extension (both
-  already exist in `src/PHPStan/` — scope-check whether extending them
-  is within this RFC's budget).
+### Q1 → Option C, with lockstep release
 
-**Recommended**: B for `#[Inject]` (binding resolution), C for
-`#[ServiceMapTyped]` (static-analysis hint). That keeps runtime code
-simple and solves both problems without generating proxy classes.
-Runtime proxies (A) are deferred unless a concrete need emerges.
+A new `gacela/symfony-bridge` package ships `GacelaInjectCompilerPass`.
+Core stays Symfony-free. **The bridge MUST release alongside PR #8** so
+the phel use case works on day one; shipping `#[Inject]` without a
+working bridge would leave the headline consumer unable to adopt it.
 
-### Q3. `debug:dependencies` output layout
+The compiler pass walks Symfony service definitions; for every
+constructor parameter carrying `#[Inject]`, it routes resolution to
+Gacela's container and removes Symfony's autowire claim for that slot.
+If both containers claim the same parameter the pass fails the build
+with a message identifying the service and parameter.
 
-Current `DebugDependenciesCommand` reports `#[ServiceMap]` properties
-per class. After `#[Inject]` ships, the same command must surface
-constructor-injected deps.
+The bridge may live in a `symfony-bridge/` subfolder of this repo and
+ship as a separate composer package via path-based autoload during
+development; it splits into its own repo once stable.
 
-**Option A.** Add a new "Injected parameters" section per class, below
-the existing "Service-mapped properties" section.
+### Q2 → Option A
 
-**Option B.** Unify into a single "Dependencies" section; distinguish
-with a column (`kind: inject | service-map | contextual-binding`).
+Ship `#[Inject]` only, constructor parameters only. The attribute
+already exists in `Gacela\Container\Attribute\Inject` and is honored by
+`DependencyResolver`. PR #8 promotes it, not implements it: docs,
+discoverability, Symfony bridge, static-analysis type upgrade,
+`debug:dependencies` surfacing, migration examples.
 
-**Option C.** Leave `debug:dependencies` untouched; ship a new
-`debug:injected` command.
+**`#[ServiceMapTyped]` is dropped from this RFC.** No concrete consumer
+for property injection exists; constructor injection is the modern-PHP
+norm and interoperates cleanly with `readonly`. If a future consumer
+emerges, a follow-up RFC can extend `#[Inject]` to `TARGET_PROPERTY`
+without breaking any of the guarantees in this one.
 
-**Recommended**: B. A single unified view matches what users actually
-want (one command, full picture of a class's DI graph). Requires a
-small cs fix to the existing command's output format.
+### Q3 → Option B
 
-## 3. Decision (to be filled after approval)
+Extend the existing per-row status with a `kind` column. One command,
+one view, minimal code churn. `ParameterStatus` gains an `INJECT` value
+and the renderer interleaves the override target (the `implementation`
+argument) when present.
 
-> **Pending.** Fill this section before opening PR #8.
+## 4. Specification
 
-## 4. Alternatives considered (not recommended)
+### 4.1 Attribute shape (no code change required)
 
-- **Status quo.** Keep `Gacela::getRequired()` everywhere. Rejected
-  because the `@psalm-suppress InternalMethod` pattern is spreading
-  and will only accumulate.
-- **Remove `@internal` markers on facade methods.** Cheaper than any of
-  the above but breaks the existing encapsulation contract — `@internal`
-  exists precisely to gate which methods are user-facing vs framework-
-  internal. Rejected.
-- **Ship `#[Inject]` on properties only.** Property injection sidesteps
-  constructor wiring but prevents `readonly` properties and hides
-  dependencies. Rejected on modern-PHP grounds.
+```php
+namespace Gacela\Container\Attribute;
 
-## 5. Consequences
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class Inject
+{
+    public function __construct(
+        public ?string $implementation = null,
+    ) {}
+}
+```
+
+This is the existing class. PR #8 adds docs, examples, and a
+re-export-via-documentation under `Gacela\Framework\Attribute\Inject`
+(class alias in bootstrap) so the user-facing namespace is consistent
+with `#[Cacheable]` and the rest of `Gacela\Framework\Attribute\`.
+
+### 4.2 Resolution order
+
+For a parameter `#[Inject($override)] Type $p` inside a class
+`Consumer` being constructed by the container:
+
+1. If `$override` is set (`#[Inject(ConcreteImpl::class)]`) → resolve `$override`.
+2. Else if `$config->when(Consumer)->needs(Type)->give(X)` → resolve `X`.
+3. Else if `$config->addBinding(Type, X)` → resolve `X`.
+4. Else if `Type` is instantiable → `new Type(...)` with recursive autowire.
+5. Else if `$p` has a default value → use the default.
+6. Else → throw `ServiceNotFoundException`.
+
+Nullable parameters (`?FooInterface`) with no binding and no default
+resolve to `null`. This is the one place `null` is a legitimate result;
+every other miss is an exception.
+
+### 4.3 Error surface
+
+| Condition | Exception |
+| --- | --- |
+| `#[Inject]` on a parameter without a type hint | `DependencyInvalidArgumentException::noParameterTypeFor` (existing) |
+| `#[Inject]` on a scalar-typed parameter with no default | `DependencyInvalidArgumentException::unableToResolve` (existing) |
+| `#[Inject($x)]` where `$x` is not a class-string | `DependencyInvalidArgumentException` (new helper) |
+| Resolution falls through every step and the type is not instantiable | `ServiceNotFoundException` (existing) |
+| Target is a protected service (see §4.4) | `ServiceNotFoundException` (existing behavior) |
+
+### 4.4 Interactions with existing DI features
+
+- **Protected services.** `$config->addProtected(id, Closure)` stores
+  the closure without invoking it. A `#[Inject]`-annotated parameter
+  cannot resolve to a protected id — protected services are designed
+  not to be instantiated by the container, and injecting one would
+  change its semantics. This requires no new code: the container's
+  existing resolution path already throws `ServiceNotFoundException`
+  when a protected id is requested as a service.
+- **Contextual bindings.** `$config->when(...)->needs(...)->give(...)`
+  takes precedence over global bindings per §4.2 step 2 vs step 3.
+- **`ContainerFixture` trait.** `resetContainer()` clears
+  `DependencyResolver::constructorCache` and any cross-process
+  constructor cache. `captureContainerState()` / `restoreContainerState()`
+  treat the resolver caches as part of the container snapshot.
+- **`#[ServiceMap]` and `ServiceResolverAwareTrait`.** Untouched. The
+  class-level dispatch map is an orthogonal mechanism for `__call`-based
+  lookup and remains the right tool for that use case.
+
+### 4.5 Static analysis
+
+- `#[Inject(ConcreteImpl::class)]` on an interface-typed parameter
+  hints Psalm and PHPStan that the runtime value is `ConcreteImpl`.
+  The existing rule set in `src/PHPStan/` is extended to upgrade the
+  inferred type on the annotated parameter's usages inside the
+  constructor body.
+- `#[Inject]` without an `implementation` override → no upgrade;
+  analyzers trust the declared type hint.
+- A user who does not install the PHPStan rules / Psalm plugin loses
+  the type upgrade but keeps runtime correctness.
+
+### 4.6 Reflection caching
+
+- Per-process: `DependencyResolver::constructorCache` already memoizes
+  `ReflectionClass::getConstructor()` per class — no change needed.
+- Cross-process: when file cache is enabled, a lightweight
+  `ConstructorInjectionsCache` (new, follows the `AbstractPhpFileCache`
+  pattern) stores per-class `#[Inject]` metadata so boot reflection
+  scans are O(changed classes), not O(all classes). Implementation
+  detail of PR #8; not a public contract. The cache participates in
+  `cache:clear` and `cache:warm` like the other `AbstractPhpFileCache`
+  instances.
+
+### 4.7 Symfony bridge (`gacela/symfony-bridge`)
+
+- New composer package, shipped with PR #8.
+- Single class of note: `GacelaInjectCompilerPass implements CompilerPassInterface`.
+- Registered by users in their Symfony kernel (`$container->addCompilerPass(new GacelaInjectCompilerPass())`).
+  The bridge ships a bundle or extension class that registers the pass
+  automatically when the bundle is enabled; the bare compiler pass
+  remains available for projects that don't use bundles.
+- The pass runs **before** Symfony's autowire pass so the rewritten
+  service definitions are stable.
+- **Conflict rule.** If a parameter is claimed by both a Gacela
+  `#[Inject]` and Symfony's own autowire/bind, the pass fails the
+  build with a message naming the service id and parameter name.
+- Parameters without `#[Inject]` are left to Symfony untouched.
+
+## 5. Migration example
+
+Before:
+
+```php
+final class PhelRunCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @psalm-suppress InternalMethod */
+        $this->getFacade()->clearCache();
+        return self::SUCCESS;
+    }
+}
+```
+
+After (with `gacela/symfony-bridge` installed and the pass registered):
+
+```php
+final class PhelRunCommand extends Command
+{
+    public function __construct(
+        #[Inject] private readonly PhelFacadeInterface $phel,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->phel->clearCache();
+        return self::SUCCESS;
+    }
+}
+```
+
+- `ServiceResolverAwareTrait` is gone.
+- `@psalm-suppress InternalMethod` is gone.
+- The constructor lists the dependency — tooling (`debug:dependencies`,
+  IDE autocomplete, static analysis) sees it.
+
+## 6. Scope for PR #8
+
+Budget: **M**, not L (the prior draft budgeted L based on the belief
+that `#[Inject]` needed to be built; it already exists).
+
+In scope:
+
+1. Bootstrap-time `class_alias(Gacela\Container\Attribute\Inject::class, Gacela\Framework\Attribute\Inject::class)`.
+2. `ConstructorInjectionsCache` (cross-process `#[Inject]` metadata).
+3. PHPStan rule(s) upgrading interface types when `#[Inject(Concrete::class)]` is present.
+4. `debug:dependencies` per Q3 (new `kind` column, extended `ParameterStatus`).
+5. `docs/container-configuration.md` section on `#[Inject]` with the
+   migration example.
+6. `gacela/symfony-bridge` package with `GacelaInjectCompilerPass`,
+   bundle glue, and tests against a minimal Symfony kernel.
+7. CHANGELOG under `Unreleased > Added`.
+
+Out of scope (deferred to future RFCs if a consumer emerges):
+
+- Property-level `#[Inject]` (`TARGET_PROPERTY`).
+- Laravel, Mezzio, or other framework bridges.
+- Runtime proxies for interfaces without a concrete binding.
+
+## 7. Alternatives considered (not recommended)
+
+- **Status quo.** Keep `Gacela::getRequired()` everywhere. Rejected —
+  `@psalm-suppress InternalMethod` is spreading in consumers.
+- **Remove `@internal` markers on facade methods.** Cheaper but breaks
+  the existing encapsulation contract. Rejected.
+- **Ship `#[Inject]` on properties too.** Hides dependencies, prevents
+  `readonly`. Rejected on modern-PHP grounds; see §3 Q2.
+- **Bundle the Symfony bridge into core.** Pins Gacela to
+  `symfony/dependency-injection`. Rejected; see §3 Q1.
+
+## 8. Consequences
 
 ### Positive
 
-- Phel's `src/php/*/Infrastructure/Command/*.php` (~10 classes) drop
-  `ServiceResolverAwareTrait` and `$this->getFacade()` calls.
-- No more `@psalm-suppress InternalMethod` on consumer facade calls
-  when they use `#[Inject]` with an interface.
-- `debug:dependencies` becomes a single source of truth for a class's
-  DI graph.
+- Phel's Symfony commands drop `ServiceResolverAwareTrait` and
+  `@psalm-suppress` comments.
+- `debug:dependencies` becomes the single source of truth for a class's
+  DI graph (bindings, contextual bindings, `#[Inject]` overrides, and
+  autowire, all in one table).
+- `#[Inject]` becomes discoverable. Today it ships undocumented inside
+  the container package.
 
 ### Negative
 
-- If Q1 lands on Option C (bridge package), consumers pay a
-  discovery tax: "why doesn't `#[Inject]` work in my Symfony command?"
-- Static-analysis hints (Q2 Option C) require users to have the Psalm
-  plugin / PHPStan extension enabled, or they lose the type upgrade.
+- Consumers on Symfony discover the bridge package separately. Mitigated
+  by the docs migration example linking to it explicitly.
+- Users without the PHPStan/Psalm plugins lose the type upgrade. The
+  runtime behavior is identical with or without the plugins — only the
+  inferred type at interface-typed `#[Inject(Concrete::class)]` sites
+  degrades to the declared interface.
 
-### Migration
+### Backwards compatibility
 
-Backwards-compatible by construction. Existing `Gacela::getRequired()`,
-`#[ServiceMap]`, and `getFacade()` call sites continue to work.
+Fully compatible. `Gacela::getRequired()`, `#[ServiceMap]`,
+`getFacade()`, `ServiceResolverAwareTrait`, and existing constructor
+autowiring all continue to work unchanged. `#[Inject]` becomes an
+additive opt-in.
 
-## 6. Scope for PR #8 (when this RFC is approved)
-
-- `#[Inject]` attribute + constructor wiring in Gacela's container.
-- `#[ServiceMapTyped]` as a typed variant of `#[ServiceMap]`.
-- `debug:dependencies` output update per Q3.
-- Psalm plugin + PHPStan extension updates if Q2-C is chosen.
-- The Symfony bridge per Q1-C, if chosen — may be a follow-up PR rather
-  than part of #8.
-- Documentation in `docs/container-configuration.md` with a migration
-  example.
-
-## 7. Open questions (for reviewers)
-
-1. Is the Q1-C bridge-package split the right scope boundary, or should
-   the core take a direct Symfony dep?
-2. For Q2, is shipping a Psalm plugin update in the same PR acceptable,
-   or does that warrant a separate PR?
-3. Any other framework containers (Laravel, Mezzio) that should be
-   considered now rather than left to future bridges?
-
-## 8. References
+## 9. References
 
 - `local/phel-lang-feature-proposals.md` §6 — original proposal
-- `local/pr-plan.md` — PR #7 (this RFC) blocks PR #8
-- Existing `#[ServiceMap]` attribute in `src/Framework/Container/`
-- Existing PHPStan rules in `src/PHPStan/`
+- `local/pr-plan.md` — PR #7 (this RFC) blocks PR #8; PR #8 budget revised M
+- `vendor/gacela-project/container/src/Container/Attribute/Inject.php` — existing attribute
+- `vendor/gacela-project/container/src/Container/DependencyResolver.php` — existing runtime support
+- `src/Framework/ServiceResolver/ServiceMap.php` — the unrelated class-level dispatch map
+- `src/Console/Infrastructure/Command/DebugDependenciesCommand.php` — target of the Q3 change

--- a/docs/rfc/0001-inject-symfony-di-interop.md
+++ b/docs/rfc/0001-inject-symfony-di-interop.md
@@ -1,166 +1,62 @@
 # RFC-0001: `#[Inject]` and Symfony DI interop
 
-- Status: **Accepted** (2026-04-15). Supersedes the prior `Proposed` draft.
+- Status: **Accepted** (2026-04-15).
 - Blocks: `feat/inject-attribute` (PR #8 in `local/pr-plan.md`).
-- Revision note: the prior draft misrepresented `#[Inject]` as new and
-  described a property-level `#[ServiceMap]` that does not exist. Both
-  issues are corrected here; see §1.2 for existing-state facts.
 
 ## 1. Context
 
-### 1.1 Pain points
+Consumers today reach Gacela services from outside facades via
+`Gacela::getRequired()`, `#[ServiceMap]` + `ServiceResolverAwareTrait`,
+or direct `getFacade()` calls with `@psalm-suppress InternalMethod`.
+None of these read as natural constructor injection. Phel's ~10 Symfony
+`Command` classes are the reference target.
 
-Gacela consumers today use one of three patterns to reach services from
-outside a facade or factory:
+**Existing state (load-bearing for the decisions below):**
 
-```php
-// Pattern A — verbose typed lookup at the call site
-$fs = Gacela::getRequired(FilesystemFacade::class);
+- `Gacela\Container\Attribute\Inject` already exists in the vendor
+  container package, targets `TARGET_PARAMETER`, and takes an optional
+  `?string $implementation` override.
+- `DependencyResolver::resolveDependenciesRecursively()` already honors
+  it; falls through to type-hint autowire otherwise.
+- Nothing under `src/Framework/` references `Inject` — it is
+  undocumented and undiscoverable.
+- `#[ServiceMap(method, className)]` at
+  `src/Framework/ServiceResolver/ServiceMap.php` targets `TARGET_CLASS`
+  — a class-level `__call` dispatch map, unrelated to property typing.
 
-// Pattern B — class-level dispatch map (current `#[ServiceMap]`)
-#[ServiceMap(method: 'getFs', className: FilesystemFacade::class)]
-final class MyClass
-{
-    use ServiceResolverAwareTrait;
-    // $this->getFs() works via __call magic
-}
+PR #8's job is therefore to **promote** `#[Inject]`, not to implement it.
 
-// Pattern C — direct facade access with Psalm suppressions
-/** @psalm-suppress InternalMethod */
-$fs = $this->getFacade()->clearCache();
-```
+## 2. Decisions
 
-None of these reads as natural constructor injection. Phel's Symfony
-commands (~10 `Command` classes under
-`src/php/*/Infrastructure/Command/`) carry `ServiceResolverAwareTrait`
-boilerplate and `@psalm-suppress` comments that `#[Inject]` can delete.
-
-### 1.2 What already exists
-
-- `Gacela\Container\Attribute\Inject` is defined in the vendor container
-  package (`vendor/gacela-project/container/src/Container/Attribute/Inject.php`)
-  with target `Attribute::TARGET_PARAMETER` and an optional
-  `?string $implementation` parameter for interface → concrete override.
-- `DependencyResolver::resolveDependenciesRecursively()` (same package)
-  already honors it: if `#[Inject($concrete)]` is present, it resolves
-  `$concrete`; otherwise it falls through to the parameter's type-hint
-  (autowire) or a default value.
-- Constructor autowiring-by-type-hint works today for any Gacela-managed
-  construction path — `#[Inject]` is an optional override, not a switch
-  to turn injection on.
-- `Gacela\Framework\` contains **zero** references to `Inject`. The
-  attribute is effectively undocumented and undiscoverable.
-- `#[ServiceMap(method, className)]` (`src/Framework/ServiceResolver/ServiceMap.php`)
-  targets `TARGET_CLASS`, is repeatable, and declares class-level
-  dispatch-map entries consumed by `ServiceResolverAwareTrait::__call()`.
-  It is **not** a property attribute and has no interface-typing mode.
-
-The prior RFC draft conflated these two attributes and proposed a new
-`#[ServiceMapTyped]`. Given `#[Inject]` already exists and already
-supports interface → concrete override, no second attribute is needed.
-
-### 1.3 Existing DI infrastructure referenced below
-
-| Concern | Today |
-| --- | --- |
-| Bindings | `GacelaConfig::addBinding(Interface, Impl)` → `BindingResolver` |
-| Contextual bindings | `GacelaConfig::when(Consumer)->needs(Interface)->give(Impl)` |
-| Protected services | `GacelaConfig::addProtected(id, Closure)` — stored raw, not instantiated |
-| Not-found error | `ServiceNotFoundException` (thrown by `Gacela::getRequired()`) |
-| Wrong-param-shape error | `DependencyInvalidArgumentException` (thrown at reflection time) |
-| `debug:dependencies` | `src/Console/Infrastructure/Command/DebugDependenciesCommand.php` — renders constructor params with a `ParameterStatus` enum tag per row |
-| Reflection caching | `DependencyResolver::constructorCache` (per-process); `AbstractPhpFileCache` (cross-process) |
-
-## 2. Problem
-
-Three questions must be resolved before PR #8 opens. Each has a
-committed decision in §3.
-
-### Q1. Who wires Symfony `Command` constructors?
-
-Phel's commands live inside a Symfony `Application`. Symfony autowires
-`Command` constructors through its own container. If Gacela's
-`#[Inject]` also wires them, the two containers race — last-writer
-wins, and the user gets silent mis-wiring that surfaces only at runtime.
-
-- **Option A.** Gacela core owns commands via a built-in Symfony
-  compiler pass. Hard dep on `symfony/dependency-injection`.
-- **Option B.** `#[Inject]` skips Symfony-owned classes; commands keep
-  using `Gacela::getRequired()` in `execute()`.
-- **Option C.** Separate `gacela/symfony-bridge` package that ships the
-  compiler pass. Core stays decoupled; Symfony coupling is explicit and
-  optional.
-
-### Q2. One attribute or two?
-
-The prior draft proposed `#[Inject]` for constructor parameters and
-`#[ServiceMapTyped]` for properties. With `#[Inject]` already
-implemented in the container and constructor injection the modern-PHP
-norm, a second property attribute doubles the surface area for a use
-case we have no concrete consumer for.
-
-- **Option A.** Ship only `#[Inject]` (constructor, targeting
-  parameters). Defer property injection until a consumer asks for it.
-- **Option B.** Extend `#[Inject]` to target both parameters and
-  properties; property injection happens in a post-construct pass.
-- **Option C.** Introduce `#[ServiceMapTyped]` as a property-only
-  attribute orthogonal to `#[Inject]`.
-
-### Q3. `debug:dependencies` output
-
-`DebugDependenciesCommand` already prints constructor parameters with
-per-row `ParameterStatus` (bound / autowirable / default / scalar /
-missing). After #8, some rows are `#[Inject]`-annotated (possibly with
-an override).
-
-- **Option A.** Add a new section for injected parameters.
-- **Option B.** Add a `kind` column to the existing rows: `inject`,
-  `contextual`, `bound`, `autowirable`, `default`, `scalar`, `missing`.
-- **Option C.** New `debug:injected` command.
-
-## 3. Decision
-
-### Q1 → Option C, with lockstep release
+### Q1. Who wires Symfony `Command` constructors? → Separate bridge, lockstep release.
 
 A new `gacela/symfony-bridge` package ships `GacelaInjectCompilerPass`.
-Core stays Symfony-free. **The bridge MUST release alongside PR #8** so
-the phel use case works on day one; shipping `#[Inject]` without a
-working bridge would leave the headline consumer unable to adopt it.
+Core stays Symfony-free. **The bridge MUST release alongside PR #8** —
+shipping `#[Inject]` without a working bridge leaves the headline
+consumer (phel commands) unable to adopt it. The pass routes
+`#[Inject]`-annotated parameters to Gacela and fails the build when
+both containers claim the same parameter. May live in a
+`symfony-bridge/` subfolder during development, split once stable.
 
-The compiler pass walks Symfony service definitions; for every
-constructor parameter carrying `#[Inject]`, it routes resolution to
-Gacela's container and removes Symfony's autowire claim for that slot.
-If both containers claim the same parameter the pass fails the build
-with a message identifying the service and parameter.
+### Q2. One attribute or two? → One. `#[Inject]`, constructor-only.
 
-The bridge may live in a `symfony-bridge/` subfolder of this repo and
-ship as a separate composer package via path-based autoload during
-development; it splits into its own repo once stable.
+The proposed `#[ServiceMapTyped]` is dropped — no concrete consumer for
+property injection, and constructor injection interoperates cleanly
+with `readonly`. A follow-up RFC can extend `TARGET_PROPERTY` later
+without breaking this one. PR #8 adds docs, a Gacela-namespace alias,
+static-analysis upgrade, `debug:dependencies` surfacing, and migration
+examples around the existing attribute.
 
-### Q2 → Option A
+### Q3. `debug:dependencies` output? → One unified view with a `kind` column.
 
-Ship `#[Inject]` only, constructor parameters only. The attribute
-already exists in `Gacela\Container\Attribute\Inject` and is honored by
-`DependencyResolver`. PR #8 promotes it, not implements it: docs,
-discoverability, Symfony bridge, static-analysis type upgrade,
-`debug:dependencies` surfacing, migration examples.
+Extend the existing per-row status with a `kind` column (`inject`,
+`contextual`, `bound`, `autowirable`, `default`, `scalar`, `missing`).
+`ParameterStatus` gains `INJECT`; the renderer inlines the override
+target when `#[Inject($impl)]` is set.
 
-**`#[ServiceMapTyped]` is dropped from this RFC.** No concrete consumer
-for property injection exists; constructor injection is the modern-PHP
-norm and interoperates cleanly with `readonly`. If a future consumer
-emerges, a follow-up RFC can extend `#[Inject]` to `TARGET_PROPERTY`
-without breaking any of the guarantees in this one.
+## 3. Specification
 
-### Q3 → Option B
-
-Extend the existing per-row status with a `kind` column. One command,
-one view, minimal code churn. `ParameterStatus` gains an `INJECT` value
-and the renderer interleaves the override target (the `implementation`
-argument) when present.
-
-## 4. Specification
-
-### 4.1 Attribute shape (no code change required)
+### 3.1 Attribute shape (no change required)
 
 ```php
 namespace Gacela\Container\Attribute;
@@ -174,96 +70,71 @@ final class Inject
 }
 ```
 
-This is the existing class. PR #8 adds docs, examples, and a
-re-export-via-documentation under `Gacela\Framework\Attribute\Inject`
-(class alias in bootstrap) so the user-facing namespace is consistent
-with `#[Cacheable]` and the rest of `Gacela\Framework\Attribute\`.
+PR #8 adds a bootstrap `class_alias` so `Gacela\Framework\Attribute\Inject`
+resolves to the same class — consistent with `#[Cacheable]` and the rest
+of `Gacela\Framework\Attribute\`.
 
-### 4.2 Resolution order
+### 3.2 Resolution order
 
-For a parameter `#[Inject($override)] Type $p` inside a class
-`Consumer` being constructed by the container:
+For `#[Inject($override)] Type $p` on `Consumer`:
 
-1. If `$override` is set (`#[Inject(ConcreteImpl::class)]`) → resolve `$override`.
-2. Else if `$config->when(Consumer)->needs(Type)->give(X)` → resolve `X`.
-3. Else if `$config->addBinding(Type, X)` → resolve `X`.
-4. Else if `Type` is instantiable → `new Type(...)` with recursive autowire.
-5. Else if `$p` has a default value → use the default.
-6. Else → throw `ServiceNotFoundException`.
+1. `$override` set → resolve `$override`.
+2. `$config->when(Consumer)->needs(Type)->give(X)` → resolve `X`.
+3. `$config->addBinding(Type, X)` → resolve `X`.
+4. `Type` instantiable → `new Type(...)` with recursive autowire.
+5. `$p` has a default → use it.
+6. Otherwise → throw `ServiceNotFoundException`.
 
-Nullable parameters (`?FooInterface`) with no binding and no default
-resolve to `null`. This is the one place `null` is a legitimate result;
-every other miss is an exception.
+Nullable parameters (`?Foo`) with no binding and no default resolve to
+`null`. Every other miss is an exception.
 
-### 4.3 Error surface
+### 3.3 Error surface
 
 | Condition | Exception |
 | --- | --- |
-| `#[Inject]` on a parameter without a type hint | `DependencyInvalidArgumentException::noParameterTypeFor` (existing) |
-| `#[Inject]` on a scalar-typed parameter with no default | `DependencyInvalidArgumentException::unableToResolve` (existing) |
+| `#[Inject]` on a parameter without a type hint | `DependencyInvalidArgumentException::noParameterTypeFor` |
+| `#[Inject]` on a scalar type with no default | `DependencyInvalidArgumentException::unableToResolve` |
 | `#[Inject($x)]` where `$x` is not a class-string | `DependencyInvalidArgumentException` (new helper) |
-| Resolution falls through every step and the type is not instantiable | `ServiceNotFoundException` (existing) |
-| Target is a protected service (see §4.4) | `ServiceNotFoundException` (existing behavior) |
+| Resolution exhausted, type not instantiable | `ServiceNotFoundException` |
 
-### 4.4 Interactions with existing DI features
+### 3.4 Interactions
 
-- **Protected services.** `$config->addProtected(id, Closure)` stores
-  the closure without invoking it. A `#[Inject]`-annotated parameter
-  cannot resolve to a protected id — protected services are designed
-  not to be instantiated by the container, and injecting one would
-  change its semantics. This requires no new code: the container's
-  existing resolution path already throws `ServiceNotFoundException`
-  when a protected id is requested as a service.
-- **Contextual bindings.** `$config->when(...)->needs(...)->give(...)`
-  takes precedence over global bindings per §4.2 step 2 vs step 3.
-- **`ContainerFixture` trait.** `resetContainer()` clears
-  `DependencyResolver::constructorCache` and any cross-process
-  constructor cache. `captureContainerState()` / `restoreContainerState()`
-  treat the resolver caches as part of the container snapshot.
-- **`#[ServiceMap]` and `ServiceResolverAwareTrait`.** Untouched. The
-  class-level dispatch map is an orthogonal mechanism for `__call`-based
-  lookup and remains the right tool for that use case.
+- **Protected services** (`$config->addProtected`) cannot be injected;
+  the existing resolution path already throws `ServiceNotFoundException`
+  for them.
+- **Contextual bindings** win over global bindings (§3.2 step 2 before 3).
+- **`ContainerFixture`**: `resetContainer()` clears the constructor
+  cache; `captureContainerState()` / `restoreContainerState()` include it.
+- **`#[ServiceMap]` and `ServiceResolverAwareTrait`** are untouched —
+  orthogonal `__call` dispatch, different use case.
 
-### 4.5 Static analysis
+### 3.5 Static analysis
 
-- `#[Inject(ConcreteImpl::class)]` on an interface-typed parameter
-  hints Psalm and PHPStan that the runtime value is `ConcreteImpl`.
-  The existing rule set in `src/PHPStan/` is extended to upgrade the
-  inferred type on the annotated parameter's usages inside the
-  constructor body.
-- `#[Inject]` without an `implementation` override → no upgrade;
-  analyzers trust the declared type hint.
-- A user who does not install the PHPStan rules / Psalm plugin loses
-  the type upgrade but keeps runtime correctness.
+`#[Inject(ConcreteImpl::class)]` on an interface-typed parameter
+upgrades the analyzer's inferred type to `ConcreteImpl`. Extend the
+existing rule set in `src/PHPStan/`. Without the override, no upgrade —
+analyzers trust the declared hint. Runtime behavior is identical with or
+without the plugin.
 
-### 4.6 Reflection caching
+### 3.6 Caching
 
-- Per-process: `DependencyResolver::constructorCache` already memoizes
-  `ReflectionClass::getConstructor()` per class — no change needed.
-- Cross-process: when file cache is enabled, a lightweight
-  `ConstructorInjectionsCache` (new, follows the `AbstractPhpFileCache`
-  pattern) stores per-class `#[Inject]` metadata so boot reflection
-  scans are O(changed classes), not O(all classes). Implementation
-  detail of PR #8; not a public contract. The cache participates in
-  `cache:clear` and `cache:warm` like the other `AbstractPhpFileCache`
-  instances.
+`DependencyResolver::constructorCache` already memoizes reflection
+per-process. Cross-process: a new `ConstructorInjectionsCache` (follows
+`AbstractPhpFileCache`) stores per-class `#[Inject]` metadata so boot
+reflection is O(changed classes). Participates in `cache:clear` /
+`cache:warm`.
 
-### 4.7 Symfony bridge (`gacela/symfony-bridge`)
+### 3.7 Symfony bridge (`gacela/symfony-bridge`)
 
-- New composer package, shipped with PR #8.
-- Single class of note: `GacelaInjectCompilerPass implements CompilerPassInterface`.
-- Registered by users in their Symfony kernel (`$container->addCompilerPass(new GacelaInjectCompilerPass())`).
-  The bridge ships a bundle or extension class that registers the pass
-  automatically when the bundle is enabled; the bare compiler pass
-  remains available for projects that don't use bundles.
-- The pass runs **before** Symfony's autowire pass so the rewritten
-  service definitions are stable.
-- **Conflict rule.** If a parameter is claimed by both a Gacela
-  `#[Inject]` and Symfony's own autowire/bind, the pass fails the
-  build with a message naming the service id and parameter name.
-- Parameters without `#[Inject]` are left to Symfony untouched.
+- New composer package, ships with PR #8.
+- `GacelaInjectCompilerPass implements CompilerPassInterface`, runs
+  **before** Symfony's autowire pass.
+- Bundle glue included for projects using Symfony bundles; the bare
+  compiler pass remains available otherwise.
+- Conflict (both containers claim a parameter) → build fails with the
+  service id and parameter name.
 
-## 5. Migration example
+## 4. Migration example
 
 Before:
 
@@ -281,7 +152,7 @@ final class PhelRunCommand extends Command
 }
 ```
 
-After (with `gacela/symfony-bridge` installed and the pass registered):
+After (bridge installed + pass registered):
 
 ```php
 final class PhelRunCommand extends Command
@@ -300,78 +171,41 @@ final class PhelRunCommand extends Command
 }
 ```
 
-- `ServiceResolverAwareTrait` is gone.
-- `@psalm-suppress InternalMethod` is gone.
-- The constructor lists the dependency — tooling (`debug:dependencies`,
-  IDE autocomplete, static analysis) sees it.
+Trait gone. `@psalm-suppress` gone. Dependency visible to tooling.
 
-## 6. Scope for PR #8
+## 5. Scope for PR #8
 
-Budget: **M**, not L (the prior draft budgeted L based on the belief
-that `#[Inject]` needed to be built; it already exists).
+Budget **M** (not L — the attribute already exists).
 
 In scope:
 
-1. Bootstrap-time `class_alias(Gacela\Container\Attribute\Inject::class, Gacela\Framework\Attribute\Inject::class)`.
-2. `ConstructorInjectionsCache` (cross-process `#[Inject]` metadata).
-3. PHPStan rule(s) upgrading interface types when `#[Inject(Concrete::class)]` is present.
-4. `debug:dependencies` per Q3 (new `kind` column, extended `ParameterStatus`).
-5. `docs/container-configuration.md` section on `#[Inject]` with the
-   migration example.
+1. Bootstrap `class_alias(Gacela\Container\Attribute\Inject::class, Gacela\Framework\Attribute\Inject::class)`.
+2. `ConstructorInjectionsCache`.
+3. PHPStan rule for `#[Inject(Concrete::class)]` type upgrade.
+4. `debug:dependencies` `kind` column + extended `ParameterStatus`.
+5. `docs/container-configuration.md` section with the migration example.
 6. `gacela/symfony-bridge` package with `GacelaInjectCompilerPass`,
-   bundle glue, and tests against a minimal Symfony kernel.
+   bundle glue, tests against a minimal Symfony kernel.
 7. CHANGELOG under `Unreleased > Added`.
 
-Out of scope (deferred to future RFCs if a consumer emerges):
+Out of scope (future RFCs if a consumer emerges): property-level
+`#[Inject]`, non-Symfony bridges, runtime proxies for unbound interfaces.
 
-- Property-level `#[Inject]` (`TARGET_PROPERTY`).
-- Laravel, Mezzio, or other framework bridges.
-- Runtime proxies for interfaces without a concrete binding.
+## 6. Consequences
 
-## 7. Alternatives considered (not recommended)
+- **Positive.** Phel's Symfony commands drop `ServiceResolverAwareTrait`
+  and `@psalm-suppress`. `#[Inject]` becomes discoverable.
+  `debug:dependencies` becomes one source of truth for a class's DI graph.
+- **Negative.** Symfony users discover the bridge separately (mitigated
+  by docs). Users without the PHPStan rule lose the type upgrade;
+  runtime is identical.
+- **Backwards compatible.** `Gacela::getRequired()`, `#[ServiceMap]`,
+  `getFacade()`, `ServiceResolverAwareTrait`, and existing autowiring
+  all continue to work unchanged.
 
-- **Status quo.** Keep `Gacela::getRequired()` everywhere. Rejected —
-  `@psalm-suppress InternalMethod` is spreading in consumers.
-- **Remove `@internal` markers on facade methods.** Cheaper but breaks
-  the existing encapsulation contract. Rejected.
-- **Ship `#[Inject]` on properties too.** Hides dependencies, prevents
-  `readonly`. Rejected on modern-PHP grounds; see §3 Q2.
-- **Bundle the Symfony bridge into core.** Pins Gacela to
-  `symfony/dependency-injection`. Rejected; see §3 Q1.
+## 7. References
 
-## 8. Consequences
-
-### Positive
-
-- Phel's Symfony commands drop `ServiceResolverAwareTrait` and
-  `@psalm-suppress` comments.
-- `debug:dependencies` becomes the single source of truth for a class's
-  DI graph (bindings, contextual bindings, `#[Inject]` overrides, and
-  autowire, all in one table).
-- `#[Inject]` becomes discoverable. Today it ships undocumented inside
-  the container package.
-
-### Negative
-
-- Consumers on Symfony discover the bridge package separately. Mitigated
-  by the docs migration example linking to it explicitly.
-- Users without the PHPStan/Psalm plugins lose the type upgrade. The
-  runtime behavior is identical with or without the plugins — only the
-  inferred type at interface-typed `#[Inject(Concrete::class)]` sites
-  degrades to the declared interface.
-
-### Backwards compatibility
-
-Fully compatible. `Gacela::getRequired()`, `#[ServiceMap]`,
-`getFacade()`, `ServiceResolverAwareTrait`, and existing constructor
-autowiring all continue to work unchanged. `#[Inject]` becomes an
-additive opt-in.
-
-## 9. References
-
-- `local/phel-lang-feature-proposals.md` §6 — original proposal
-- `local/pr-plan.md` — PR #7 (this RFC) blocks PR #8; PR #8 budget revised M
-- `vendor/gacela-project/container/src/Container/Attribute/Inject.php` — existing attribute
-- `vendor/gacela-project/container/src/Container/DependencyResolver.php` — existing runtime support
-- `src/Framework/ServiceResolver/ServiceMap.php` — the unrelated class-level dispatch map
-- `src/Console/Infrastructure/Command/DebugDependenciesCommand.php` — target of the Q3 change
+- `vendor/gacela-project/container/src/Container/Attribute/Inject.php`
+- `vendor/gacela-project/container/src/Container/DependencyResolver.php`
+- `src/Framework/ServiceResolver/ServiceMap.php`
+- `src/Console/Infrastructure/Command/DebugDependenciesCommand.php`


### PR DESCRIPTION
## 📚 Description

Revises RFC-0001 (`#[Inject]` + Symfony DI interop) so it can actually gate PR #8. The prior draft was `Proposed` with an empty `Decision` section and misdescribed the existing state — not implementable as-is.

Key re-grounding: `Gacela\Container\Attribute\Inject` already exists in the vendor container package and is already honored by `DependencyResolver`. PR #8's job is to *promote* it (docs, discoverability, Symfony bridge, static-analysis upgrade, `debug:dependencies` surfacing), not to build it. Revised #8 budget: **M**, not L.

## 🔖 Changes

- Correct §1.2 existing state: `#[Inject]` exists; `#[ServiceMap]` is class-level dispatch (not property typing).
- Fill §3 Decisions — Q1: separate `gacela/symfony-bridge` package, ships lockstep with #8; Q2: one attribute only, drop the proposed `#[ServiceMapTyped]`; Q3: unified `kind` column via extended `ParameterStatus`.
- New §4 Specification — resolution order, error surface, interactions with protected services / contextual bindings / `ContainerFixture`, static analysis, reflection caching, Symfony bridge compiler pass.
- Add §5 before/after migration example (phel `Command` dropping `ServiceResolverAwareTrait`).
- Flip status to **Accepted** (2026-04-15).

Unblocks PR #8.