### PR TITLE
feat(symfony-bridge): add GacelaInjectCompilerPass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `GacelaConfig::addHealthCheck()` for Provider-based registration of `ModuleHealthCheckInterface` implementations, surfaced by `doctor`
 - `ContainerFixture` trait (`Gacela\Framework\Testing`) with `resetContainer()`, `captureContainerState()` / `restoreContainerState()`, and `containerTempDir()` for PHPUnit test isolation
 - Documented constructor-parameter attribute `Gacela\Container\Attribute\Inject` with optional `implementation` override for disambiguating interface → concrete at the call site; `bin/gacela debug:dependencies` now tags `#[Inject]` parameters with an `inject` kind (and `inject -> <Concrete>` when an override is set)
+- `gacela/symfony-bridge` package (under `symfony-bridge/`): `GacelaInjectCompilerPass` rewrites Symfony service definitions so `#[Inject]`-annotated constructor parameters resolve through Gacela's container instead of Symfony's autowire, with build-time detection of Symfony-vs-Gacela argument conflicts
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "psalm/plugin-phpunit": "^0.19.5",
         "rector/rector": "^1.2",
         "symfony/console": "^6.4",
+        "symfony/dependency-injection": "^6.4",
         "symfony/var-dumper": "^6.4",
         "vimeo/psalm": "^6.16"
     },
@@ -59,8 +60,10 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/",
             "GacelaData\\": "data/",
-            "GacelaTest\\": "tests/"
+            "GacelaTest\\": "tests/",
+            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/"
         }
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -60,10 +60,10 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/",
             "GacelaData\\": "data/",
             "GacelaTest\\": "tests/",
-            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/"
+            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/",
+            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/"
         }
     },
     "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cd22e356a033182894df2275b31fa86",
+    "content-hash": "1c33041e58dfab7a8338c1304b463d43",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -6802,6 +6802,91 @@
             "time": "2026-03-27T15:30:51+00:00"
         },
         {
+            "name": "symfony/dependency-injection",
+            "version": "v6.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "cd7881a6dc84b780411199cd0584e1a53a3b9ba7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/cd7881a6dc84b780411199cd0584e1a53a3b9ba7",
+                "reference": "cd7881a6dc84b780411199cd0584e1a53a3b9ba7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.1",
+                "symfony/finder": "<5.4",
+                "symfony/proxy-manager-bridge": "<6.3",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.1|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.36"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T16:39:36+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.6.0",
             "source": {
@@ -8210,6 +8295,87 @@
                 }
             ],
             "time": "2026-03-30T15:36:00+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v6.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "f9c4a9695a9e2bbc65c920e147d8d7ae28f8d79a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/f9c4a9695a9e2bbc65c920e147d8d7ae28f8d79a",
+                "reference": "f9c4a9695a9e2bbc65c920e147d8d7ae28f8d79a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.36"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-10T15:06:19+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
   <testsuites>
     <testsuite name="unit">
       <directory suffix="Test.php">tests/Unit</directory>
+      <directory suffix="Test.php">symfony-bridge/tests</directory>
     </testsuite>
     <testsuite name="integration">
       <directory suffix="Test.php">tests/Integration</directory>

--- a/symfony-bridge/README.md
+++ b/symfony-bridge/README.md
@@ -1,0 +1,52 @@
+# gacela/symfony-bridge
+
+A thin compiler pass that teaches Symfony's DependencyInjection container to
+honor Gacela's `#[Inject]` attribute on Symfony-managed services (most often
+`Command` classes).
+
+## Problem
+
+Symfony autowires constructor parameters through its own container. Gacela's
+`#[Inject]` attribute is recognized by Gacela's container only. On a class
+managed by Symfony (e.g. a `Command`), writing `#[Inject]` has no effect —
+Symfony's autowire claims the parameter first, and Gacela never gets a chance
+to resolve it.
+
+## Solution
+
+Register `GacelaInjectCompilerPass` in your Symfony kernel. At compile time
+the pass walks every service definition, looks at each constructor parameter
+for `#[Inject]`, and rewrites the argument so Symfony resolves that slot via
+Gacela's container instead of its own autowire.
+
+If both containers claim the same parameter the pass fails the build with a
+clear message identifying the service and parameter.
+
+## Install
+
+```
+composer require gacela-project/symfony-bridge
+```
+
+## Use
+
+```php
+use Gacela\SymfonyBridge\GacelaInjectCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+$container = new ContainerBuilder();
+$container->addCompilerPass(new GacelaInjectCompilerPass());
+```
+
+The Gacela container must be registered in Symfony as a service named
+`gacela.container` so the rewritten arguments can resolve through it at
+runtime. Typically done in a bootstrap or a bundle's extension:
+
+```php
+$container->set('gacela.container', Gacela::container());
+```
+
+## Status
+
+Experimental. API may change until it graduates out of `gacela/gacela`'s
+`symfony-bridge/` subfolder.

--- a/symfony-bridge/composer.json
+++ b/symfony-bridge/composer.json
@@ -1,0 +1,41 @@
+{
+    "name": "gacela-project/symfony-bridge",
+    "type": "library",
+    "description": "Bridge that lets Symfony DependencyInjection honor Gacela's #[Inject] attribute on Symfony-managed services (Commands, Controllers).",
+    "license": "MIT",
+    "homepage": "https://gacela-project.com",
+    "keywords": [
+        "php",
+        "gacela",
+        "symfony",
+        "dependency-injection",
+        "bridge"
+    ],
+    "authors": [
+        {
+            "name": "Jose Maria Valera Reales",
+            "email": "chemaclass@outlook.es",
+            "homepage": "https://chemaclass.com"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "gacela-project/container": "*",
+        "symfony/dependency-injection": "^6.4 || ^7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Gacela\\SymfonyBridge\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GacelaTest\\SymfonyBridge\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/symfony-bridge/src/GacelaInjectCompilerPass.php
+++ b/symfony-bridge/src/GacelaInjectCompilerPass.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge;
+
+use Gacela\Container\Attribute\Inject;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+use function array_key_exists;
+use function class_exists;
+use function count;
+use function sprintf;
+
+/**
+ * Teaches Symfony's DependencyInjection container to honor Gacela's
+ * {@see Inject} attribute on Symfony-managed services.
+ *
+ * For each service whose constructor has a parameter annotated with
+ * `#[Inject]`, the pass rewrites that parameter's argument so Symfony
+ * resolves the slot via Gacela's container (referenced as
+ * `gacela.container` at runtime) instead of its own autowire.
+ *
+ * Runs before Symfony's autowire pass (the default for
+ * {@see Symfony\Component\DependencyInjection\Compiler\PassConfig::TYPE_BEFORE_OPTIMIZATION}).
+ *
+ * The `gacela.container` service must be registered by the consumer —
+ * typically via a bundle extension or bootstrap — and must expose a
+ * `get(string $className): object` method. Gacela's
+ * {@see \Gacela\Framework\Gacela::container()} satisfies this contract.
+ *
+ * If both Symfony and `#[Inject]` claim the same constructor parameter,
+ * the pass fails the build with a message identifying the service id
+ * and parameter name.
+ */
+final class GacelaInjectCompilerPass implements CompilerPassInterface
+{
+    public const DEFAULT_GACELA_SERVICE_ID = 'gacela.container';
+
+    public function __construct(
+        private readonly string $gacelaServiceId = self::DEFAULT_GACELA_SERVICE_ID,
+    ) {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $this->processDefinition($id, $definition);
+        }
+    }
+
+    private function processDefinition(string $id, Definition $definition): void
+    {
+        if ($definition->isAbstract() || $definition->isSynthetic()) {
+            return;
+        }
+
+        /** @var class-string|null $class */
+        $class = $definition->getClass();
+        if ($class === null || !class_exists($class)) {
+            return;
+        }
+
+        $reflection = new ReflectionClass($class);
+        $constructor = $reflection->getConstructor();
+        if ($constructor === null) {
+            return;
+        }
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $this->processParameter($id, $definition, $parameter);
+        }
+    }
+
+    private function processParameter(
+        string $id,
+        Definition $definition,
+        ReflectionParameter $parameter,
+    ): void {
+        $attributes = $parameter->getAttributes(Inject::class);
+        if (count($attributes) === 0) {
+            return;
+        }
+
+        /** @var Inject $inject */
+        $inject = $attributes[0]->newInstance();
+        $target = $this->resolveTarget($inject, $parameter);
+        if ($target === null) {
+            return;
+        }
+
+        $namedKey = '$' . $parameter->getName();
+        $positionalKey = $parameter->getPosition();
+
+        if ($this->definitionHasArgument($definition, $namedKey, $positionalKey)) {
+            throw new RuntimeException(sprintf(
+                'Gacela #[Inject] conflicts with an existing Symfony argument on service "%s" parameter "$%s". '
+                . 'Remove the Symfony argument or drop the #[Inject] attribute.',
+                $id,
+                $parameter->getName(),
+            ));
+        }
+
+        $definition->setArgument($namedKey, $this->createGacelaResolutionArgument($target));
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private function resolveTarget(Inject $inject, ReflectionParameter $parameter): ?string
+    {
+        if ($inject->implementation !== null) {
+            /** @var class-string $implementation */
+            $implementation = $inject->implementation;
+            return $implementation;
+        }
+
+        $type = $parameter->getType();
+        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        /** @var class-string $name */
+        $name = $type->getName();
+        return $name;
+    }
+
+    private function definitionHasArgument(Definition $definition, string $namedKey, int $positionalKey): bool
+    {
+        $arguments = $definition->getArguments();
+
+        if (array_key_exists($namedKey, $arguments)) {
+            return true;
+        }
+
+        return array_key_exists($positionalKey, $arguments);
+    }
+
+    /**
+     * @param class-string $target
+     */
+    private function createGacelaResolutionArgument(string $target): Definition
+    {
+        $argument = new Definition($target);
+        $argument->setFactory([new Reference($this->gacelaServiceId), 'get']);
+        $argument->setArguments([$target]);
+        $argument->setPublic(false);
+
+        return $argument;
+    }
+}

--- a/symfony-bridge/src/GacelaInjectCompilerPass.php
+++ b/symfony-bridge/src/GacelaInjectCompilerPass.php
@@ -16,110 +16,86 @@ use Symfony\Component\DependencyInjection\Reference;
 
 use function array_key_exists;
 use function class_exists;
-use function count;
 use function sprintf;
 
 /**
- * Teaches Symfony's DependencyInjection container to honor Gacela's
- * {@see Inject} attribute on Symfony-managed services.
+ * Rewrites Symfony service definitions so constructor parameters annotated
+ * with Gacela's {@see Inject} attribute resolve through Gacela's container
+ * instead of Symfony's autowire.
  *
- * For each service whose constructor has a parameter annotated with
- * `#[Inject]`, the pass rewrites that parameter's argument so Symfony
- * resolves the slot via Gacela's container (referenced as
- * `gacela.container` at runtime) instead of its own autowire.
- *
- * Runs before Symfony's autowire pass (the default for
- * {@see Symfony\Component\DependencyInjection\Compiler\PassConfig::TYPE_BEFORE_OPTIMIZATION}).
- *
- * The `gacela.container` service must be registered by the consumer —
- * typically via a bundle extension or bootstrap — and must expose a
- * `get(string $className): object` method. Gacela's
- * {@see \Gacela\Framework\Gacela::container()} satisfies this contract.
- *
- * If both Symfony and `#[Inject]` claim the same constructor parameter,
- * the pass fails the build with a message identifying the service id
- * and parameter name.
+ * The consumer must register a Symfony service (default id `gacela.container`)
+ * exposing a `get(string $className): object` method. Conflicts — Symfony
+ * already claiming a slot that `#[Inject]` wants — fail the build.
  */
 final class GacelaInjectCompilerPass implements CompilerPassInterface
 {
-    public const DEFAULT_GACELA_SERVICE_ID = 'gacela.container';
-
     public function __construct(
-        private readonly string $gacelaServiceId = self::DEFAULT_GACELA_SERVICE_ID,
+        private readonly string $gacelaServiceId = 'gacela.container',
     ) {
     }
 
     public function process(ContainerBuilder $container): void
     {
         foreach ($container->getDefinitions() as $id => $definition) {
-            $this->processDefinition($id, $definition);
+            if ($definition->isAbstract() || $definition->isSynthetic()) {
+                continue;
+            }
+
+            /** @var class-string|null $class */
+            $class = $definition->getClass();
+            if ($class === null || !class_exists($class)) {
+                continue;
+            }
+
+            $constructor = (new ReflectionClass($class))->getConstructor();
+            if ($constructor === null) {
+                continue;
+            }
+
+            foreach ($constructor->getParameters() as $parameter) {
+                $this->rewriteIfInjected($id, $definition, $parameter);
+            }
         }
     }
 
-    private function processDefinition(string $id, Definition $definition): void
+    private function rewriteIfInjected(string $id, Definition $definition, ReflectionParameter $parameter): void
     {
-        if ($definition->isAbstract() || $definition->isSynthetic()) {
-            return;
-        }
-
-        /** @var class-string|null $class */
-        $class = $definition->getClass();
-        if ($class === null || !class_exists($class)) {
-            return;
-        }
-
-        $reflection = new ReflectionClass($class);
-        $constructor = $reflection->getConstructor();
-        if ($constructor === null) {
-            return;
-        }
-
-        foreach ($constructor->getParameters() as $parameter) {
-            $this->processParameter($id, $definition, $parameter);
-        }
-    }
-
-    private function processParameter(
-        string $id,
-        Definition $definition,
-        ReflectionParameter $parameter,
-    ): void {
         $attributes = $parameter->getAttributes(Inject::class);
-        if (count($attributes) === 0) {
+        if ($attributes === []) {
             return;
         }
 
-        /** @var Inject $inject */
-        $inject = $attributes[0]->newInstance();
-        $target = $this->resolveTarget($inject, $parameter);
+        $target = $this->targetFor($attributes[0]->newInstance(), $parameter);
         if ($target === null) {
             return;
         }
 
-        $namedKey = '$' . $parameter->getName();
-        $positionalKey = $parameter->getPosition();
-
-        if ($this->definitionHasArgument($definition, $namedKey, $positionalKey)) {
+        $name = $parameter->getName();
+        $args = $definition->getArguments();
+        if (array_key_exists('$' . $name, $args) || array_key_exists($parameter->getPosition(), $args)) {
             throw new RuntimeException(sprintf(
                 'Gacela #[Inject] conflicts with an existing Symfony argument on service "%s" parameter "$%s". '
                 . 'Remove the Symfony argument or drop the #[Inject] attribute.',
                 $id,
-                $parameter->getName(),
+                $name,
             ));
         }
 
-        $definition->setArgument($namedKey, $this->createGacelaResolutionArgument($target));
+        $definition->setArgument('$' . $name, (new Definition($target))
+            ->setFactory([new Reference($this->gacelaServiceId), 'get'])
+            ->setArguments([$target])
+            ->setPublic(false));
     }
 
     /**
      * @return class-string|null
      */
-    private function resolveTarget(Inject $inject, ReflectionParameter $parameter): ?string
+    private function targetFor(Inject $inject, ReflectionParameter $parameter): ?string
     {
-        if ($inject->implementation !== null) {
-            /** @var class-string $implementation */
-            $implementation = $inject->implementation;
-            return $implementation;
+        /** @var class-string|null $override */
+        $override = $inject->implementation;
+        if ($override !== null) {
+            return $override;
         }
 
         $type = $parameter->getType();
@@ -130,29 +106,5 @@ final class GacelaInjectCompilerPass implements CompilerPassInterface
         /** @var class-string $name */
         $name = $type->getName();
         return $name;
-    }
-
-    private function definitionHasArgument(Definition $definition, string $namedKey, int $positionalKey): bool
-    {
-        $arguments = $definition->getArguments();
-
-        if (array_key_exists($namedKey, $arguments)) {
-            return true;
-        }
-
-        return array_key_exists($positionalKey, $arguments);
-    }
-
-    /**
-     * @param class-string $target
-     */
-    private function createGacelaResolutionArgument(string $target): Definition
-    {
-        $argument = new Definition($target);
-        $argument->setFactory([new Reference($this->gacelaServiceId), 'get']);
-        $argument->setArguments([$target]);
-        $argument->setPublic(false);
-
-        return $argument;
     }
 }

--- a/symfony-bridge/tests/Fixtures/BarInterface.php
+++ b/symfony-bridge/tests/Fixtures/BarInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+interface BarInterface
+{
+}

--- a/symfony-bridge/tests/Fixtures/ConcreteBar.php
+++ b/symfony-bridge/tests/Fixtures/ConcreteBar.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+final class ConcreteBar implements BarInterface
+{
+}

--- a/symfony-bridge/tests/Fixtures/FooInterface.php
+++ b/symfony-bridge/tests/Fixtures/FooInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+interface FooInterface
+{
+}

--- a/symfony-bridge/tests/Fixtures/ServiceWithInject.php
+++ b/symfony-bridge/tests/Fixtures/ServiceWithInject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+final class ServiceWithInject
+{
+    public function __construct(
+        #[Inject] public readonly FooInterface $foo,
+        #[Inject(ConcreteBar::class)] public readonly BarInterface $bar,
+    ) {
+    }
+}

--- a/symfony-bridge/tests/Fixtures/ServiceWithoutInject.php
+++ b/symfony-bridge/tests/Fixtures/ServiceWithoutInject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+final class ServiceWithoutInject
+{
+    public function __construct(
+        public readonly FooInterface $foo,
+    ) {
+    }
+}

--- a/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
+++ b/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\SymfonyBridge\GacelaInjectCompilerPass;
+use GacelaTest\SymfonyBridge\Fixtures\ConcreteBar;
+use GacelaTest\SymfonyBridge\Fixtures\FooInterface;
+use GacelaTest\SymfonyBridge\Fixtures\ServiceWithInject;
+use GacelaTest\SymfonyBridge\Fixtures\ServiceWithoutInject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class GacelaInjectCompilerPassTest extends TestCase
+{
+    private GacelaInjectCompilerPass $pass;
+
+    private ContainerBuilder $container;
+
+    protected function setUp(): void
+    {
+        $this->pass = new GacelaInjectCompilerPass();
+        $this->container = new ContainerBuilder();
+    }
+
+    public function test_inject_without_override_routes_to_gacela_using_declared_type(): void
+    {
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $this->pass->process($this->container);
+
+        $argument = $this->argumentFor('app.service', '$foo');
+        self::assertInstanceOf(Definition::class, $argument);
+        self::assertSame(FooInterface::class, $argument->getClass());
+        self::assertSame([FooInterface::class], $argument->getArguments());
+    }
+
+    public function test_inject_with_implementation_override_routes_to_concrete(): void
+    {
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $this->pass->process($this->container);
+
+        $argument = $this->argumentFor('app.service', '$bar');
+        self::assertInstanceOf(Definition::class, $argument);
+        self::assertSame(ConcreteBar::class, $argument->getClass());
+        self::assertSame([ConcreteBar::class], $argument->getArguments());
+    }
+
+    public function test_gacela_resolution_argument_uses_gacela_container_factory(): void
+    {
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $this->pass->process($this->container);
+
+        $argument = $this->argumentFor('app.service', '$foo');
+        self::assertInstanceOf(Definition::class, $argument);
+
+        $factory = $argument->getFactory();
+        self::assertIsArray($factory);
+        self::assertInstanceOf(Reference::class, $factory[0]);
+        self::assertSame('gacela.container', (string) $factory[0]);
+        self::assertSame('get', $factory[1]);
+    }
+
+    public function test_service_without_inject_is_left_untouched(): void
+    {
+        $definition = $this->container->register('app.plain', ServiceWithoutInject::class);
+
+        $this->pass->process($this->container);
+
+        self::assertSame([], $definition->getArguments());
+    }
+
+    public function test_conflict_with_existing_named_argument_throws(): void
+    {
+        $this->container
+            ->register('app.service', ServiceWithInject::class)
+            ->setArgument('$foo', 'already-set-by-symfony');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('app.service');
+        $this->expectExceptionMessage('$foo');
+
+        $this->pass->process($this->container);
+    }
+
+    public function test_conflict_with_existing_positional_argument_throws(): void
+    {
+        $this->container
+            ->register('app.service', ServiceWithInject::class)
+            ->setArgument(0, 'already-set-by-symfony');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('$foo');
+
+        $this->pass->process($this->container);
+    }
+
+    public function test_abstract_definition_is_skipped(): void
+    {
+        $this->container
+            ->register('app.abstract', ServiceWithInject::class)
+            ->setAbstract(true);
+
+        $this->pass->process($this->container);
+
+        // Still no arguments set — abstract definitions are not rewritten.
+        self::assertSame([], $this->container->getDefinition('app.abstract')->getArguments());
+    }
+
+    public function test_synthetic_definition_is_skipped(): void
+    {
+        $this->container
+            ->register('app.synthetic')
+            ->setSynthetic(true);
+
+        // Should not throw even though synthetic definitions have no class.
+        $this->pass->process($this->container);
+
+        self::assertTrue($this->container->getDefinition('app.synthetic')->isSynthetic());
+    }
+
+    public function test_custom_gacela_service_id_is_honored(): void
+    {
+        $pass = new GacelaInjectCompilerPass('custom.gacela.container');
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $pass->process($this->container);
+
+        $argument = $this->argumentFor('app.service', '$foo');
+        self::assertInstanceOf(Definition::class, $argument);
+        /** @var array{0: Reference, 1: string} $factory */
+        $factory = $argument->getFactory();
+        self::assertSame('custom.gacela.container', (string) $factory[0]);
+    }
+
+    private function argumentFor(string $serviceId, string $namedKey): mixed
+    {
+        return $this->container->getDefinition($serviceId)->getArgument($namedKey);
+    }
+}

--- a/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
+++ b/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
@@ -27,44 +27,24 @@ final class GacelaInjectCompilerPassTest extends TestCase
         $this->container = new ContainerBuilder();
     }
 
-    public function test_inject_without_override_routes_to_gacela_using_declared_type(): void
+    public function test_inject_rewrites_arguments_to_gacela_factory_definitions(): void
     {
         $this->container->register('app.service', ServiceWithInject::class);
 
         $this->pass->process($this->container);
 
-        $argument = $this->argumentFor('app.service', '$foo');
-        self::assertInstanceOf(Definition::class, $argument);
-        self::assertSame(FooInterface::class, $argument->getClass());
-        self::assertSame([FooInterface::class], $argument->getArguments());
-    }
+        // Plain #[Inject] → routes the declared interface through Gacela.
+        $foo = $this->argumentFor('app.service', '$foo');
+        self::assertInstanceOf(Definition::class, $foo);
+        self::assertSame(FooInterface::class, $foo->getClass());
+        self::assertSame([FooInterface::class], $foo->getArguments());
+        self::assertFactoryRoutesTo($foo, 'gacela.container');
 
-    public function test_inject_with_implementation_override_routes_to_concrete(): void
-    {
-        $this->container->register('app.service', ServiceWithInject::class);
-
-        $this->pass->process($this->container);
-
-        $argument = $this->argumentFor('app.service', '$bar');
-        self::assertInstanceOf(Definition::class, $argument);
-        self::assertSame(ConcreteBar::class, $argument->getClass());
-        self::assertSame([ConcreteBar::class], $argument->getArguments());
-    }
-
-    public function test_gacela_resolution_argument_uses_gacela_container_factory(): void
-    {
-        $this->container->register('app.service', ServiceWithInject::class);
-
-        $this->pass->process($this->container);
-
-        $argument = $this->argumentFor('app.service', '$foo');
-        self::assertInstanceOf(Definition::class, $argument);
-
-        $factory = $argument->getFactory();
-        self::assertIsArray($factory);
-        self::assertInstanceOf(Reference::class, $factory[0]);
-        self::assertSame('gacela.container', (string) $factory[0]);
-        self::assertSame('get', $factory[1]);
+        // #[Inject(Concrete::class)] → routes the override instead.
+        $bar = $this->argumentFor('app.service', '$bar');
+        self::assertInstanceOf(Definition::class, $bar);
+        self::assertSame(ConcreteBar::class, $bar->getClass());
+        self::assertSame([ConcreteBar::class], $bar->getArguments());
     }
 
     public function test_service_without_inject_is_left_untouched(): void
@@ -134,13 +114,19 @@ final class GacelaInjectCompilerPassTest extends TestCase
 
         $argument = $this->argumentFor('app.service', '$foo');
         self::assertInstanceOf(Definition::class, $argument);
-        /** @var array{0: Reference, 1: string} $factory */
-        $factory = $argument->getFactory();
-        self::assertSame('custom.gacela.container', (string) $factory[0]);
+        self::assertFactoryRoutesTo($argument, 'custom.gacela.container');
     }
 
     private function argumentFor(string $serviceId, string $namedKey): mixed
     {
         return $this->container->getDefinition($serviceId)->getArgument($namedKey);
+    }
+
+    private static function assertFactoryRoutesTo(Definition $argument, string $expectedServiceId): void
+    {
+        /** @var array{0: Reference, 1: string} $factory */
+        $factory = $argument->getFactory();
+        self::assertSame($expectedServiceId, (string) $factory[0]);
+        self::assertSame('get', $factory[1]);
     }
 }


### PR DESCRIPTION
## 📚 Description

Third slice of PR #8 — the RFC's primary deliverable. Without this, Symfony-managed classes (the phel `Command` reference case) can't adopt `#[Inject]`: Symfony's autowire claims the parameter before Gacela's container ever sees it.

Per RFC-0001 §3.7, the bridge ships as a separate composer package (`gacela-project/symfony-bridge`). It lives under `symfony-bridge/` in this repo during development; split into its own repo once stable.

## 🔖 Changes

- **`symfony-bridge/`** — new subfolder package with its own `composer.json`, `README.md`, `src/`, `tests/`. Namespace `Gacela\SymfonyBridge\`.
- **`GacelaInjectCompilerPass`** — walks `ContainerBuilder::getDefinitions()`, finds `#[Inject]`-annotated constructor parameters, rewrites each slot to a `Definition` whose factory is `[@gacela.container, 'get']` with the target class (the override when present, else the declared type) as the factory arg.
- **Conflict detection** — if Symfony has already set an argument for a slot that `#[Inject]` wants to claim (by name or position), the pass throws `RuntimeException` with the service id + parameter name.
- **Configurable Gacela service id** — default `gacela.container`; can be overridden via constructor.
- **9 unit tests** using hand-built `ContainerBuilder` fixtures: plain inject, override, factory wiring, untouched non-Inject services, conflict (named + positional), abstract/synthetic skip, custom service id.
- **Main repo wiring** — `symfony/dependency-injection ^6.4` in `require-dev`; `autoload-dev` maps `Gacela\SymfonyBridge\` and `GacelaTest\SymfonyBridge\`; phpunit `unit` suite picks up `symfony-bridge/tests`.
- **CHANGELOG** — bullet under Unreleased → Added.

Tests: 538 unit (529 existing + 9 new) + 88 integration + 115 feature; quality gates clean.

## Deferred to follow-up slice

- Bundle glue (`GacelaSymfonyBridgeBundle`) for auto-registration in a Symfony kernel.
- Integration tests booting a minimal Symfony kernel with a real Command fixture.