### PR TITLE
fix: derive bin/gacela version from Composer metadata instead of hardcoding

### DIFF
--- a/bin/gacela
+++ b/bin/gacela
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Application;
 
         Gacela::bootstrap($cwd);
 
-        $bootstrap = new ConsoleBootstrap(name: 'Gacela', version: '1.16.0');
+        $bootstrap = new ConsoleBootstrap(name: 'Gacela', version: Gacela::version());
         $bootstrap->run();
     } catch (Throwable $e) {
         fwrite(STDERR, 'gacela script failed. Error: ' . $e->getMessage() . PHP_EOL);

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework;
 
 use Closure;
+use Composer\InstalledVersions;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
@@ -29,9 +30,24 @@ final class Gacela
 {
     private const GACELA_PHP_FILENAME = 'gacela.php';
 
+    private const PACKAGE_NAME = 'gacela-project/gacela';
+
     private static ?Container $mainContainer = null;
 
     private static ?string $appRootDir = null;
+
+    /**
+     * The installed version of gacela, derived at runtime from Composer's
+     * metadata so it never drifts from the actual release being shipped.
+     */
+    public static function version(): string
+    {
+        if (!InstalledVersions::isInstalled(self::PACKAGE_NAME)) {
+            return 'unknown';
+        }
+
+        return InstalledVersions::getPrettyVersion(self::PACKAGE_NAME) ?? 'unknown';
+    }
 
     /**
      * Define the entry point of Gacela.

--- a/tests/Unit/Framework/Gacela/VersionTest.php
+++ b/tests/Unit/Framework/Gacela/VersionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Gacela;
+
+use Composer\InstalledVersions;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class VersionTest extends TestCase
+{
+    public function test_version_is_derived_from_the_installed_package(): void
+    {
+        self::assertSame(
+            InstalledVersions::getPrettyVersion('gacela-project/gacela'),
+            Gacela::version(),
+        );
+    }
+
+    public function test_version_is_not_a_hardcoded_empty_or_stale_literal(): void
+    {
+        $version = Gacela::version();
+
+        self::assertNotSame('', $version);
+        self::assertNotSame('1.16.0', $version);
+    }
+}


### PR DESCRIPTION
Closes #418

## 📚 Description

`bin/gacela` hardcoded the CLI version string (`'1.16.0'`), so `bin/gacela --version` (and the Symfony console header) reported a stale version after every release bump — the same class of drift that produced the 1.14.1 fix. There was no single source of truth to derive from.

The version is now derived at runtime from Composer's installed-package metadata, so it always matches the release actually being shipped and never needs a manual edit.

## 🔖 Changes

- Add `Gacela::version()` which returns the installed `gacela-project/gacela` version via `Composer\InstalledVersions` (falls back to `'unknown'` when the package metadata is unavailable)
- `bin/gacela` now passes `Gacela::version()` to `ConsoleBootstrap` instead of the hardcoded `'1.16.0'`
- Add `VersionTest` asserting the version is derived from Composer metadata and is neither empty nor the stale literal

## Test plan

- `composer quality` (cs-fixer, psalm, phpstan) — green
- `composer phpunit` (unit, integration, feature) — 770 passing
- `php bin/gacela --version` now prints the derived version (`Gacela dev-main` in-repo; the real tag when installed as a dependency)