### PR TITLE
ref: share one Container across resolvers instead of rebuilding per type

### DIFF
--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -27,9 +27,13 @@ abstract class AbstractClassResolver
 
     private static ?ClassNameFinderInterface $classNameFinder = null;
 
-    private ?GacelaConfigFileInterface $gacelaFileConfig = null;
+    /**
+     * Shared across every resolver instance/subclass: the bindings and
+     * contextual bindings are process-global, so one Container serves all.
+     */
+    private static ?Container $container = null;
 
-    private ?Container $container = null;
+    private ?GacelaConfigFileInterface $gacelaFileConfig = null;
 
     /**
      * @internal remove all cached instances: facade, factory, config, dependency-provider
@@ -38,6 +42,7 @@ abstract class AbstractClassResolver
     {
         self::$cachedInstances = [];
         self::$classNameFinder = null;
+        self::$container = null;
     }
 
     /**
@@ -142,8 +147,8 @@ abstract class AbstractClassResolver
      */
     private function createInstance(string $resolvedClassName): object
     {
-        if (!$this->container instanceof Container) {
-            $this->container = new Container(
+        if (!self::$container instanceof Container) {
+            self::$container = new Container(
                 $this->getGacelaConfigFile()->getBindings(),
             );
 
@@ -151,13 +156,13 @@ abstract class AbstractClassResolver
                 foreach ($needs as $abstract => $implementation) {
                     /** @var class-string $concrete */
                     /** @var class-string $abstract */
-                    $this->container->when($concrete)->needs($abstract)->give($implementation);
+                    self::$container->when($concrete)->needs($abstract)->give($implementation);
                 }
             }
         }
 
         /** @var object $instance */
-        $instance = $this->container->get($resolvedClassName);
+        $instance = self::$container->get($resolvedClassName);
 
         return $instance;
     }

--- a/tests/Integration/Framework/ClassResolver/SharedContainerTest.php
+++ b/tests/Integration/Framework/ClassResolver/SharedContainerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver;
+
+use Gacela\Container\Container;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\ClassResolver\Config\ConfigResolver;
+use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
+use Gacela\Framework\ClassResolver\Provider\DependencyProviderResolver;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\ModuleWithExternalDependencies\Supplier\Facade;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+final class SharedContainerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+        AbstractClassResolver::resetCache();
+        InMemoryCache::resetCache();
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+        AbstractClassResolver::resetCache();
+        InMemoryCache::resetCache();
+    }
+
+    public function test_resolvers_share_a_single_container_instance(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+
+        $caller = new Facade();
+
+        (new FactoryResolver())->resolve($caller);
+        $afterFactory = $this->sharedContainer();
+        self::assertInstanceOf(Container::class, $afterFactory);
+
+        (new ConfigResolver())->resolve($caller);
+        (new DependencyProviderResolver())->resolve($caller);
+
+        self::assertSame(
+            $afterFactory,
+            $this->sharedContainer(),
+            'resolving Factory, Config and Provider must reuse one Container',
+        );
+    }
+
+    public function test_reset_cache_clears_the_shared_container(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+
+        (new FactoryResolver())->resolve(new Facade());
+        self::assertInstanceOf(Container::class, $this->sharedContainer());
+
+        AbstractClassResolver::resetCache();
+
+        self::assertNull($this->sharedContainer());
+    }
+
+    private function sharedContainer(): ?Container
+    {
+        $property = new ReflectionProperty(AbstractClassResolver::class, 'container');
+
+        /** @var Container|null $value */
+        $value = $property->getValue();
+
+        return $value;
+    }
+}


### PR DESCRIPTION
Closes #429

## 📚 Description

`AbstractClassResolver::createInstance()` built a fresh `Container` (global bindings + the full contextual-bindings loop) for every resolver instance. Because resolvers are constructed fresh per call site (`new FactoryResolver()`, `new ConfigResolver()`, `new ProviderResolver()`, `new DependencyProviderResolver()`), each module paid up to 4–5 redundant Container constructions per request — even though `getBindings()` and `getContextualBindings()` are process-global and every build is byte-identical.

The `Container` is now memoized once in a shared static field and reused across all resolver instances/subclasses, and reset alongside the other static caches in `resetCache()` (same lifecycle as the existing static `$cachedInstances` / `$classNameFinder`).

## 🔖 Changes

- Make `AbstractClassResolver::$container` a shared `static` field, built once from the global bindings + contextual bindings and reused by every resolver
- Reset it in `AbstractClassResolver::resetCache()` (so `Gacela::resetCache()` clears it too)
- Add an integration test asserting Factory/Config/Provider resolution reuses one Container, and that `resetCache()` clears it

## Notes on the `#[Singleton]` caveat

The shared Container also shares its resolution cache. This is safe because resolvers only build top-level module classes, which `AbstractClassResolver::$cachedInstances` already caches once per key. `#[Singleton]` scoping and contextual-binding resolution are verified unchanged by the existing integration + feature suites (all green), and the container follows the same reset lifecycle as the pre-existing static caches.

## Test plan

- `composer quality` — green
- `composer phpunit` (unit, integration, feature) — 786 passing