### PR TITLE
docs: clarify validate:config gacela.php presence is optional, not a check

### DIFF
--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -218,7 +218,7 @@ final class ValidateConfigCommand extends Command
 This command validates your Gacela configuration for common errors and potential issues.
 
 <info>What it checks:</info>
-  - Existence of gacela.php configuration file
+  - Presence of the optional gacela.php file (its absence is not an error; it is only reported when found)
   - Bindings configuration:
     - Validates that binding keys (interfaces/classes) exist
     - Validates that binding values (classes) exist

--- a/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
+++ b/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
@@ -35,6 +35,16 @@ final class ValidateConfigCommandTest extends TestCase
         self::assertStringContainsString('Checking bindings...', $output);
     }
 
+    public function test_help_does_not_imply_a_missing_gacela_php_is_flagged(): void
+    {
+        $help = (new ValidateConfigCommand())->getHelp();
+
+        // A missing gacela.php stays silent, so the help must not present its
+        // existence as a pass/fail check.
+        self::assertStringNotContainsString('Existence of gacela.php', $help);
+        self::assertStringContainsString('absence is not an error', $help);
+    }
+
     public function test_validate_config_is_silent_when_gacela_php_missing(): void
     {
         $this->command->execute([]);


### PR DESCRIPTION
Closes #428

## 📚 Description

The `validate:config` help listed "Existence of gacela.php configuration file" under "What it checks", but a missing `gacela.php` produces no output at all (it is optional and only reported when present). The help therefore implied a check that never visibly fails, so a clean pass could be mistaken for the file's presence having been verified.

## 🔖 Changes

- Reword the help "What it checks" entry to describe it as a presence report: "Presence of the optional gacela.php file (its absence is not an error; it is only reported when found)"
- Runtime behavior is unchanged (a present file still prints the checkmark; a missing one stays silent)
- Add a feature test asserting the help no longer implies a missing `gacela.php` is flagged

## Test plan

- `composer quality` — green
- `composer phpunit` (ValidateConfigCommandTest) — 6 passing