### PR TITLE
feat(events): add framework lifecycle events for observability/DX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Framework lifecycle events for observability, all allocation-guarded so they stay zero-cost when nothing listens: `GacelaBootstrapStartedEvent`/`GacelaBootstrapFinishedEvent(durationMs)`, `ConfigInitializedEvent(keyCount)`, `ConfigKeyReadEvent(key)`, `ConfigKeyNotFoundEvent(key)`, `ServiceResolvedEvent(id)` (once per container service), `BindingRegisteredEvent(id)`, `ProviderRegisteredEvent(providerClass, moduleName)`, `CacheClearedEvent(cacheFile)`, `CacheWarmedEvent(moduleCount, failedCount)`
+
+### Fixed
+
+- `Config::getEventDispatcher()` no longer throws when called before bootstrap; it returns a no-op dispatcher so guarded dispatch sites (e.g. cache-file deletion) stay silent
+- Re-bootstrapping now rebuilds the event dispatcher from the new setup; previously a dispatcher cached by a prior bootstrap kept serving stale listeners unless the in-memory cache was reset
+
 - Typed config accessors on `Config`/`AbstractConfig`: `getString()`, `getInt()`, `getFloat()`, `getBool()`, `getArray()`. Each returns a concrete type (no more `mixed` casts), uses a `null` default to mean "required", and throws `ConfigException` on a type mismatch instead of coercing (`getFloat()` accepts an int via lossless widening). Self-contained implementations: a typed read is faster than `get()` + a manual cast (single `array_key_exists`, no default sentinel comparison)
 
 ### Changed

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -14,6 +14,8 @@ use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\Cache\CacheWarmedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,6 +33,7 @@ use function filesize;
  */
 final class CacheWarmCommand extends Command
 {
+    use EventDispatchingCapabilities;
     use ServiceResolverAwareTrait;
 
     protected function configure(): void
@@ -72,6 +75,10 @@ final class CacheWarmCommand extends Command
             [$resolvedCount, $skippedCount] = $moduleWarmer->warmModules($modules, $warmAttributes);
         } finally {
             AbstractPhpFileCache::commitBatch();
+        }
+
+        if (self::shouldDispatch(CacheWarmedEvent::class)) {
+            self::dispatchEvent(new CacheWarmedEvent(count($modules), $skippedCount));
         }
 
         $formatter->writeSummary(

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
+use Gacela\Framework\ClassResolver\ClassInfo;
 use Gacela\Framework\ClassResolver\Provider\DependencyProviderResolver;
 use Gacela\Framework\ClassResolver\Provider\ProviderNotFoundException;
 use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
 
 /**
  * @template TConfig of AbstractConfig = AbstractConfig
@@ -17,6 +20,7 @@ abstract class AbstractFactory
 {
     /** @use ConfigResolverAwareTrait<TConfig> */
     use ConfigResolverAwareTrait;
+    use EventDispatchingCapabilities;
 
     /** @var array<string,Container> */
     private static array $containers = [];
@@ -69,15 +73,31 @@ abstract class AbstractFactory
 
         $resolver = (new ProviderResolver())->resolve($this);
         $resolver?->register($container);
+        if ($resolver !== null) {
+            $this->notifyProviderRegistered($resolver::class);
+        }
 
         // Temporal solution to keep BC with the AbstractDependencyProvider
         $dpResolver = (new DependencyProviderResolver())->resolve($this);
         $dpResolver?->provideModuleDependencies($container);
+        if ($dpResolver !== null) {
+            $this->notifyProviderRegistered($dpResolver::class);
+        }
 
         if ($resolver === null && $dpResolver === null) {
             throw new ProviderNotFoundException(static::class);
         }
 
         return $container;
+    }
+
+    private function notifyProviderRegistered(string $providerClass): void
+    {
+        if (self::shouldDispatch(ProviderRegisteredEvent::class)) {
+            self::dispatchEvent(new ProviderRegisteredEvent(
+                $providerClass,
+                ClassInfo::from($this)->getModuleName(),
+            ));
+        }
     }
 }

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Cache;
 
+use Gacela\Framework\Event\Cache\CacheClearedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+
 use function bin2hex;
 use function count;
 use function dirname;
@@ -56,6 +59,8 @@ use const PREG_OFFSET_CAPTURE;
  */
 final class FileCache
 {
+    use EventDispatchingCapabilities;
+
     private const INDEX_FILENAME = '.gacela-filecache.lock';
 
     public readonly string $directory;
@@ -269,6 +274,10 @@ final class FileCache
         if (is_file($file)) {
             @unlink($file);
             self::invalidateOpcacheFor($file);
+
+            if (self::shouldDispatch(CacheClearedEvent::class)) {
+                self::dispatchEvent(new CacheClearedEvent($file));
+            }
         }
     }
 

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -110,17 +110,13 @@ final class Config implements ConfigInterface
         }
 
         if ($default !== self::DEFAULT_CONFIG_VALUE && !$this->hasKey($key)) {
-            if (self::shouldDispatch(ConfigKeyNotFoundEvent::class)) {
-                self::dispatchEvent(new ConfigKeyNotFoundEvent($key));
-            }
+            self::notifyKeyNotFound($key);
 
             return $default;
         }
 
         if (!$this->hasKey($key)) {
-            if (self::shouldDispatch(ConfigKeyNotFoundEvent::class)) {
-                self::dispatchEvent(new ConfigKeyNotFoundEvent($key));
-            }
+            self::notifyKeyNotFound($key);
 
             throw ConfigException::keyNotFound($key, self::class);
         }
@@ -381,6 +377,13 @@ final class Config implements ConfigInterface
     public function hasKey(string $key): bool
     {
         return array_key_exists($key, $this->config);
+    }
+
+    private static function notifyKeyNotFound(string $key): void
+    {
+        if (self::shouldDispatch(ConfigKeyNotFoundEvent::class)) {
+            self::dispatchEvent(new ConfigKeyNotFoundEvent($key));
+        }
     }
 
     /**

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Event\Config\ConfigInitializedEvent;
+use Gacela\Framework\Event\Config\ConfigKeyNotFoundEvent;
+use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
 use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
 
 use function array_key_exists;
+use function count;
 use function is_array;
 use function is_bool;
 use function is_float;
@@ -18,9 +24,13 @@ use function is_string;
 
 final class Config implements ConfigInterface
 {
+    use EventDispatchingCapabilities;
+
     private static ?self $instance = null;
 
     private static ?EventDispatcherInterface $eventDispatcher = null;
+
+    private static ?NullEventDispatcher $preBootstrapDispatcher = null;
 
     private ?ConfigFactory $configFactory = null;
 
@@ -43,6 +53,8 @@ final class Config implements ConfigInterface
     public static function createWithSetup(SetupGacelaInterface $setup): self
     {
         self::$instance = new self($setup);
+        // A new setup brings its own listeners; drop the dispatcher built from the previous one.
+        self::$eventDispatcher = null;
 
         return self::$instance;
     }
@@ -67,11 +79,19 @@ final class Config implements ConfigInterface
 
     public static function getEventDispatcher(): EventDispatcherInterface
     {
-        if (!self::$eventDispatcher instanceof EventDispatcherInterface) {
-            self::$eventDispatcher = self::getInstance()
-                ->getSetupGacela()
-                ->getEventDispatcher();
+        if (self::$eventDispatcher instanceof EventDispatcherInterface) {
+            return self::$eventDispatcher;
         }
+
+        // Dispatch sites can run before bootstrap (e.g. clearing cache files);
+        // without a Config instance there is nothing to listen, so stay silent.
+        if (!self::$instance instanceof self) {
+            return self::$preBootstrapDispatcher ??= new NullEventDispatcher();
+        }
+
+        self::$eventDispatcher = self::$instance
+            ->getSetupGacela()
+            ->getEventDispatcher();
 
         return self::$eventDispatcher;
     }
@@ -85,11 +105,23 @@ final class Config implements ConfigInterface
             $this->init();
         }
 
+        if (self::shouldDispatch(ConfigKeyReadEvent::class)) {
+            self::dispatchEvent(new ConfigKeyReadEvent($key));
+        }
+
         if ($default !== self::DEFAULT_CONFIG_VALUE && !$this->hasKey($key)) {
+            if (self::shouldDispatch(ConfigKeyNotFoundEvent::class)) {
+                self::dispatchEvent(new ConfigKeyNotFoundEvent($key));
+            }
+
             return $default;
         }
 
         if (!$this->hasKey($key)) {
+            if (self::shouldDispatch(ConfigKeyNotFoundEvent::class)) {
+                self::dispatchEvent(new ConfigKeyNotFoundEvent($key));
+            }
+
             throw ConfigException::keyNotFound($key, self::class);
         }
 
@@ -263,6 +295,10 @@ final class Config implements ConfigInterface
         ];
 
         $this->initialized = true;
+
+        if (self::shouldDispatch(ConfigInitializedEvent::class)) {
+            self::dispatchEvent(new ConfigInitializedEvent(count($this->config)));
+        }
     }
 
     /**

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -8,6 +8,9 @@ use Gacela\Container\Container as GacelaContainer;
 use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Event\Container\ServiceResolvedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Plugins\LazyHandlerRegistry;
 
 /**
@@ -17,6 +20,11 @@ use Gacela\Framework\Plugins\LazyHandlerRegistry;
  */
 final class Container extends GacelaContainer implements ContainerInterface
 {
+    use EventDispatchingCapabilities;
+
+    /** @var array<string, true> */
+    private array $resolvedServiceIds = [];
+
     public static function withConfig(Config $config): self
     {
         return self::withContainerConfiguration(
@@ -28,6 +36,21 @@ final class Container extends GacelaContainer implements ContainerInterface
     public function getLocator(): LocatorInterface
     {
         return Locator::getInstance($this);
+    }
+
+    public function get(string $id): mixed
+    {
+        /** @var mixed $service */
+        $service = parent::get($id);
+
+        if (!isset($this->resolvedServiceIds[$id])) {
+            $this->resolvedServiceIds[$id] = true;
+            if (self::shouldDispatch(ServiceResolvedEvent::class)) {
+                self::dispatchEvent(new ServiceResolvedEvent($id));
+            }
+        }
+
+        return $service;
     }
 
     /**
@@ -42,16 +65,23 @@ final class Container extends GacelaContainer implements ContainerInterface
             $containerConfig->getServicesToExtend(),
         );
 
+        foreach (array_keys($bindings) as $id) {
+            self::notifyBindingRegistered($id);
+        }
+
         foreach ($containerConfig->getFactories() as $id => $factory) {
             $container->set($id, $container->factory($factory));
+            self::notifyBindingRegistered($id);
         }
 
         foreach ($containerConfig->getProtectedServices() as $id => $service) {
             $container->set($id, $container->protect($service));
+            self::notifyBindingRegistered($id);
         }
 
         foreach ($containerConfig->getAliases() as $alias => $id) {
             $container->alias($alias, $id);
+            self::notifyBindingRegistered($alias);
         }
 
         foreach ($containerConfig->getContextualBindings() as $concrete => $needs) {
@@ -59,6 +89,7 @@ final class Container extends GacelaContainer implements ContainerInterface
                 /** @var class-string $concrete */
                 /** @var class-string $abstract */
                 $container->when($concrete)->needs($abstract)->give($implementation);
+                self::notifyBindingRegistered($abstract);
             }
         }
 
@@ -72,8 +103,16 @@ final class Container extends GacelaContainer implements ContainerInterface
         // Register lazy services - wrapped as factories that instantiate on first access
         foreach ($containerConfig->getLazyServices() as $id => $lazyFactory) {
             $container->set($id, $container->factory(static fn (): mixed => $lazyFactory($container)));
+            self::notifyBindingRegistered($id);
         }
 
         return $container;
+    }
+
+    private static function notifyBindingRegistered(string $id): void
+    {
+        if (self::shouldDispatch(BindingRegisteredEvent::class)) {
+            self::dispatchEvent(new BindingRegisteredEvent($id));
+        }
     }
 }

--- a/src/Framework/Event/Bootstrap/GacelaBootstrapFinishedEvent.php
+++ b/src/Framework/Event/Bootstrap/GacelaBootstrapFinishedEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Bootstrap;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class GacelaBootstrapFinishedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly float $durationMs,
+    ) {
+    }
+
+    public function durationMs(): float
+    {
+        return $this->durationMs;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {durationMs:%.3f}',
+            self::class,
+            $this->durationMs,
+        );
+    }
+}

--- a/src/Framework/Event/Bootstrap/GacelaBootstrapStartedEvent.php
+++ b/src/Framework/Event/Bootstrap/GacelaBootstrapStartedEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Bootstrap;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class GacelaBootstrapStartedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $appRootDir,
+    ) {
+    }
+
+    public function appRootDir(): string
+    {
+        return $this->appRootDir;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {appRootDir:"%s"}',
+            self::class,
+            $this->appRootDir,
+        );
+    }
+}

--- a/src/Framework/Event/Cache/CacheClearedEvent.php
+++ b/src/Framework/Event/Cache/CacheClearedEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Cache;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class CacheClearedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $cacheFile,
+    ) {
+    }
+
+    public function cacheFile(): string
+    {
+        return $this->cacheFile;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {cacheFile:"%s"}',
+            self::class,
+            $this->cacheFile,
+        );
+    }
+}

--- a/src/Framework/Event/Cache/CacheWarmedEvent.php
+++ b/src/Framework/Event/Cache/CacheWarmedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Cache;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class CacheWarmedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly int $moduleCount,
+        private readonly int $failedCount,
+    ) {
+    }
+
+    public function moduleCount(): int
+    {
+        return $this->moduleCount;
+    }
+
+    public function failedCount(): int
+    {
+        return $this->failedCount;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {moduleCount:%d, failedCount:%d}',
+            self::class,
+            $this->moduleCount,
+            $this->failedCount,
+        );
+    }
+}

--- a/src/Framework/Event/Config/ConfigInitializedEvent.php
+++ b/src/Framework/Event/Config/ConfigInitializedEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Config;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class ConfigInitializedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly int $keyCount,
+    ) {
+    }
+
+    public function keyCount(): int
+    {
+        return $this->keyCount;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {keyCount:%d}',
+            self::class,
+            $this->keyCount,
+        );
+    }
+}

--- a/src/Framework/Event/Config/ConfigKeyNotFoundEvent.php
+++ b/src/Framework/Event/Config/ConfigKeyNotFoundEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Config;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class ConfigKeyNotFoundEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $key,
+    ) {
+    }
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {key:"%s"}',
+            self::class,
+            $this->key,
+        );
+    }
+}

--- a/src/Framework/Event/Config/ConfigKeyReadEvent.php
+++ b/src/Framework/Event/Config/ConfigKeyReadEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Config;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class ConfigKeyReadEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $key,
+    ) {
+    }
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {key:"%s"}',
+            self::class,
+            $this->key,
+        );
+    }
+}

--- a/src/Framework/Event/Container/BindingRegisteredEvent.php
+++ b/src/Framework/Event/Container/BindingRegisteredEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Container;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class BindingRegisteredEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $id,
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {id:"%s"}',
+            self::class,
+            $this->id,
+        );
+    }
+}

--- a/src/Framework/Event/Container/ServiceResolvedEvent.php
+++ b/src/Framework/Event/Container/ServiceResolvedEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Container;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class ServiceResolvedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $id,
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {id:"%s"}',
+            self::class,
+            $this->id,
+        );
+    }
+}

--- a/src/Framework/Event/Provider/ProviderRegisteredEvent.php
+++ b/src/Framework/Event/Provider/ProviderRegisteredEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Provider;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+final class ProviderRegisteredEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $providerClass,
+        private readonly string $moduleName,
+    ) {
+    }
+
+    public function providerClass(): string
+    {
+        return $this->providerClass;
+    }
+
+    public function moduleName(): string
+    {
+        return $this->moduleName;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {providerClass:"%s", moduleName:"%s"}',
+            self::class,
+            $this->providerClass,
+            $this->moduleName,
+        );
+    }
+}

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -20,6 +20,9 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\ConfigFactory;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Locator;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapStartedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Exception\ServiceNotFoundException;
 use Gacela\Framework\Health\HealthCheckRegistry;
@@ -30,6 +33,8 @@ use function sprintf;
 
 final class Gacela
 {
+    use EventDispatchingCapabilities;
+
     private const GACELA_PHP_FILENAME = 'gacela.php';
 
     private const PACKAGE_NAME = 'gacela-project/gacela';
@@ -58,6 +63,8 @@ final class Gacela
      */
     public static function bootstrap(string $appRootDir, ?Closure $configFn = null): void
     {
+        $startTime = hrtime(true);
+
         self::$appRootDir = $appRootDir;
         self::$mainContainer = null;
 
@@ -75,6 +82,10 @@ final class Gacela
         $config = Config::createWithSetup($setup);
         $config->setAppRootDir($appRootDir);
 
+        if (self::shouldDispatch(GacelaBootstrapStartedEvent::class)) {
+            self::dispatchEvent(new GacelaBootstrapStartedEvent($appRootDir));
+        }
+
         // Batch the file-cache writes produced while resolving classes during
         // bootstrap into a single atomic write per cache file (like cache:warm
         // does), instead of one full-file rewrite per newly discovered key.
@@ -85,6 +96,10 @@ final class Gacela
             self::runPlugins($config);
         } finally {
             AbstractPhpFileCache::commitBatch();
+        }
+
+        if (self::shouldDispatch(GacelaBootstrapFinishedEvent::class)) {
+            self::dispatchEvent(new GacelaBootstrapFinishedEvent((float)(hrtime(true) - $startTime) / 1e6));
         }
     }
 

--- a/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
+++ b/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
@@ -8,6 +8,7 @@ use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\Cache\CacheWarmedEvent;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -42,6 +43,28 @@ final class CacheWarmCommandTest extends TestCase
     protected function tearDown(): void
     {
         $this->removeGeneratedCaches();
+    }
+
+    public function test_cache_warm_dispatches_cache_warmed_event(): void
+    {
+        $warmedEvents = [];
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$warmedEvents): void {
+            $config->resetInMemoryCache();
+            $config->enableFileCache(__DIR__ . '/cache');
+            $config->registerSpecificListener(
+                CacheWarmedEvent::class,
+                static function (object $event) use (&$warmedEvents): void {
+                    $warmedEvents[] = $event;
+                },
+            );
+        });
+
+        $this->command->execute([]);
+
+        self::assertCount(1, $warmedEvents);
+        self::assertInstanceOf(CacheWarmedEvent::class, $warmedEvents[0]);
+        self::assertGreaterThanOrEqual(0, $warmedEvents[0]->moduleCount());
+        self::assertGreaterThanOrEqual(0, $warmedEvents[0]->failedCount());
     }
 
     public function test_cache_warm_creates_cache_file(): void

--- a/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php
+++ b/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php
@@ -31,8 +31,13 @@ final class GacelaClassResolverGeneralListenerTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
 
+            // This test asserts the exact class-resolver event stream; ignore
+            // the framework lifecycle events (bootstrap, config, ...) that a
+            // generic listener also receives.
             $config->registerGenericListener(function (GacelaEventInterface $event): void {
-                $this->saveInMemoryEvent($event);
+                if (str_starts_with($event::class, 'Gacela\Framework\Event\ClassResolver\\')) {
+                    $this->saveInMemoryEvent($event);
+                }
             });
         });
     }

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/LifecycleEventsTest.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/LifecycleEventsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapStartedEvent;
+use Gacela\Framework\Event\Config\ConfigInitializedEvent;
+use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Event\Container\ServiceResolvedEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
+use Gacela\Framework\Gacela;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LifecycleEventsTest extends TestCase
+{
+    /** @var list<GacelaEventInterface> */
+    private array $events = [];
+
+    protected function setUp(): void
+    {
+        $this->events = [];
+
+        Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(StringValueInterface::class, StringValue::class);
+
+            $config->registerGenericListener(function (GacelaEventInterface $event): void {
+                $this->events[] = $event;
+            });
+        });
+    }
+
+    public function test_bootstrap_dispatches_started_config_initialized_and_finished_in_order(): void
+    {
+        $startedAt = $this->firstPositionOf(GacelaBootstrapStartedEvent::class);
+        $configInitializedAt = $this->firstPositionOf(ConfigInitializedEvent::class);
+        $finishedAt = $this->firstPositionOf(GacelaBootstrapFinishedEvent::class);
+
+        self::assertNotNull($startedAt, 'GacelaBootstrapStartedEvent was not dispatched');
+        self::assertNotNull($configInitializedAt, 'ConfigInitializedEvent was not dispatched');
+        self::assertNotNull($finishedAt, 'GacelaBootstrapFinishedEvent was not dispatched');
+
+        self::assertLessThan($configInitializedAt, $startedAt);
+        self::assertLessThan($finishedAt, $configInitializedAt);
+    }
+
+    public function test_bootstrap_started_event_carries_app_root_dir(): void
+    {
+        $started = $this->firstEventOf(GacelaBootstrapStartedEvent::class);
+
+        self::assertInstanceOf(GacelaBootstrapStartedEvent::class, $started);
+        self::assertSame(__DIR__, $started->appRootDir());
+    }
+
+    public function test_bootstrap_finished_event_carries_positive_duration(): void
+    {
+        $finished = $this->firstEventOf(GacelaBootstrapFinishedEvent::class);
+
+        self::assertInstanceOf(GacelaBootstrapFinishedEvent::class, $finished);
+        self::assertGreaterThan(0.0, $finished->durationMs());
+    }
+
+    public function test_resolving_a_module_dispatches_provider_binding_and_service_events(): void
+    {
+        $facade = new Module\Facade();
+
+        self::assertSame('hello lifecycle', $facade->greet());
+
+        $provider = $this->firstEventOf(ProviderRegisteredEvent::class);
+        self::assertInstanceOf(ProviderRegisteredEvent::class, $provider);
+        self::assertSame(Module\Provider::class, $provider->providerClass());
+        self::assertSame('Module', $provider->moduleName());
+
+        $binding = $this->firstEventOf(BindingRegisteredEvent::class);
+        self::assertInstanceOf(BindingRegisteredEvent::class, $binding);
+        self::assertSame(StringValueInterface::class, $binding->id());
+
+        $serviceIds = array_map(
+            static fn (ServiceResolvedEvent $event): string => $event->id(),
+            array_values(array_filter(
+                $this->events,
+                static fn (GacelaEventInterface $event): bool => $event instanceof ServiceResolvedEvent,
+            )),
+        );
+        self::assertContains(Module\Provider::GREETING, $serviceIds);
+    }
+
+    /**
+     * @param class-string<GacelaEventInterface> $eventClass
+     */
+    private function firstPositionOf(string $eventClass): ?int
+    {
+        foreach ($this->events as $position => $event) {
+            if ($event instanceof $eventClass) {
+                return $position;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param class-string<GacelaEventInterface> $eventClass
+     */
+    private function firstEventOf(string $eventClass): ?GacelaEventInterface
+    {
+        $position = $this->firstPositionOf($eventClass);
+
+        return $position === null ? null : $this->events[$position];
+    }
+}

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/Module/Facade.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/Module/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle\Module;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function greet(): string
+    {
+        return $this->getFactory()->createGreeting();
+    }
+}

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/Module/Factory.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/Module/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle\Module;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createGreeting(): string
+    {
+        return (string)$this->getProvidedDependency(Provider::GREETING);
+    }
+}

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/Module/Provider.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/Module/Provider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle\Module;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class Provider extends AbstractProvider
+{
+    public const GREETING = 'lifecycle-greeting';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::GREETING, static fn (): string => 'hello lifecycle');
+    }
+}

--- a/tests/Fixtures/SpyEventDispatcher.php
+++ b/tests/Fixtures/SpyEventDispatcher.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Fixtures;
+
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+
+use function array_values;
+
+final class SpyEventDispatcher implements EventDispatcherInterface
+{
+    /** @var list<object> */
+    private array $dispatched = [];
+
+    public function __construct(
+        private readonly bool $hasListeners = true,
+    ) {
+    }
+
+    public function dispatch(object $event): void
+    {
+        $this->dispatched[] = $event;
+    }
+
+    public function hasListeners(string $eventClass): bool
+    {
+        return $this->hasListeners;
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function dispatchedEvents(): array
+    {
+        return $this->dispatched;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $eventClass
+     *
+     * @return list<T>
+     */
+    public function dispatchedEventsOf(string $eventClass): array
+    {
+        return array_values(
+            array_filter(
+                $this->dispatched,
+                static fn (object $event): bool => $event instanceof $eventClass,
+            ),
+        );
+    }
+}

--- a/tests/Integration/Framework/ServiceResolver/DocBlockResolverCacheTest.php
+++ b/tests/Integration/Framework/ServiceResolver/DocBlockResolverCacheTest.php
@@ -27,8 +27,13 @@ final class DocBlockResolverCacheTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
 
+            // This test asserts the exact class-resolver event stream; ignore
+            // the framework lifecycle events (bootstrap, config, ...) that a
+            // generic listener also receives.
             $config->registerGenericListener(function (GacelaEventInterface $event): void {
-                $this->saveInMemoryEvent($event);
+                if (str_starts_with($event::class, 'Gacela\Framework\Event\ClassResolver\\')) {
+                    $this->saveInMemoryEvent($event);
+                }
             });
         });
     }

--- a/tests/Unit/Framework/Event/Lifecycle/CacheClearedEventTest.php
+++ b/tests/Unit/Framework/Event/Lifecycle/CacheClearedEventTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Lifecycle;
+
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\Cache\CacheClearedEvent;
+use GacelaTest\Fixtures\SpyEventDispatcher;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class CacheClearedEventTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+    }
+
+    public function test_deleting_a_cache_file_dispatches_cache_cleared_event(): void
+    {
+        $spy = new SpyEventDispatcher();
+        Config::createWithSetup((new SetupGacela())->setEventDispatcher($spy));
+
+        $file = $this->createTempCacheFile();
+        FileCache::delete($file);
+
+        self::assertFileDoesNotExist($file);
+
+        $clearedEvents = $spy->dispatchedEventsOf(CacheClearedEvent::class);
+        self::assertCount(1, $clearedEvents);
+        self::assertSame($file, $clearedEvents[0]->cacheFile());
+    }
+
+    public function test_deleting_a_missing_file_dispatches_nothing(): void
+    {
+        $spy = new SpyEventDispatcher();
+        Config::createWithSetup((new SetupGacela())->setEventDispatcher($spy));
+
+        FileCache::delete(sys_get_temp_dir() . '/gacela-does-not-exist.php');
+
+        self::assertSame([], $spy->dispatchedEvents());
+    }
+
+    public function test_deleting_before_bootstrap_stays_silent(): void
+    {
+        Config::resetInstance();
+
+        $file = $this->createTempCacheFile();
+        FileCache::delete($file);
+
+        self::assertFileDoesNotExist($file);
+    }
+
+    private function createTempCacheFile(): string
+    {
+        $file = sys_get_temp_dir() . '/gacela-cache-cleared-' . uniqid('', true) . '.php';
+        file_put_contents($file, '<?php return [];');
+
+        return $file;
+    }
+}

--- a/tests/Unit/Framework/Event/Lifecycle/ConfigLifecycleEventsTest.php
+++ b/tests/Unit/Framework/Event/Lifecycle/ConfigLifecycleEventsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Lifecycle;
+
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\Config\ConfigInitializedEvent;
+use Gacela\Framework\Event\Config\ConfigKeyNotFoundEvent;
+use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
+use Gacela\Framework\Exception\ConfigException;
+use GacelaTest\Fixtures\SpyEventDispatcher;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigLifecycleEventsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+    }
+
+    public function test_init_dispatches_config_initialized_event(): void
+    {
+        $spy = $this->bootstrapWithSpy();
+
+        Config::getInstance()->init();
+
+        self::assertCount(1, $spy->dispatchedEventsOf(ConfigInitializedEvent::class));
+    }
+
+    public function test_get_with_default_dispatches_read_and_not_found_events(): void
+    {
+        $spy = $this->bootstrapWithSpy();
+
+        $value = Config::getInstance()->get('unknown-key', 'fallback');
+
+        self::assertSame('fallback', $value);
+
+        $readEvents = $spy->dispatchedEventsOf(ConfigKeyReadEvent::class);
+        self::assertCount(1, $readEvents);
+        self::assertSame('unknown-key', $readEvents[0]->key());
+
+        $notFoundEvents = $spy->dispatchedEventsOf(ConfigKeyNotFoundEvent::class);
+        self::assertCount(1, $notFoundEvents);
+        self::assertSame('unknown-key', $notFoundEvents[0]->key());
+    }
+
+    public function test_get_missing_key_without_default_dispatches_not_found_and_throws(): void
+    {
+        $spy = $this->bootstrapWithSpy();
+
+        try {
+            Config::getInstance()->get('missing-key');
+            self::fail('Expected ConfigException was not thrown');
+        } catch (ConfigException) {
+        }
+
+        $notFoundEvents = $spy->dispatchedEventsOf(ConfigKeyNotFoundEvent::class);
+        self::assertCount(1, $notFoundEvents);
+        self::assertSame('missing-key', $notFoundEvents[0]->key());
+    }
+
+    public function test_no_events_dispatched_when_nothing_listens(): void
+    {
+        $spy = $this->bootstrapWithSpy(hasListeners: false);
+
+        Config::getInstance()->get('unknown-key', 'fallback');
+
+        self::assertSame([], $spy->dispatchedEvents());
+    }
+
+    private function bootstrapWithSpy(bool $hasListeners = true): SpyEventDispatcher
+    {
+        $spy = new SpyEventDispatcher($hasListeners);
+
+        Config::createWithSetup((new SetupGacela())->setEventDispatcher($spy));
+        Config::getInstance()->setAppRootDir(__DIR__);
+
+        return $spy;
+    }
+}

--- a/tests/Unit/Framework/Event/Lifecycle/ContainerLifecycleEventsTest.php
+++ b/tests/Unit/Framework/Event/Lifecycle/ContainerLifecycleEventsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Lifecycle;
+
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Event\Container\ServiceResolvedEvent;
+use GacelaTest\Fixtures\SpyEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class ContainerLifecycleEventsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+    }
+
+    public function test_service_resolved_event_dispatched_once_per_service_id(): void
+    {
+        $spy = $this->bootstrapWithSpy();
+
+        $container = new Container();
+        $container->set('my-service', static fn (): stdClass => new stdClass());
+
+        $container->get('my-service');
+        $container->get('my-service');
+
+        $resolvedEvents = $spy->dispatchedEventsOf(ServiceResolvedEvent::class);
+        self::assertCount(1, $resolvedEvents);
+        self::assertSame('my-service', $resolvedEvents[0]->id());
+    }
+
+    public function test_no_service_resolved_event_when_nothing_listens(): void
+    {
+        $spy = $this->bootstrapWithSpy(hasListeners: false);
+
+        $container = new Container();
+        $container->set('my-service', static fn (): stdClass => new stdClass());
+        $container->get('my-service');
+
+        self::assertSame([], $spy->dispatchedEvents());
+    }
+
+    private function bootstrapWithSpy(bool $hasListeners = true): SpyEventDispatcher
+    {
+        $spy = new SpyEventDispatcher($hasListeners);
+
+        Config::createWithSetup((new SetupGacela())->setEventDispatcher($spy));
+
+        return $spy;
+    }
+}

--- a/tests/Unit/Framework/Event/Lifecycle/LifecycleEventGettersTest.php
+++ b/tests/Unit/Framework/Event/Lifecycle/LifecycleEventGettersTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Lifecycle;
+
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapStartedEvent;
+use Gacela\Framework\Event\Cache\CacheClearedEvent;
+use Gacela\Framework\Event\Cache\CacheWarmedEvent;
+use Gacela\Framework\Event\Config\ConfigInitializedEvent;
+use Gacela\Framework\Event\Config\ConfigKeyNotFoundEvent;
+use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
+use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Event\Container\ServiceResolvedEvent;
+use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
+use PHPUnit\Framework\TestCase;
+
+final class LifecycleEventGettersTest extends TestCase
+{
+    public function test_bootstrap_started_event_renders_to_string(): void
+    {
+        $event = new GacelaBootstrapStartedEvent('/app/root');
+
+        self::assertSame('/app/root', $event->appRootDir());
+        self::assertStringContainsString(GacelaBootstrapStartedEvent::class, $event->toString());
+    }
+
+    public function test_bootstrap_finished_event_exposes_duration(): void
+    {
+        $event = new GacelaBootstrapFinishedEvent(12.5);
+
+        self::assertSame(12.5, $event->durationMs());
+        self::assertStringContainsString('12.5', $event->toString());
+    }
+
+    public function test_config_initialized_event_exposes_key_count(): void
+    {
+        $event = new ConfigInitializedEvent(42);
+
+        self::assertSame(42, $event->keyCount());
+    }
+
+    public function test_config_key_read_event_exposes_key(): void
+    {
+        $event = new ConfigKeyReadEvent('db.host');
+
+        self::assertSame('db.host', $event->key());
+    }
+
+    public function test_config_key_not_found_event_exposes_key(): void
+    {
+        $event = new ConfigKeyNotFoundEvent('missing.key');
+
+        self::assertSame('missing.key', $event->key());
+    }
+
+    public function test_service_resolved_event_exposes_id(): void
+    {
+        $event = new ServiceResolvedEvent('logger');
+
+        self::assertSame('logger', $event->id());
+    }
+
+    public function test_binding_registered_event_exposes_id(): void
+    {
+        $event = new BindingRegisteredEvent('router');
+
+        self::assertSame('router', $event->id());
+    }
+
+    public function test_provider_registered_event_exposes_provider_and_module(): void
+    {
+        $event = new ProviderRegisteredEvent('App\ModuleA\Provider', 'ModuleA');
+
+        self::assertSame('App\ModuleA\Provider', $event->providerClass());
+        self::assertSame('ModuleA', $event->moduleName());
+    }
+
+    public function test_cache_cleared_event_exposes_cache_file(): void
+    {
+        $event = new CacheClearedEvent('/cache/gacela-file.php');
+
+        self::assertSame('/cache/gacela-file.php', $event->cacheFile());
+    }
+
+    public function test_cache_warmed_event_exposes_counts(): void
+    {
+        $event = new CacheWarmedEvent(10, 2);
+
+        self::assertSame(10, $event->moduleCount());
+        self::assertSame(2, $event->failedCount());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds framework lifecycle events so devs can hook into Gacela internals (profiling, tracing, debugging) via the existing listener API, without patching the framework. Every dispatch site uses the `hasListeners()` guard from #449, so with no listeners registered nothing is allocated and the hot paths stay zero-cost (benchmark: 0.261μs vs 0.255μs warm resolve, within noise; the new phpbench CI guard also covers this).

## 🔖 Changes

- New events: `GacelaBootstrapStartedEvent`/`GacelaBootstrapFinishedEvent(durationMs)`, `ConfigInitializedEvent(keyCount)`, `ConfigKeyReadEvent(key)`, `ConfigKeyNotFoundEvent(key)`, `ServiceResolvedEvent(id)` (once per container service), `BindingRegisteredEvent(id)`, `ProviderRegisteredEvent(providerClass, moduleName)`, `CacheClearedEvent(cacheFile)`, `CacheWarmedEvent(moduleCount, failedCount)`
- `Config::getEventDispatcher()` returns a no-op dispatcher before bootstrap (cache deletion can run pre-bootstrap) instead of throwing
- A new bootstrap now rebuilds the dispatcher from its own setup; previously stale listeners survived re-bootstraps unless the in-memory cache was reset
- Tests: getters per event, spy-dispatcher unit tests (config/container/cache), feature test asserting bootstrap→config→finish ordering and provider/binding/service events, `cache:warm` event assertion
- Two exact-stream listener tests now filter to `Event\ClassResolver\*` since generic listeners also receive lifecycle events

Closes #450