### PR TITLE
Fix bugs in class resolver, module finder, config, and parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 - `#[Cacheable]` storage is pluggable via `CacheStorageInterface`; supports per-method TTL overrides and `{N}` key placeholders
 - `MergedConfigCache` uses `FileCache::writeAtomically()` for atomic writes
 
+### Fixed
+
+- `ResolvableType::fromClassName()` now uses `str_ends_with` to correctly match suffix types (e.g. `FacadeFactory` no longer misresolves as `Facade`)
+- `AllAppModulesFinder::buildClassName()` handles filenames with a leading dot correctly
+- `GacelaConfig::getExternalService()` throws `InvalidArgumentException` on missing key instead of silently returning null
+
 ### Performance
 
 - `#[Cacheable]` hot path: memoized reflection, miss sentinel, scalar-key fast-path

--- a/src/Console/Application/CacheWarm/CacheWarmService.php
+++ b/src/Console/Application/CacheWarm/CacheWarmService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Application\CacheWarm;
 
+use Exception;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
@@ -47,7 +48,7 @@ final class CacheWarmService
         foreach ($this->classResolvers() as $resolver) {
             try {
                 $resolver->resolve($facadeClass);
-            } catch (Throwable) {
+            } catch (Exception) {
                 // A module may legitimately lack a Factory/Config/Provider, or
                 // its dependencies may not be constructible during warm; skip.
             }

--- a/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
+++ b/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
@@ -78,7 +78,10 @@ final class AllAppModulesFinder
 
     private function getNamespace(SplFileInfo $fileInfo): string
     {
-        $fileContent = (string)file_get_contents($fileInfo->getRealPath());
+        $fileContent = file_get_contents($fileInfo->getRealPath());
+        if ($fileContent === false) {
+            return '';
+        }
 
         preg_match('#namespace (.*);#', $fileContent, $matches);
 

--- a/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
+++ b/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
@@ -90,7 +90,9 @@ final class AllAppModulesFinder
         $pieces = explode(DIRECTORY_SEPARATOR, $fileInfo->getFilename());
         $filename = end($pieces);
 
-        return substr($filename, 0, strpos($filename, '.') ?: 1);
+        $dotPos = strpos($filename, '.');
+
+        return $dotPos !== false ? substr($filename, 0, $dotPos) : $filename;
     }
 
     private function isFacade(AppModule $appModule): bool

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -248,6 +248,7 @@ final class GacelaConfig
      */
     public function addAppConfigKeyValue(string $key, mixed $value): self
     {
+        $this->configKeyValues ??= [];
         $this->configKeyValues[$key] = $value;
 
         return $this;
@@ -412,6 +413,7 @@ final class GacelaConfig
      */
     public function extendGacelaConfig(string $className): self
     {
+        $this->gacelaConfigsToExtend ??= [];
         $this->gacelaConfigsToExtend[] = $className;
 
         return $this;
@@ -432,6 +434,7 @@ final class GacelaConfig
      */
     public function addPlugin(string|callable $plugin): self
     {
+        $this->plugins ??= [];
         $this->plugins[] = $plugin;
 
         return $this;

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -14,6 +14,10 @@ use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use InvalidArgumentException;
+
+use function array_key_exists;
+use function sprintf;
 
 final class GacelaConfig
 {
@@ -190,6 +194,10 @@ final class GacelaConfig
      */
     public function getExternalService(string $key)
     {
+        if (!array_key_exists($key, $this->externalServices)) {
+            throw new InvalidArgumentException(sprintf('External service "%s" not found. Available keys: %s', $key, implode(', ', array_keys($this->externalServices)) ?: 'none'));
+        }
+
         return $this->externalServices[$key];
     }
 

--- a/src/Framework/ClassResolver/DocBlockService/DocBlockParser.php
+++ b/src/Framework/ClassResolver/DocBlockService/DocBlockParser.php
@@ -24,10 +24,14 @@ final class DocBlockParser
             static fn (string $l): bool => str_contains($l, $method),
         );
 
-        /** @var array<int, string> $lineSplit */
-        $lineSplit = explode(' ', (string)reset($lines));
+        $firstLine = reset($lines);
+        $classFromMethod = '';
 
-        $classFromMethod = $lineSplit[3] ?? '';
+        if ($firstLine !== false) {
+            /** @var array<int, string> $lineSplit */
+            $lineSplit = explode(' ', $firstLine);
+            $classFromMethod = $lineSplit[3] ?? '';
+        }
         if ($classFromMethod !== '') {
             return $classFromMethod;
         }

--- a/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
+++ b/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
@@ -37,8 +37,12 @@ final class UseBlockParser
             static fn (string $l): bool => str_starts_with($l, 'use ') && str_contains($l, $needle),
         );
 
-        /** @psalm-suppress RedundantCast */
-        $lineSplit = explode(' ', (string)reset($lines));
+        $firstLine = reset($lines);
+        if ($firstLine === false) {
+            return '';
+        }
+
+        $lineSplit = explode(' ', $firstLine);
 
         return rtrim($lineSplit[1] ?? '', ';');
     }
@@ -53,8 +57,13 @@ final class UseBlockParser
             explode(PHP_EOL, $phpCode),
             static fn (string $l): bool => str_starts_with($l, 'namespace '),
         );
-        /** @psalm-suppress RedundantCast */
-        $lineSplit = explode(' ', (string)reset($lines));
+
+        $firstLine = reset($lines);
+        if ($firstLine === false) {
+            return '';
+        }
+
+        $lineSplit = explode(' ', $firstLine);
 
         return rtrim($lineSplit[1] ?? '', ';');
     }

--- a/src/Framework/ClassResolver/ResolvableType.php
+++ b/src/Framework/ClassResolver/ResolvableType.php
@@ -27,7 +27,7 @@ final class ResolvableType
     public static function fromClassName(string $className): self
     {
         foreach (self::DEFAULT_ALLOWED_TYPES as $resolvableType) {
-            if (str_contains($className, $resolvableType)) {
+            if (str_ends_with($className, $resolvableType)) {
                 $moduleName = substr($className, 0, strlen($className) - strlen($resolvableType));
                 return new self($resolvableType, $moduleName);
             }


### PR DESCRIPTION
## 📚 Description

Fix several bugs across class resolution, module discovery, config access, and docblock parsing.

## 🔖 Changes

- **ResolvableType**: use `str_ends_with` instead of `str_contains` to avoid mismatching suffixes (e.g. `FacadeFactory` → `Facade`)
- **AllAppModulesFinder**: fix falsy-zero `strpos` bug for dotfiles; check `file_get_contents` return value
- **GacelaConfig**: throw on missing external service key; use `??= []` before appending to nullable arrays
- **DocBlockParser / UseBlockParser**: guard `reset()` on empty arrays instead of casting `false` to string
- **CacheWarmService**: narrow `catch (Throwable)` to `catch (Exception)` so real errors propagate