### PR TITLE
docs: document GacelaConfig::addHealthCheck() for bin/gacela doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - `Gacela\Framework\Event\ClassResolver\GenericEvent` — dead code; the event was never dispatched
 - `GacelaFileCache::isEnabledFromCacheConfig()` — dead code with no callers; use `GacelaFileCache::isEnabled()`
 
+### Documentation
+
+- `docs/module-health-checks.md` now documents `GacelaConfig::addHealthCheck()` and how registered checks surface in `bin/gacela doctor`, previously the CLI integration point was undocumented
+
 ## [1.16.0](https://github.com/gacela-project/gacela/compare/1.15.0...1.16.0) - 2026-07-15
 
 ### Fixed

--- a/docs/module-health-checks.md
+++ b/docs/module-health-checks.md
@@ -46,6 +46,44 @@ $checker = new HealthChecker([
 $report = $checker->checkAll();
 ```
 
+## CLI integration (`bin/gacela doctor`)
+
+Register a check with `GacelaConfig::addHealthCheck()` in your `gacela.php` and it runs automatically as part of `bin/gacela doctor`, alongside the built-in cache-staleness and suffix-mismatch checks.
+
+```php
+// gacela.php
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->addHealthCheck(DatabaseHealthCheck::class);
+    // or an instance:
+    $config->addHealthCheck(new DatabaseHealthCheck($pdo));
+};
+```
+
+`addHealthCheck()` accepts either a `class-string<ModuleHealthCheckInterface>` (resolved through the container) or a ready-made `ModuleHealthCheckInterface` instance:
+
+```php
+public function addHealthCheck(string|ModuleHealthCheckInterface $check): self
+```
+
+Running the command surfaces each registered check as a `module health: <module name>` line:
+
+```
+$ bin/gacela doctor
+
+Gacela Doctor
+============================================================
+
+✓ module health: Database
+    Database operational
+
+============================================================
+✓ All checks passed
+```
+
+A `degraded` check reports as a warning; an `unhealthy` check reports as an error and makes `doctor` exit non-zero. Check metadata is printed under the status line.
+
 ## Status levels
 
 | Level       | When to use                                  |
@@ -136,4 +174,11 @@ $status->toArray(): array
 ```php
 $checker->checkAll(): HealthCheckReport
 $checker->count(): int
+```
+
+### `GacelaConfig`
+
+```php
+// Register a check to run under `bin/gacela doctor`
+$config->addHealthCheck(string|ModuleHealthCheckInterface $check): self
 ```


### PR DESCRIPTION
## 📚 Description

Documents `GacelaConfig::addHealthCheck()` — the only way to surface a `ModuleHealthCheckInterface` check in `bin/gacela doctor`. This CLI integration point was previously undocumented; `docs/module-health-checks.md` only showed manual `new HealthChecker([...])->checkAll()`.

Closes #427

## 🔖 Changes

- Add **CLI integration (`bin/gacela doctor`)** section to `docs/module-health-checks.md` with a `gacela.php` example calling `addHealthCheck()` (both class-string and instance forms), the `addHealthCheck()` signature, and sample `doctor` output showing `module health: <name>` lines
- Note degraded → warning, unhealthy → error (non-zero exit)
- Add `GacelaConfig::addHealthCheck()` to the API reference section
- `CHANGELOG.md`: new `### Documentation` entry under `## Unreleased`

Documented flow already guarded by `tests/Feature/Console/Doctor/DoctorCommandTest.php` (4 tests, green).
