### PR TITLE
docs(events): event system guide + listener hook cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@
 ### Added
 
 - Framework lifecycle events for observability, all allocation-guarded so they stay zero-cost when nothing listens: `GacelaBootstrapStartedEvent`/`GacelaBootstrapFinishedEvent(durationMs)`, `ConfigInitializedEvent(keyCount)`, `ConfigKeyReadEvent(key)`, `ConfigKeyNotFoundEvent(key)`, `ServiceResolvedEvent(id)` (once per container service), `BindingRegisteredEvent(id)`, `ProviderRegisteredEvent(providerClass, moduleName)`, `CacheClearedEvent(cacheFile)`, `CacheWarmedEvent(moduleCount, failedCount)`
+- Typed config accessors on `Config`/`AbstractConfig`: `getString()`, `getInt()`, `getFloat()`, `getBool()`, `getArray()`. Each returns a concrete type (no more `mixed` casts), uses a `null` default to mean "required", and throws `ConfigException` on a type mismatch instead of coercing (`getFloat()` accepts an int via lossless widening). Self-contained implementations: a typed read is faster than `get()` + a manual cast (single `array_key_exists`, no default sentinel comparison)
 
 ### Fixed
 
 - `Config::getEventDispatcher()` no longer throws when called before bootstrap; it returns a no-op dispatcher so guarded dispatch sites (e.g. cache-file deletion) stay silent
 - Re-bootstrapping now rebuilds the event dispatcher from the new setup; previously a dispatcher cached by a prior bootstrap kept serving stale listeners unless the in-memory cache was reset
 
-- Typed config accessors on `Config`/`AbstractConfig`: `getString()`, `getInt()`, `getFloat()`, `getBool()`, `getArray()`. Each returns a concrete type (no more `mixed` casts), uses a `null` default to mean "required", and throws `ConfigException` on a type mismatch instead of coercing (`getFloat()` accepts an int via lossless widening). Self-contained implementations: a typed read is faster than `get()` + a manual cast (single `array_key_exists`, no default sentinel comparison)
+### Documentation
+
+- New `docs/events.md`: event system guide with the dispatch model, a complete event catalog (payloads, firing sites, hot-path markers), and a listener cookbook; linked from the README and docs index
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ app/
 - [Container configuration](docs/container-configuration.md)
 - [Static analysis (PHPStan / Psalm)](docs/static-analysis.md)
 - [Module health checks](docs/module-health-checks.md)
+- [Events](docs/events.md)
 - [Opcache preload](docs/opcache-preload.md)
 - Full reference: [gacela-project.com](https://gacela-project.com/)
 - Examples: [gacela-example](https://github.com/gacela-project/gacela-example)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Container configuration](container-configuration.md) — factories, aliases, contextual bindings
 - [Static analysis](static-analysis.md) — PHPStan and Psalm setup
 - [Module health checks](module-health-checks.md) — report module operational status
+- [Events](events.md) — listen to Gacela internals: dispatch model, event catalog, cookbook
 - [Caching](caching.md) — overview of Gacela's three caching layers and when to reach for each
 - [Cacheable methods](cacheable-methods.md) — cache facade method results with `#[Cacheable]`
 - [Opcache preload](opcache-preload.md) — production performance tuning

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,212 @@
+# Events
+
+Gacela dispatches domain events while it works: bootstrapping, reading config, resolving classes,
+wiring providers, touching caches. Listening to them is the best window into "how does Gacela
+resolve my modules" — useful for debugging, profiling, tracing, and CI guards, without patching
+the framework.
+
+## Dispatch model
+
+- Every event is a small immutable class implementing `GacelaEventInterface` (one `toString()` method).
+- By default nothing listens: the dispatcher is a `NullEventDispatcher`, and every dispatch site is
+  guarded by `EventDispatcherInterface::hasListeners()`, so **no event object is even allocated**
+  unless a listener is registered for it. Events are zero-cost when unused, including on the
+  class-resolution hot path.
+- Registering any listener switches to a `ConfigurableEventDispatcher`. Listeners are plain
+  callables receiving the event object; they are notify-only (events are immutable, there is no
+  propagation stopping).
+
+Two kinds of listeners:
+
+```php
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
+use Gacela\Framework\Gacela;
+
+Gacela::bootstrap($appRootDir, static function (GacelaConfig $config): void {
+    // Generic: receives every event
+    $config->registerGenericListener(static function (GacelaEventInterface $event): void {
+        error_log($event->toString());
+    });
+
+    // Specific: receives only that event class
+    $config->registerSpecificListener(
+        ResolvedClassCreatedEvent::class,
+        static function (ResolvedClassCreatedEvent $event): void {
+            error_log('created: ' . $event->classInfo()->getCacheKey());
+        },
+    );
+});
+```
+
+A generic listener makes *every* dispatch site allocate its event, including hot paths — prefer
+specific listeners in production.
+
+## Lifecycle ordering
+
+```
+Gacela::bootstrap()
+ ├─ GacelaBootstrapStartedEvent
+ ├─ ReadPhpConfigEvent               (per config file)
+ ├─ ConfigInitializedEvent
+ └─ GacelaBootstrapFinishedEvent
+
+first Facade/Factory/Config access (per module)
+ ├─ ClassName*Event                  (find the class name; cached vs candidates)
+ ├─ ResolvedClass*Event              (created / cached / parent / default)
+ ├─ BindingRegisteredEvent           (per configured binding, on container build)
+ ├─ ProviderRegisteredEvent          (module provider wired)
+ └─ ServiceResolvedEvent             (per service, first `get()` on the container)
+```
+
+## Event catalog
+
+All classes live under `Gacela\Framework\Event\`. "Hot path" marks events fired on every warm
+resolve — with only unrelated listeners registered they still cost nothing.
+
+### Bootstrap (`Event\Bootstrap`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `GacelaBootstrapStartedEvent` | `Gacela::bootstrap()` begins (after the setup is processed) | `appRootDir()` | no |
+| `GacelaBootstrapFinishedEvent` | bootstrap completed | `durationMs()` | no |
+
+### Config (`Event\Config`, `Event\ConfigReader`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `ConfigInitializedEvent` | merged config built by `Config::init()` | `keyCount()` | no |
+| `ConfigKeyReadEvent` | every `Config::get()` | `key()` | **yes** |
+| `ConfigKeyNotFoundEvent` | `Config::get()` misses (default returned or exception thrown) | `key()` | no |
+| `ConfigReader\ReadPhpConfigEvent` | a PHP config file is read | `absolutePath()` | no |
+
+### Class resolution (`Event\ClassResolver`)
+
+All four resolver events extend `AbstractGacelaClassResolverEvent` and expose `classInfo()`.
+
+| Event | Fires when | Hot path |
+|---|---|---|
+| `ResolvedClassCachedEvent` | resolve served from the in-memory instance cache | **yes** |
+| `ResolvedClassCreatedEvent` | a new instance was created for the caller | no |
+| `ResolvedClassTriedFromParentEvent` | resolution retried with the caller's parent class | no |
+| `ResolvedCreatedDefaultClassEvent` | no class found; default (e.g. anonymous config) used | no |
+
+### Class-name finding (`Event\ClassResolver\ClassNameFinder`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `ClassNameCachedFoundEvent` | class name served from cache | `cacheKey()`, `className()` | **yes** |
+| `ClassNameValidCandidateFoundEvent` | a candidate class name exists | `className()` | no |
+| `ClassNameInvalidCandidateFoundEvent` | a candidate class name does not exist | `className()` | no |
+| `ClassNameNotFoundEvent` | no candidate matched | `classInfo()`, `resolvableTypes()` | no |
+
+### Resolver caches (`Event\ClassResolver\Cache`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `ClassNameCacheCachedEvent` | class-name cache instance reused | — | **yes** |
+| `ClassNamePhpCacheCreatedEvent` | file-backed class-name cache created | `cacheDir()` | no |
+| `ClassNameInMemoryCacheCreatedEvent` | in-memory class-name cache created | — | no |
+| `CustomServicesCacheCachedEvent` | custom-services cache instance reused | — | **yes** |
+| `CustomServicesPhpCacheCreatedEvent` | file-backed custom-services cache created | — | no |
+| `CustomServicesInMemoryCacheCreatedEvent` | in-memory custom-services cache created | — | no |
+
+### Container (`Event\Container`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `ServiceResolvedEvent` | first `get()` of a service id on a container | `id()` | **yes** |
+| `BindingRegisteredEvent` | a binding/factory/alias/contextual binding is registered on container build | `id()` | no |
+
+### Provider (`Event\Provider`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `ProviderRegisteredEvent` | a module's provider wired its dependencies | `providerClass()`, `moduleName()` | no |
+
+### Cache files (`Event\Cache`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `CacheClearedEvent` | a Gacela cache file is deleted | `cacheFile()` | no |
+| `CacheWarmedEvent` | `bin/gacela cache:warm` finished | `moduleCount()`, `failedCount()` | no |
+
+## Cookbook
+
+### Log every resolved class
+
+```php
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\ClassResolver\AbstractGacelaClassResolverEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
+
+$config->registerGenericListener(static function (GacelaEventInterface $event): void {
+    if ($event instanceof AbstractGacelaClassResolverEvent) {
+        error_log($event->toString());
+    }
+});
+```
+
+### Time the bootstrap
+
+```php
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+
+$config->registerSpecificListener(
+    GacelaBootstrapFinishedEvent::class,
+    static function (GacelaBootstrapFinishedEvent $event): void {
+        error_log(sprintf('gacela booted in %.2fms', $event->durationMs()));
+    },
+);
+```
+
+### Fail CI on unresolved classes
+
+```php
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameNotFoundEvent;
+
+$config->registerSpecificListener(
+    ClassNameNotFoundEvent::class,
+    static function (ClassNameNotFoundEvent $event): void {
+        throw new RuntimeException('Unresolvable gacela class: ' . $event->toString());
+    },
+);
+```
+
+### Trace config key reads
+
+```php
+use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
+
+/** @var array<string,int> $reads */
+$reads = [];
+$config->registerSpecificListener(
+    ConfigKeyReadEvent::class,
+    static function (ConfigKeyReadEvent $event) use (&$reads): void {
+        $reads[$event->key()] = ($reads[$event->key()] ?? 0) + 1;
+    },
+);
+```
+
+### Export a resolution timeline (profiler / OpenTelemetry)
+
+```php
+use Gacela\Framework\Event\GacelaEventInterface;
+
+/** @var list<array{t: float, event: string}> $timeline */
+$timeline = [];
+$config->registerGenericListener(static function (GacelaEventInterface $event) use (&$timeline): void {
+    $timeline[] = ['t' => microtime(true), 'event' => $event->toString()];
+});
+
+// Later: convert each entry into a span/annotation for your tracer, e.g.
+// $span->addEvent($entry['event'], ['timestamp' => $entry['t']]);
+```
+
+## Custom dispatchers
+
+`SetupGacela::setEventDispatcher()` accepts any `EventDispatcherInterface`. Implementations must
+provide `dispatch(object $event): void` **and** `hasListeners(string $eventClass): bool` — return
+`false` from `hasListeners()` for event classes you don't care about and the framework will skip
+allocating them entirely.

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/EventDocExamplesTest.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/EventDocExamplesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+use Gacela\Framework\Event\ClassResolver\AbstractGacelaClassResolverEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs the copy-paste recipes from docs/events.md end-to-end so the
+ * documentation cannot silently rot when the event API changes.
+ */
+final class EventDocExamplesTest extends TestCase
+{
+    public function test_recipe_log_every_resolved_class(): void
+    {
+        /** @var list<string> $logged */
+        $logged = [];
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$logged): void {
+            $config->resetInMemoryCache();
+
+            $config->registerGenericListener(static function (GacelaEventInterface $event) use (&$logged): void {
+                if ($event instanceof AbstractGacelaClassResolverEvent) {
+                    $logged[] = $event->toString();
+                }
+            });
+        });
+
+        (new Module\Facade())->greet();
+
+        self::assertNotEmpty($logged);
+        self::assertStringContainsString('classInfo:', $logged[0]);
+    }
+
+    public function test_recipe_time_bootstrap(): void
+    {
+        /** @var list<float> $durations */
+        $durations = [];
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$durations): void {
+            $config->resetInMemoryCache();
+
+            $config->registerSpecificListener(
+                GacelaBootstrapFinishedEvent::class,
+                static function (GacelaBootstrapFinishedEvent $event) use (&$durations): void {
+                    $durations[] = $event->durationMs();
+                },
+            );
+        });
+
+        self::assertCount(1, $durations);
+        self::assertGreaterThan(0.0, $durations[0]);
+    }
+}


### PR DESCRIPTION
## 📚 Description

The event system was undocumented: devs couldn't discover which events exist, when they fire, or how to hook in. This ships a complete guide so a developer can understand the dispatch model, register a listener, and trace resolution/bootstrap/config in minutes.

## 🔖 Changes

- New `docs/events.md`: dispatch model (generic vs specific listeners, `NullEventDispatcher` default, `hasListeners()` zero-cost guard), lifecycle ordering diagram, and a catalog of all 25 event classes with payloads, firing sites, and hot-path markers
- Cookbook recipes: log resolved classes, time bootstrap, fail CI on `ClassNameNotFoundEvent`, trace config key reads, export a resolution timeline
- Custom-dispatcher section documents the `hasListeners()` contract from #449
- Linked from the README documentation list and `docs/README.md` index
- `EventDocExamplesTest` runs the first two recipes end-to-end so the docs cannot silently rot

Closes #451

---
Refactor pass done after implementation: docs-only change plus one feature test; nothing to refactor. Catalog cross-checked against `find src/Framework/Event -name '*Event.php'`: all 25 event classes documented.