### PR TITLE
fix: GacelaConfig constructor wipes registered health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Health checks registered in `gacela.php` are no longer wiped when a project also ships `gacela-{APP_ENV}.php`: `GacelaConfig::__construct()` no longer resets the shared `HealthCheckRegistry` on every instantiation. The registry is now cleared exactly once per `Gacela::bootstrap()`, so checks from the default and env config files accumulate together without leaking across bootstraps
 - `bin/gacela` now exits 1 and writes to STDERR on every failure path — missing `vendor/autoload.php`, missing `symfony/console`, a `Gacela::bootstrap()` failure, or any `Throwable` (incl. `Error`/`TypeError`) from the runner — instead of exiting 0 or 255 with a raw stack trace
 - `cache:clear` is now registered in the console; it shipped in 1.13.0 but was never wired in, so `bin/gacela cache:clear` was unavailable
 - `cache:clear` now also removes the custom-services cache file (`gacela-custom-services.php`); the no-cache-found guard and size report cover both cache files

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -94,7 +94,6 @@ final class GacelaConfig
         $this->appConfigBuilder = new AppConfigBuilder();
         $this->suffixTypesBuilder = new SuffixTypesBuilder();
         $this->bindingsBuilder = new BindingsBuilder();
-        HealthCheckRegistry::reset();
     }
 
     /**

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -21,6 +21,7 @@ use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Locator;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Exception\ServiceNotFoundException;
+use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
 
 use function is_string;
@@ -58,6 +59,11 @@ final class Gacela
     {
         self::$appRootDir = $appRootDir;
         self::$mainContainer = null;
+
+        // Clear health checks once per bootstrap, before the config files are
+        // read, so checks registered across gacela.php + gacela-{env}.php
+        // accumulate within a single bootstrap without leaking across bootstraps.
+        HealthCheckRegistry::reset();
 
         $setup = self::processConfigFnIntoSetup($configFn);
 

--- a/tests/Feature/Framework/HealthCheckAcrossEnvFiles/FeatureTest.php
+++ b/tests/Feature/Framework/HealthCheckAcrossEnvFiles/FeatureTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\HealthCheckAcrossEnvFiles;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Health\HealthCheckRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('APP_ENV');
+        HealthCheckRegistry::reset();
+    }
+
+    public function test_health_checks_from_default_and_env_file_are_both_registered(): void
+    {
+        putenv('APP_ENV=dev');
+
+        $this->bootstrapGacela();
+
+        self::assertSame(
+            [HealthCheckA::class, HealthCheckB::class],
+            HealthCheckRegistry::all(),
+        );
+    }
+
+    public function test_health_checks_do_not_accumulate_across_bootstraps(): void
+    {
+        putenv('APP_ENV=dev');
+
+        $this->bootstrapGacela();
+        $this->bootstrapGacela();
+
+        self::assertSame(
+            [HealthCheckA::class, HealthCheckB::class],
+            HealthCheckRegistry::all(),
+        );
+    }
+
+    private function bootstrapGacela(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+    }
+}

--- a/tests/Feature/Framework/HealthCheckAcrossEnvFiles/HealthCheckA.php
+++ b/tests/Feature/Framework/HealthCheckAcrossEnvFiles/HealthCheckA.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\HealthCheckAcrossEnvFiles;
+
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+
+final class HealthCheckA implements ModuleHealthCheckInterface
+{
+    public function checkHealth(): HealthStatus
+    {
+        return HealthStatus::healthy();
+    }
+
+    public function getModuleName(): string
+    {
+        return 'A';
+    }
+}

--- a/tests/Feature/Framework/HealthCheckAcrossEnvFiles/HealthCheckB.php
+++ b/tests/Feature/Framework/HealthCheckAcrossEnvFiles/HealthCheckB.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\HealthCheckAcrossEnvFiles;
+
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+
+final class HealthCheckB implements ModuleHealthCheckInterface
+{
+    public function checkHealth(): HealthStatus
+    {
+        return HealthStatus::healthy();
+    }
+
+    public function getModuleName(): string
+    {
+        return 'B';
+    }
+}

--- a/tests/Feature/Framework/HealthCheckAcrossEnvFiles/gacela-dev.php
+++ b/tests/Feature/Framework/HealthCheckAcrossEnvFiles/gacela-dev.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\Framework\HealthCheckAcrossEnvFiles\HealthCheckB;
+
+return static function (GacelaConfig $config): void {
+    $config->addHealthCheck(HealthCheckB::class);
+};

--- a/tests/Feature/Framework/HealthCheckAcrossEnvFiles/gacela.php
+++ b/tests/Feature/Framework/HealthCheckAcrossEnvFiles/gacela.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\Framework\HealthCheckAcrossEnvFiles\HealthCheckA;
+
+return static function (GacelaConfig $config): void {
+    $config->addHealthCheck(HealthCheckA::class);
+};

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -12,6 +12,16 @@ use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        HealthCheckRegistry::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        HealthCheckRegistry::reset();
+    }
+
     public function test_default_php_config_registers_default_paths(): void
     {
         $closure = GacelaConfig::defaultPhpConfig();


### PR DESCRIPTION
## 📚 Description

`GacelaConfig::__construct()` unconditionally reset the shared static `HealthCheckRegistry` on every instantiation. When a project ships both `gacela.php` and an env-specific `gacela-{APP_ENV}.php`, building the second file's `GacelaConfig` wiped the health checks the first file already registered — silently discarding them. `DoctorCommand` and any HTTP health endpoint then omitted those modules with no error.

The registry is now cleared exactly **once per `Gacela::bootstrap()`** (before the config files are read), so checks from the default and env config files accumulate together within a bootstrap, without leaking across independent bootstraps.

## 🔖 Changes

- Removed `HealthCheckRegistry::reset()` from `GacelaConfig::__construct()`
- Added an unconditional `HealthCheckRegistry::reset()` at the start of `Gacela::bootstrap()`, before config files are read (not in `resetCache()`, which runs only conditionally and after config closures have already registered their checks)
- Updated `GacelaConfigTest` to reset the registry explicitly in `setUp()`/`tearDown()` (no longer relies on constructor-triggered reset)
- Added a feature test (`tests/Feature/Framework/HealthCheckAcrossEnvFiles/`): fixture app with `gacela.php` (registers check A) + `gacela-dev.php` (registers check B); asserts the registry contains **both** A and B after bootstrap, and that checks do not accumulate across repeated bootstraps

Closes #421