### PR TITLE
ci: add phpbench performance regression guard

### DIFF
--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -1,0 +1,57 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+#
+# Performance regression guard: benchmarks the PR base branch, then benchmarks
+# the PR head against that stored baseline. The suite-wide assertion configured
+# in phpbench.json (mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%)
+# fails the job when a benchmarked path regresses by more than 10%.
+
+on:
+  pull_request:
+
+name: PHPBench
+
+permissions:
+  contents: read
+
+jobs:
+
+  regression-guard:
+    name: "Performance regression guard"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the base branch can be checked out for the baseline run.
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "phpbench-php-8.4-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "phpbench-php-8.4-"
+
+      - name: Benchmark base branch (${{ github.base_ref }}) and store as baseline
+        run: |
+          git checkout --detach "origin/${{ github.base_ref }}"
+          composer install --no-interaction --no-progress
+          vendor/bin/phpbench run --tag=base --store --progress=none
+
+      - name: Restore PR head
+        run: git checkout --detach "${{ github.event.pull_request.head.sha }}"
+
+      - name: Install PR head dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Assert no >10% regression against the base baseline
+        run: vendor/bin/phpbench run --ref=base --report=aggregate --progress=none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,3 @@ jobs:
 
       - name: Run feature tests
         run: vendor/bin/phpunit --testsuite feature
-
-      - name: Run PHPBench
-        run: vendor/bin/phpbench run --iterations=3 --warmup=1 --report=aggregate


### PR DESCRIPTION
## 📚 Description

Turns PHPBench into a real CI performance guard. Today the `Run PHPBench` step just executes the benches with no baseline — it can't detect a regression (a benchmark could get 3× slower and CI would stay green). This adds a dedicated workflow that benchmarks the PR **base** branch, stores it as a baseline, then benchmarks the PR **head** against it and fails on a >10% slowdown.

Follow-up to #454 (which added `ConfigTypedAccessBench`).

## 🔖 Changes

- New workflow `.github/workflows/phpbench.yml` (`pull_request` only):
  1. Checkout with full history.
  2. Checkout the base branch, `composer install`, run `phpbench run --tag=base --store` → baseline.
  3. Checkout the PR head, `composer install`.
  4. `phpbench run --ref=base` → the suite-wide assertion in `phpbench.json` (`mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%`) fails the job on a regression.
- Removed the old non-asserting `Run PHPBench` step from `tests.yml`: it ran across the full 8-cell PHP×OS matrix and guarded nothing. The new job runs benches once, on one PHP version, and actually asserts.

## ✅ Verification (run locally)

- `phpbench run --tag=base --store` then `phpbench run --ref=base` → exit `0`, deltas reported within tolerance.
- Forced-regression proof: `phpbench run --ref=base --assert='mode(variant.time.avg) <= mode(baseline.time.avg) * 0.5'` → exit `2` (job would fail). The guard genuinely blocks.
- Both workflow YAMLs validated.
- `.phpbench` storage is already gitignored — no artifacts committed.

## 📝 Design notes / best practices

- **Base-vs-head in a single job** (not a stored-on-main cache) so the comparison is always against the exact merge target, and needs no cross-run state.
- **Reuses the existing `phpbench.json` `+/-10%` threshold** rather than inventing a second one — one source of truth, and it already governs local `composer phpbench`.
- **Single PHP version (8.4)** for the guard: perf comparison wants one stable environment, not a correctness matrix.
- **Blocking**, per the intent of a guard. If runner noise proves flaky in practice, the lever is the threshold in `phpbench.json` (bump to ~15–20%) or pinning a larger `revs`/`iterations` — no workflow change needed.
