### PR TITLE
docs(container): surface #[Inject]/#[Singleton]/#[Factory] to modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Documentation
 
 - New `docs/events.md`: event system guide with the dispatch model, a complete event catalog (payloads, firing sites, hot-path markers), and a listener cookbook; linked from the README and docs index
+- `docs/container-configuration.md` now documents the container's class attributes `#[Singleton]` and `#[Factory]` for module authors (attribute vs imperative registration, lifetime semantics through Gacela factories); a feature test proves all three DI attributes work through `getProvidedDependency()`
 
 ### Changed
 

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -182,6 +182,54 @@ compiler pass is required to route `#[Inject]` parameters to Gacela before
 Symfony's autowire claims them. A dedicated `gacela/symfony-bridge` package
 ships this pass; adopt it in projects where Symfony owns the container.
 
+## Class Attributes: `#[Singleton]` and `#[Factory]`
+
+Instead of registering a binding or an `addFactory()` closure, module authors can
+annotate the service class itself. Any class resolved through the container —
+including via `getProvidedDependency()` in a Gacela `Factory` — honors these:
+
+```php
+use Gacela\Container\Attribute\Factory;
+use Gacela\Container\Attribute\Singleton;
+
+#[Singleton]
+final class ConnectionPool {}   // one instance, cached and reused
+
+#[Factory]
+final class ReportBuilder {}    // fresh instance on every resolution
+```
+
+```php
+final class MyModuleFactory extends AbstractFactory
+{
+    public function createPool(): ConnectionPool
+    {
+        /** @var ConnectionPool */
+        return $this->getProvidedDependency(ConnectionPool::class);  // same instance every call
+    }
+}
+```
+
+The attribute lives with the class, so the lifetime choice travels with the code
+instead of a `gacela.php` entry. Equivalent imperative registrations:
+
+| Attribute | Imperative equivalent |
+|---|---|
+| `#[Singleton]` on `Pool` | `$container->set(Pool::class, new Pool())` in a provider |
+| `#[Factory]` on `Builder` | `$config->addFactory(Builder::class, static fn() => new Builder())` |
+| `#[Inject(X::class)]` on a param | `$config->when(Consumer::class)->needs(Type::class)->give(X::class)` |
+
+Notes:
+
+- `#[Singleton]` instances are cached per container. Each Gacela module factory
+  keeps one container, so repeated resolves through the same module share the
+  instance.
+- Without any attribute, an unregistered class is autowired fresh on each
+  `get()` — `#[Singleton]` is the opt-in for caching, `#[Factory]` documents
+  the fresh-instance intent explicitly.
+- Constructor params of attribute-annotated classes still go through the normal
+  resolution order (bindings, contextual bindings, `#[Inject]`).
+
 ## Quick Reference
 
 | Type | Behavior | Use Case |
@@ -192,6 +240,8 @@ ships this pass; adopt it in projects where Symfony owns the container.
 | Alias | Points to another service | Backward compatibility, short names |
 | Contextual | Different impl per class | Per-controller loggers, context-specific deps |
 | `#[Inject]` | Constructor-param opt-in | Explicit concrete override, tool visibility |
+| `#[Singleton]` | One cached instance per container | Shared stateful services, no registration needed |
+| `#[Factory]` | New instance each resolution | Explicit fresh-instance intent on the class |
 
 ## Example
 

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/CounterServiceSingleton.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/CounterServiceSingleton.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+use Gacela\Container\Attribute\Singleton;
+
+#[Singleton]
+final class CounterServiceSingleton
+{
+    public int $count = 0;
+
+    public function increment(): int
+    {
+        return ++$this->count;
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/DefaultGreeting.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/DefaultGreeting.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+final class DefaultGreeting implements GreetingInterface
+{
+    public function greet(): string
+    {
+        return 'hello from the binding';
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/FreshPrinter.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/FreshPrinter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+use Gacela\Container\Attribute\Factory;
+
+#[Factory]
+final class FreshPrinter
+{
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/GreeterWithInject.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/GreeterWithInject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+use Gacela\Container\Attribute\Inject;
+
+final class GreeterWithInject
+{
+    public function __construct(
+        #[Inject(SpecialGreeting::class)]
+        public readonly GreetingInterface $greeting,
+    ) {
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/GreetingInterface.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/GreetingInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+interface GreetingInterface
+{
+    public function greet(): string;
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/PlainGreeter.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/PlainGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+final class PlainGreeter
+{
+    public function __construct(
+        public readonly GreetingInterface $greeting,
+    ) {
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Domain/SpecialGreeting.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Domain/SpecialGreeting.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module\Domain;
+
+final class SpecialGreeting implements GreetingInterface
+{
+    public function greet(): string
+    {
+        return 'hello from the #[Inject] override';
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Factory.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Factory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\CounterServiceSingleton;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\FreshPrinter;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\GreeterWithInject;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\PlainGreeter;
+
+final class Factory extends AbstractFactory
+{
+    public function createSingletonCounter(): CounterServiceSingleton
+    {
+        /** @var CounterServiceSingleton */
+        return $this->getProvidedDependency(CounterServiceSingleton::class);
+    }
+
+    public function createFreshPrinter(): FreshPrinter
+    {
+        /** @var FreshPrinter */
+        return $this->getProvidedDependency(FreshPrinter::class);
+    }
+
+    public function createGreeterWithInject(): GreeterWithInject
+    {
+        /** @var GreeterWithInject */
+        return $this->getProvidedDependency(GreeterWithInject::class);
+    }
+
+    public function createPlainGreeter(): PlainGreeter
+    {
+        /** @var PlainGreeter */
+        return $this->getProvidedDependency(PlainGreeter::class);
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Provider.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Provider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes\Module;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class Provider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/ModuleAttributesTest.php
+++ b/tests/Feature/Container/ModuleAttributes/ModuleAttributesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\DefaultGreeting;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\GreetingInterface;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\SpecialGreeting;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(GreetingInterface::class, DefaultGreeting::class);
+        });
+    }
+
+    public function test_singleton_attribute_returns_the_same_instance_across_resolves(): void
+    {
+        $factory = new Module\Factory();
+
+        $first = $factory->createSingletonCounter();
+        $second = $factory->createSingletonCounter();
+
+        self::assertSame($first, $second);
+
+        $first->increment();
+        self::assertSame(1, $second->count);
+    }
+
+    public function test_factory_attribute_returns_fresh_instances(): void
+    {
+        $factory = new Module\Factory();
+
+        self::assertNotSame(
+            $factory->createFreshPrinter(),
+            $factory->createFreshPrinter(),
+        );
+    }
+
+    public function test_inject_attribute_overrides_the_bound_implementation(): void
+    {
+        $greeter = (new Module\Factory())->createGreeterWithInject();
+
+        self::assertInstanceOf(SpecialGreeting::class, $greeter->greeting);
+        self::assertSame('hello from the #[Inject] override', $greeter->greeting->greet());
+    }
+
+    public function test_binding_is_used_when_no_inject_attribute_is_present(): void
+    {
+        $greeter = (new Module\Factory())->createPlainGreeter();
+
+        self::assertInstanceOf(DefaultGreeting::class, $greeter->greeting);
+        self::assertSame('hello from the binding', $greeter->greeting->greet());
+    }
+}


### PR DESCRIPTION
## 📚 Description

The issue asked to investigate whether the container's DI attributes work for module authors before building anything. The spike confirmed they already work end-to-end: classes resolved through a Gacela `Factory` via `getProvidedDependency()` are auto-wired by the container, which honors `#[Singleton]`/`#[Factory]` in `DependencyCacheManager::instantiate()` and applies `#[Inject]` before bindings. No wiring gap — per the issue, this ships the proving feature test plus documentation.

## 🔖 Changes

- `ModuleAttributesTest` + fixture module asserting through a real Gacela factory: `#[Singleton]` returns the identical instance across resolves, `#[Factory]` returns fresh instances, `#[Inject(X)]` overrides the bound implementation, and the binding still wins without the attribute
- `docs/container-configuration.md`: new "Class Attributes" section for module authors — attribute vs imperative registration table, per-container singleton lifetime through module factories, quick-reference rows for `#[Singleton]`/`#[Factory]`

Closes #452

---
Refactor pass done after implementation: docs + test fixtures only; fixtures are minimal by design, nothing to refactor.