### PR TITLE
ref: mark AbstractProvider::register() final to protect the #[Provides] scan

### DIFF
--- a/src/Framework/AbstractProvider.php
+++ b/src/Framework/AbstractProvider.php
@@ -22,7 +22,7 @@ abstract class AbstractProvider
     /**
      * @internal
      */
-    public function register(Container $container): void
+    final public function register(Container $container): void
     {
         ProvidesScanner::scan($this, $container);
         $this->provideModuleDependencies($container);

--- a/tests/Unit/Framework/Attribute/ProvidesScannerTest.php
+++ b/tests/Unit/Framework/Attribute/ProvidesScannerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Attribute;
 
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\ProvidesScanner;
 use Gacela\Framework\Container\Container;
 use GacelaTest\Unit\Framework\Attribute\Providers\CallCounter;
@@ -14,6 +15,7 @@ use GacelaTest\Unit\Framework\Attribute\Providers\ProviderWithMixedStyles;
 use GacelaTest\Unit\Framework\Attribute\Providers\ProviderWithoutAttributes;
 use GacelaTest\Unit\Framework\Attribute\Providers\ProviderWithPrivateAttribute;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 final class ProvidesScannerTest extends TestCase
 {
@@ -91,6 +93,15 @@ final class ProvidesScannerTest extends TestCase
 
         self::assertSame('hello', $containerA->get('string_service'));
         self::assertSame('hello', $containerB->get('string_service'));
+    }
+
+    public function test_register_is_final_to_protect_the_provides_scan(): void
+    {
+        // register() runs ProvidesScanner::scan(); overriding it would silently
+        // disable #[Provides] scanning, so it must be final.
+        self::assertTrue(
+            (new ReflectionMethod(AbstractProvider::class, 'register'))->isFinal(),
+        );
     }
 
     public function test_register_combines_attributes_with_manual_provides(): void


### PR DESCRIPTION
Closes #426

## 📚 Description

`AbstractProvider::register()` is `@internal` but was public and non-final, sitting right next to the intended extension point `provideModuleDependencies()`. A user who overrode `register()` by mistake would silently skip `ProvidesScanner::scan()`, so their `#[Provides]`-annotated factory methods stop being registered — surfacing later as a confusing missing-service failure with no error at the mistake site.

`register()` is the real invocation entry point (called from `AbstractFactory`), so it stays public — but it is now `final`, enforcing its `@internal` contract and making `provideModuleDependencies()` the only supported extension point. No subclass in the repo overrides `register()`, so this is BC-safe.

## 🔖 Changes

- Add `final` to `AbstractProvider::register()`
- Add a unit test asserting `register()` is `final` (the mixed attribute + manual `provideModuleDependencies()` regression is already covered by `test_register_combines_attributes_with_manual_provides`)

## Test plan

- `composer quality` — green
- `composer phpunit` (unit, integration, feature) — 774 passing