### PR TITLE
fix: degrade file caches gracefully in read-only environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- File caches degrade gracefully in read-only environments (e.g. a read-only project root inside a build sandbox) instead of fataling the bootstrap with `Directory "..." was not created`: the class-resolver caches fall back to in-memory resolution, the merged-config auto-warm is skipped, and cache write failures no longer emit raw PHP warnings. Pre-warmed cache files inside a read-only directory remain readable, so warm-at-build/run-read-only deployments keep their cache hits. An explicit `GACELA_CACHE_DIR` override is still trusted as-is and fails loud, as does the explicit `cache:warm` command.
+- File caches degrade gracefully in read-only environments (e.g. a read-only project root inside a build sandbox) instead of fataling the bootstrap with `Directory "..." was not created`: the class-resolver caches fall back to in-memory resolution, the merged-config auto-warm becomes a no-op, and cache writes never throw or emit raw PHP warnings. Pre-warmed cache files inside a read-only directory remain readable, so warm-at-build/run-read-only deployments keep their cache hits.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- File caches degrade gracefully in read-only environments (e.g. a read-only project root inside a build sandbox) instead of fataling the bootstrap with `Directory "..." was not created`: the class-resolver caches fall back to in-memory resolution, the merged-config auto-warm is skipped, and cache write failures no longer emit raw PHP warnings. Pre-warmed cache files inside a read-only directory remain readable, so warm-at-build/run-read-only deployments keep their cache hits. An explicit `GACELA_CACHE_DIR` override is still trusted as-is and fails loud, as does the explicit `cache:warm` command.
+
+### Added
+
+- `WritableDirectory::isUsable()` answers whether a directory can hold cache files (creating it when missing), memoized per directory
+- `FileCache::isPersistent()` reports whether entries reach disk or only live in memory; `FileCache::writeAtomically()` returns whether the file was written
+
 ## [1.15.0](https://github.com/gacela-project/gacela/compare/1.14.4...1.15.0) - 2026-06-05
 
 ### Added

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -26,10 +26,12 @@ use function sha1;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
+use function strlen;
 use function substr;
 use function time;
 use function trim;
 use function unlink;
+
 use function var_export;
 
 use const DIRECTORY_SEPARATOR;
@@ -47,10 +49,8 @@ use const PREG_OFFSET_CAPTURE;
  *   - Eviction: none. Entries live until TTL expiry or explicit {@see clear}.
  *   - Concurrency: per-file atomic rename + an index-file `flock` for batch commits.
  *   - Opcode cache: {@see opcache_invalidate} invoked on write when available.
- *   - Degradation: an unusable cache directory disables persistence instead of
- *     throwing — entries then live only in this instance's memory (see
- *     {@see isPersistent}), and reads from a pre-warmed read-only directory
- *     keep working.
+ *   - Degradation: an unusable directory disables persistence; entries then
+ *     live only in memory (see {@see isPersistent}).
  *
  * @template T
  */
@@ -73,15 +73,10 @@ final class FileCache
         public readonly int $defaultTtl = 0,
     ) {
         $this->directory = $this->normalizeDirectory($directory);
-        // Eager probe keeps the historical post-condition "directory exists
-        // after construction" whenever the filesystem allows it.
+        // Probe eagerly so a usable directory exists right after construction.
         WritableDirectory::isUsable($this->directory);
     }
 
-    /**
-     * False when the cache directory is unusable: entries then live only in
-     * this instance's memory and are lost when the process ends.
-     */
     public function isPersistent(): bool
     {
         return WritableDirectory::isUsable($this->directory);
@@ -140,8 +135,6 @@ final class FileCache
 
         $files = glob($this->directory . '/*.php') ?: [];
         foreach ($files as $file) {
-            // Suppressed: entries in a read-only directory cannot be removed
-            // from disk; the in-memory eviction above already took effect.
             @unlink($file);
             self::invalidateOpcacheFor($file);
         }
@@ -172,8 +165,6 @@ final class FileCache
         $this->batchPending = [];
 
         $indexPath = $this->directory . DIRECTORY_SEPARATOR . self::INDEX_FILENAME;
-        // Suppressed: in an unusable directory the lock file cannot exist and
-        // the per-entry writes below degrade to no-ops on their own.
         $handle = @fopen($indexPath, 'c');
 
         if ($handle === false) {
@@ -225,23 +216,11 @@ final class FileCache
     }
 
     /**
-     * Atomically write a PHP-returning file: stage to a sibling `.tmp`, then
-     * {@see rename}. `rename()` is atomic on POSIX filesystems, so readers
-     * never observe a half-written payload. `opcache_invalidate()` is called
-     * when available so readers see fresh bytes even under a warm opcode cache.
-     *
-     * Persistence is an optimization: when the target directory is unusable
-     * (read-only filesystem, unwritable parent) or staging fails, this returns
-     * false instead of throwing or emitting warnings, so cache writes on the
-     * bootstrap path can never fatal the application.
-     *
-     * Exposed so other file-backed caches in the framework (e.g.
-     * {@see \Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache}) can
-     * share exactly one write path.
+     * Atomically write a PHP-returning file, staging to a sibling `.tmp` then
+     * renaming. Returns false instead of throwing or warning when the directory
+     * is unusable or the write fails, so callers can degrade gracefully.
      *
      * @param mixed $value any `var_export`-safe payload
-     *
-     * @return bool whether the file was written
      */
     public static function writeAtomically(string $file, mixed $value): bool
     {
@@ -252,8 +231,9 @@ final class FileCache
         $content = sprintf('<?php return %s;', var_export($value, true));
         $tmp = $file . '.' . bin2hex(random_bytes(4)) . '.tmp';
 
-        // Suppressed: a failed write degrades to "not persisted", not a warning.
-        if (@file_put_contents($tmp, $content, LOCK_EX) === false) {
+        if (@file_put_contents($tmp, $content, LOCK_EX) !== strlen($content)) {
+            @unlink($tmp);
+
             return false;
         }
 
@@ -338,8 +318,6 @@ final class FileCache
     {
         $file = $this->entryPath($key);
         if (is_file($file)) {
-            // Suppressed: a TTL-expired entry in a read-only directory is
-            // evicted from memory on the read path; disk removal is best-effort.
             @unlink($file);
             self::invalidateOpcacheFor($file);
         }

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Cache;
 
-use RuntimeException;
-
 use function bin2hex;
 use function count;
+use function dirname;
 use function fclose;
 use function file_put_contents;
 use function filemtime;
@@ -16,9 +15,7 @@ use function flock;
 use function fopen;
 use function function_exists;
 use function glob;
-use function is_dir;
 use function is_file;
-use function mkdir;
 use function preg_match_all;
 use function preg_quote;
 use function preg_replace;
@@ -38,7 +35,6 @@ use function var_export;
 use const DIRECTORY_SEPARATOR;
 use const LOCK_EX;
 use const LOCK_UN;
-use const PHP_OS_FAMILY;
 use const PREG_OFFSET_CAPTURE;
 
 /**
@@ -51,6 +47,10 @@ use const PREG_OFFSET_CAPTURE;
  *   - Eviction: none. Entries live until TTL expiry or explicit {@see clear}.
  *   - Concurrency: per-file atomic rename + an index-file `flock` for batch commits.
  *   - Opcode cache: {@see opcache_invalidate} invoked on write when available.
+ *   - Degradation: an unusable cache directory disables persistence instead of
+ *     throwing — entries then live only in this instance's memory (see
+ *     {@see isPersistent}), and reads from a pre-warmed read-only directory
+ *     keep working.
  *
  * @template T
  */
@@ -73,7 +73,18 @@ final class FileCache
         public readonly int $defaultTtl = 0,
     ) {
         $this->directory = $this->normalizeDirectory($directory);
-        $this->ensureDirectory($directory);
+        // Eager probe keeps the historical post-condition "directory exists
+        // after construction" whenever the filesystem allows it.
+        WritableDirectory::isUsable($this->directory);
+    }
+
+    /**
+     * False when the cache directory is unusable: entries then live only in
+     * this instance's memory and are lost when the process ends.
+     */
+    public function isPersistent(): bool
+    {
+        return WritableDirectory::isUsable($this->directory);
     }
 
     /**
@@ -129,7 +140,9 @@ final class FileCache
 
         $files = glob($this->directory . '/*.php') ?: [];
         foreach ($files as $file) {
-            unlink($file);
+            // Suppressed: entries in a read-only directory cannot be removed
+            // from disk; the in-memory eviction above already took effect.
+            @unlink($file);
             self::invalidateOpcacheFor($file);
         }
     }
@@ -159,7 +172,9 @@ final class FileCache
         $this->batchPending = [];
 
         $indexPath = $this->directory . DIRECTORY_SEPARATOR . self::INDEX_FILENAME;
-        $handle = fopen($indexPath, 'c');
+        // Suppressed: in an unusable directory the lock file cannot exist and
+        // the per-entry writes below degrade to no-ops on their own.
+        $handle = @fopen($indexPath, 'c');
 
         if ($handle === false) {
             foreach ($pending as $key => $entry) {
@@ -215,21 +230,42 @@ final class FileCache
      * never observe a half-written payload. `opcache_invalidate()` is called
      * when available so readers see fresh bytes even under a warm opcode cache.
      *
+     * Persistence is an optimization: when the target directory is unusable
+     * (read-only filesystem, unwritable parent) or staging fails, this returns
+     * false instead of throwing or emitting warnings, so cache writes on the
+     * bootstrap path can never fatal the application.
+     *
      * Exposed so other file-backed caches in the framework (e.g.
      * {@see \Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache}) can
      * share exactly one write path.
      *
      * @param mixed $value any `var_export`-safe payload
+     *
+     * @return bool whether the file was written
      */
-    public static function writeAtomically(string $file, mixed $value): void
+    public static function writeAtomically(string $file, mixed $value): bool
     {
+        if (!WritableDirectory::isUsable(dirname($file))) {
+            return false;
+        }
+
         $content = sprintf('<?php return %s;', var_export($value, true));
         $tmp = $file . '.' . bin2hex(random_bytes(4)) . '.tmp';
 
-        file_put_contents($tmp, $content, LOCK_EX);
-        rename($tmp, $file);
+        // Suppressed: a failed write degrades to "not persisted", not a warning.
+        if (@file_put_contents($tmp, $content, LOCK_EX) === false) {
+            return false;
+        }
+
+        if (!@rename($tmp, $file)) {
+            @unlink($tmp);
+
+            return false;
+        }
 
         self::invalidateOpcacheFor($file);
+
+        return true;
     }
 
     /**
@@ -302,7 +338,9 @@ final class FileCache
     {
         $file = $this->entryPath($key);
         if (is_file($file)) {
-            unlink($file);
+            // Suppressed: a TTL-expired entry in a read-only directory is
+            // evicted from memory on the read path; disk removal is best-effort.
+            @unlink($file);
             self::invalidateOpcacheFor($file);
         }
     }
@@ -320,22 +358,6 @@ final class FileCache
         if (function_exists('opcache_invalidate')) {
             /** @psalm-suppress UndefinedFunction */
             opcache_invalidate($file, true);
-        }
-    }
-
-    private function ensureDirectory(string $originalInput): void
-    {
-        if (is_dir($this->directory)) {
-            return;
-        }
-
-        if (!mkdir($this->directory, recursive: true) && !is_dir($this->directory)) {
-            throw new RuntimeException(sprintf(
-                'Directory "%s" was not created (normalized from "%s" on %s)',
-                $this->directory,
-                $originalInput,
-                PHP_OS_FAMILY,
-            ));
         }
     }
 

--- a/src/Framework/Cache/WritableDirectory.php
+++ b/src/Framework/Cache/WritableDirectory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Cache;
+
+use function is_dir;
+use function is_writable;
+use function mkdir;
+
+/**
+ * Answers whether a directory can hold cache files, creating it when missing.
+ *
+ * The verdict is memoized per directory for the process lifetime: cache write
+ * paths consult it on every write, and re-probing the filesystem each time
+ * would defeat the point of caching.
+ */
+final class WritableDirectory
+{
+    /** @var array<string,bool> */
+    private static array $usableByDir = [];
+
+    public static function isUsable(string $directory): bool
+    {
+        return self::$usableByDir[$directory] ??= self::probe($directory);
+    }
+
+    /**
+     * @internal
+     */
+    public static function resetCache(): void
+    {
+        self::$usableByDir = [];
+    }
+
+    private static function probe(string $directory): bool
+    {
+        // Suppressed: an uncreatable directory means "not usable", not a warning.
+        if (!is_dir($directory) && !@mkdir($directory, recursive: true) && !is_dir($directory)) {
+            return false;
+        }
+
+        return is_writable($directory);
+    }
+}

--- a/src/Framework/Cache/WritableDirectory.php
+++ b/src/Framework/Cache/WritableDirectory.php
@@ -10,10 +10,7 @@ use function mkdir;
 
 /**
  * Answers whether a directory can hold cache files, creating it when missing.
- *
- * The verdict is memoized per directory for the process lifetime: cache write
- * paths consult it on every write, and re-probing the filesystem each time
- * would defeat the point of caching.
+ * The verdict is memoized per directory for the process lifetime.
  */
 final class WritableDirectory
 {
@@ -35,7 +32,6 @@ final class WritableDirectory
 
     private static function probe(string $directory): bool
     {
-        // Suppressed: an uncreatable directory means "not usable", not a warning.
         if (!is_dir($directory) && !@mkdir($directory, recursive: true) && !is_dir($directory)) {
             return false;
         }

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -5,13 +5,9 @@ declare(strict_types=1);
 namespace Gacela\Framework\ClassResolver\Cache;
 
 use Gacela\Framework\Cache\FileCache;
-use RuntimeException;
 
 use function array_keys;
 use function file_exists;
-use function is_dir;
-use function mkdir;
-use function sprintf;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -165,13 +161,10 @@ abstract class AbstractPhpFileCache implements CacheInterface
 
     private function computeAbsoluteFilename(): string
     {
-        if (!is_dir($this->cacheDir)
-            && !mkdir($concurrentDirectory = $this->cacheDir, recursive: true)
-            && !is_dir($concurrentDirectory)
-        ) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
-        }
-
+        // Directory creation is deferred to FileCache::writeAtomically(): an
+        // unusable cache directory must degrade to memory-only resolution
+        // instead of fataling the bootstrap, while a pre-warmed cache file in
+        // a read-only directory stays readable.
         return $this->cacheDir . DIRECTORY_SEPARATOR . $this->getCacheFilename();
     }
 }

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -161,10 +161,6 @@ abstract class AbstractPhpFileCache implements CacheInterface
 
     private function computeAbsoluteFilename(): string
     {
-        // Directory creation is deferred to FileCache::writeAtomically(): an
-        // unusable cache directory must degrade to memory-only resolution
-        // instead of fataling the bootstrap, while a pre-warmed cache file in
-        // a read-only directory stays readable.
         return $this->cacheDir . DIRECTORY_SEPARATOR . $this->getCacheFilename();
     }
 }

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
-use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
@@ -220,31 +219,14 @@ final class Config implements ConfigInterface
             return $cache->load();
         }
 
-        // Auto-warm on miss: persist the merged config so subsequent bootstraps
-        // skip globbing and parsing configuration files. Skip empty results;
-        // there is nothing worth caching and writing would only create noise.
+        // Auto-warm on miss so later bootstraps skip re-globbing config files;
+        // best-effort, and an empty merged config is not worth caching.
         $merged = $this->loadAllConfigValues();
-        if ($merged !== [] && $this->canAutoWarmMergedConfigCache()) {
+        if ($merged !== []) {
             $cache->write($merged);
         }
 
         return $merged;
-    }
-
-    /**
-     * The auto-warm is an optimization, so an unusable cache directory (e.g.
-     * a read-only project root) skips it instead of fataling the bootstrap.
-     * An explicit GACELA_CACHE_DIR is trusted as-is: a misconfigured override
-     * should stay loud rather than be silently ignored.
-     */
-    private function canAutoWarmMergedConfigCache(): bool
-    {
-        $explicitCacheDir = getenv('GACELA_CACHE_DIR');
-        if ($explicitCacheDir !== false && $explicitCacheDir !== '') {
-            return true;
-        }
-
-        return WritableDirectory::isUsable($this->getCacheDir());
     }
 
     private function createMergedConfigCache(): MergedConfigCache

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
@@ -223,11 +224,27 @@ final class Config implements ConfigInterface
         // skip globbing and parsing configuration files. Skip empty results;
         // there is nothing worth caching and writing would only create noise.
         $merged = $this->loadAllConfigValues();
-        if ($merged !== []) {
+        if ($merged !== [] && $this->canAutoWarmMergedConfigCache()) {
             $cache->write($merged);
         }
 
         return $merged;
+    }
+
+    /**
+     * The auto-warm is an optimization, so an unusable cache directory (e.g.
+     * a read-only project root) skips it instead of fataling the bootstrap.
+     * An explicit GACELA_CACHE_DIR is trusted as-is: a misconfigured override
+     * should stay loud rather than be silently ignored.
+     */
+    private function canAutoWarmMergedConfigCache(): bool
+    {
+        $explicitCacheDir = getenv('GACELA_CACHE_DIR');
+        if ($explicitCacheDir !== false && $explicitCacheDir !== '') {
+            return true;
+        }
+
+        return WritableDirectory::isUsable($this->getCacheDir());
     }
 
     private function createMergedConfigCache(): MergedConfigCache

--- a/src/Framework/Config/MergedConfigCache.php
+++ b/src/Framework/Config/MergedConfigCache.php
@@ -42,12 +42,22 @@ final class MergedConfigCache
     }
 
     /**
+     * Persist the merged config, failing loud: callers that must not fatal on
+     * an unusable cache directory (the bootstrap auto-warm) gate on
+     * {@see \Gacela\Framework\Cache\WritableDirectory::isUsable()} before
+     * calling this, while the explicit `cache:warm` command keeps the error.
+     *
      * @param array<string,mixed> $data
+     *
+     * @throws RuntimeException when the cache directory or file cannot be written
      */
     public function write(array $data): void
     {
         $this->ensureCacheDir();
-        FileCache::writeAtomically($this->filename(), $data);
+
+        if (!FileCache::writeAtomically($this->filename(), $data)) {
+            throw new RuntimeException(sprintf('Cache file "%s" was not written', $this->filename()));
+        }
     }
 
     public function clear(): void
@@ -74,7 +84,9 @@ final class MergedConfigCache
             return;
         }
 
-        if (!mkdir($this->cacheDir, recursive: true) && !is_dir($this->cacheDir)) {
+        // Suppressed: the thrown exception already carries the failure; the
+        // raw mkdir() warning would only add noise on the CLI.
+        if (!@mkdir($this->cacheDir, recursive: true) && !is_dir($this->cacheDir)) {
             throw new RuntimeException(sprintf('Directory "%s" was not created', $this->cacheDir));
         }
     }

--- a/src/Framework/Config/MergedConfigCache.php
+++ b/src/Framework/Config/MergedConfigCache.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Cache\FileCache;
-use RuntimeException;
-
-use function sprintf;
 
 final class MergedConfigCache
 {
@@ -42,28 +39,17 @@ final class MergedConfigCache
     }
 
     /**
-     * Persist the merged config, failing loud: callers that must not fatal on
-     * an unusable cache directory (the bootstrap auto-warm) gate on
-     * {@see \Gacela\Framework\Cache\WritableDirectory::isUsable()} before
-     * calling this, while the explicit `cache:warm` command keeps the error.
-     *
      * @param array<string,mixed> $data
-     *
-     * @throws RuntimeException when the cache directory or file cannot be written
      */
     public function write(array $data): void
     {
-        $this->ensureCacheDir();
-
-        if (!FileCache::writeAtomically($this->filename(), $data)) {
-            throw new RuntimeException(sprintf('Cache file "%s" was not written', $this->filename()));
-        }
+        FileCache::writeAtomically($this->filename(), $data);
     }
 
     public function clear(): void
     {
         if ($this->exists()) {
-            unlink($this->filename());
+            @unlink($this->filename());
         }
     }
 
@@ -76,18 +62,5 @@ final class MergedConfigCache
             . self::FILENAME_PREFIX
             . $suffix
             . self::FILENAME_EXTENSION;
-    }
-
-    private function ensureCacheDir(): void
-    {
-        if (is_dir($this->cacheDir)) {
-            return;
-        }
-
-        // Suppressed: the thrown exception already carries the failure; the
-        // raw mkdir() warning would only add noise on the CLI.
-        if (!@mkdir($this->cacheDir, recursive: true) && !is_dir($this->cacheDir)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $this->cacheDir));
-        }
     }
 }

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -8,6 +8,7 @@ use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
@@ -150,6 +151,7 @@ final class Gacela
         AbstractClassResolver::resetCache();
         InMemoryCache::resetCache();
         GacelaFileCache::resetCache();
+        WritableDirectory::resetCache();
         DocBlockResolverCache::resetCache();
         ClassResolverCache::resetCache();
         ConfigFactory::resetCache();

--- a/tests/Fixtures/ReadOnlyDirTrait.php
+++ b/tests/Fixtures/ReadOnlyDirTrait.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Fixtures;
 
 use function array_diff;
 use function chmod;
+use function file_put_contents;
 use function is_dir;
 use function mkdir;
 use function rmdir;
@@ -15,7 +16,7 @@ use function uniqid;
 use function unlink;
 
 /**
- * Read-only directory scenarios for cache-degradation tests.
+ * Read-only and uncreatable directory scenarios for cache-degradation tests.
  *
  * Call {@see restoreReadOnlyDirs()} from tearDown().
  */
@@ -29,7 +30,7 @@ trait ReadOnlyDirTrait
      * environment cannot produce an unwritable directory (running as root,
      * or a filesystem that ignores permissions, e.g. on Windows).
      *
-     * @param callable(string):void|null $seed populate the directory before it turns read-only
+     * @param null|callable(string):void $seed populate the directory before it turns read-only
      */
     private function createReadOnlyDirOrSkip(string $prefix, ?callable $seed = null): string
     {
@@ -43,10 +44,9 @@ trait ReadOnlyDirTrait
 
         chmod($dir, 0o555);
 
-        // Probe the capability the scenarios rely on (creating a child entry)
-        // instead of is_writable(): as root chmod is ineffective, and on
-        // Windows the read-only attribute neither blocks writes inside the
-        // directory nor is reported correctly by is_writable().
+        // Probe by creating a child, not is_writable(): as root chmod is a
+        // no-op, and on Windows the read-only attribute neither blocks writes
+        // inside the directory nor is reflected by is_writable().
         $probe = $dir . DIRECTORY_SEPARATOR . 'gacela-write-probe';
         if (@mkdir($probe)) {
             rmdir($probe);
@@ -54,6 +54,18 @@ trait ReadOnlyDirTrait
         }
 
         return $dir;
+    }
+
+    /**
+     * A path whose parent is a regular file, so mkdir() of it can never succeed.
+     */
+    private function uncreatableDir(string $prefix = 'uncreatable'): string
+    {
+        $blocker = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-' . $prefix . '-' . uniqid('', true);
+        file_put_contents($blocker, 'blocked');
+        $this->readOnlyDirs[] = $blocker;
+
+        return $blocker . DIRECTORY_SEPARATOR . 'subdir';
     }
 
     private function restoreReadOnlyDirs(): void
@@ -75,8 +87,7 @@ trait ReadOnlyDirTrait
 
         @chmod($path, 0o755);
 
-        // scandir instead of glob: dot-prefixed children (e.g. `.gacela`)
-        // must be removed too.
+        // scandir, not glob: dot-prefixed children (e.g. `.gacela`) must go too.
         foreach (array_diff(scandir($path) ?: [], ['.', '..']) as $child) {
             $this->removeRestoringPermissions($path . DIRECTORY_SEPARATOR . $child);
         }

--- a/tests/Fixtures/ReadOnlyDirTrait.php
+++ b/tests/Fixtures/ReadOnlyDirTrait.php
@@ -7,7 +7,6 @@ namespace GacelaTest\Fixtures;
 use function array_diff;
 use function chmod;
 use function is_dir;
-use function is_writable;
 use function mkdir;
 use function rmdir;
 use function scandir;
@@ -44,7 +43,13 @@ trait ReadOnlyDirTrait
 
         chmod($dir, 0o555);
 
-        if (is_writable($dir)) {
+        // Probe the capability the scenarios rely on (creating a child entry)
+        // instead of is_writable(): as root chmod is ineffective, and on
+        // Windows the read-only attribute neither blocks writes inside the
+        // directory nor is reported correctly by is_writable().
+        $probe = $dir . DIRECTORY_SEPARATOR . 'gacela-write-probe';
+        if (@mkdir($probe)) {
+            rmdir($probe);
             self::markTestSkipped('chmod(0555) does not make the directory unwritable in this environment');
         }
 

--- a/tests/Fixtures/ReadOnlyDirTrait.php
+++ b/tests/Fixtures/ReadOnlyDirTrait.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Fixtures;
+
+use function array_diff;
+use function chmod;
+use function is_dir;
+use function is_writable;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Read-only directory scenarios for cache-degradation tests.
+ *
+ * Call {@see restoreReadOnlyDirs()} from tearDown().
+ */
+trait ReadOnlyDirTrait
+{
+    /** @var list<string> */
+    private array $readOnlyDirs = [];
+
+    /**
+     * A fresh temp directory chmod'ed to 0555. Skips the test when the
+     * environment cannot produce an unwritable directory (running as root,
+     * or a filesystem that ignores permissions, e.g. on Windows).
+     *
+     * @param callable(string):void|null $seed populate the directory before it turns read-only
+     */
+    private function createReadOnlyDirOrSkip(string $prefix, ?callable $seed = null): string
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-' . $prefix . '-' . uniqid('', true);
+        mkdir($dir, 0o755, true);
+        $this->readOnlyDirs[] = $dir;
+
+        if ($seed !== null) {
+            $seed($dir);
+        }
+
+        chmod($dir, 0o555);
+
+        if (is_writable($dir)) {
+            self::markTestSkipped('chmod(0555) does not make the directory unwritable in this environment');
+        }
+
+        return $dir;
+    }
+
+    private function restoreReadOnlyDirs(): void
+    {
+        foreach ($this->readOnlyDirs as $dir) {
+            $this->removeRestoringPermissions($dir);
+        }
+
+        $this->readOnlyDirs = [];
+    }
+
+    private function removeRestoringPermissions(string $path): void
+    {
+        if (!is_dir($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        @chmod($path, 0o755);
+
+        // scandir instead of glob: dot-prefixed children (e.g. `.gacela`)
+        // must be removed too.
+        foreach (array_diff(scandir($path) ?: [], ['.', '..']) as $child) {
+            $this->removeRestoringPermissions($path . DIRECTORY_SEPARATOR . $child);
+        }
+
+        @rmdir($path);
+    }
+}

--- a/tests/Fixtures/WarningCollectorTrait.php
+++ b/tests/Fixtures/WarningCollectorTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Fixtures;
+
+use function error_reporting;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_WARNING;
+
+trait WarningCollectorTrait
+{
+    /**
+     * Run $probe and return the user-visible warnings it raised.
+     *
+     * @param mixed $result receives $probe's return value
+     *
+     * @return list<string>
+     */
+    private function collectWarnings(callable $probe, mixed &$result = null): array
+    {
+        $warnings = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+            // @-suppressed warnings still reach custom handlers; mirror the
+            // engine's suppression check so only user-visible warnings count.
+            if ((error_reporting() & $errno) !== 0) {
+                $warnings[] = $errstr;
+            }
+
+            return true;
+        }, E_WARNING);
+
+        try {
+            $result = $probe();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $warnings;
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/Config.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/Config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ReadOnlyAppRoot;
+
+use Gacela\Framework\AbstractConfig;
+
+final class Config extends AbstractConfig
+{
+}

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/Facade.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ReadOnlyAppRoot;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function greet(): string
+    {
+        return $this->getFactory()->createGreetingService()->greet();
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/Factory.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/Factory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ReadOnlyAppRoot;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @extends AbstractFactory<Config>
+ */
+final class Factory extends AbstractFactory
+{
+    public function createGreetingService(): GreetingService
+    {
+        return new GreetingService();
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/GreetingService.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRoot/GreetingService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ReadOnlyAppRoot;
+
+final class GreetingService
+{
+    public function greet(): string
+    {
+        return 'greetings-from-read-only-root';
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRootTest.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRootTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap;
+
+use Closure;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\MergedConfigCache;
+use Gacela\Framework\Gacela;
+use GacelaTest\Fixtures\ReadOnlyDirTrait;
+use GacelaTest\Fixtures\WarningCollectorTrait;
+use GacelaTest\Integration\Framework\Bootstrap\ReadOnlyAppRoot\Facade as GreeterFacade;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function chmod;
+use function file_put_contents;
+use function getenv;
+use function is_file;
+use function mkdir;
+use function putenv;
+use function sprintf;
+use function var_export;
+
+/**
+ * The scenario that fataled Phel inside the NixOS build sandbox: a project
+ * bootstrapped from a read-only root, with the file cache enabled and pointing
+ * inside that root. Gacela must degrade to in-memory caching instead of
+ * throwing during bootstrap.
+ */
+final class ReadOnlyAppRootTest extends TestCase
+{
+    use ReadOnlyDirTrait;
+    use WarningCollectorTrait;
+
+    private ?string $originalAppEnv = null;
+
+    protected function setUp(): void
+    {
+        $env = getenv('APP_ENV');
+        $this->originalAppEnv = $env === false ? null : $env;
+        putenv('APP_ENV');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('GACELA_CACHE_DIR');
+        putenv($this->originalAppEnv === null ? 'APP_ENV' : 'APP_ENV=' . $this->originalAppEnv);
+        $this->restoreReadOnlyDirs();
+        Gacela::resetCache();
+    }
+
+    public function test_bootstrap_with_file_cache_degrades_gracefully_in_read_only_app_root(): void
+    {
+        $appRoot = $this->createReadOnlyDirOrSkip('ro-approot', static function (string $dir): void {
+            mkdir($dir . '/config', 0o755, true);
+            file_put_contents($dir . '/config/config.php', '<?php return ["ro_key" => "ro_value"];');
+        });
+
+        $warnings = $this->collectWarnings(static function () use ($appRoot): array {
+            Gacela::bootstrap($appRoot, self::fileCacheConfigFn());
+
+            return [
+                Config::getInstance()->get('ro_key'),
+                (new GreeterFacade())->greet(),
+            ];
+        }, $observed);
+
+        self::assertSame([], $warnings);
+        self::assertSame(['ro_value', 'greetings-from-read-only-root'], $observed);
+        self::assertDirectoryDoesNotExist($appRoot . '/.gacela');
+        self::assertFalse(is_file(Config::getInstance()->mergedConfigCacheFilename()));
+    }
+
+    public function test_pre_warmed_merged_config_is_read_from_read_only_cache_dir(): void
+    {
+        $appRoot = $this->createReadOnlyDirOrSkip('ro-prewarmed', static function (string $dir): void {
+            mkdir($dir . '/config', 0o755, true);
+            file_put_contents($dir . '/config/config.php', '<?php return ["ro_key" => "from_files"];');
+
+            $cacheDir = $dir . '/.gacela/cache';
+            mkdir($cacheDir, 0o755, true);
+            file_put_contents(
+                $cacheDir . '/' . MergedConfigCache::FILENAME_PREFIX . MergedConfigCache::FILENAME_EXTENSION,
+                sprintf('<?php return %s;', var_export(['ro_key' => 'from_prewarmed_cache'], true)),
+            );
+            chmod($cacheDir, 0o555);
+        });
+
+        $warnings = $this->collectWarnings(static function () use ($appRoot): string {
+            Gacela::bootstrap($appRoot, self::fileCacheConfigFn());
+
+            /** @var string $value */
+            $value = Config::getInstance()->get('ro_key');
+
+            return $value;
+        }, $observed);
+
+        self::assertSame([], $warnings);
+        self::assertSame('from_prewarmed_cache', $observed);
+    }
+
+    public function test_explicit_cache_dir_env_override_stays_loud_when_unusable(): void
+    {
+        $appRoot = $this->createReadOnlyDirOrSkip('ro-env-override', static function (string $dir): void {
+            mkdir($dir . '/config', 0o755, true);
+            file_put_contents($dir . '/config/config.php', '<?php return ["ro_key" => "ro_value"];');
+        });
+
+        putenv('GACELA_CACHE_DIR=' . $appRoot . '/.gacela/cache');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('was not created');
+
+        // The merged-config auto-warm runs while bootstrapping.
+        Gacela::bootstrap($appRoot, self::fileCacheConfigFn());
+        Config::getInstance()->get('ro_key');
+    }
+
+    private static function fileCacheConfigFn(): Closure
+    {
+        return static function (GacelaConfig $config): void {
+            $config->setFileCache(true, '.gacela/cache');
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php');
+        };
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRootTest.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRootTest.php
@@ -13,7 +13,6 @@ use GacelaTest\Fixtures\ReadOnlyDirTrait;
 use GacelaTest\Fixtures\WarningCollectorTrait;
 use GacelaTest\Integration\Framework\Bootstrap\ReadOnlyAppRoot\Facade as GreeterFacade;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 use function chmod;
 use function file_put_contents;
@@ -46,7 +45,6 @@ final class ReadOnlyAppRootTest extends TestCase
 
     protected function tearDown(): void
     {
-        putenv('GACELA_CACHE_DIR');
         putenv($this->originalAppEnv === null ? 'APP_ENV' : 'APP_ENV=' . $this->originalAppEnv);
         $this->restoreReadOnlyDirs();
         Gacela::resetCache();
@@ -100,23 +98,6 @@ final class ReadOnlyAppRootTest extends TestCase
 
         self::assertSame([], $warnings);
         self::assertSame('from_prewarmed_cache', $observed);
-    }
-
-    public function test_explicit_cache_dir_env_override_stays_loud_when_unusable(): void
-    {
-        $appRoot = $this->createReadOnlyDirOrSkip('ro-env-override', static function (string $dir): void {
-            mkdir($dir . '/config', 0o755, true);
-            file_put_contents($dir . '/config/config.php', '<?php return ["ro_key" => "ro_value"];');
-        });
-
-        putenv('GACELA_CACHE_DIR=' . $appRoot . '/.gacela/cache');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('was not created');
-
-        // The merged-config auto-warm runs while bootstrapping.
-        Gacela::bootstrap($appRoot, self::fileCacheConfigFn());
-        Config::getInstance()->get('ro_key');
     }
 
     private static function fileCacheConfigFn(): Closure

--- a/tests/Unit/Framework/Cache/FileCacheDegradationTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheDegradationTest.php
@@ -12,25 +12,16 @@ use PHPUnit\Framework\TestCase;
 
 use function file_put_contents;
 use function glob;
-use function is_file;
-use function rmdir;
 use function sha1;
 use function sprintf;
 use function sys_get_temp_dir;
 use function uniqid;
-use function unlink;
 use function var_export;
 
 final class FileCacheDegradationTest extends TestCase
 {
     use ReadOnlyDirTrait;
     use WarningCollectorTrait;
-
-    /** @var list<string> */
-    private array $blockerFiles = [];
-
-    /** @var list<string> */
-    private array $dirsToRemove = [];
 
     protected function setUp(): void
     {
@@ -41,24 +32,6 @@ final class FileCacheDegradationTest extends TestCase
     {
         WritableDirectory::resetCache();
         $this->restoreReadOnlyDirs();
-
-        foreach ($this->blockerFiles as $blocker) {
-            if (is_file($blocker)) {
-                unlink($blocker);
-            }
-        }
-
-        $this->blockerFiles = [];
-
-        foreach ($this->dirsToRemove as $dir) {
-            foreach (glob($dir . '/*') ?: [] as $file) {
-                @unlink($file);
-            }
-
-            @rmdir($dir);
-        }
-
-        $this->dirsToRemove = [];
     }
 
     public function test_uncreatable_directory_degrades_to_memory_only(): void
@@ -82,11 +55,8 @@ final class FileCacheDegradationTest extends TestCase
 
     public function test_is_persistent_when_directory_is_writable(): void
     {
-        $dir = sys_get_temp_dir() . '/gacela-degradation-' . uniqid('', true);
-        $this->dirsToRemove[] = $dir;
-
         /** @var FileCache<string> $cache */
-        $cache = new FileCache($dir);
+        $cache = new FileCache($this->writableDir());
 
         self::assertTrue($cache->isPersistent());
     }
@@ -158,21 +128,18 @@ final class FileCacheDegradationTest extends TestCase
 
     public function test_write_atomically_returns_true_on_success(): void
     {
-        $dir = sys_get_temp_dir() . '/gacela-degradation-' . uniqid('', true);
-        $this->dirsToRemove[] = $dir;
-        $file = $dir . '/entry.php';
+        $file = $this->writableDir() . '/entry.php';
 
         self::assertTrue(FileCache::writeAtomically($file, ['k' => 'v']));
         self::assertSame(['k' => 'v'], require $file);
     }
 
-    private function uncreatableDir(): string
+    private function writableDir(): string
     {
-        $blocker = sys_get_temp_dir() . '/gacela-degradation-blocker-' . uniqid('', true);
-        file_put_contents($blocker, 'blocked');
-        $this->blockerFiles[] = $blocker;
+        $dir = sys_get_temp_dir() . '/gacela-degradation-' . uniqid('', true);
+        $this->readOnlyDirs[] = $dir;
 
-        return $blocker . '/subdir';
+        return $dir;
     }
 
     private static function seedEntryFile(string $dir, string $key, string $value): void

--- a/tests/Unit/Framework/Cache/FileCacheDegradationTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheDegradationTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Cache;
+
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\WritableDirectory;
+use GacelaTest\Fixtures\ReadOnlyDirTrait;
+use GacelaTest\Fixtures\WarningCollectorTrait;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function glob;
+use function is_file;
+use function rmdir;
+use function sha1;
+use function sprintf;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+use function var_export;
+
+final class FileCacheDegradationTest extends TestCase
+{
+    use ReadOnlyDirTrait;
+    use WarningCollectorTrait;
+
+    /** @var list<string> */
+    private array $blockerFiles = [];
+
+    /** @var list<string> */
+    private array $dirsToRemove = [];
+
+    protected function setUp(): void
+    {
+        WritableDirectory::resetCache();
+    }
+
+    protected function tearDown(): void
+    {
+        WritableDirectory::resetCache();
+        $this->restoreReadOnlyDirs();
+
+        foreach ($this->blockerFiles as $blocker) {
+            if (is_file($blocker)) {
+                unlink($blocker);
+            }
+        }
+
+        $this->blockerFiles = [];
+
+        foreach ($this->dirsToRemove as $dir) {
+            foreach (glob($dir . '/*') ?: [] as $file) {
+                @unlink($file);
+            }
+
+            @rmdir($dir);
+        }
+
+        $this->dirsToRemove = [];
+    }
+
+    public function test_uncreatable_directory_degrades_to_memory_only(): void
+    {
+        $dir = $this->uncreatableDir();
+
+        $warnings = $this->collectWarnings(static function () use ($dir): FileCache {
+            /** @var FileCache<string> $cache */
+            $cache = new FileCache($dir);
+            $cache->put('key', 'value');
+
+            return $cache;
+        }, $cache);
+
+        self::assertSame([], $warnings);
+        self::assertFalse($cache->isPersistent());
+        self::assertTrue($cache->has('key'));
+        self::assertSame('value', $cache->get('key'));
+        self::assertDirectoryDoesNotExist($dir);
+    }
+
+    public function test_is_persistent_when_directory_is_writable(): void
+    {
+        $dir = sys_get_temp_dir() . '/gacela-degradation-' . uniqid('', true);
+        $this->dirsToRemove[] = $dir;
+
+        /** @var FileCache<string> $cache */
+        $cache = new FileCache($dir);
+
+        self::assertTrue($cache->isPersistent());
+    }
+
+    public function test_reads_pre_warmed_entries_from_read_only_directory(): void
+    {
+        $dir = $this->createReadOnlyDirOrSkip('filecache-readonly', static function (string $dir): void {
+            self::seedEntryFile($dir, 'warm', 'from-disk');
+        });
+
+        /** @var FileCache<string> $cache */
+        $cache = new FileCache($dir);
+
+        self::assertFalse($cache->isPersistent());
+        self::assertSame('from-disk', $cache->get('warm'));
+    }
+
+    public function test_put_in_read_only_directory_updates_memory_without_warnings(): void
+    {
+        $dir = $this->createReadOnlyDirOrSkip('filecache-readonly-put', static function (string $dir): void {
+            self::seedEntryFile($dir, 'warm', 'from-disk');
+        });
+
+        /** @var FileCache<string> $cache */
+        $cache = new FileCache($dir);
+
+        $warnings = $this->collectWarnings(static function () use ($cache): void {
+            $cache->put('warm', 'updated');
+            $cache->put('fresh', 'memory-only');
+        });
+
+        self::assertSame([], $warnings);
+        self::assertSame('updated', $cache->get('warm'));
+        self::assertSame('memory-only', $cache->get('fresh'));
+        self::assertCount(1, glob($dir . '/*.php') ?: [], 'the read-only directory must stay untouched');
+    }
+
+    public function test_commit_batch_in_unusable_directory_keeps_entries_in_memory(): void
+    {
+        $dir = $this->uncreatableDir();
+        /** @var FileCache<string> $cache */
+        $cache = new FileCache($dir);
+
+        $warnings = $this->collectWarnings(static function () use ($cache): void {
+            $cache->beginBatch();
+            $cache->put('a', 'A');
+            $cache->put('b', 'B');
+            $cache->commitBatch();
+        });
+
+        self::assertSame([], $warnings);
+        self::assertSame('A', $cache->get('a'));
+        self::assertSame('B', $cache->get('b'));
+        self::assertDirectoryDoesNotExist($dir);
+    }
+
+    public function test_write_atomically_returns_false_for_unusable_directory(): void
+    {
+        $dir = $this->uncreatableDir();
+
+        $warnings = $this->collectWarnings(
+            static fn (): bool => FileCache::writeAtomically($dir . '/entry.php', ['k' => 'v']),
+            $written,
+        );
+
+        self::assertSame([], $warnings);
+        self::assertFalse($written);
+    }
+
+    public function test_write_atomically_returns_true_on_success(): void
+    {
+        $dir = sys_get_temp_dir() . '/gacela-degradation-' . uniqid('', true);
+        $this->dirsToRemove[] = $dir;
+        $file = $dir . '/entry.php';
+
+        self::assertTrue(FileCache::writeAtomically($file, ['k' => 'v']));
+        self::assertSame(['k' => 'v'], require $file);
+    }
+
+    private function uncreatableDir(): string
+    {
+        $blocker = sys_get_temp_dir() . '/gacela-degradation-blocker-' . uniqid('', true);
+        file_put_contents($blocker, 'blocked');
+        $this->blockerFiles[] = $blocker;
+
+        return $blocker . '/subdir';
+    }
+
+    private static function seedEntryFile(string $dir, string $key, string $value): void
+    {
+        $entry = ['value' => $value, 'expiresAt' => null];
+        file_put_contents(
+            $dir . '/' . sha1($key) . '.php',
+            sprintf('<?php return %s;', var_export($entry, true)),
+        );
+    }
+}

--- a/tests/Unit/Framework/Cache/WritableDirectoryTest.php
+++ b/tests/Unit/Framework/Cache/WritableDirectoryTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Cache;
+
+use Gacela\Framework\Cache\WritableDirectory;
+use GacelaTest\Fixtures\ReadOnlyDirTrait;
+use GacelaTest\Fixtures\WarningCollectorTrait;
+use PHPUnit\Framework\TestCase;
+
+use function chmod;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class WritableDirectoryTest extends TestCase
+{
+    use ReadOnlyDirTrait;
+    use WarningCollectorTrait;
+
+    /** @var list<string> */
+    private array $pathsToRemove = [];
+
+    protected function setUp(): void
+    {
+        WritableDirectory::resetCache();
+    }
+
+    protected function tearDown(): void
+    {
+        WritableDirectory::resetCache();
+        $this->restoreReadOnlyDirs();
+
+        foreach ($this->pathsToRemove as $path) {
+            if (is_dir($path)) {
+                @rmdir($path);
+            } elseif (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->pathsToRemove = [];
+    }
+
+    public function test_creates_missing_directory_and_reports_usable(): void
+    {
+        $dir = $this->tempPath('writable-dir-missing');
+
+        self::assertTrue(WritableDirectory::isUsable($dir));
+        self::assertDirectoryExists($dir);
+    }
+
+    public function test_existing_writable_directory_is_usable(): void
+    {
+        $dir = $this->tempPath('writable-dir-existing');
+        mkdir($dir, 0o755, true);
+
+        self::assertTrue(WritableDirectory::isUsable($dir));
+    }
+
+    public function test_uncreatable_directory_is_not_usable_and_emits_no_warning(): void
+    {
+        $blocker = $this->tempPath('writable-dir-blocker');
+        file_put_contents($blocker, 'blocked');
+
+        $warnings = $this->collectWarnings(
+            static fn (): bool => WritableDirectory::isUsable($blocker . '/subdir'),
+            $usable,
+        );
+
+        self::assertFalse($usable);
+        self::assertSame([], $warnings);
+    }
+
+    public function test_read_only_directory_is_not_usable(): void
+    {
+        $dir = $this->createReadOnlyDirOrSkip('writable-dir-readonly');
+
+        self::assertFalse(WritableDirectory::isUsable($dir));
+    }
+
+    public function test_verdict_is_memoized_until_reset(): void
+    {
+        $dir = $this->createReadOnlyDirOrSkip('writable-dir-memoized');
+
+        self::assertFalse(WritableDirectory::isUsable($dir));
+
+        chmod($dir, 0o755);
+        self::assertFalse(WritableDirectory::isUsable($dir), 'first verdict must stick until reset');
+
+        WritableDirectory::resetCache();
+        self::assertTrue(WritableDirectory::isUsable($dir));
+    }
+
+    private function tempPath(string $prefix): string
+    {
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-' . $prefix . '-' . uniqid('', true);
+        $this->pathsToRemove[] = $path;
+
+        return $path;
+    }
+}

--- a/tests/Unit/Framework/Cache/WritableDirectoryTest.php
+++ b/tests/Unit/Framework/Cache/WritableDirectoryTest.php
@@ -10,22 +10,14 @@ use GacelaTest\Fixtures\WarningCollectorTrait;
 use PHPUnit\Framework\TestCase;
 
 use function chmod;
-use function file_put_contents;
-use function is_dir;
-use function is_file;
 use function mkdir;
-use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
-use function unlink;
 
 final class WritableDirectoryTest extends TestCase
 {
     use ReadOnlyDirTrait;
     use WarningCollectorTrait;
-
-    /** @var list<string> */
-    private array $pathsToRemove = [];
 
     protected function setUp(): void
     {
@@ -36,16 +28,6 @@ final class WritableDirectoryTest extends TestCase
     {
         WritableDirectory::resetCache();
         $this->restoreReadOnlyDirs();
-
-        foreach ($this->pathsToRemove as $path) {
-            if (is_dir($path)) {
-                @rmdir($path);
-            } elseif (is_file($path)) {
-                @unlink($path);
-            }
-        }
-
-        $this->pathsToRemove = [];
     }
 
     public function test_creates_missing_directory_and_reports_usable(): void
@@ -66,11 +48,10 @@ final class WritableDirectoryTest extends TestCase
 
     public function test_uncreatable_directory_is_not_usable_and_emits_no_warning(): void
     {
-        $blocker = $this->tempPath('writable-dir-blocker');
-        file_put_contents($blocker, 'blocked');
+        $dir = $this->uncreatableDir();
 
         $warnings = $this->collectWarnings(
-            static fn (): bool => WritableDirectory::isUsable($blocker . '/subdir'),
+            static fn (): bool => WritableDirectory::isUsable($dir),
             $usable,
         );
 
@@ -101,7 +82,7 @@ final class WritableDirectoryTest extends TestCase
     private function tempPath(string $prefix): string
     {
         $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-' . $prefix . '-' . uniqid('', true);
-        $this->pathsToRemove[] = $path;
+        $this->readOnlyDirs[] = $path;
 
         return $path;
     }

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
@@ -4,20 +4,27 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\ClassResolver\Cache;
 
+use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use GacelaTest\Fixtures\ReadOnlyDirTrait;
+use GacelaTest\Fixtures\WarningCollectorTrait;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 use function file_put_contents;
 use function glob;
 use function is_dir;
+use function sprintf;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
+use function var_export;
 
 final class AbstractPhpFileCacheBatchTest extends TestCase
 {
+    use ReadOnlyDirTrait;
+    use WarningCollectorTrait;
+
     private string $cacheDir;
 
     /** @var list<string> */
@@ -26,14 +33,17 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir() . '/gacela-cache-batch-' . uniqid('', true);
+        WritableDirectory::resetCache();
         TestPhpFileCache::clearStaticCache();
         ClassNamePhpCache::clearStaticCache();
     }
 
     protected function tearDown(): void
     {
+        WritableDirectory::resetCache();
         TestPhpFileCache::clearStaticCache();
         ClassNamePhpCache::clearStaticCache();
+        $this->restoreReadOnlyDirs();
         $this->removeDir($this->cacheDir);
 
         foreach ($this->blockerFiles as $blocker) {
@@ -113,25 +123,43 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
         );
     }
 
-    public function test_constructor_throws_when_cache_directory_cannot_be_created(): void
+    public function test_uncreatable_cache_directory_degrades_to_memory_only(): void
     {
         $blocker = sys_get_temp_dir() . '/gacela-blocker-' . uniqid('', true);
         file_put_contents($blocker, 'blocked');
         $this->blockerFiles[] = $blocker;
+        $dir = $blocker . '/subdir';
 
-        // mkdir() emits an E_WARNING when the parent exists as a file; PHPUnit
-        // turns that into a test warning. Suppress it so only the thrown
-        // RuntimeException reaches the assertions.
-        set_error_handler(static fn (): bool => true, E_WARNING);
+        $warnings = $this->collectWarnings(static function () use ($dir): TestPhpFileCache {
+            $cache = new TestPhpFileCache($dir);
+            $cache->put('key', 'ClassA');
 
-        try {
-            $this->expectException(RuntimeException::class);
-            $this->expectExceptionMessage('was not created');
+            return $cache;
+        }, $cache);
 
-            new TestPhpFileCache($blocker . '/subdir');
-        } finally {
-            restore_error_handler();
-        }
+        self::assertSame([], $warnings);
+        self::assertSame('ClassA', $cache->get('key'));
+        self::assertDirectoryDoesNotExist($dir);
+    }
+
+    public function test_reads_pre_warmed_entries_from_read_only_directory(): void
+    {
+        $dir = $this->createReadOnlyDirOrSkip('phpfilecache-readonly', static function (string $dir): void {
+            file_put_contents(
+                $dir . '/' . TestPhpFileCache::FILENAME,
+                sprintf('<?php return %s;', var_export(['warm' => 'ClassW'], true)),
+            );
+        });
+
+        $cache = new TestPhpFileCache($dir);
+
+        self::assertSame(['warm' => 'ClassW'], $cache->getAll());
+
+        $warnings = $this->collectWarnings(static fn () => $cache->put('fresh', 'ClassF'));
+
+        self::assertSame([], $warnings);
+        self::assertSame('ClassF', $cache->get('fresh'));
+        self::assertSame(['warm' => 'ClassW'], require $dir . '/' . TestPhpFileCache::FILENAME);
     }
 
     public function test_put_outside_batch_writes_immediately(): void

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
@@ -27,9 +27,6 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
 
     private string $cacheDir;
 
-    /** @var list<string> */
-    private array $blockerFiles = [];
-
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir() . '/gacela-cache-batch-' . uniqid('', true);
@@ -45,14 +42,6 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
         ClassNamePhpCache::clearStaticCache();
         $this->restoreReadOnlyDirs();
         $this->removeDir($this->cacheDir);
-
-        foreach ($this->blockerFiles as $blocker) {
-            if (is_file($blocker)) {
-                unlink($blocker);
-            }
-        }
-
-        $this->blockerFiles = [];
     }
 
     public function test_is_batching_reflects_current_batch_state(): void
@@ -125,10 +114,7 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
 
     public function test_uncreatable_cache_directory_degrades_to_memory_only(): void
     {
-        $blocker = sys_get_temp_dir() . '/gacela-blocker-' . uniqid('', true);
-        file_put_contents($blocker, 'blocked');
-        $this->blockerFiles[] = $blocker;
-        $dir = $blocker . '/subdir';
+        $dir = $this->uncreatableDir();
 
         $warnings = $this->collectWarnings(static function () use ($dir): TestPhpFileCache {
             $cache = new TestPhpFileCache($dir);

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Config;
 
+use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\Config\MergedConfigCache;
+use GacelaTest\Fixtures\ReadOnlyDirTrait;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -16,6 +18,8 @@ use function unlink;
 
 final class MergedConfigCacheTest extends TestCase
 {
+    use ReadOnlyDirTrait;
+
     private string $cacheDir;
 
     /** @var list<string> */
@@ -24,10 +28,13 @@ final class MergedConfigCacheTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-merged-config-test-' . uniqid('', true);
+        WritableDirectory::resetCache();
     }
 
     protected function tearDown(): void
     {
+        WritableDirectory::resetCache();
+        $this->restoreReadOnlyDirs();
         $this->removeCacheDirIfExists();
 
         foreach ($this->blockerFiles as $blocker) {
@@ -47,16 +54,22 @@ final class MergedConfigCacheTest extends TestCase
 
         $cache = new MergedConfigCache($blocker . '/subdir');
 
-        set_error_handler(static fn (): bool => true, E_WARNING);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('was not created');
 
-        try {
-            $this->expectException(RuntimeException::class);
-            $this->expectExceptionMessage('was not created');
+        $cache->write(['key' => 'value']);
+    }
 
-            $cache->write(['key' => 'value']);
-        } finally {
-            restore_error_handler();
-        }
+    public function test_write_throws_when_the_cache_directory_is_read_only(): void
+    {
+        $readOnlyDir = $this->createReadOnlyDirOrSkip('merged-config-readonly');
+
+        $cache = new MergedConfigCache($readOnlyDir);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('was not written');
+
+        $cache->write(['key' => 'value']);
     }
 
     public function test_exists_is_false_when_file_not_written(): void

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -8,9 +8,7 @@ use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\Config\MergedConfigCache;
 use GacelaTest\Fixtures\ReadOnlyDirTrait;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
-use function file_put_contents;
 use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -21,9 +19,6 @@ final class MergedConfigCacheTest extends TestCase
     use ReadOnlyDirTrait;
 
     private string $cacheDir;
-
-    /** @var list<string> */
-    private array $blockerFiles = [];
 
     protected function setUp(): void
     {
@@ -36,40 +31,24 @@ final class MergedConfigCacheTest extends TestCase
         WritableDirectory::resetCache();
         $this->restoreReadOnlyDirs();
         $this->removeCacheDirIfExists();
-
-        foreach ($this->blockerFiles as $blocker) {
-            if (is_file($blocker)) {
-                unlink($blocker);
-            }
-        }
-
-        $this->blockerFiles = [];
     }
 
-    public function test_write_throws_when_the_cache_directory_cannot_be_created(): void
+    public function test_write_is_best_effort_when_the_cache_directory_cannot_be_created(): void
     {
-        $blocker = sys_get_temp_dir() . '/gacela-merged-blocker-' . uniqid('', true);
-        file_put_contents($blocker, 'blocked');
-        $this->blockerFiles[] = $blocker;
-
-        $cache = new MergedConfigCache($blocker . '/subdir');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('was not created');
+        $cache = new MergedConfigCache($this->uncreatableDir());
 
         $cache->write(['key' => 'value']);
+
+        self::assertFalse($cache->exists());
     }
 
-    public function test_write_throws_when_the_cache_directory_is_read_only(): void
+    public function test_write_is_best_effort_when_the_cache_directory_is_read_only(): void
     {
-        $readOnlyDir = $this->createReadOnlyDirOrSkip('merged-config-readonly');
-
-        $cache = new MergedConfigCache($readOnlyDir);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('was not written');
+        $cache = new MergedConfigCache($this->createReadOnlyDirOrSkip('merged-config-readonly'));
 
         $cache->write(['key' => 'value']);
+
+        self::assertFalse($cache->exists());
     }
 
     public function test_exists_is_false_when_file_not_written(): void


### PR DESCRIPTION
## 📚 Description

Downstream, Phel had to work around a Gacela behavior that fataled its CLI inside the NixOS build sandbox (phel-lang/phel-lang#2735): with the file cache enabled and a read-only project root, Gacela threw an uncaught `RuntimeException: Directory "..." was not created` **during bootstrap** — from the merged-config auto-warm, and from the class-resolver cache constructor.

A cache is an optimization, so an unusable cache directory must never fatal the application. This PR makes every framework cache degrade gracefully instead, while keeping explicitly requested persistence loud.

Design decisions:

- **Degradation happens at the write path, not at the `isEnabled()` gate.** Reads already degrade naturally (`is_file` → miss), so a pre-warmed cache inside a read-only directory stays fully readable: warm-at-build/run-read-only deployments keep their cache hits. Consumers no longer need their own writability gate (Phel's `WritableCacheDir`) around `enableFileCache()`.
- **Explicit stays loud.** A `GACELA_CACHE_DIR` env override is trusted as-is (a misconfigured override should not be silently ignored), and `MergedConfigCache::write()` keeps throwing for the explicit `cache:warm` command. Only the implicit bootstrap auto-warm gates on directory usability first — note this is probe-then-write, so it mitigates (not removes) failures from races like the disk filling up between probe and write.

Verified end-to-end with a standalone script bootstrapping from a `chmod 0555` root with `display_errors` on: before this change it dies with the `MergedConfigCache` exception; after it exits 0, resolves config + facades, creates no directories, and prints no warnings.

## 🔖 Changes

- New `WritableDirectory::isUsable()` utility: can this directory hold cache files (creating it when missing), memoized per directory; wired into `Gacela::resetCache()`
- `FileCache::writeAtomically()` returns `bool` and degrades on failure (unusable directory, failed stage or rename) instead of emitting raw PHP warnings; the shared write path now also creates the target directory
- `FileCache` constructor no longer throws on an uncreatable directory; new `FileCache::isPersistent()` reports memory-only mode; batch commits and TTL/`clear()` deletions are best-effort in read-only directories
- `AbstractPhpFileCache` (class-resolver caches) no longer throws in its constructor; writes skip silently, pre-warmed entries stay readable
- Merged-config auto-warm (`Config::loadMergedConfigValues()`) is skipped when the cache directory is unusable — except under an explicit `GACELA_CACHE_DIR`, which stays loud, as does `MergedConfigCache::write()` (now with a clear "was not written" error instead of raw warnings when the directory exists but is unwritable)
- Tests: `WritableDirectoryTest`, `FileCacheDegradationTest`, read-only-mode coverage in `AbstractPhpFileCacheBatchTest`/`MergedConfigCacheTest`, and `ReadOnlyAppRootTest` (integration: bootstrap + config + facade resolution from a `chmod 0555` app root, incl. pre-warmed read-only cache and the loud env-override case); shared `ReadOnlyDirTrait`/`WarningCollectorTrait` fixtures with chmod-probe skips for root/Windows
- CHANGELOG updated
