### PR TITLE
fix: report when a list:modules filter matches no modules

### DIFF
--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function sprintf;
+
 /**
  * @method ConsoleFacade getFacade()
  */
@@ -41,10 +43,17 @@ final class ListModulesCommand extends Command
         $this->output = $output;
 
         $filter = (string)$input->getArgument('filter');
+        $modules = $this->getFacade()->findAllAppModules($filter);
+
+        if ($modules === []) {
+            $output->writeln(sprintf('<comment>No modules match filter "%s".</comment>', $filter));
+
+            return self::SUCCESS;
+        }
 
         $this->generateListOfModules(
             (bool)$input->getOption('detailed'),
-            $this->getFacade()->findAllAppModules($filter),
+            $modules,
         );
 
         return self::SUCCESS;

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -95,6 +95,26 @@ TXT;
         self::assertStringNotContainsString('ToBeIgnored', $out);
     }
 
+    public function test_non_matching_filter_reports_no_modules(): void
+    {
+        $this->command->execute(['filter' => 'NoSuchModuleXYZ']);
+
+        $output = $this->command->getDisplay();
+
+        self::assertStringContainsString('No modules match filter "NoSuchModuleXYZ".', $output);
+        self::assertStringNotContainsString('┌────', $output);
+    }
+
+    public function test_non_matching_filter_reports_no_modules_in_detailed_view(): void
+    {
+        $this->command->execute(['filter' => 'NoSuchModuleXYZ', '--detailed' => true]);
+
+        self::assertStringContainsString(
+            'No modules match filter "NoSuchModuleXYZ".',
+            $this->command->getDisplay(),
+        );
+    }
+
     public static function commandInputProvider(): iterable
     {
         yield 'slashes' => ['ListModules/TestModule1'];


### PR DESCRIPTION
Closes #424

## 📚 Description

When a `list:modules` filter matched nothing, the command printed an empty headers-only table (default view) or nothing at all (`--detailed`), both exiting 0 — leaving the user with no indication the filter matched zero modules. Sibling commands (`DebugConfigCommand`, `DebugModulesCommand`) already give explicit feedback here.

## 🔖 Changes

- `ListModulesCommand::execute()` now guards on an empty result and prints `No modules match filter "<filter>".` (mirroring `DebugModulesCommand`) before rendering, for both the default and `--detailed` views
- Matching-filter behavior (simple and detailed) is unchanged
- Add feature tests for the non-matching-filter message in both views

## Test plan

- `composer quality` — green
- `composer phpunit` (feature suite) — 125 passing