### PR TITLE
perf(events): zero-cost event dispatch on the resolver hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Bumped `gacela-project/container` to `^0.9.0`
+- Event dispatch on the class-resolution hot path is now zero-cost when nothing listens: dispatch sites check the new `EventDispatcherInterface::hasListeners()` before allocating the event object (~20% faster warm resolves; custom `EventDispatcherInterface` implementations must add the method)
 
 ## [1.17.0](https://github.com/gacela-project/gacela/compare/1.16.0...1.17.0) - 2026-07-18
 

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -62,7 +62,9 @@ abstract class AbstractClassResolver
         $cacheKey = $previousCacheKey ?? $classInfo->getCacheKey();
         $resolvedClass = $this->resolveCached($cacheKey);
         if ($resolvedClass !== null) {
-            self::dispatchEvent(new ResolvedClassCachedEvent($classInfo));
+            if (self::shouldDispatch(ResolvedClassCachedEvent::class)) {
+                self::dispatchEvent(new ResolvedClassCachedEvent($classInfo));
+            }
 
             return $resolvedClass;
         }
@@ -70,19 +72,26 @@ abstract class AbstractClassResolver
         $resolvedClassName = $this->findClassName($classInfo);
         if ($resolvedClassName !== null) {
             $instance = $this->createInstance($resolvedClassName);
-            self::dispatchEvent(new ResolvedClassCreatedEvent($classInfo));
+            if (self::shouldDispatch(ResolvedClassCreatedEvent::class)) {
+                self::dispatchEvent(new ResolvedClassCreatedEvent($classInfo));
+            }
         } else {
             // Try again with its parent class
             if (is_object($caller)) {
                 $parentClass = get_parent_class($caller);
                 if ($parentClass !== false) {
-                    self::dispatchEvent(new ResolvedClassTriedFromParentEvent($classInfo));
+                    if (self::shouldDispatch(ResolvedClassTriedFromParentEvent::class)) {
+                        self::dispatchEvent(new ResolvedClassTriedFromParentEvent($classInfo));
+                    }
 
                     return $this->doResolve($parentClass, $cacheKey);
                 }
             }
 
-            self::dispatchEvent(new ResolvedCreatedDefaultClassEvent($classInfo));
+            if (self::shouldDispatch(ResolvedCreatedDefaultClassEvent::class)) {
+                self::dispatchEvent(new ResolvedCreatedDefaultClassEvent($classInfo));
+            }
+
             $instance = $this->createDefaultGacelaClass();
         }
 

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
@@ -40,7 +40,9 @@ final class ClassNameFinder implements ClassNameFinderInterface
 
         if ($this->cache->has($cacheKey)) {
             $cached = $this->cache->get($cacheKey);
-            self::dispatchEvent(new ClassNameCachedFoundEvent($cacheKey, $cached));
+            if (self::shouldDispatch(ClassNameCachedFoundEvent::class)) {
+                self::dispatchEvent(new ClassNameCachedFoundEvent($cacheKey, $cached));
+            }
 
             return $cached;
         }
@@ -55,17 +57,23 @@ final class ClassNameFinder implements ClassNameFinderInterface
 
                     if ($this->classValidator->isClassNameValid($className)) {
                         $this->cache->put($cacheKey, $className);
-                        self::dispatchEvent(new ClassNameValidCandidateFoundEvent($className));
+                        if (self::shouldDispatch(ClassNameValidCandidateFoundEvent::class)) {
+                            self::dispatchEvent(new ClassNameValidCandidateFoundEvent($className));
+                        }
 
                         return $className;
                     }
 
-                    self::dispatchEvent(new ClassNameInvalidCandidateFoundEvent($className));
+                    if (self::shouldDispatch(ClassNameInvalidCandidateFoundEvent::class)) {
+                        self::dispatchEvent(new ClassNameInvalidCandidateFoundEvent($className));
+                    }
                 }
             }
         }
 
-        self::dispatchEvent(new ClassNameNotFoundEvent($classInfo, $resolvableTypes));
+        if (self::shouldDispatch(ClassNameNotFoundEvent::class)) {
+            self::dispatchEvent(new ClassNameNotFoundEvent($classInfo, $resolvableTypes));
+        }
 
         return null;
     }

--- a/src/Framework/ClassResolver/ClassResolverCache.php
+++ b/src/Framework/ClassResolver/ClassResolverCache.php
@@ -32,16 +32,22 @@ final class ClassResolverCache
     {
         $cache = self::$cache;
         if ($cache instanceof CacheInterface) {
-            self::dispatchEvent(new ClassNameCacheCachedEvent());
+            if (self::shouldDispatch(ClassNameCacheCachedEvent::class)) {
+                self::dispatchEvent(new ClassNameCacheCachedEvent());
+            }
             return $cache;
         }
 
         if (self::isEnabled()) {
             $cacheDir = Config::getInstance()->getCacheDir();
-            self::dispatchEvent(new ClassNamePhpCacheCreatedEvent($cacheDir));
+            if (self::shouldDispatch(ClassNamePhpCacheCreatedEvent::class)) {
+                self::dispatchEvent(new ClassNamePhpCacheCreatedEvent($cacheDir));
+            }
             $cache = new ClassNamePhpCache($cacheDir);
         } else {
-            self::dispatchEvent(new ClassNameInMemoryCacheCreatedEvent());
+            if (self::shouldDispatch(ClassNameInMemoryCacheCreatedEvent::class)) {
+                self::dispatchEvent(new ClassNameInMemoryCacheCreatedEvent());
+            }
             $cache = new InMemoryCache(ClassNamePhpCache::class);
         }
 

--- a/src/Framework/Config/ConfigReader/PhpConfigReader.php
+++ b/src/Framework/Config/ConfigReader/PhpConfigReader.php
@@ -25,7 +25,9 @@ final class PhpConfigReader implements ConfigReaderInterface
             return [];
         }
 
-        self::dispatchEvent(new ReadPhpConfigEvent($absolutePath));
+        if (self::shouldDispatch(ReadPhpConfigEvent::class)) {
+            self::dispatchEvent(new ReadPhpConfigEvent($absolutePath));
+        }
 
         /**
          * @psalm-suppress UnresolvableInclude

--- a/src/Framework/Event/Dispatcher/ConfigurableEventDispatcher.php
+++ b/src/Framework/Event/Dispatcher/ConfigurableEventDispatcher.php
@@ -31,6 +31,12 @@ final class ConfigurableEventDispatcher implements EventDispatcherInterface
         $this->specificListeners[$event][] = $listener;
     }
 
+    public function hasListeners(string $eventClass): bool
+    {
+        return $this->genericListeners !== []
+            || isset($this->specificListeners[$eventClass]);
+    }
+
     public function dispatch(object $event): void
     {
         foreach ($this->genericListeners as $listener) {

--- a/src/Framework/Event/Dispatcher/EventDispatcherInterface.php
+++ b/src/Framework/Event/Dispatcher/EventDispatcherInterface.php
@@ -7,4 +7,12 @@ namespace Gacela\Framework\Event\Dispatcher;
 interface EventDispatcherInterface
 {
     public function dispatch(object $event): void;
+
+    /**
+     * Whether any listener would receive an event of the given class.
+     * Lets hot-path dispatch sites skip allocating the event when nothing listens.
+     *
+     * @param class-string $eventClass
+     */
+    public function hasListeners(string $eventClass): bool;
 }

--- a/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
+++ b/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
@@ -9,6 +9,17 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 trait EventDispatchingCapabilities
 {
+    /**
+     * Guard every dispatchEvent() call with this check so the event object
+     * is only allocated when a listener is actually registered for it.
+     *
+     * @param class-string<GacelaEventInterface> $eventClass
+     */
+    private static function shouldDispatch(string $eventClass): bool
+    {
+        return Config::getEventDispatcher()->hasListeners($eventClass);
+    }
+
     private static function dispatchEvent(GacelaEventInterface $event): void
     {
         Config::getEventDispatcher()->dispatch($event);

--- a/src/Framework/Event/Dispatcher/NullEventDispatcher.php
+++ b/src/Framework/Event/Dispatcher/NullEventDispatcher.php
@@ -9,4 +9,9 @@ final class NullEventDispatcher implements EventDispatcherInterface
     public function dispatch(object $event): void
     {
     }
+
+    public function hasListeners(string $eventClass): bool
+    {
+        return false;
+    }
 }

--- a/src/Framework/ServiceResolver/DocBlockResolverCache.php
+++ b/src/Framework/ServiceResolver/DocBlockResolverCache.php
@@ -29,16 +29,22 @@ final class DocBlockResolverCache
     {
         $cache = self::$cache;
         if ($cache instanceof CacheInterface) {
-            self::dispatchEvent(new CustomServicesCacheCachedEvent());
+            if (self::shouldDispatch(CustomServicesCacheCachedEvent::class)) {
+                self::dispatchEvent(new CustomServicesCacheCachedEvent());
+            }
 
             return $cache;
         }
 
         if (self::isProjectCacheEnabled()) {
-            self::dispatchEvent(new CustomServicesPhpCacheCreatedEvent());
+            if (self::shouldDispatch(CustomServicesPhpCacheCreatedEvent::class)) {
+                self::dispatchEvent(new CustomServicesPhpCacheCreatedEvent());
+            }
             $cache = new CustomServicesPhpCache(Config::getInstance()->getCacheDir());
         } else {
-            self::dispatchEvent(new CustomServicesInMemoryCacheCreatedEvent());
+            if (self::shouldDispatch(CustomServicesInMemoryCacheCreatedEvent::class)) {
+                self::dispatchEvent(new CustomServicesInMemoryCacheCreatedEvent());
+            }
             $cache = new InMemoryCache(CustomServicesPhpCache::class);
         }
 

--- a/tests/Benchmark/ClassResolver/EventDispatchBench.php
+++ b/tests/Benchmark/ClassResolver/EventDispatchBench.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\ClassResolver;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameNotFoundEvent;
+use Gacela\Framework\Gacela;
+use GacelaTest\Benchmark\ModuleExample\ModuleExampleFacade;
+
+use function dirname;
+
+/**
+ * Warm-resolve throughput of the guarded event dispatch on the
+ * class-resolution hot path: every rev is a cache-hit resolve, which is
+ * exactly the ResolvedClassCachedEvent dispatch site.
+ *
+ * @Revs(1000)
+ *
+ * @Iterations(5)
+ */
+final class EventDispatchBench
+{
+    public function setUpWithoutListeners(): void
+    {
+        Gacela::bootstrap(dirname(__DIR__) . '/ModuleExample', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $this->warmResolverCache();
+    }
+
+    public function setUpWithUnrelatedListener(): void
+    {
+        Gacela::bootstrap(dirname(__DIR__) . '/ModuleExample', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->registerSpecificListener(ClassNameNotFoundEvent::class, static function (): void {});
+        });
+
+        $this->warmResolverCache();
+    }
+
+    /**
+     * @BeforeMethods("setUpWithoutListeners")
+     */
+    public function bench_warm_resolve_without_listeners(): void
+    {
+        (new FactoryResolver())->resolve(ModuleExampleFacade::class);
+    }
+
+    /**
+     * @BeforeMethods("setUpWithUnrelatedListener")
+     */
+    public function bench_warm_resolve_with_unrelated_specific_listener(): void
+    {
+        (new FactoryResolver())->resolve(ModuleExampleFacade::class);
+    }
+
+    private function warmResolverCache(): void
+    {
+        (new FactoryResolver())->resolve(ModuleExampleFacade::class);
+    }
+}

--- a/tests/Unit/Framework/Event/Dispatcher/ConfigurableEventDispatcherTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/ConfigurableEventDispatcherTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Dispatcher;
+
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameNotFoundEvent;
+use Gacela\Framework\Event\ClassResolver\ResolvedClassCachedEvent;
+use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurableEventDispatcherTest extends TestCase
+{
+    public function test_has_no_listeners_when_nothing_registered(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+
+        self::assertFalse($dispatcher->hasListeners(ResolvedClassCachedEvent::class));
+    }
+
+    public function test_has_no_listeners_when_registered_generic_listeners_are_empty(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+        $dispatcher->registerGenericListeners([]);
+
+        self::assertFalse($dispatcher->hasListeners(ResolvedClassCachedEvent::class));
+    }
+
+    public function test_has_listeners_for_any_event_class_when_generic_listener_registered(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+        $dispatcher->registerGenericListeners([static function (): void {}]);
+
+        self::assertTrue($dispatcher->hasListeners(ResolvedClassCachedEvent::class));
+        self::assertTrue($dispatcher->hasListeners(ClassNameNotFoundEvent::class));
+    }
+
+    public function test_has_listeners_only_for_the_registered_specific_event_class(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+        $dispatcher->registerSpecificListener(ClassNameNotFoundEvent::class, static function (): void {});
+
+        self::assertTrue($dispatcher->hasListeners(ClassNameNotFoundEvent::class));
+        self::assertFalse($dispatcher->hasListeners(ResolvedClassCachedEvent::class));
+    }
+}

--- a/tests/Unit/Framework/Event/Dispatcher/EventDispatchingCapabilitiesTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/EventDispatchingCapabilitiesTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Dispatcher;
+
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\ConfigReader\ReadPhpConfigEvent;
+use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+use Gacela\Framework\Event\GacelaEventInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EventDispatchingCapabilitiesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+    }
+
+    public function test_no_listeners_skips_event_creation_and_dispatch(): void
+    {
+        $spy = $this->createSpyDispatcher(hasListeners: false);
+        $this->bootstrapWithDispatcher($spy);
+
+        $stand = $this->createDispatchingStand();
+        $stand->fire();
+
+        self::assertSame(0, $stand->createdEvents());
+        self::assertSame([], $spy->dispatchedEvents());
+    }
+
+    public function test_registered_listener_creates_and_dispatches_event(): void
+    {
+        $spy = $this->createSpyDispatcher(hasListeners: true);
+        $this->bootstrapWithDispatcher($spy);
+
+        $stand = $this->createDispatchingStand();
+        $stand->fire();
+
+        self::assertSame(1, $stand->createdEvents());
+        self::assertCount(1, $spy->dispatchedEvents());
+        self::assertInstanceOf(ReadPhpConfigEvent::class, $spy->dispatchedEvents()[0]);
+    }
+
+    public function test_null_dispatcher_from_default_setup_never_dispatches(): void
+    {
+        Config::createWithSetup(new SetupGacela());
+
+        $stand = $this->createDispatchingStand();
+        $stand->fire();
+
+        self::assertSame(0, $stand->createdEvents());
+    }
+
+    public function test_specific_listener_for_another_event_skips_event_creation(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+        $dispatcher->registerSpecificListener(FakeUnrelatedEvent::class, static function (): void {});
+        $this->bootstrapWithDispatcher($dispatcher);
+
+        $stand = $this->createDispatchingStand();
+        $stand->fire();
+
+        self::assertSame(0, $stand->createdEvents());
+    }
+
+    private function bootstrapWithDispatcher(EventDispatcherInterface $dispatcher): void
+    {
+        Config::createWithSetup((new SetupGacela())->setEventDispatcher($dispatcher));
+    }
+
+    private function createDispatchingStand(): DispatchingStandInterface
+    {
+        return new class() implements DispatchingStandInterface {
+            use EventDispatchingCapabilities;
+
+            private int $createdEvents = 0;
+
+            public function fire(): void
+            {
+                if (self::shouldDispatch(ReadPhpConfigEvent::class)) {
+                    ++$this->createdEvents;
+                    self::dispatchEvent(new ReadPhpConfigEvent('fake-path.php'));
+                }
+            }
+
+            public function createdEvents(): int
+            {
+                return $this->createdEvents;
+            }
+        };
+    }
+
+    private function createSpyDispatcher(bool $hasListeners): SpyEventDispatcher
+    {
+        return new class($hasListeners) implements SpyEventDispatcher {
+            /** @var list<object> */
+            private array $dispatched = [];
+
+            public function __construct(
+                private readonly bool $hasListeners,
+            ) {
+            }
+
+            public function dispatch(object $event): void
+            {
+                $this->dispatched[] = $event;
+            }
+
+            public function hasListeners(string $eventClass): bool
+            {
+                return $this->hasListeners;
+            }
+
+            public function dispatchedEvents(): array
+            {
+                return $this->dispatched;
+            }
+        };
+    }
+}
+
+interface DispatchingStandInterface
+{
+    public function fire(): void;
+
+    public function createdEvents(): int;
+}
+
+interface SpyEventDispatcher extends EventDispatcherInterface
+{
+    /**
+     * @return list<object>
+     */
+    public function dispatchedEvents(): array;
+}
+
+final class FakeUnrelatedEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return self::class;
+    }
+}

--- a/tests/Unit/Framework/Event/Dispatcher/NullEventDispatcherTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/NullEventDispatcherTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Dispatcher;
+
+use Gacela\Framework\Event\ConfigReader\ReadPhpConfigEvent;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class NullEventDispatcherTest extends TestCase
+{
+    public function test_has_no_listeners_for_any_event_class(): void
+    {
+        $dispatcher = new NullEventDispatcher();
+
+        self::assertFalse($dispatcher->hasListeners(ReadPhpConfigEvent::class));
+        self::assertFalse($dispatcher->hasListeners(stdClass::class));
+    }
+}


### PR DESCRIPTION
## 📚 Description

Every class-resolution on the hot path allocated an event object and called the dispatcher even when nothing listens (the default `NullEventDispatcher`). Dispatch sites now probe the dispatcher first and only allocate the event when a listener is registered for that event class, so warm resolves produce zero throwaway objects.

## 🔖 Changes

- Added `EventDispatcherInterface::hasListeners(string $eventClass): bool` (`NullEventDispatcher` → always `false`; `ConfigurableEventDispatcher` → generic listeners or a specific listener for that class)
- Added `shouldDispatch()` guard to `EventDispatchingCapabilities`; all 15 dispatch sites now allocate the event inside the guard
- Used the `if`-guard form instead of a closure factory: a micro-benchmark showed the closure allocation costs more than the current code (327ns vs 248ns per site), while the guard drops it to 138ns
- No trait-level dispatcher cache: `Config::getEventDispatcher()` already caches statically and is invalidated via `Gacela::resetCache()`
- PHPBench warm-resolve benchmark (`EventDispatchBench`): 0.318μs → 0.255μs (no listeners), 0.335μs → 0.270μs (unrelated specific listener), ~20% faster
- Unit tests for `hasListeners()` and the gating behavior (spy dispatcher counting event creations)

Closes #449

---
Refactor pass done after implementation: no further changes needed. The per-site `if (shouldDispatch(...))` repetition is intentional; hoisting it into `dispatchEvent()` would re-introduce the event allocation the guard exists to avoid.