### PR TITLE
test: cover BytesFormatter unit-selection boundary values

### DIFF
--- a/tests/Unit/Console/Application/CacheWarm/BytesFormatterTest.php
+++ b/tests/Unit/Console/Application/CacheWarm/BytesFormatterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\CacheWarm;
+
+use Gacela\Console\Application\CacheWarm\BytesFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BytesFormatterTest extends TestCase
+{
+    #[DataProvider('boundaryValuesProvider')]
+    public function test_formats_boundary_values(int $bytes, string $expected): void
+    {
+        self::assertSame($expected, BytesFormatter::format($bytes));
+    }
+
+    /**
+     * @return iterable<string, array{int, string}>
+     */
+    public static function boundaryValuesProvider(): iterable
+    {
+        yield 'zero' => [0, '0 B'];
+        yield 'largest bytes' => [1023, '1023 B'];
+        yield 'kb boundary' => [1024, '1.00 KB'];
+        yield 'largest kb rounds up to 1024.00' => [1048575, '1024.00 KB'];
+        yield 'mb boundary' => [1048576, '1.00 MB'];
+        yield 'large non-round mb' => [1572864, '1.50 MB'];
+    }
+}


### PR DESCRIPTION
Closes #432

## 📚 Description

`BytesFormatter`'s B/KB/MB unit-selection boundaries had no direct unit test — the only incidental coverage was a `cache:warm` feature-test regex that matches any unit and any number, so an off-by-one at a boundary (e.g. `1024` formatting as `1024 B` instead of `1.00 KB`) would produce silently wrong human-readable output with no test catching it.

## 🔖 Changes

- Add `BytesFormatterTest` with a data provider asserting exact strings at each boundary: `0 -> "0 B"`, `1023 -> "1023 B"`, `1024 -> "1.00 KB"`, `1048575 -> "1024.00 KB"` (non-round, forces the rounding), `1048576 -> "1.00 MB"`, and a large non-round MB value

## Test plan

- `composer quality` — green
- `composer test-unit` (BytesFormatterTest) — 6 cases passing