### PR TITLE
test: cover ConstructorInspector NoTypeHint/UnsupportedType/MissingType branches

### DIFF
--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -9,4 +9,5 @@ parameters:
         - %currentWorkingDirectory%/tests/Unit/PHPStan/Rules/Fixture/*
     ignoreErrors:
         - '#Class GacelaTest\\Unit\\Framework\\Container\\NonExisting not found.#'
+        - '#has invalid type Totally\\Missing\\Type#'
         - '#Access to constant on internal class Gacela\\Framework\\Container\\Locator.#'

--- a/tests/Feature/Console/DebugDependencies/Fixtures/UntypedAndUnionService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/UntypedAndUnionService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+/**
+ * Exercises the three otherwise-uncovered ConstructorInspector branches:
+ * an untyped parameter without a default (NoTypeHint), a union-typed
+ * parameter (UnsupportedType), and a parameter typed to a non-existent
+ * class (MissingType).
+ */
+final class UntypedAndUnionService
+{
+    /**
+     * @param mixed $untyped
+     */
+    public function __construct(
+        $untyped,
+        int|string $union,
+        \Totally\Missing\Type $missing,
+    ) {
+    }
+}

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
@@ -14,6 +14,7 @@ use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\InjectService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\MixedDependenciesService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\UntypedAndUnionService;
 use PHPUnit\Framework\TestCase;
 
 final class ConstructorInspectorTest extends TestCase
@@ -37,6 +38,18 @@ final class ConstructorInspectorTest extends TestCase
         self::assertFalse($inspection->hasConstructor);
         self::assertSame([], $inspection->parameters);
         self::assertTrue($inspection->isFullyResolvable());
+    }
+
+    public function test_untyped_union_and_missing_types_are_categorized(): void
+    {
+        $inspection = $this->inspector->inspect(UntypedAndUnionService::class);
+
+        self::assertTrue($inspection->hasConstructor);
+        self::assertCount(3, $inspection->parameters);
+
+        self::assertSame(ParameterStatus::NoTypeHint, $inspection->parameters[0]->status);
+        self::assertSame(ParameterStatus::UnsupportedType, $inspection->parameters[1]->status);
+        self::assertSame(ParameterStatus::MissingType, $inspection->parameters[2]->status);
     }
 
     public function test_mixed_dependencies_are_categorized(): void


### PR DESCRIPTION
Closes #431

## 📚 Description

Three of `ConstructorInspector`'s `ParameterStatus` branches — `NoTypeHint`, `UnsupportedType`, `MissingType` — had no test coverage, so a regression mislabeling untyped, union-typed, or non-existent-class constructor parameters (all surfaced by `debug:dependencies`) would go unnoticed.

## 🔖 Changes

- Add fixture `UntypedAndUnionService` with `__construct($untyped, int|string $union, \Totally\Missing\Type $missing)` — one parameter per uncovered branch
- Add a `ConstructorInspectorTest` case asserting the three parameters map to `NoTypeHint`, `UnsupportedType`, and `MissingType`
- Ignore the intentional `class.notFound` for `Totally\Missing\Type` in `phpstan-tests.neon` (same pattern as the existing `NonExisting` fixture ignore; psalm only scans `src/`, so it is unaffected)

## Test plan

- `composer quality` — green
- `composer phpunit` (unit, integration, feature) — 783 passing