### PR TITLE
docs: describe profile:report profiler as manual instrumentation

### DIFF
--- a/src/Console/Infrastructure/Command/ProfileReportCommand.php
+++ b/src/Console/Infrastructure/Command/ProfileReportCommand.php
@@ -187,11 +187,15 @@ use Gacela\Framework\Profiler\Profiler;
 Profiler::getInstance()->enable();
 ```
 
-2. Profiling is automatically tracked for:
-- Module resolution
-- Service resolution
-- Container operations
-- Factory creation
+2. Manually instrument the code you want to measure by wrapping it in
+matching start()/stop() calls (same operation and subject):
+```php
+$profiler = Profiler::getInstance();
+
+$profiler->start('db-query', 'users');
+$users = $repository->findAll();
+$profiler->stop('db-query', 'users');
+```
 
 3. View the profiling report:
 ```bash

--- a/tests/Feature/Console/ProfileReport/ProfileReportCommandTest.php
+++ b/tests/Feature/Console/ProfileReport/ProfileReportCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ProfileReport;
+
+use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
+use PHPUnit\Framework\TestCase;
+
+final class ProfileReportCommandTest extends TestCase
+{
+    public function test_help_describes_manual_instrumentation_not_automatic_tracking(): void
+    {
+        $help = (new ProfileReportCommand())->getHelp();
+
+        // The framework does not instrument itself, so the help must not
+        // promise automatic tracking (which always yields an empty report).
+        self::assertStringNotContainsString('automatically tracked', $help);
+
+        // It must show a concrete manual start()/stop() example instead.
+        self::assertStringContainsString("\$profiler->start('db-query', 'users')", $help);
+        self::assertStringContainsString("\$profiler->stop('db-query', 'users')", $help);
+    }
+}


### PR DESCRIPTION
Closes #422

## 📚 Description

The `profile:report` help text claimed profiling is "automatically tracked" for module/service resolution, container operations, and factory creation. Nothing in the framework instruments itself (`Profiler::start()`/`stop()` are never called from resolution/container/factory code), so a user who follows the documented steps always gets "No profiling data available".

The help now describes `Profiler` as a **manual** instrumentation utility, with a concrete `start()`/`stop()` example. (Wiring real automatic instrumentation is a separate, larger change and out of scope.)

## 🔖 Changes

- Rewrite the `ProfileReportCommand` help Usage section: replace the "automatically tracked for …" list with a manual instrumentation example wrapping user code in matching `start('op', 'subject')` / `stop('op', 'subject')` calls
- Add a feature test asserting the help contains the manual example and no longer claims automatic tracking (guards against the misleading text returning)

## Test plan

- `composer quality` — green
- `composer phpunit` (feature suite) — 124 passing