### PR TITLE
fix(config): track initialization with a flag instead of empty-config sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `Config::get()` and `Config::getAllValues()` no longer re-run the full `init()` (re-globbing and re-parsing every config source) on every access when the merged configuration is legitimately empty; initialization is now tracked with a dedicated flag instead of treating an empty config array as "not initialized"
 - `cache:warm` no longer aborts the whole run when one module's facade resolution raises a PHP `Error`/`TypeError` (e.g. a Factory/Config/Provider that is not constructible during warm). The per-module facade-resolution step is now guarded like the per-class loop — the failing module is reported and skipped and warming continues for the rest — on both the sequential and parallel (Fiber) paths, since both go through `ModuleWarmer::warmModule`
 - `cache:clear` now also removes the custom-services cache file (`gacela-custom-services.php`); previously only `gacela-class-names.php` and the merged-config cache were cleared, so stale custom-service resolutions survived an explicit clear even though the command's help promised it clears the custom services cache. The "no cache files found" guard and the per-file size report now cover both cache files
 - `cache:clear` command is now registered in the console application; it was shipped in 1.13.0 but never wired into the command list, so `bin/gacela cache:clear` was unavailable

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -25,6 +25,10 @@ final class Config implements ConfigInterface
     /** @var array<string,mixed> */
     private array $config = [];
 
+    // A separate flag, because a legitimately empty merged config is still "initialized";
+    // keying off $config === [] re-ran the full init() on every access in that case.
+    private bool $initialized = false;
+
     private ?string $cacheDir = null;
 
     private function __construct(
@@ -73,7 +77,7 @@ final class Config implements ConfigInterface
      */
     public function get(string $key, mixed $default = self::DEFAULT_CONFIG_VALUE): mixed
     {
-        if ($this->config === []) {
+        if (!$this->initialized) {
             $this->init();
         }
 
@@ -97,7 +101,7 @@ final class Config implements ConfigInterface
      */
     public function getAllValues(): array
     {
-        if ($this->config === []) {
+        if (!$this->initialized) {
             $this->init();
         }
 
@@ -118,6 +122,8 @@ final class Config implements ConfigInterface
             ...$this->loadMergedConfigValues(),
             ...$this->setup->getConfigKeyValues(),
         ];
+
+        $this->initialized = true;
     }
 
     /**

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -211,4 +211,19 @@ final class ConfigTest extends TestCase
 
         self::assertSame('lazy_value', $config->get('lazy_key'));
     }
+
+    public function test_does_not_reinitialize_on_every_access_when_merged_config_is_empty(): void
+    {
+        $config = Config::getInstance();
+
+        // First access initialises and builds the internal ConfigFactory.
+        $config->getAllValues();
+        $firstFactory = $config->getFactory();
+
+        // A second access on an empty merged config must not re-run init(),
+        // which nulls and rebuilds the ConfigFactory on every call.
+        $config->getAllValues();
+
+        self::assertSame($firstFactory, $config->getFactory());
+    }
 }


### PR DESCRIPTION
## 📚 Description

`Config::get()` and `Config::getAllValues()` guarded initialization with `if ($this->config === [])`. When the merged configuration is legitimately empty (no config files and no bootstrap key-values), that condition stays true forever, so **every** access re-ran the full `init()` — re-globbing config paths, rebuilding the `ConfigFactory` and `ConfigLoader`, and re-`include`-ing files — on each call.

## 🔖 Changes

- Add a dedicated `bool $initialized` flag, set at the end of `init()`
- Guard `get()` / `getAllValues()` on `!$this->initialized` instead of `$this->config === []`
- Integration test proving a second access on an empty merged config does not re-run `init()` (the memoized `ConfigFactory` instance is preserved)
- Refactor pass: no extra changes needed

Closes #407