### PR TITLE
ref: fix and optimize release.sh

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -29,7 +29,7 @@ The script (and a manual release) assume:
    - Rename the current `## Unreleased` header to
      `## [X.Y.Z](https://github.com/gacela-project/gacela/compare/<prev>...<X.Y.Z>) - YYYY-MM-DD`
    - Insert a fresh empty `## Unreleased` section at the top.
-3. **Run quality + tests**: `composer quality && composer test`
+3. **Confirm CI is green** for the current `main` HEAD (the script checks GitHub check-runs). Locally you can still run `composer quality && composer test` if you want extra assurance.
 4. **Commit, tag, push**:
    ```bash
    git add CHANGELOG.md

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -24,7 +24,7 @@ The script (and a manual release) assume:
 
 ## Manual steps (if not using the script)
 
-1. **Bump the version** in [`bin/gacela`](../bin/gacela) — update the `version:` argument passed to `ConsoleBootstrap`.
+1. **No version file to bump** — the version is derived at runtime from Composer's metadata (the git tag), so creating the tag in step 4 is what sets the version.
 2. **Update [`CHANGELOG.md`](../CHANGELOG.md)**:
    - Rename the current `## Unreleased` header to
      `## [X.Y.Z](https://github.com/gacela-project/gacela/compare/<prev>...<X.Y.Z>) - YYYY-MM-DD`
@@ -32,7 +32,7 @@ The script (and a manual release) assume:
 3. **Run quality + tests**: `composer quality && composer test`
 4. **Commit, tag, push**:
    ```bash
-   git add bin/gacela CHANGELOG.md
+   git add CHANGELOG.md
    git commit -m "chore(release): X.Y.Z"
    git tag -a X.Y.Z -m "Release X.Y.Z"
    git push origin main

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -34,7 +34,7 @@ The script (and a manual release) assume:
    ```bash
    git add CHANGELOG.md
    git commit -m "chore(release): X.Y.Z"
-   git tag -a X.Y.Z -m "Release X.Y.Z"
+   git tag -s X.Y.Z -m "Release X.Y.Z"
    git push origin main
    git push origin X.Y.Z
    ```

--- a/release.sh
+++ b/release.sh
@@ -45,7 +45,7 @@ Arguments:
 Options:
   --dry-run          Preview changes without modifying files or pushing.
   --force            Skip interactive confirmation (for CI).
-  --skip-tests       Skip 'composer quality' and 'composer test'.
+  --skip-tests       Skip the CI-status verification for HEAD.
   --without-gh-release
                      Tag and push, but do not create a GitHub release.
   --rollback         Restore CHANGELOG.md from latest backup.
@@ -255,20 +255,43 @@ update_changelog() {
 }
 
 #########################
-###     TEST SUITE    ###
+###  CI VERIFICATION  ###
 #########################
 
-run_tests() {
-  [[ "$SKIP_TESTS" == true ]] && { log_warn "Skipping tests (--skip-tests)"; return; }
+# Preflight already asserts local HEAD == origin/main, which CI has run against.
+# Rather than re-run the full 'composer quality && composer test' locally (minutes
+# CI already spent), confirm CI is green for this exact commit via GitHub check-runs.
+verify_ci_green() {
+  [[ "$SKIP_TESTS" == true ]] && { log_warn "Skipping CI verification (--skip-tests)"; return; }
   if [[ "$DRY_RUN" == true ]]; then
-    log_dry "Would run: composer quality && composer test"
+    log_dry "Would verify CI is green for HEAD via GitHub check-runs"
     return
   fi
-  log_info "Running composer quality..."
-  composer quality
-  log_info "Running composer test..."
-  composer test
-  log_success "Quality + tests passed."
+
+  local head total bad
+  head=$(git rev-parse HEAD)
+  log_info "Verifying CI status for $head..."
+
+  total=$(gh api "repos/${GITHUB_REPO_PATH}/commits/${head}/check-runs" \
+          --jq '.check_runs | length')
+  [[ "$total" -gt 0 ]] || {
+    log_error "No CI check-runs found for HEAD. Wait for CI to start, or use --skip-tests to override."
+    exit $EXIT_VALIDATION_ERROR
+  }
+
+  bad=$(gh api "repos/${GITHUB_REPO_PATH}/commits/${head}/check-runs" \
+        --jq '.check_runs[]
+              | select(.status != "completed"
+                       or (.conclusion != "success"
+                           and .conclusion != "skipped"
+                           and .conclusion != "neutral"))
+              | "\(.name): \(.status)/\(.conclusion // "pending")"')
+  [[ -z "$bad" ]] || {
+    log_error "CI is not green for HEAD. Failing or pending checks:"
+    printf '%s\n' "$bad" | sed 's/^/    /' >&2
+    exit $EXIT_VALIDATION_ERROR
+  }
+  log_success "CI is green for HEAD ($total checks)."
 }
 
 #########################
@@ -344,7 +367,7 @@ main() {
 
   capture_release_notes
   update_changelog
-  run_tests
+  verify_ci_green
   git_commit_and_tag
   git_push
   create_gh_release

--- a/release.sh
+++ b/release.sh
@@ -305,7 +305,7 @@ git_commit_and_tag() {
   fi
   git add "${RELEASE_FILES[@]}"
   git commit -m "chore(release): ${VERSION}"
-  git tag -a "$VERSION" -m "Release $VERSION"
+  git tag -s "$VERSION" -m "Release $VERSION"
   log_success "Commit + tag $VERSION created."
 }
 

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ declare -r EXIT_EXECUTION_ERROR=2
 
 GITHUB_REPO_PATH="gacela-project/gacela"
 GITHUB_REPO_URL="https://github.com/${GITHUB_REPO_PATH}"
-RELEASE_FILES=("bin/gacela" "CHANGELOG.md")
+RELEASE_FILES=("CHANGELOG.md")
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -48,7 +48,7 @@ Options:
   --skip-tests       Skip 'composer quality' and 'composer test'.
   --without-gh-release
                      Tag and push, but do not create a GitHub release.
-  --rollback         Restore bin/gacela and CHANGELOG.md from latest backup.
+  --rollback         Restore CHANGELOG.md from latest backup.
   -h, --help         Show this message.
 
 Examples:
@@ -150,10 +150,11 @@ run_preflight() {
 #########################
 
 read_current_version() {
-  CURRENT_VERSION=$(grep -oE "version:\s*'[0-9]+\.[0-9]+\.[0-9]+'" bin/gacela \
-                    | head -1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+  # Version is derived at runtime from Composer metadata (the git tag), so the
+  # latest tag — not a file — is the source of truth for the current version.
+  CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
   [[ -n "$CURRENT_VERSION" ]] || {
-    log_error "Could not read current version from bin/gacela."
+    log_error "Could not read current version from git tags."
     exit $EXIT_VALIDATION_ERROR
   }
 }
@@ -191,7 +192,6 @@ rollback_manual() {
   latest=$(find .release-state -maxdepth 1 -type d -name 'backup-*' 2>/dev/null | sort -r | head -1)
   [[ -n "$latest" ]] || { log_error "No backup found in .release-state."; exit $EXIT_VALIDATION_ERROR; }
   log_info "Restoring from $latest"
-  cp "$latest/gacela" bin/gacela
   cp "$latest/CHANGELOG.md" CHANGELOG.md
   log_success "Files restored. Remember to review 'git status'."
 }
@@ -199,16 +199,6 @@ rollback_manual() {
 #########################
 ###   FILE UPDATES    ###
 #########################
-
-update_bin_gacela() {
-  if [[ "$DRY_RUN" == true ]]; then
-    log_dry "Would update bin/gacela: $CURRENT_VERSION → $VERSION"
-    return
-  fi
-  sed -i.bak "s|version: '${CURRENT_VERSION}'|version: '${VERSION}'|" bin/gacela
-  rm -f bin/gacela.bak
-  log_success "bin/gacela → $VERSION"
-}
 
 capture_release_notes() {
   local notes
@@ -353,7 +343,6 @@ main() {
   [[ "$DRY_RUN" == true ]] || backup_init
 
   capture_release_notes
-  update_bin_gacela
   update_changelog
   run_tests
   git_commit_and_tag


### PR DESCRIPTION
## 📚 Description

Unbreaks and streamlines `release.sh`. After the switch to deriving the version at runtime from Composer metadata (the git tag), the script still grepped `bin/gacela` for a literal version string, so it exited 1 before doing anything. This fixes that and cuts the biggest time cost out of a release.

## 🔖 Changes

- **`fix`: read version from git tag, not `bin/gacela`** — `bin/gacela` no longer holds a literal version, so `read_current_version` now reads the latest git tag (`git describe --tags --abbrev=0`). Drops `bin/gacela` from the tracked release files (backup, rollback, changelog).
- **`ref`: gate on CI status instead of re-running the suite** — preflight already asserts local HEAD equals `origin/main`, which CI has run. Instead of re-running `composer quality && composer test` locally, verify CI is green for the exact HEAD via GitHub check-runs. `--skip-tests` overrides the check.
- **`fix`: sign the release git tag** — `git tag -a` → `git tag -s`, matching the project's GPG signing setup.
- `.github/RELEASE.md` updated to match all three.
