### PR TITLE
docs(container): document #[Inject] + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `GacelaConfig::addHandlerRegistry($key, [...])` for Provider-registered dispatch tables (lazy, container-resolved, frozen after boot) replacing hand-rolled `match` blocks
 - `GacelaConfig::addHealthCheck()` for Provider-based registration of `ModuleHealthCheckInterface` implementations, surfaced by `doctor`
 - `ContainerFixture` trait (`Gacela\Framework\Testing`) with `resetContainer()`, `captureContainerState()` / `restoreContainerState()`, and `containerTempDir()` for PHPUnit test isolation
+- Documented constructor-parameter attribute `Gacela\Container\Attribute\Inject` with optional `implementation` override for disambiguating interface → concrete at the call site; `bin/gacela debug:dependencies` now tags `#[Inject]` parameters with an `inject` kind (and `inject -> <Concrete>` when an override is set)
 
 ### Changed
 

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -73,6 +73,115 @@ $config->when([ApiController::class, WebController::class])
     ->give(RedisCache::class);
 ```
 
+## Constructor Injection with `#[Inject]`
+
+The container autowires constructor parameters by type-hint. For most cases
+that's all you need — declare the type, the container resolves it.
+
+`#[Inject]` is the opt-in for the two cases autowiring alone can't express:
+disambiguating an interface with multiple possible concretes, and marking a
+parameter as explicitly container-owned for tooling like `debug:dependencies`.
+
+```php
+use Gacela\Container\Attribute\Inject;
+
+final class CatalogService
+{
+    public function __construct(
+        #[Inject] private readonly LoggerInterface $logger,
+        #[Inject(RedisCache::class)] private readonly CacheInterface $cache,
+    ) {}
+}
+```
+
+- `#[Inject]` with no argument flags the parameter for the container — the
+  type hint drives resolution.
+- `#[Inject(RedisCache::class)]` routes this specific parameter to
+  `RedisCache`, independent of any global `addBinding` for `CacheInterface`.
+
+### Resolution order
+
+For `#[Inject($override)] Type $p` on a class `Consumer`, the container tries:
+
+1. `$override` set → resolve `$override`.
+2. `$config->when(Consumer)->needs(Type)->give(X)` → resolve `X`.
+3. `$config->addBinding(Type, X)` → resolve `X`.
+4. `Type` is an instantiable class → `new Type(...)` with recursive autowire.
+5. `$p` has a default → use it.
+6. Otherwise → throw `ServiceNotFoundException`.
+
+Nullable parameters (`?Foo`) with no binding and no default resolve to `null`.
+Every other miss is an exception.
+
+### Interactions
+
+- Contextual bindings win over global `addBinding` (step 2 before step 3).
+- Protected services (`addProtected`) cannot be injected — they're stored
+  as raw closures and the container won't instantiate them.
+- `#[Inject]` does not replace `#[ServiceMap]` or `ServiceResolverAwareTrait`
+  — those serve a different `__call`-based dispatch use case and remain
+  supported.
+
+### Visibility in tooling
+
+`bin/gacela debug:dependencies <Class>` lists every constructor parameter
+with its resolution kind. `#[Inject]` parameters show up tagged `inject`,
+with the override concrete rendered inline when present:
+
+```
+✓ $logger LoggerInterface (inject)
+✓ $cache CacheInterface (inject -> App\Cache\RedisCache)
+```
+
+### Migration from `ServiceResolverAwareTrait`
+
+Before:
+
+```php
+final class PhelRunCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @psalm-suppress InternalMethod */
+        $this->getFacade()->clearCache();
+        return self::SUCCESS;
+    }
+}
+```
+
+After:
+
+```php
+use Gacela\Container\Attribute\Inject;
+
+final class PhelRunCommand extends Command
+{
+    public function __construct(
+        #[Inject] private readonly PhelFacadeInterface $phel,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->phel->clearCache();
+        return self::SUCCESS;
+    }
+}
+```
+
+Trait gone. `@psalm-suppress` gone. Dependency visible to tooling.
+
+### Symfony `Command` classes
+
+Symfony `Command` constructors are autowired by Symfony's own container.
+`#[Inject]` on a Symfony-managed class does not take effect on its own — a
+compiler pass is required to route `#[Inject]` parameters to Gacela before
+Symfony's autowire claims them. A dedicated `gacela/symfony-bridge` package
+ships this pass; adopt it in projects where Symfony owns the container.
+
 ## Quick Reference
 
 | Type | Behavior | Use Case |
@@ -82,6 +191,7 @@ $config->when([ApiController::class, WebController::class])
 | Protected | Returns closure as-is | Lazy initialization, callable configs |
 | Alias | Points to another service | Backward compatibility, short names |
 | Contextual | Different impl per class | Per-controller loggers, context-specific deps |
+| `#[Inject]` | Constructor-param opt-in | Explicit concrete override, tool visibility |
 
 ## Example
 


### PR DESCRIPTION
## 📚 Description

Second slice of PR #8. Makes `#[Inject]` — already supported by the vendor container and surfaced by `debug:dependencies` in #387 — discoverable to users.

## 🔖 Changes

- `docs/container-configuration.md` gains a **Constructor Injection with `#[Inject]`** section covering:
  - Basic usage + optional implementation override.
  - Resolution order summarised from RFC §3.2.
  - Interactions with contextual bindings, protected services, `#[ServiceMap]` / `ServiceResolverAwareTrait`.
  - `debug:dependencies` visibility (what the `inject` tag looks like).
  - Before/after migration example from `ServiceResolverAwareTrait`.
  - Caveat for Symfony `Command` classes pointing at the forthcoming `gacela/symfony-bridge` package.
- Quick Reference table gains an `#[Inject]` row.
- Canonical import documented as `use Gacela\Container\Attribute\Inject;` per RFC-0001 amendment.
- `CHANGELOG.md` Unreleased → Added: new bullet for the attribute + `debug:dependencies` `inject` kind.

Tests: 529 unit + 88 integration + 115 feature all green.

Remaining slices of PR #8: PHPStan type-upgrade extension, `gacela/symfony-bridge` package.