### PR TITLE
fix(console): cache:warm skips an unwarmable module instead of aborting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `cache:warm` no longer aborts the whole run when one module's facade resolution raises a PHP `Error`/`TypeError` (e.g. a Factory/Config/Provider that is not constructible during warm). The per-module facade-resolution step is now guarded like the per-class loop — the failing module is reported and skipped and warming continues for the rest — on both the sequential and parallel (Fiber) paths, since both go through `ModuleWarmer::warmModule`
 - `cache:clear` now also removes the custom-services cache file (`gacela-custom-services.php`); previously only `gacela-class-names.php` and the merged-config cache were cleared, so stale custom-service resolutions survived an explicit clear even though the command's help promised it clears the custom services cache. The "no cache files found" guard and the per-file size report now cover both cache files
 - `cache:clear` command is now registered in the console application; it was shipped in 1.13.0 but never wired into the command list, so `bin/gacela cache:clear` was unavailable
 - `cache:warm` attribute pre-warming now works: it called the non-existent `DocBlockResolver::fromClassName()`, so the resulting `Error` was silently swallowed and the attribute cache was never warmed; the named constructor now exists

--- a/src/Console/Application/CacheWarm/ModuleWarmer.php
+++ b/src/Console/Application/CacheWarm/ModuleWarmer.php
@@ -76,7 +76,14 @@ final class ModuleWarmer
             }
         }
 
-        $this->cacheWarmService->warmClassResolution($module->facadeClass());
+        try {
+            $this->cacheWarmService->warmClassResolution($module->facadeClass());
+        } catch (Throwable $e) {
+            // A module that cannot be resolved during warm (even via a PHP Error) must be
+            // reported and skipped, not abort warming for every remaining module.
+            $this->formatter->writeClassFailed('Facade', $module->facadeClass(), $e->getMessage());
+            ++$skippedCount;
+        }
 
         $this->formatter->writeEmptyLine();
 

--- a/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Broken/BrokenFacade.php
+++ b/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Broken/BrokenFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Broken;
+
+use Gacela\Framework\AbstractFacade;
+
+final class BrokenFacade extends AbstractFacade
+{
+}

--- a/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Broken/BrokenProvider.php
+++ b/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Broken/BrokenProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Broken;
+
+use Error;
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class BrokenProvider extends AbstractProvider
+{
+    public function __construct()
+    {
+        // Stands in for a module whose provider is not constructible during warm
+        // (e.g. a TypeError from a real constructor): a PHP Error, not an Exception.
+        throw new Error('cannot construct BrokenProvider during warm');
+    }
+
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Healthy/HealthyFacade.php
+++ b/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Healthy/HealthyFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Healthy;
+
+use Gacela\Framework\AbstractFacade;
+
+final class HealthyFacade extends AbstractFacade
+{
+}

--- a/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Healthy/HealthyFactory.php
+++ b/tests/Integration/Console/CacheWarm/FacadeWarm/Domain/Healthy/HealthyFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Healthy;
+
+use Gacela\Framework\AbstractFactory;
+
+final class HealthyFactory extends AbstractFactory
+{
+}

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm;
+
+use Gacela\Console\Application\CacheWarm\CacheWarmOutputFormatter;
+use Gacela\Console\Application\CacheWarm\CacheWarmService;
+use Gacela\Console\Application\CacheWarm\ModuleWarmer;
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Broken\BrokenFacade;
+use GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Healthy\HealthyFacade;
+use GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Healthy\HealthyFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function array_values;
+use function implode;
+use function is_dir;
+use function rmdir;
+use function uniqid;
+use function unlink;
+
+final class ModuleWarmerFacadeWarmTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = __DIR__ . DIRECTORY_SEPARATOR . '.gacela-cache-' . uniqid('', true);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(true, $cacheDir);
+            $config->setProjectNamespaces(['GacelaTest\\Integration\\Console\\CacheWarm\\FacadeWarm\\Domain']);
+        });
+
+        ClassNamePhpCache::clearStaticCache();
+    }
+
+    protected function tearDown(): void
+    {
+        ClassNamePhpCache::clearStaticCache();
+        $this->removeCacheDir();
+    }
+
+    public function test_a_php_error_warming_one_module_facade_does_not_abort_the_remaining_modules(): void
+    {
+        $warmer = new ModuleWarmer(
+            new CacheWarmService(new ConsoleFacade()),
+            new CacheWarmOutputFormatter($output = new BufferedOutput()),
+        );
+
+        // Broken first: before the fix its Error aborts the loop and Healthy is never warmed.
+        $broken = new AppModule('Broken', 'Broken', BrokenFacade::class);
+        $healthy = new AppModule('Healthy', 'Healthy', HealthyFacade::class, HealthyFactory::class);
+
+        [, $skippedCount] = $warmer->warmModules([$broken, $healthy], warmAttributes: false);
+
+        $resolved = implode('|', array_values(ClassNamePhpCache::all()));
+
+        self::assertStringContainsString('HealthyFactory', $resolved, 'warming must continue past the broken module');
+        self::assertGreaterThanOrEqual(1, $skippedCount, 'the broken module must be counted as skipped');
+        self::assertStringContainsString('Broken', $output->fetch(), 'the failed module must be reported');
+    }
+
+    private function removeCacheDir(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            return;
+        }
+
+        foreach (glob($this->cacheDir . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->cacheDir);
+    }
+}


### PR DESCRIPTION
## 📚 Description

During `cache:warm`, one module's facade-resolution step (`ModuleWarmer::warmModule` line 79) sat outside the resilient per-class `try/catch`, and `CacheWarmService::warmClassResolution` catches only `Exception`. A PHP `Error`/`TypeError` raised while resolving one module (e.g. a Factory/Config/Provider that is not constructible during warm) therefore propagated out and aborted warming for **every remaining module** — on both the sequential and the parallel (Fiber) paths.

## 🔖 Changes

- Wrap the facade-resolution call in `ModuleWarmer::warmModule` in a `try/catch (Throwable)`, mirroring the per-class loop: the failing module is reported via the output formatter and counted as skipped, and warming continues
- Both sequential and parallel warmers go through `warmModule`, so both are fixed by the one change
- `CacheWarmService::warmClassResolution` keeps its intentional `Exception`-only catch (legitimate "module lacks a pillar" skips); real `Error`s are now handled one level up, per module
- Integration test with a healthy + a broken fixture module proving warming continues past the failing one
- Refactor pass: no extra changes needed

Closes #405