### PR TITLE
fix(cache): harden FileCache directory path against malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Cache-dir resolution on Windows (drive-letter regex, separator handling)
 - Exception messages produced by `ClassResolverExceptionTrait` are now platform-independent
+- `FileCache` hardens its directory input: trims whitespace, folds mixed `/` and `\` to `DIRECTORY_SEPARATOR`, preserves UNC prefix, and strips an embedded Windows absolute path when a caller accidentally concatenates it onto a cwd (defensive fix for [phel-lang/phel-lang#1459](https://github.com/phel-lang/phel-lang/issues/1459)). The `RuntimeException` on failure now includes the original input and platform.
 
 ## [1.14.3](https://github.com/gacela-project/gacela/compare/1.14.2...1.14.3) - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Fixed
 
 - Cache-dir resolution on Windows (drive-letter regex, separator handling)
-- Exception messages produced by `ClassResolverExceptionTrait` are now platform-independent
-- `FileCache` hardens its directory input: trims whitespace, folds mixed `/` and `\` to `DIRECTORY_SEPARATOR`, preserves UNC prefix, and strips an embedded Windows absolute path when a caller accidentally concatenates it onto a cwd (defensive fix for [phel-lang/phel-lang#1459](https://github.com/phel-lang/phel-lang/issues/1459)). The `RuntimeException` on failure now includes the original input and platform.
+- Platform-independent exception messages in `ClassResolverExceptionTrait`
+- `FileCache` normalizes its directory input (trim, fold separators, preserve UNC, strip embedded Windows absolute path)
 
 ## [1.14.3](https://github.com/gacela-project/gacela/compare/1.14.2...1.14.3) - 2026-04-17
 

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -19,17 +19,27 @@ use function glob;
 use function is_dir;
 use function is_file;
 use function mkdir;
+use function preg_match_all;
+use function preg_quote;
+use function preg_replace;
 use function random_bytes;
 use function rename;
+use function rtrim;
 use function sha1;
 use function sprintf;
+use function str_replace;
+use function str_starts_with;
+use function substr;
 use function time;
+use function trim;
 use function unlink;
 use function var_export;
 
 use const DIRECTORY_SEPARATOR;
 use const LOCK_EX;
 use const LOCK_UN;
+use const PHP_OS_FAMILY;
+use const PREG_OFFSET_CAPTURE;
 
 /**
  * Small, typed, file-backed cache primitive.
@@ -48,6 +58,8 @@ final class FileCache
 {
     private const INDEX_FILENAME = '.gacela-filecache.lock';
 
+    public readonly string $directory;
+
     /** @var array<string, array{value: T, expiresAt: int|null}> */
     private array $memory = [];
 
@@ -57,10 +69,11 @@ final class FileCache
     private array $batchPending = [];
 
     public function __construct(
-        public readonly string $directory,
+        string $directory,
         public readonly int $defaultTtl = 0,
     ) {
-        $this->ensureDirectory();
+        $this->directory = self::normalizeDirectory($directory);
+        $this->ensureDirectory($directory);
     }
 
     /**
@@ -310,14 +323,62 @@ final class FileCache
         }
     }
 
-    private function ensureDirectory(): void
+    private function ensureDirectory(string $originalInput): void
     {
         if (is_dir($this->directory)) {
             return;
         }
 
         if (!mkdir($this->directory, recursive: true) && !is_dir($this->directory)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $this->directory));
+            throw new RuntimeException(sprintf(
+                'Directory "%s" was not created (normalized from "%s" on %s)',
+                $this->directory,
+                $originalInput,
+                PHP_OS_FAMILY,
+            ));
         }
+    }
+
+    /**
+     * Defensive normalization of the cache directory input:
+     *
+     *   - trim surrounding whitespace
+     *   - if a Windows-style absolute path (e.g. `C:\...`) is embedded mid-string,
+     *     keep only the substring from the last such occurrence. This protects against
+     *     callers that accidentally concatenate `getcwd()` with an already-absolute
+     *     path such as `sys_get_temp_dir()` on Windows
+     *   - fold both `/` and `\` to `DIRECTORY_SEPARATOR`, preserving a leading
+     *     `\\` UNC prefix on Windows
+     *   - collapse runs of the separator and trim trailing separators
+     */
+    private static function normalizeDirectory(string $dir): string
+    {
+        $dir = trim($dir);
+
+        $count = preg_match_all('#[A-Za-z]:[\\\\/]#', $dir, $matches, PREG_OFFSET_CAPTURE);
+        if ($count !== false && $count > 1) {
+            $positions = $matches[0];
+            $lastOffset = $positions[$count - 1][1];
+            if ($lastOffset > 0) {
+                $dir = substr($dir, $lastOffset);
+            }
+        }
+
+        $dir = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $dir);
+
+        $uncPrefix = '';
+        if (DIRECTORY_SEPARATOR === '\\' && str_starts_with($dir, '\\\\')) {
+            $uncPrefix = '\\\\';
+            $dir = substr($dir, 2);
+        }
+
+        $collapsed = preg_replace(
+            '#' . preg_quote(DIRECTORY_SEPARATOR, '#') . '{2,}#',
+            DIRECTORY_SEPARATOR,
+            $dir,
+        );
+        $dir = $collapsed ?? $dir;
+
+        return $uncPrefix . rtrim($dir, '/\\');
     }
 }

--- a/tests/Unit/Framework/Cache/FileCacheTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheTest.php
@@ -164,7 +164,7 @@ final class FileCacheTest extends TestCase
 
     public function test_constructor_trims_whitespace_from_directory(): void
     {
-        $dir = sys_get_temp_dir() . '/gacela-filecache-trim-' . uniqid('', true);
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-filecache-trim-' . uniqid('', true);
         $cache = new FileCache('  ' . $dir . '  ');
 
         self::assertSame($dir, $cache->directory);

--- a/tests/Unit/Framework/Cache/FileCacheTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheTest.php
@@ -8,6 +8,8 @@ use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\FileCacheStats;
 use PHPUnit\Framework\TestCase;
 
+use ReflectionMethod;
+
 use function count;
 use function filesize;
 use function glob;
@@ -158,6 +160,49 @@ final class FileCacheTest extends TestCase
 
         self::assertDirectoryExists($dir);
         $this->removeDir($dir);
+    }
+
+    public function test_constructor_trims_whitespace_from_directory(): void
+    {
+        $dir = sys_get_temp_dir() . '/gacela-filecache-trim-' . uniqid('', true);
+        $cache = new FileCache('  ' . $dir . '  ');
+
+        self::assertSame($dir, $cache->directory);
+        self::assertDirectoryExists($dir);
+        $this->removeDir($dir);
+    }
+
+    public function test_constructor_collapses_duplicate_separators(): void
+    {
+        $dir = sys_get_temp_dir() . '/gacela-filecache-dup-' . uniqid('', true);
+        $cache = new FileCache($dir . '//nested///deep/');
+
+        self::assertStringNotContainsString('//', $cache->directory);
+        self::assertDirectoryExists($cache->directory);
+        $this->removeDir($cache->directory);
+    }
+
+    public function test_normalize_strips_prefix_when_windows_absolute_path_is_embedded(): void
+    {
+        // Regression: caller concats getcwd() with an already-absolute
+        // `sys_get_temp_dir()` via a POSIX separator on Windows (phel-lang #1459).
+        $bogus = 'C:\\demo\\example-app/C:\\Users\\u\\AppData\\Local\\Temp/phel/cache';
+        $normalized = $this->invokeNormalize($bogus);
+
+        self::assertStringStartsWith('C:', $normalized);
+        self::assertStringNotContainsString('example-app', $normalized);
+        self::assertStringNotContainsString('demo', $normalized);
+    }
+
+    public function test_normalize_preserves_windows_unc_prefix(): void
+    {
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            self::markTestSkipped('UNC semantics only apply on Windows.');
+        }
+
+        $result = $this->invokeNormalize('\\\\server\\share\\gacela');
+
+        self::assertStringStartsWith('\\\\', $result);
     }
 
     public function test_ttl_zero_means_forever(): void
@@ -351,6 +396,13 @@ final class FileCacheTest extends TestCase
 
         self::assertFileExists($path);
         self::assertSame(['a' => 1, 'b' => [2, 3]], require $path);
+    }
+
+    private function invokeNormalize(string $dir): string
+    {
+        $method = new ReflectionMethod(FileCache::class, 'normalizeDirectory');
+
+        return (string) $method->invoke(null, $dir);
     }
 
     private function removeDir(string $dir): void


### PR DESCRIPTION
## 📚 Description

Defensive hardening of `FileCache`'s directory input, motivated by [phel-lang/phel-lang#1459](https://github.com/phel-lang/phel-lang/issues/1459): on Windows, Phel concatenates `getcwd()` with an already-absolute `sys_get_temp_dir()` via a POSIX `/` separator, producing a malformed path like:

```
 C:\demo\example-app/C:\Users\u\AppData\Local\Temp/phel/cache/dependency-graph
```

`mkdir()` rejects this and `FileCache::__construct()` throws. The real fix belongs in the caller, but Gacela can and should be defensive since `FileCache` is a public primitive and the failure mode is very hard to diagnose from the raw `mkdir` error.

## 🔖 Changes

- `FileCache` now normalizes the directory input on construction:
  - trims surrounding whitespace
  - folds mixed `/` and `\` to `DIRECTORY_SEPARATOR`
  - preserves a leading `\\` UNC prefix on Windows
  - collapses runs of the separator and rtrims trailing separators
  - strips the leading segment when a Windows absolute path (`X:\...`) is embedded mid-string (keeps only the substring from the last drive-letter anchor)
- `ensureDirectory()` failure now includes the original input and `PHP_OS_FAMILY` in the `RuntimeException` message.
- New unit tests cover trimming, duplicate-separator collapsing, the phel-lang concatenation case, and UNC-prefix preservation (Windows-only).
- `CHANGELOG.md` updated under `## Unreleased` → `### Fixed`.