### PR TITLE
feat: expose FileCache::writeContentsAtomically for raw content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - `bin/gacela` now exits with status 1 on failure (missing `vendor/autoload.php` or an exception escaping the console runner) and writes the error to STDERR; both paths previously reported exit code 0
 - Resolving a deprecated `AbstractDependencyProvider` no longer fatals in projects without `symfony/deprecation-contracts`: the `trigger_deprecation()` call is now guarded, since that function is not part of Gacela's runtime dependencies
 
+### Added
+
+- `FileCache::writeContentsAtomically(string $file, string $content): bool` atomically writes pre-rendered file contents (compiled PHP source, reports, text artifacts) through the same writability short-circuit, stage-to-`.tmp` + `rename`, and false-on-failure guarantees as `writeAtomically()`, which is now a thin wrapper over it. Downstream caches that write raw content can reuse this primitive instead of duplicating the staging/rename logic
+
 ### Changed
 
 - `AbstractFactory::singleton()` and `CacheableTrait::cached()` are now generic (`@template T`): static analysis infers the creator/callback return type instead of `mixed`

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -224,11 +224,22 @@ final class FileCache
      */
     public static function writeAtomically(string $file, mixed $value): bool
     {
+        return self::writeContentsAtomically($file, sprintf('<?php return %s;', var_export($value, true)));
+    }
+
+    /**
+     * Atomically write pre-rendered file contents, staging to a sibling `.tmp`
+     * then renaming. Shares the writability short-circuit and false-on-failure
+     * guarantees of {@see writeAtomically}, without wrapping/serializing the
+     * payload, so callers can persist raw content (compiled PHP source, reports,
+     * text artifacts) through the same primitive.
+     */
+    public static function writeContentsAtomically(string $file, string $content): bool
+    {
         if (!WritableDirectory::isUsable(dirname($file))) {
             return false;
         }
 
-        $content = sprintf('<?php return %s;', var_export($value, true));
         $tmp = $file . '.' . bin2hex(random_bytes(4)) . '.tmp';
 
         if (@file_put_contents($tmp, $content, LOCK_EX) !== strlen($content)) {

--- a/tests/Unit/Framework/Cache/FileCacheDegradationTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheDegradationTest.php
@@ -10,6 +10,7 @@ use GacelaTest\Fixtures\ReadOnlyDirTrait;
 use GacelaTest\Fixtures\WarningCollectorTrait;
 use PHPUnit\Framework\TestCase;
 
+use function file_get_contents;
 use function file_put_contents;
 use function glob;
 use function sha1;
@@ -132,6 +133,27 @@ final class FileCacheDegradationTest extends TestCase
 
         self::assertTrue(FileCache::writeAtomically($file, ['k' => 'v']));
         self::assertSame(['k' => 'v'], require $file);
+    }
+
+    public function test_write_contents_atomically_returns_false_for_unusable_directory(): void
+    {
+        $dir = $this->uncreatableDir();
+
+        $warnings = $this->collectWarnings(
+            static fn (): bool => FileCache::writeContentsAtomically($dir . '/raw.php', 'content'),
+            $written,
+        );
+
+        self::assertSame([], $warnings);
+        self::assertFalse($written);
+    }
+
+    public function test_write_contents_atomically_returns_true_on_success(): void
+    {
+        $file = $this->writableDir() . '/raw.php';
+
+        self::assertTrue(FileCache::writeContentsAtomically($file, 'raw content'));
+        self::assertSame('raw content', file_get_contents($file));
     }
 
     private function writableDir(): string

--- a/tests/Unit/Framework/Cache/FileCacheTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheTest.php
@@ -13,6 +13,7 @@ use ReflectionClass;
 use ReflectionMethod;
 
 use function count;
+use function file_get_contents;
 use function filesize;
 use function glob;
 use function sys_get_temp_dir;
@@ -395,6 +396,24 @@ final class FileCacheTest extends TestCase
 
         self::assertFileExists($path);
         self::assertSame(['a' => 1, 'b' => [2, 3]], require $path);
+    }
+
+    public function test_write_contents_atomically_writes_raw_content_verbatim(): void
+    {
+        $path = $this->cacheDir . '/report.txt';
+        $content = "<?php\n// compiled\nnamespace Acme;\n";
+
+        self::assertTrue(FileCache::writeContentsAtomically($path, $content));
+        self::assertFileExists($path);
+        self::assertSame($content, file_get_contents($path));
+    }
+
+    public function test_write_contents_atomically_leaves_no_tmp_files_behind(): void
+    {
+        FileCache::writeContentsAtomically($this->cacheDir . '/raw.php', 'hello');
+
+        $leftovers = glob($this->cacheDir . '/*.tmp') ?: [];
+        self::assertCount(0, $leftovers);
     }
 
     private function invokeNormalize(string $dir): string


### PR DESCRIPTION
## 📚 Description

Exposes a raw-content sibling to `FileCache::writeAtomically()` so consumers can atomically persist pre-rendered file content (compiled PHP source, HTML reports, text artifacts) without re-implementing Gacela's staging + rename + writability + `@`-suppression logic.

`writeAtomically($file, $value)` is now a thin wrapper that serializes via `var_export` and delegates to the new method, keeping a single implementation of the atomic-write primitive.

Closes #400

## 🔖 Changes

- Add `FileCache::writeContentsAtomically(string $file, string $content): bool` — same `WritableDirectory::isUsable()` short-circuit, stage-to-`.tmp` + atomic `rename`, and `false`-on-failure guarantees, minus the serialization step
- Refactor `writeAtomically()` into a thin wrapper over `writeContentsAtomically()`
- Add unit tests for verbatim raw-content writes, no leftover `.tmp` files, unusable-directory degradation, and the success path
- Document the addition under `## Unreleased` in `CHANGELOG.md`
