### PR TITLE
fix(console): bin/gacela honors its exit-1/STDERR failure contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `cache:clear` command is now registered in the console application; it was shipped in 1.13.0 but never wired into the command list, so `bin/gacela cache:clear` was unavailable
 - `cache:warm` attribute pre-warming now works: it called the non-existent `DocBlockResolver::fromClassName()`, so the resulting `Error` was silently swallowed and the attribute cache was never warmed; the named constructor now exists
 - `cache:warm` no longer hides errors: a module-discovery failure now prints a warning instead of silently warming zero modules, and a PHP `Error` during attribute pre-warming is reported per class instead of being swallowed
+- `bin/gacela` now honors its exit-1/STDERR failure contract for every failure path: a missing `symfony/console`, a failure inside `Gacela::bootstrap()`, and a PHP `Error`/`TypeError` (not only `Exception`) escaping the console runner previously escaped the handler and exited 255 with a raw stack trace. The guarded block now wraps the class check, bootstrap, and run, and catches `Throwable`
 - `bin/gacela` now exits with status 1 on failure (missing `vendor/autoload.php` or an exception escaping the console runner) and writes the error to STDERR; both paths previously reported exit code 0
 - Resolving a deprecated `AbstractDependencyProvider` no longer fatals in projects without `symfony/deprecation-contracts`: the `trigger_deprecation()` call is now guarded, since that function is not part of Gacela's runtime dependencies
 

--- a/bin/gacela
+++ b/bin/gacela
@@ -17,17 +17,17 @@ use Symfony\Component\Console\Application;
 
     require $autoloadPath;
 
-    if (!class_exists(Application::class)) {
-        $error = 'Cannot find class: %s. Did you forgot to require `%s` in your composer?';
-        throw new RuntimeException(sprintf($error, Application::class, 'symfony/console'));
-    }
-
-    Gacela::bootstrap($cwd);
-
-    $bootstrap = new ConsoleBootstrap(name: 'Gacela', version: '1.16.0');
     try {
+        if (!class_exists(Application::class)) {
+            $error = 'Cannot find class: %s. Did you forgot to require `%s` in your composer?';
+            throw new RuntimeException(sprintf($error, Application::class, 'symfony/console'));
+        }
+
+        Gacela::bootstrap($cwd);
+
+        $bootstrap = new ConsoleBootstrap(name: 'Gacela', version: '1.16.0');
         $bootstrap->run();
-    } catch (Exception $e) {
+    } catch (Throwable $e) {
         fwrite(STDERR, 'gacela script failed. Error: ' . $e->getMessage() . PHP_EOL);
         exit(1);
     }

--- a/tests/Feature/Console/BinGacela/BinGacelaTest.php
+++ b/tests/Feature/Console/BinGacela/BinGacelaTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 use function dirname;
 use function fclose;
+use function file_put_contents;
 use function mkdir;
 use function proc_close;
 use function proc_open;
@@ -15,6 +16,7 @@ use function rmdir;
 use function stream_get_contents;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unlink;
 
 use const PHP_BINARY;
 
@@ -22,9 +24,56 @@ final class BinGacelaTest extends TestCase
 {
     public function test_it_exits_non_zero_and_writes_to_stderr_when_autoload_is_missing(): void
     {
+        [$exitCode, $stdout, $stderr] = $this->runBinGacela(autoloadStub: null);
+
+        self::assertSame(1, $exitCode, 'bin/gacela must exit 1 when it cannot load the autoloader');
+        self::assertStringContainsString("Cannot load composer's autoload file", $stderr);
+        self::assertStringNotContainsString(
+            "Cannot load composer's autoload file",
+            $stdout,
+            'the error must be written to STDERR, not STDOUT',
+        );
+    }
+
+    public function test_it_exits_1_and_writes_to_stderr_when_symfony_console_is_missing(): void
+    {
+        // Autoloader that resolves nothing, so Symfony's Application class is absent.
+        [$exitCode, $stdout, $stderr] = $this->runBinGacela(autoloadStub: '<?php');
+
+        self::assertSame(1, $exitCode, 'bin/gacela must exit 1 when symfony/console is not installed');
+        self::assertStringContainsString('gacela script failed', $stderr);
+        self::assertStringNotContainsString('gacela script failed', $stdout);
+    }
+
+    public function test_it_exits_1_when_a_php_error_escapes_bootstrap(): void
+    {
+        // Symfony's Application exists (passes the class check) but Gacela's classes do not,
+        // so Gacela::bootstrap() raises a PHP Error (not an Exception) that must still be caught.
+        $stub = '<?php namespace Symfony\Component\Console; class Application {}';
+
+        [$exitCode, $stdout, $stderr] = $this->runBinGacela(autoloadStub: $stub);
+
+        self::assertSame(1, $exitCode, 'a PHP Error escaping bootstrap must still exit 1');
+        self::assertStringContainsString('gacela script failed', $stderr);
+        self::assertStringNotContainsString('gacela script failed', $stdout);
+    }
+
+    /**
+     * Runs bin/gacela in a throwaway working directory. When $autoloadStub is null the directory
+     * has no vendor/autoload.php; otherwise the stub is written there as the autoloader.
+     *
+     * @return array{int, string, string} exit code, stdout, stderr
+     */
+    private function runBinGacela(?string $autoloadStub): array
+    {
         $binGacela = dirname(__DIR__, 4) . '/bin/gacela';
-        $cwdWithoutVendor = sys_get_temp_dir() . '/gacela-bin-' . uniqid('', true);
-        mkdir($cwdWithoutVendor);
+        $cwd = sys_get_temp_dir() . '/gacela-bin-' . uniqid('', true);
+        mkdir($cwd);
+
+        if ($autoloadStub !== null) {
+            mkdir($cwd . '/vendor');
+            file_put_contents($cwd . '/vendor/autoload.php', $autoloadStub);
+        }
 
         try {
             $descriptors = [
@@ -33,7 +82,7 @@ final class BinGacelaTest extends TestCase
                 2 => ['pipe', 'w'],
             ];
 
-            $process = proc_open([PHP_BINARY, $binGacela], $descriptors, $pipes, $cwdWithoutVendor);
+            $process = proc_open([PHP_BINARY, $binGacela], $descriptors, $pipes, $cwd);
             self::assertIsResource($process);
 
             fclose($pipes[0]);
@@ -43,15 +92,13 @@ final class BinGacelaTest extends TestCase
             fclose($pipes[2]);
             $exitCode = proc_close($process);
 
-            self::assertSame(1, $exitCode, 'bin/gacela must exit 1 when it cannot load the autoloader');
-            self::assertStringContainsString("Cannot load composer's autoload file", $stderr);
-            self::assertStringNotContainsString(
-                "Cannot load composer's autoload file",
-                $stdout,
-                'the error must be written to STDERR, not STDOUT',
-            );
+            return [$exitCode, $stdout, $stderr];
         } finally {
-            rmdir($cwdWithoutVendor);
+            if ($autoloadStub !== null) {
+                unlink($cwd . '/vendor/autoload.php');
+                rmdir($cwd . '/vendor');
+            }
+            rmdir($cwd);
         }
     }
 }


### PR DESCRIPTION
## 📚 Description

`bin/gacela` advertises "exit 1 + message on STDERR" on failure, but three paths bypassed it and exited 255 with a raw stack trace: a missing `symfony/console`, a failure inside `Gacela::bootstrap()`, and a PHP `Error`/`TypeError` (which is not an `Exception`) escaping the console runner. The class check, bootstrap, and construction all sat outside the `try`, and the `catch` only matched `Exception`.

## 🔖 Changes

- Wrap the `symfony/console` class check, `Gacela::bootstrap()`, and the console run in a single `try`
- Catch `Throwable` (not just `Exception`) so PHP `Error`/`TypeError` are reported to STDERR with exit code 1
- Feature tests (via a shared `runBinGacela()` helper) covering the missing-`symfony/console` path and a PHP `Error` escaping bootstrap
- Refactor pass: no extra changes needed

Closes #404