### PR TITLE
fix: resolve undocumented methods to nothing instead of the first use import

### DIFF
--- a/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
+++ b/src/Framework/ClassResolver/DocBlockService/UseBlockParser.php
@@ -10,7 +10,7 @@ final class UseBlockParser
 {
     public function getUseStatement(string $className, string $phpCode): string
     {
-        if ($phpCode === '') {
+        if ($className === '' || $phpCode === '') {
             return '';
         }
 

--- a/tests/Integration/Framework/ServiceResolver/DocBlockResolverTest.php
+++ b/tests/Integration/Framework/ServiceResolver/DocBlockResolverTest.php
@@ -12,6 +12,7 @@ use Gacela\Framework\Gacela;
 use Gacela\Framework\ServiceResolver\DocBlockResolvable;
 use Gacela\Framework\ServiceResolver\DocBlockResolver;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeCommand;
+use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeCommandWithUnrelatedImport;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeConfig;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeFacade;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeFactory;
@@ -38,6 +39,18 @@ final class DocBlockResolverTest extends TestCase
         $this->expectException(MissingClassDefinitionException::class);
 
         (new FakeCommand())->getUnknown();
+    }
+
+    /**
+     * An undocumented method on a class that has a docblock for a different
+     * method plus unrelated `use` imports must throw, not silently resolve to
+     * the first imported class.
+     */
+    public function test_throws_exception_for_undocumented_method_with_unrelated_import(): void
+    {
+        $this->expectException(MissingClassDefinitionException::class);
+
+        (new FakeCommandWithUnrelatedImport())->getSomethingUndocumented();
     }
 
     /**

--- a/tests/Integration/Framework/ServiceResolver/Module/FakeCommandWithUnrelatedImport.php
+++ b/tests/Integration/Framework/ServiceResolver/Module/FakeCommandWithUnrelatedImport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ServiceResolver\Module;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Documents one method and imports an unrelated real class (`AbstractFacade`,
+ * which sorts first among the imports). Used to prove that calling an
+ * undocumented method throws instead of silently resolving to the first
+ * `use` import.
+ *
+ * @method FakeFacade getFacade()
+ */
+final class FakeCommandWithUnrelatedImport
+{
+    use ServiceResolverAwareTrait;
+
+    public function unrelated(): ?AbstractFacade
+    {
+        return null;
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/UseBlockParserTest.php
@@ -23,6 +23,16 @@ final class UseBlockParserTest extends TestCase
         self::assertSame('', $actual);
     }
 
+    public function test_empty_class_name_does_not_match_the_first_use_statement(): void
+    {
+        // With an empty class name the needle would degrade to ';', which every
+        // `use ...;` line contains, so the parser would wrongly resolve to the
+        // first import. An empty class name must resolve to nothing instead.
+        $actual = $this->parser->getUseStatement('', $this->phpCode());
+
+        self::assertSame('', $actual);
+    }
+
     public function test_get_class_from_use(): void
     {
         $actual = $this->parser->getUseStatement('ExistingClassInOtherNs', $this->phpCode());


### PR DESCRIPTION
Closes #420

## 📚 Description

When a method resolved through `ServiceResolverAwareTrait` / `DocBlockResolverAwareTrait` had no matching `@method` / `@property` / `#[ServiceMap]` declaration, `DocBlockResolver` silently resolved it to the **first `use ...;` import** in the caller's file instead of throwing `MissingClassDefinitionException`.

The cause is in `UseBlockParser`: when the class name is empty (which is exactly what `DocBlockResolver` passes once the doc/attribute lookups fail), the search needle degrades to `';'`, and every `use ...;` line contains a semicolon — so the first import matches unconditionally. Any typo'd, undocumented, or forgotten-`@method` accessor therefore received an unrelated imported class, producing confusing downstream `TypeError`s instead of the clear diagnostic the path is designed to give.

## 🔖 Changes

- `UseBlockParser::getUseStatement()` now short-circuits to `''` when the class name is empty, so the universal `';'` match can no longer occur; the caller then falls through to the `getFactory` default or throws `MissingClassDefinitionException` as intended
- Unit test: `getUseStatement('', <code with use statements>)` returns `''`, not the first import
- Integration test + fixture: calling an undocumented method on a class that documents a different method and imports an unrelated real class now throws `MissingClassDefinitionException`

## Test plan

- `composer quality` (cs-fixer, psalm, phpstan) — green
- `composer phpunit` (unit, integration, feature) — 772 passing
- `getFactory` / `getConfig` and all existing documented-method resolution still pass