### PR TITLE
feat(facade): add CacheableTrait to AbstractFacade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `CacheableTrait` in `AbstractFacade` — facades can now use `#[Cacheable]` out of the box
 - `#[Inject]` constructor-parameter attribute with optional `implementation` override; `debug:dependencies` surfaces it
 - `gacela/symfony-bridge`: `GacelaInjectCompilerPass` routes `#[Inject]` parameters through Gacela's container in Symfony apps
 - `#[Provides('ID')]` attribute for declarative provider registration

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,11 +41,6 @@ parameters:
 			path: src/Console/Infrastructure/Command/CacheWarmCommand.php
 
 		-
-			message: "#^Trait Gacela\\\\Framework\\\\Attribute\\\\CacheableTrait is used zero times and is not analysed\\.$#"
-			count: 1
-			path: src/Framework/Attribute/CacheableTrait.php
-
-		-
 			message: "#^Trait Gacela\\\\Framework\\\\Testing\\\\ContainerFixture is used zero times and is not analysed\\.$#"
 			count: 1
 			path: src/Framework/Testing/ContainerFixture.php

--- a/src/Framework/AbstractFacade.php
+++ b/src/Framework/AbstractFacade.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
+use Gacela\Framework\Attribute\CacheableTrait;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 
 /**
@@ -11,12 +12,15 @@ use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
  */
 abstract class AbstractFacade
 {
+    use CacheableTrait;
+
     /** @var array<string, AbstractFactory> */
     private static array $factories = [];
 
     public static function resetCache(): void
     {
         self::$factories = [];
+        self::clearMethodCache();
     }
 
     /**

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -78,17 +78,18 @@ trait CacheableTrait
     {
         if ($method === null) {
             $frame = debug_backtrace(0, 2)[1] ?? null;
-            if ($frame === null || !isset($frame['function'])) {
+            if ($frame === null) {
                 return $callback();
             }
 
             $method = $frame['function'];
-            /** @var list<mixed> $args */
-            $args ??= $frame['args'] ?? [];
+            /** @var list<mixed> $frameArgs */
+            $frameArgs = $frame['args'] ?? [];
+            $args = $args ?? $frameArgs;
         } else {
             if (str_contains($method, '::')) {
                 $parts = explode('::', $method);
-                $method = (string) end($parts);
+                $method = end($parts);
             }
 
             $args ??= [];
@@ -103,11 +104,13 @@ trait CacheableTrait
         $cacheKey = $this->buildCacheKey($method, $args, $attribute);
 
         $miss = self::$cacheMissSentinel ??= new stdClass();
+        /** @var mixed $cached */
         $cached = $storage->get($cacheKey, $miss);
         if ($cached !== $miss) {
             return $cached;
         }
 
+        /** @var mixed $result */
         $result = $callback();
         $ttl = CacheableConfig::resolveTtl(sprintf('%s::%s', static::class, $method), $attribute->ttl);
         $storage->set($cacheKey, $result, $ttl);
@@ -149,6 +152,7 @@ trait CacheableTrait
         }
 
         if (count($args) === 1) {
+            /** @var mixed $first */
             $first = $args[0];
             if (is_int($first) || is_string($first)) {
                 return (string) $first;
@@ -169,6 +173,7 @@ trait CacheableTrait
             '/\{(\d+)\}/',
             static function (array $match) use ($args): string {
                 $index = (int) $match[1];
+                /** @var mixed $value */
                 $value = $args[$index] ?? '';
                 if ($value === null || is_scalar($value)) {
                     return (string) $value;


### PR DESCRIPTION
## 📚 Description

Facades can now use `#[Cacheable]` out of the box — no need to manually `use CacheableTrait` in every facade subclass.

## 🔖 Changes

- Add `use CacheableTrait` to `AbstractFacade`
- `resetCache()` now also clears method cache for clean state
- Fix latent Psalm/PHPStan issues in `CacheableTrait` (surfaced now that trait is used in production code)
- Remove stale PHPStan baseline entry for unused trait