### PR TITLE
fix: give debug:container --stats precedence over the class argument

### DIFF
--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -38,8 +38,14 @@ final class DebugContainerCommand extends Command
     {
         /** @var string|null $className */
         $className = $input->getArgument('class');
+        $showStats = (bool) $input->getOption('stats');
         /** @var bool $showTree */
         $showTree = (bool) $input->getOption('tree');
+
+        // --stats takes precedence, even when combined with a class argument
+        if ($showStats) {
+            return $this->displayStats($output);
+        }
 
         if ($showTree && $className === null) {
             $output->writeln('<error>The --tree option requires a class name argument</error>');

--- a/tests/Feature/Console/DebugContainer/DebugContainerCommandTest.php
+++ b/tests/Feature/Console/DebugContainer/DebugContainerCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugContainer;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugContainerCommandTest extends TestCase
+{
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $this->command = new CommandTester(new DebugContainerCommand());
+    }
+
+    public function test_stats_flag_takes_precedence_over_class_argument(): void
+    {
+        $this->command->execute(['class' => ConsoleFacade::class, '--stats' => true]);
+
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('Container Statistics', $output);
+        self::assertStringNotContainsString('Dependency Tree for', $output);
+    }
+
+    public function test_no_arguments_still_shows_stats(): void
+    {
+        $this->command->execute([]);
+
+        self::assertStringContainsString('Container Statistics', $this->command->getDisplay());
+    }
+
+    public function test_class_argument_without_flag_shows_dependency_tree(): void
+    {
+        $this->command->execute(['class' => ConsoleFacade::class]);
+
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('Dependency Tree for', $output);
+        self::assertStringNotContainsString('Container Statistics', $output);
+    }
+}


### PR DESCRIPTION
Closes #423

## 📚 Description

The `--stats` option on `debug:container` was a dead flag: `execute()` never read `getOption('stats')`. Whenever a class argument was present the command ran `displayDependencyTree()` unconditionally, so `debug:container <Class> --stats` printed the dependency tree instead of statistics, with no error or hint.

## 🔖 Changes

- `execute()` now reads `--stats` and gives it explicit precedence: when set, it always renders the container statistics, even when combined with a class argument
- Behavior preserved: no args → stats; `<Class>` alone → dependency tree; `--tree` without a class → error
- Add feature tests covering all three precedence branches (help examples were already consistent, so left unchanged)

## Test plan

- `composer quality` — green
- `composer phpunit` (feature suite) — 126 passing