### PR TITLE
feat: batch file-cache writes during bootstrap like cache:warm does

### DIFF
--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Cache\WritableDirectory;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
 use Gacela\Framework\ClassResolver\ClassResolverCache;
@@ -72,10 +73,19 @@ final class Gacela
         }
 
         $config = Config::createWithSetup($setup);
-        $config->setAppRootDir($appRootDir)
-            ->init();
+        $config->setAppRootDir($appRootDir);
 
-        self::runPlugins($config);
+        // Batch the file-cache writes produced while resolving classes during
+        // bootstrap into a single atomic write per cache file (like cache:warm
+        // does), instead of one full-file rewrite per newly discovered key.
+        AbstractPhpFileCache::beginBatch();
+
+        try {
+            $config->init();
+            self::runPlugins($config);
+        } finally {
+            AbstractPhpFileCache::commitBatch();
+        }
     }
 
     /**

--- a/tests/Integration/Framework/Bootstrap/BootstrapBatchesFileCacheTest.php
+++ b/tests/Integration/Framework/Bootstrap/BootstrapBatchesFileCacheTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class BootstrapBatchesFileCacheTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+        });
+    }
+
+    public function test_bootstrap_batches_file_cache_writes_while_resolving_classes(): void
+    {
+        $batchingWhileResolving = null;
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$batchingWhileResolving): void {
+            $config->resetInMemoryCache();
+            // Plugins run during bootstrap's resolution phase; capture whether
+            // file-cache writes are being batched at that point.
+            $config->addPlugin(static function () use (&$batchingWhileResolving): void {
+                $batchingWhileResolving = AbstractPhpFileCache::isBatching();
+            });
+        });
+
+        self::assertTrue(
+            $batchingWhileResolving,
+            'file-cache writes must be batched while bootstrap resolves classes',
+        );
+        self::assertFalse(
+            AbstractPhpFileCache::isBatching(),
+            'the bootstrap batch must be committed before bootstrap() returns',
+        );
+    }
+}


### PR DESCRIPTION
Closes #430

## 📚 Description

`beginBatch()`/`commitBatch()` on `AbstractPhpFileCache` exist to collapse many full-file cache rewrites into a single atomic write per file, but they were only wired into `cache:warm`. During a normal `Gacela::bootstrap()`, each class/service resolved while wiring up plugins triggered its own full-array serialize + atomic rename + `opcache_invalidate`.

`bootstrap()` now brackets its resolution phase (`config->init()` + `runPlugins()`) in a batch, exactly like `cache:warm` does, and commits it in a `finally` before returning.

## 🔖 Changes

- Wrap bootstrap's `init()` + `runPlugins()` in `AbstractPhpFileCache::beginBatch()` / `try … finally { commitBatch() }`
- Add an integration test asserting file-cache writes are batched while bootstrap resolves classes (a plugin observes `isBatching()`), and that the batch is committed before `bootstrap()` returns

## Notes

- The batch is committed before `bootstrap()` returns, so **request-time** resolution (facades/factories resolved after bootstrap) keeps writing eagerly — no change to when those land on disk, and the existing `FileCacheFeatureTest` (which asserts cache files exist right after resolution) still passes.
- Deferring request-time writes to shutdown was intentionally avoided: it would change the observable "cache written eagerly" contract and the worker-flush lifecycle. This change is scoped to bootstrap, matching the title.

## Test plan

- `composer quality` — green
- `composer phpunit` (unit, integration, feature) — 792 passing