### PR TITLE
fix(console): cache:clear removes the custom-services cache file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `cache:clear` now also removes the custom-services cache file (`gacela-custom-services.php`); previously only `gacela-class-names.php` and the merged-config cache were cleared, so stale custom-service resolutions survived an explicit clear even though the command's help promised it clears the custom services cache. The "no cache files found" guard and the per-file size report now cover both cache files
 - `cache:clear` command is now registered in the console application; it was shipped in 1.13.0 but never wired into the command list, so `bin/gacela cache:clear` was unavailable
 - `cache:warm` attribute pre-warming now works: it called the non-existent `DocBlockResolver::fromClassName()`, so the resulting `Error` was silently swallowed and the attribute cache was never warmed; the named constructor now exists
 - `cache:warm` no longer hides errors: a module-discovery failure now prints a warning instead of silently warming zero modules, and a PHP `Error` during attribute pre-warming is reported per class instead of being swallowed

--- a/src/Console/Application/CacheWarm/CacheManager.php
+++ b/src/Console/Application/CacheWarm/CacheManager.php
@@ -5,25 +5,35 @@ declare(strict_types=1);
 namespace Gacela\Console\Application\CacheWarm;
 
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Config\Config;
 
+use function array_filter;
+use function array_map;
+use function array_values;
 use function file_exists;
+use function filesize;
 
 final class CacheManager
 {
+    private const CACHE_FILENAMES = [
+        ClassNamePhpCache::FILENAME,
+        CustomServicesPhpCache::FILENAME,
+    ];
+
     public function clearCache(): void
     {
-        $cacheFile = $this->getCacheFilePath();
-
-        if (file_exists($cacheFile)) {
+        foreach ($this->existingCacheFiles() as $cacheFile) {
             unlink($cacheFile);
         }
     }
 
+    /**
+     * Absolute path of the primary warm cache (the class-resolution cache written by cache:warm).
+     */
     public function getCacheFilePath(): string
     {
-        $cacheDir = Config::getInstance()->getCacheDir();
-        return $cacheDir . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
+        return $this->cacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
     }
 
     public function cacheFileExists(): bool
@@ -45,5 +55,50 @@ final class CacheManager
     public function getFormattedCacheFileSize(): string
     {
         return BytesFormatter::format($this->getCacheFileSize());
+    }
+
+    /**
+     * Every managed cache file that currently exists, mapped to its human-readable size.
+     * Captured before clearCache() removes them so callers can report what was cleared.
+     *
+     * @return array<string, string>
+     */
+    public function getExistingCacheFilesWithSize(): array
+    {
+        $result = [];
+        foreach ($this->existingCacheFiles() as $cacheFile) {
+            $result[$cacheFile] = BytesFormatter::format((int) filesize($cacheFile));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function existingCacheFiles(): array
+    {
+        return array_values(array_filter(
+            $this->allCacheFilePaths(),
+            static fn (string $cacheFile): bool => file_exists($cacheFile),
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allCacheFilePaths(): array
+    {
+        $cacheDir = $this->cacheDir();
+
+        return array_map(
+            static fn (string $filename): string => $cacheDir . DIRECTORY_SEPARATOR . $filename,
+            self::CACHE_FILENAMES,
+        );
+    }
+
+    private function cacheDir(): string
+    {
+        return Config::getInstance()->getCacheDir();
     }
 }

--- a/src/Console/Infrastructure/Command/CacheClearCommand.php
+++ b/src/Console/Infrastructure/Command/CacheClearCommand.php
@@ -39,17 +39,16 @@ final class CacheClearCommand extends Command
         $output->writeln('<info>Clearing Gacela cache...</info>');
         $output->writeln('');
 
-        if (!$cacheManager->cacheFileExists() && !$mergedConfigCacheExists) {
+        $clearedFiles = $cacheManager->getExistingCacheFilesWithSize();
+
+        if ($clearedFiles === [] && !$mergedConfigCacheExists) {
             $output->writeln('<comment>No cache files found.</comment>');
             return Command::SUCCESS;
         }
 
-        if ($cacheManager->cacheFileExists()) {
-            $cacheFile = $cacheManager->getCacheFilePath();
-            $cacheSize = $cacheManager->getFormattedCacheFileSize();
+        $cacheManager->clearCache();
 
-            $cacheManager->clearCache();
-
+        foreach ($clearedFiles as $cacheFile => $cacheSize) {
             $output->writeln(sprintf(
                 '<info>✓</info> Cleared cache file: <comment>%s</comment> (<comment>%s</comment>)',
                 $cacheFile,

--- a/tests/Feature/Console/CacheClear/CacheClearCommandTest.php
+++ b/tests/Feature/Console/CacheClear/CacheClearCommandTest.php
@@ -8,6 +8,7 @@ use Gacela\Console\Infrastructure\Command\CacheClearCommand;
 use Gacela\Console\Infrastructure\ConsoleBootstrap;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
@@ -25,6 +26,8 @@ final class CacheClearCommandTest extends TestCase
 {
     private string $cacheFile;
 
+    private string $customServicesCacheFile;
+
     private string $mergedConfigCacheFile;
 
     protected function setUp(): void
@@ -34,7 +37,9 @@ final class CacheClearCommandTest extends TestCase
             $config->enableFileCache(__DIR__ . '/cache');
         });
 
-        $this->cacheFile = Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
+        $cacheDir = Config::getInstance()->getCacheDir();
+        $this->cacheFile = $cacheDir . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
+        $this->customServicesCacheFile = $cacheDir . DIRECTORY_SEPARATOR . CustomServicesPhpCache::FILENAME;
         $this->mergedConfigCacheFile = Config::getInstance()->mergedConfigCacheFilename();
 
         $this->removeGeneratedCaches();
@@ -70,6 +75,23 @@ final class CacheClearCommandTest extends TestCase
         self::assertFileDoesNotExist($this->cacheFile);
     }
 
+    public function test_cache_clear_removes_the_custom_services_cache_file(): void
+    {
+        $cacheDir = dirname($this->customServicesCacheFile);
+        if (!is_dir($cacheDir)) {
+            mkdir($cacheDir, 0777, true);
+        }
+        file_put_contents($this->customServicesCacheFile, '<?php return [];');
+
+        $command = new CommandTester(new CacheClearCommand());
+        $exitCode = $command->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Cleared cache file', $command->getDisplay());
+        self::assertStringContainsString('Cache cleared successfully!', $command->getDisplay());
+        self::assertFileDoesNotExist($this->customServicesCacheFile);
+    }
+
     public function test_cache_clear_reports_when_no_cache_is_present(): void
     {
         $command = new CommandTester(new CacheClearCommand());
@@ -83,6 +105,10 @@ final class CacheClearCommandTest extends TestCase
     {
         if (file_exists($this->cacheFile)) {
             unlink($this->cacheFile);
+        }
+
+        if (file_exists($this->customServicesCacheFile)) {
+            unlink($this->customServicesCacheFile);
         }
 
         if (file_exists($this->mergedConfigCacheFile)) {


### PR DESCRIPTION
## 📚 Description

`cache:clear` promised (in its help text) to clear the custom services cache, but only ever removed `gacela-class-names.php` and the merged-config cache. The custom-services cache file (`gacela-custom-services.php`) was left on disk, so stale custom-service resolutions survived an explicit clear — the exact scenario the command exists to fix.

## 🔖 Changes

- `CacheManager::clearCache()` now removes every managed cache file (`gacela-class-names.php` + `gacela-custom-services.php`)
- `cache:clear`'s "no cache files found" guard and per-file size report now cover both files (previously the guard checked only the class-names file, so a lone custom-services file was reported as "nothing to clear")
- `cache:warm` reporting is unchanged: it still reports the primary class-resolution cache it writes; `--clear` now clears both files for a true fresh start
- Feature test covering removal of the custom-services cache file
- Refactor pass: no extra changes needed — diff introduces no duplication or dead code

Closes #403