### PR TITLE
feat(console): add GacelaConfig::setAppModulePaths to restrict module scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- `GacelaConfig::setAppModulePaths(array $paths)` — restrict directories scanned when discovering app modules (`list:modules`, `debug:modules`, `cache:warm`, `doctor`). Accepts absolute or root-relative paths. Missing paths are skipped with an `E_USER_WARNING`. Empty/unset preserves the previous behavior of walking the application root.
+- `GacelaConfig::setAppModulePaths()` to scope module discovery to specific directories
 
 ### Fixed
 
-- `list:modules` / `debug:modules` no longer emit PHP warning when repo contains top-level dotfile PHP configs (e.g. `.php-cs-fixer.dist.php`)
+- `list:modules` / `debug:modules` no longer warn on top-level dotfile PHP configs
 
 ## [1.14.1](https://github.com/gacela-project/gacela/compare/1.14.0...1.14.1) - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `GacelaConfig::setAppModulePaths(array $paths)` — restrict directories scanned when discovering app modules (`list:modules`, `debug:modules`, `cache:warm`, `doctor`). Accepts absolute or root-relative paths. Missing paths are skipped with an `E_USER_WARNING`. Empty/unset preserves the previous behavior of walking the application root.
+
 ### Fixed
 
 - `list:modules` / `debug:modules` no longer emit PHP warning when repo contains top-level dotfile PHP configs (e.g. `.php-cs-fixer.dist.php`)

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Console;
 
+use AppendIterator;
 use FilesystemIterator;
 use Gacela\Console\Domain\AllAppModules\AllAppModulesFinder;
 use Gacela\Console\Domain\AllAppModules\AppModuleCreator;
@@ -19,11 +20,20 @@ use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\ClassResolver\Config\ConfigResolver;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
+use OuterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use SplFileInfo;
 use Symfony\Component\Console\Command\Command;
+
+use function is_dir;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function trigger_error;
 
 /**
  * @extends AbstractFactory<ConsoleConfig>
@@ -63,7 +73,7 @@ final class ConsoleFactory extends AbstractFactory
     public function createAllAppModulesFinder(): AllAppModulesFinder
     {
         return new AllAppModulesFinder(
-            $this->createRecursiveIterator(),
+            $this->createModuleScanIterator(),
             $this->createAppModuleCreator(),
         );
     }
@@ -103,14 +113,57 @@ final class ConsoleFactory extends AbstractFactory
     }
 
     /**
+     * @psalm-suppress MixedReturnTypeCoercion
+     *
+     * @return OuterIterator<array-key, SplFileInfo>
+     */
+    private function createModuleScanIterator(): OuterIterator
+    {
+        $paths = Config::getInstance()->getSetupGacela()->getAppModulePaths();
+        $rootDir = Gacela::rootDir();
+
+        if ($paths === []) {
+            return $this->createRecursiveIteratorFor($rootDir);
+        }
+
+        $append = new AppendIterator();
+        foreach ($paths as $path) {
+            $resolved = $this->resolveScanPath($path, $rootDir);
+            if (!is_dir($resolved)) {
+                trigger_error(
+                    sprintf('Gacela: appModulePaths entry "%s" is not a directory, skipping.', $path),
+                    E_USER_WARNING,
+                );
+                continue;
+            }
+            $append->append($this->createRecursiveIteratorFor($resolved));
+        }
+
+        /** @var OuterIterator<array-key, SplFileInfo> $append */
+        return $append;
+    }
+
+    /**
      * @return RecursiveIteratorIterator<RecursiveDirectoryIterator>
      */
-    private function createRecursiveIterator(): RecursiveIteratorIterator
+    private function createRecursiveIteratorFor(string $dir): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator(Gacela::rootDir(), FilesystemIterator::SKIP_DOTS),
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::LEAVES_ONLY,
         );
+    }
+
+    private function resolveScanPath(string $path, string $rootDir): string
+    {
+        if ($path === '') {
+            return $rootDir;
+        }
+        if (str_starts_with($path, '/') || (strlen($path) > 1 && $path[1] === ':')) {
+            return $path;
+        }
+
+        return rtrim($rootDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($path, '/\\');
     }
 
     private function createFileContentIo(): FileContentIoInterface

--- a/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
+++ b/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
@@ -6,8 +6,6 @@ namespace Gacela\Console\Domain\AllAppModules;
 
 use Gacela\Framework\AbstractFacade;
 use OuterIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use ReflectionClass;
 use SplFileInfo;
 
@@ -16,7 +14,7 @@ use function sprintf;
 final class AllAppModulesFinder
 {
     /**
-     * @param RecursiveIteratorIterator<RecursiveDirectoryIterator> $fileIterator
+     * @param OuterIterator<array-key, SplFileInfo> $fileIterator
      */
     public function __construct(
         private readonly OuterIterator $fileIterator,

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -21,6 +21,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const projectNamespaces = 'projectNamespaces';
 
+    public const appModulePaths = 'appModulePaths';
+
     public const configKeyValues = 'configKeyValues';
 
     public const servicesToExtend = 'servicesToExtend';
@@ -48,6 +50,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const DEFAULT_FILE_CACHE_DIRECTORY = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
 
     protected const DEFAULT_PROJECT_NAMESPACES = [];
+
+    protected const DEFAULT_APP_MODULE_PATHS = [];
 
     protected const DEFAULT_CONFIG_KEY_VALUES = [];
 

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -37,6 +37,9 @@ final class GacelaConfig
     /** @var list<string> */
     private ?array $projectNamespaces = null;
 
+    /** @var list<string> */
+    private ?array $appModulePaths = null;
+
     /** @var array<string,mixed> */
     private ?array $configKeyValues = null;
 
@@ -240,6 +243,23 @@ final class GacelaConfig
     public function setProjectNamespaces(array $list): self
     {
         $this->projectNamespaces = $list;
+
+        return $this;
+    }
+
+    /**
+     * Restrict which directories are scanned when discovering application modules
+     * (used by console commands: list:modules, debug:modules, cache:warm, doctor).
+     *
+     * Paths can be absolute or relative to the application root. Missing paths are
+     * skipped with a warning at scan time. When unset, scanning walks the entire
+     * application root directory.
+     *
+     * @param list<string> $paths
+     */
+    public function setAppModulePaths(array $paths): self
+    {
+        $this->appModulePaths = $paths;
 
         return $this;
     }
@@ -477,6 +497,7 @@ final class GacelaConfig
             $this->fileCacheEnabled,
             $this->fileCacheDirectory,
             $this->projectNamespaces,
+            $this->appModulePaths,
             $this->configKeyValues,
             $this->genericListeners,
             $this->specificListeners,

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -14,6 +14,7 @@ final class GacelaConfigTransfer
     /**
      * @param ?array<string, class-string|object|callable> $externalServices
      * @param ?list<string> $projectNamespaces
+     * @param ?list<string> $appModulePaths
      * @param ?array<string,mixed> $configKeyValues
      * @param ?list<callable> $genericListeners
      * @param ?array<class-string,list<callable>> $specificListeners
@@ -35,6 +36,7 @@ final class GacelaConfigTransfer
         public readonly ?bool $fileCacheEnabled,
         public readonly ?string $fileCacheDirectory,
         public readonly ?array $projectNamespaces,
+        public readonly ?array $appModulePaths,
         public readonly ?array $configKeyValues,
         public readonly ?array $genericListeners,
         public readonly ?array $specificListeners,

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -42,6 +42,9 @@ final class Properties
     /** @var ?list<string> */
     public ?array $projectNamespaces = null;
 
+    /** @var ?list<string> */
+    public ?array $appModulePaths = null;
+
     /** @var ?array<string,mixed> */
     public ?array $configKeyValues = null;
 

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -28,6 +28,7 @@ final class SetupInitializer
             ->setFileCacheEnabled($dto->fileCacheEnabled)
             ->setFileCacheDirectory($dto->fileCacheDirectory)
             ->setProjectNamespaces($dto->projectNamespaces)
+            ->setAppModulePaths($dto->appModulePaths)
             ->setConfigKeyValues($dto->configKeyValues)
             ->setAreEventListenersEnabled($dto->areEventListenersEnabled)
             ->setGenericListeners($dto->genericListeners)

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -242,6 +242,28 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
+     * @param ?list<string> $paths
+     */
+    public function setAppModulePaths(?array $paths): self
+    {
+        $this->properties->appModulePaths = $this->setPropertyWithTracking(
+            self::appModulePaths,
+            $paths,
+            self::DEFAULT_APP_MODULE_PATHS,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getAppModulePaths(): array
+    {
+        return $this->properties->appModulePaths ?? self::DEFAULT_APP_MODULE_PATHS;
+    }
+
+    /**
      * @return array<string,mixed>
      */
     public function getConfigKeyValues(): array

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -22,6 +22,14 @@ interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerC
     public function getProjectNamespaces(): array;
 
     /**
+     * Get the list of paths scanned when discovering application modules.
+     * Empty array means scan the application root directory.
+     *
+     * @return list<string>
+     */
+    public function getAppModulePaths(): array;
+
+    /**
      * Get the list of key:value configuration.
      *
      * @return array<string,mixed>

--- a/tests/Integration/Console/AllAppModules/Domain/AllAppModulesFinderTest.php
+++ b/tests/Integration/Console/AllAppModules/Domain/AllAppModulesFinderTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Integration\Console\AllAppModules\Domain;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use GacelaTest\Integration\Console\AllAppModules\Domain\Module1\Module1Config;
 use GacelaTest\Integration\Console\AllAppModules\Domain\Module1\Module1Facade;
@@ -65,5 +66,73 @@ final class AllAppModulesFinderTest extends TestCase
         ];
 
         self::assertEquals($expected, $actual);
+    }
+
+    public function test_app_module_paths_restricts_scan_to_configured_directories(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['Module1']);
+        });
+        $this->consoleFacade = new ConsoleFacade();
+
+        $actual = $this->consoleFacade->findAllAppModules();
+
+        $expected = [
+            new AppModule(
+                implode('\\', array_slice(explode('\\', Module1Facade::class), 0, -1)),
+                'Module1',
+                Module1Facade::class,
+                Module1Factory::class,
+                Module1Config::class,
+                Module1Provider::class,
+            ),
+        ];
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_app_module_paths_accepts_absolute_paths(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setAppModulePaths([__DIR__ . '/Module2']);
+        });
+        $this->consoleFacade = new ConsoleFacade();
+
+        $actual = $this->consoleFacade->findAllAppModules();
+
+        $expected = [
+            new AppModule(
+                implode('\\', array_slice(explode('\\', Module2Facade::class), 0, -1)),
+                'Module2',
+                Module2Facade::class,
+            ),
+        ];
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_app_module_paths_warns_and_skips_missing_directory(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['does/not/exist', 'Module1']);
+        });
+        $this->consoleFacade = new ConsoleFacade();
+
+        $capturedMessages = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$capturedMessages): bool {
+            $capturedMessages[] = $errstr;
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            $actual = $this->consoleFacade->findAllAppModules();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertCount(1, $actual);
+        self::assertSame(Module1Facade::class, $actual[0]->facadeClass());
+        self::assertCount(1, $capturedMessages);
+        self::assertStringContainsString('does/not/exist', $capturedMessages[0]);
     }
 }

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -27,6 +27,23 @@ final class GacelaConfigTest extends TestCase
         self::assertSame('config/local.php', $paths[0]->pathLocal());
     }
 
+    public function test_app_module_paths_default_to_null_in_transfer(): void
+    {
+        $config = new GacelaConfig();
+
+        self::assertNull($config->toTransfer()->appModulePaths);
+    }
+
+    public function test_set_app_module_paths_exposes_list_on_transfer(): void
+    {
+        $config = new GacelaConfig();
+
+        $returned = $config->setAppModulePaths(['src/php', '/abs/path']);
+
+        self::assertSame($config, $returned);
+        self::assertSame(['src/php', '/abs/path'], $config->toTransfer()->appModulePaths);
+    }
+
     public function test_add_mapping_interface_is_an_alias_of_add_binding(): void
     {
         $a = new GacelaConfig();


### PR DESCRIPTION
## 📚 Description

Adds `GacelaConfig::setAppModulePaths(array $paths)` to restrict which directories are walked when discovering application modules. Scoping the scan cuts bootstrap time for `list:modules`, `debug:modules`, `cache:warm`, and `doctor` on projects that keep PHP modules in a specific subtree (e.g. `src/php/`) while other directories (Phel sources, tests, build artifacts) have no modules and don't need scanning.

Empty/unset preserves the previous behavior of walking the application root, so this is a pure opt-in addition.

## 🔖 Changes

- `GacelaConfig::setAppModulePaths(array $paths)` — fluent setter. Paths may be absolute or relative to `Gacela::rootDir()`.
- Propagated through `GacelaConfigTransfer` → `SetupInitializer` → `SetupGacela::getAppModulePaths()` (exposed on `SetupGacelaInterface`).
- `ConsoleFactory::createModuleScanIterator()` builds an `AppendIterator` of per-path `RecursiveIteratorIterator`s when paths are configured; falls back to walking root otherwise.
- Missing paths are skipped with an `E_USER_WARNING` (warn-and-skip per request).
- Unit test for the setter + transfer wiring.
- Integration tests covering: relative path scoping, absolute path, and warn-and-skip on missing directory.
- `CHANGELOG.md` Unreleased entry.

## Test plan

- [x] `composer test-unit`
- [x] `composer test-integration`
- [x] `composer test-feature`
- [x] `composer quality` (cs-fixer, psalm, phpstan)