### PR TITLE
feat: config introspection and resolution diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `GacelaConfig::addLazy()` registers lazy-loaded services that are only instantiated on first access, deferring expensive service creation to improve startup performance
+- `debug:config` console command prints the effective merged configuration (optionally filtered by a key substring), plus a `Config::getAllValues()` accessor
+- Class-resolution failures now list the exact class-name candidates that were tried, making naming-convention and namespace mismatches easier to diagnose
 
 ### Changed
 

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -6,6 +6,7 @@ namespace Gacela\Console;
 
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
 use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
 use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
 use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
@@ -37,6 +38,7 @@ final class ConsoleProvider extends AbstractProvider
             new MakeFileCommand(),
             new MakeModuleCommand(),
             new ListModulesCommand(),
+            new DebugConfigCommand(),
             new DebugContainerCommand(),
             new DebugDependenciesCommand(),
             new DebugModulesCommand(),

--- a/src/Console/Infrastructure/Command/DebugConfigCommand.php
+++ b/src/Console/Infrastructure/Command/DebugConfigCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function count;
+use function is_bool;
+use function is_scalar;
+use function ksort;
+use function sprintf;
+
+use function str_contains;
+
+use const JSON_UNESCAPED_SLASHES;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+final class DebugConfigCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('debug:config')
+            ->setDescription('Show the effective merged configuration')
+            ->addArgument('filter', InputArgument::OPTIONAL, 'Only show keys containing this substring')
+            ->setHelp($this->getHelpText());
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $filter = (string)$input->getArgument('filter');
+
+        $values = Config::getInstance()->getAllValues();
+        ksort($values);
+
+        $rows = [];
+        /** @psalm-suppress MixedAssignment */
+        foreach ($values as $key => $value) {
+            if ($filter !== '' && !str_contains($key, $filter)) {
+                continue;
+            }
+
+            $rows[] = [$key, $this->renderValue($value)];
+        }
+
+        if ($rows === []) {
+            $output->writeln($filter === ''
+                ? '<comment>No configuration values found.</comment>'
+                : sprintf('<comment>No configuration keys match "%s".</comment>', $filter));
+
+            return Command::SUCCESS;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(['Key', 'Value']);
+        $table->setRows($rows);
+        $table->render();
+
+        $output->writeln('');
+        $output->writeln(sprintf('<info>%d configuration value(s).</info>', count($rows)));
+
+        return Command::SUCCESS;
+    }
+
+    private function renderValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_scalar($value)) {
+            return (string)$value;
+        }
+
+        return (string)json_encode($value, JSON_UNESCAPED_SLASHES);
+    }
+
+    private function getHelpText(): string
+    {
+        return <<<'HELP'
+This command prints the effective configuration after all sources are merged
+(config files, environment values, and values set via GacelaConfig).
+
+<info>What it does:</info>
+  - Resolves the merged configuration the same way the application sees it
+  - Renders every key/value pair as a table
+  - Optionally filters keys by a substring
+
+<info>Examples:</info>
+  # Show every configuration value
+  bin/gacela debug:config
+
+  # Show only keys containing "database"
+  bin/gacela debug:config database
+HELP;
+    }
+}

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\ClassResolver;
 
+use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithModulePrefix;
+use Gacela\Framework\ClassResolver\ClassNameFinder\Rule\FinderRuleWithoutModulePrefix;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\Exception\ErrorSuggestionHelper;
+use Throwable;
 
+use function array_unique;
+use function array_values;
 use function sprintf;
 
 trait ClassResolverExceptionTrait
@@ -34,7 +40,47 @@ trait ClassResolverExceptionTrait
             $this->findClassNameExample($callerClassInfo, $resolvableType),
         ) . "\n";
 
+        $candidates = $this->candidatesTried($callerClassInfo, $resolvableType);
+        if ($candidates !== []) {
+            $message .= 'Tried resolving the following class names:' . "\n";
+            foreach ($candidates as $candidate) {
+                $message .= '  - ' . $candidate . "\n";
+            }
+        }
+
         return $message . ErrorSuggestionHelper::addHelpfulTip('facade_not_found');
+    }
+
+    /**
+     * Reproduce the class-name candidates the finder would attempt, so the
+     * developer can see exactly which names were looked up and why the lookup
+     * failed (e.g. a naming-convention or namespace mismatch).
+     *
+     * @return list<string>
+     */
+    private function candidatesTried(ClassInfo $classInfo, string $resolvableType): array
+    {
+        try {
+            $projectNamespaces = Config::getInstance()->getSetupGacela()->getProjectNamespaces();
+        } catch (Throwable) {
+            return [];
+        }
+
+        $projectNamespaces[] = $classInfo->getModuleNamespace();
+
+        $rules = [
+            new FinderRuleWithModulePrefix(),
+            new FinderRuleWithoutModulePrefix(),
+        ];
+
+        $candidates = [];
+        foreach ($projectNamespaces as $projectNamespace) {
+            foreach ($rules as $rule) {
+                $candidates[] = $rule->buildClassCandidate($projectNamespace, $resolvableType, $classInfo);
+            }
+        }
+
+        return array_values(array_unique($candidates));
     }
 
     private function findClassNameExample(ClassInfo $classInfo, string $resolvableType): string

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -89,6 +89,22 @@ final class Config implements ConfigInterface
     }
 
     /**
+     * Return the effective merged configuration (all sources combined).
+     *
+     * @throws ConfigException
+     *
+     * @return array<string,mixed>
+     */
+    public function getAllValues(): array
+    {
+        if ($this->config === []) {
+            $this->init();
+        }
+
+        return $this->config;
+    }
+
+    /**
      * Force loading all config values in memory.
      *
      * @throws ConfigException

--- a/src/Framework/Config/ConfigInterface.php
+++ b/src/Framework/Config/ConfigInterface.php
@@ -18,6 +18,15 @@ interface ConfigInterface
      */
     public function get(string $key, mixed $default = self::DEFAULT_CONFIG_VALUE);
 
+    /**
+     * Return the effective merged configuration (all sources combined).
+     *
+     * @throws ConfigException
+     *
+     * @return array<string,mixed>
+     */
+    public function getAllValues(): array;
+
     public function getSetupGacela(): SetupGacelaInterface;
 
     public function hasKey(string $key): bool;

--- a/tests/Feature/Console/DebugConfig/DebugConfigCommandTest.php
+++ b/tests/Feature/Console/DebugConfig/DebugConfigCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugConfig;
+
+use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugConfigCommandTest extends TestCase
+{
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfigKeyValue('app_name', 'gacela-demo');
+            $config->addAppConfigKeyValue('debug_enabled', true);
+        });
+
+        $this->command = new CommandTester(new DebugConfigCommand());
+    }
+
+    public function test_shows_all_config_values(): void
+    {
+        $this->command->execute([]);
+
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('app_name', $output);
+        self::assertStringContainsString('gacela-demo', $output);
+        self::assertStringContainsString('debug_enabled', $output);
+        self::assertStringContainsString('true', $output);
+    }
+
+    public function test_filters_keys_by_substring(): void
+    {
+        $this->command->execute(['filter' => 'app_name']);
+
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('app_name', $output);
+        self::assertStringNotContainsString('debug_enabled', $output);
+    }
+
+    public function test_reports_when_no_keys_match_the_filter(): void
+    {
+        $this->command->execute(['filter' => 'nonexistent_key_xyz']);
+
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('No configuration keys match', $output);
+    }
+}

--- a/tests/Feature/Framework/ClassResolver/ResolutionCandidatesTest.php
+++ b/tests/Feature/Framework/ClassResolver/ResolutionCandidatesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ClassResolver;
+
+use Gacela\Framework\ClassResolver\Provider\ProviderNotFoundException;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class ResolutionCandidatesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+    }
+
+    public function test_not_found_exception_lists_the_candidates_tried(): void
+    {
+        $exception = new ProviderNotFoundException(self::class);
+
+        $message = $exception->getMessage();
+
+        self::assertStringContainsString('Tried resolving the following class names:', $message);
+        // The two finder rules produce a module-prefixed and a bare candidate.
+        self::assertStringContainsString('\\ClassResolver\\ClassResolverProvider', $message);
+        self::assertStringContainsString('\\ClassResolver\\Provider', $message);
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockServiceNotFoundExceptionTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockServiceNotFoundExceptionTest.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\ClassResolver\DocBlockService;
 
 use Gacela\Framework\ClassResolver\DocBlockService\DocBlockServiceNotFoundException;
+use Gacela\Framework\Config\Config;
 use GacelaTest\Unit\FakeModule\FakeFacade;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockServiceNotFoundExceptionTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        // Without a bootstrapped Config the candidate list is omitted, keeping
+        // this a deterministic message-format assertion. The with-candidates
+        // path is covered by ResolutionCandidatesTest.
+        Config::resetInstance();
+    }
+
     public function test_exception_message(): void
     {
         $facade = new FakeFacade();


### PR DESCRIPTION
## 📚 Description

Two high-value developer-experience improvements for working with configuration and class resolution.

**1. See the effective configuration.** There was no way to inspect the merged config a running app actually sees — you had to write debug code. This adds a `debug:config` console command that prints every effective config key/value (optionally filtered by a key substring), backed by a new `Config::getAllValues()` accessor.

**2. Class-resolution errors now show what was tried.** When a Facade/Factory/Config/Provider failed to resolve, the error said *what* was missing but not *which* class names were attempted — so naming-convention or namespace mismatches were hard to debug. The exception now lists the exact candidates the finder tried (reconstructed from the same project namespaces + finder rules), and gracefully omits them when no Config is bootstrapped.

## 🔖 Changes

- New `debug:config` command (`src/Console/Infrastructure/Command/DebugConfigCommand.php`), registered in `ConsoleProvider`
- New `Config::getAllValues()` on `Config` + `ConfigInterface`
- `ClassResolverExceptionTrait` appends a "Tried resolving the following class names" list to resolution-failure messages
- Feature tests for the command (show / filter / no-match) and the candidate listing; unit message-format test pinned to the no-Config path
- Changelog updated
