### PR TITLE
fix: report external-service key '0' instead of 'none' when lookup fails

### DIFF
--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -18,7 +18,6 @@ use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use InvalidArgumentException;
 
 use function array_key_exists;
-use function in_array;
 use function sprintf;
 
 /**
@@ -209,7 +208,13 @@ final class GacelaConfig
     public function getExternalService(string $key): string|object|callable
     {
         if (!array_key_exists($key, $this->externalServices)) {
-            throw new InvalidArgumentException(sprintf('External service "%s" not found. Available keys: %s', $key, in_array(implode(', ', array_keys($this->externalServices)), ['', '0'], true) ? 'none' : implode(', ', array_keys($this->externalServices))));
+            $availableKeys = $this->externalServices === []
+                ? 'none'
+                : implode(', ', array_keys($this->externalServices));
+
+            throw new InvalidArgumentException(
+                sprintf('External service "%s" not found. Available keys: %s', $key, $availableKeys),
+            );
         }
 
         return $this->externalServices[$key];

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -8,6 +8,7 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 final class GacelaConfigTest extends TestCase
@@ -42,6 +43,27 @@ final class GacelaConfigTest extends TestCase
         $config = new GacelaConfig();
 
         self::assertNull($config->toTransfer()->appModulePaths);
+    }
+
+    public function test_get_external_service_reports_numeric_string_key_zero_not_none(): void
+    {
+        $config = new GacelaConfig();
+        $config->addExternalService('0', 'value');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Available keys: 0');
+
+        $config->getExternalService('missing');
+    }
+
+    public function test_get_external_service_reports_none_when_no_services_registered(): void
+    {
+        $config = new GacelaConfig();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Available keys: none');
+
+        $config->getExternalService('missing');
     }
 
     public function test_set_app_module_paths_exposes_list_on_transfer(): void


### PR DESCRIPTION
Closes #425

## 📚 Description

`GacelaConfig::getExternalService()` decided whether to print "none" in its not-found error by string-comparing the imploded keys against `['', '0']`. A single service registered under the numeric-string key `'0'` (which PHP stores as int `0`) imploded to `'0'`, matched the sentinel, and was wrongly reported as "Available keys: none".

## 🔖 Changes

- Replace the fragile imploded-string comparison with a direct emptiness check: report "none" only when no external services are registered, otherwise list the actual keys
- Add unit tests: a registered `'0'` key is reported in "Available keys"; an empty registry still reports "none"

## Test plan

- `composer quality` — green
- `composer phpunit` (unit, integration, feature) — 784 passing