### PR TITLE
feat(debug): surface #[Inject] in debug:dependencies

### DIFF
--- a/src/Console/Application/Debug/ConstructorInspector.php
+++ b/src/Console/Application/Debug/ConstructorInspector.php
@@ -52,6 +52,11 @@ final class ConstructorInspector
         $name = '$' . $parameter->getName();
         $renderedType = $this->renderType($type);
 
+        $inject = $this->readInject($parameter);
+        if ($inject !== null) {
+            return new ParameterInspection($name, $renderedType, ParameterStatus::Inject, $inject);
+        }
+
         if ($type === null) {
             return $parameter->isDefaultValueAvailable()
                 ? new ParameterInspection($name, $renderedType, ParameterStatus::HasDefault, $this->defaultDetail($parameter))
@@ -138,5 +143,18 @@ final class ConstructorInspector
         } catch (Throwable) {
             return [];
         }
+    }
+
+    private function readInject(ReflectionParameter $parameter): ?string
+    {
+        $attributes = $parameter->getAttributes(\Gacela\Container\Attribute\Inject::class);
+        if ($attributes === []) {
+            return null;
+        }
+
+        $inject = $attributes[0]->newInstance();
+        return $inject->implementation !== null
+            ? sprintf('inject -> %s', $inject->implementation)
+            : 'inject';
     }
 }

--- a/src/Console/Application/Debug/ParameterStatus.php
+++ b/src/Console/Application/Debug/ParameterStatus.php
@@ -9,6 +9,7 @@ enum ParameterStatus: string
     case Bound = 'bound';
     case Autowirable = 'autowirable';
     case HasDefault = 'default';
+    case Inject = 'inject';
     case NoTypeHint = 'no-type-hint';
     case ScalarWithoutDefault = 'scalar-without-default';
     case UnboundInterface = 'unbound-interface';
@@ -18,7 +19,7 @@ enum ParameterStatus: string
     public function isResolvable(): bool
     {
         return match ($this) {
-            self::Bound, self::Autowirable, self::HasDefault => true,
+            self::Bound, self::Autowirable, self::HasDefault, self::Inject => true,
             default => false,
         };
     }

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -258,6 +258,7 @@ declares the target class.
   <fg=green>✓ bound</fg=green>        a binding in gacela.php maps the type to a concrete implementation
   <fg=green>✓ autowirable</fg=green>  concrete class exists and will be constructed automatically
   <fg=green>✓ default</fg=green>      the parameter has a default value
+  <fg=green>✓ inject</fg=green>       parameter is annotated with #[Inject] (optionally with an implementation override)
   <fg=red>✗ scalar</fg=red>       built-in type (string, int, ...) with no default
   <fg=red>✗ interface</fg=red>    interface type with no binding
   <fg=red>✗ missing</fg=red>      type does not exist

--- a/tests/Feature/Console/DebugDependencies/Fixtures/InjectService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/InjectService.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+final class InjectService
+{
+    public function __construct(
+        #[Inject] public readonly BoundContract $plain,
+        #[Inject(BoundImplementation::class)] public readonly BoundContract $withOverride,
+    ) {
+    }
+}

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\AutowirableCollaborator;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundContract;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\InjectService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\MixedDependenciesService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
 use PHPUnit\Framework\TestCase;
@@ -79,5 +80,24 @@ final class ConstructorInspectorTest extends TestCase
         self::assertSame('$collaborator', $collaborator->name);
         self::assertSame(AutowirableCollaborator::class, $collaborator->renderedType);
         self::assertSame('autowirable', $collaborator->detail);
+    }
+
+    public function test_inject_parameter_is_flagged(): void
+    {
+        $inspection = $this->inspector->inspect(InjectService::class);
+
+        self::assertCount(2, $inspection->parameters);
+        self::assertSame(ParameterStatus::Inject, $inspection->parameters[0]->status);
+        self::assertSame('inject', $inspection->parameters[0]->detail);
+        self::assertTrue($inspection->parameters[0]->isResolvable());
+    }
+
+    public function test_inject_parameter_with_override_shows_implementation(): void
+    {
+        $inspection = $this->inspector->inspect(InjectService::class);
+
+        $override = $inspection->parameters[1];
+        self::assertSame(ParameterStatus::Inject, $override->status);
+        self::assertSame('inject -> ' . BoundImplementation::class, $override->detail);
     }
 }


### PR DESCRIPTION
## 📚 Description

First slice of PR #8 (`feat/inject-attribute`) per RFC-0001 §3 Q3. Makes `#[Inject]` visible to `bin/gacela debug:dependencies` so users can see which constructor parameters the container will resolve via the attribute — and whether an implementation override is set.

Self-contained and independently reviewable. The PHPStan type-upgrade extension, Symfony bridge package, docs section, and CHANGELOG entry will land as follow-up slices (see RFC §5 scope, soft-blocked on #386's amendment merging).

## 🔖 Changes

- `ParameterStatus::Inject` case; counts as resolvable alongside Bound / Autowirable / HasDefault.
- `ConstructorInspector` reads `Gacela\Container\Attribute\Inject` on each parameter first; when present, status = `Inject` and detail is either `inject` or `inject -> <ConcreteImpl>` when the override is set.
- `debug:dependencies` help text lists the new inject category.
- `InjectService` fixture + two inspector tests (plain `#[Inject]` and `#[Inject(Impl::class)]`).

Tests: 529 unit + 88 integration + 115 feature all green.