### PR TITLE
feat(console): debug:module inspection command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Framework lifecycle events for observability, all allocation-guarded so they stay zero-cost when nothing listens: `GacelaBootstrapStartedEvent`/`GacelaBootstrapFinishedEvent(durationMs)`, `ConfigInitializedEvent(keyCount)`, `ConfigKeyReadEvent(key)`, `ConfigKeyNotFoundEvent(key)`, `ServiceResolvedEvent(id)` (once per container service), `BindingRegisteredEvent(id)`, `ProviderRegisteredEvent(providerClass, moduleName)`, `CacheClearedEvent(cacheFile)`, `CacheWarmedEvent(moduleCount, failedCount)`
+- `debug:module <ModuleName>` console command: given a module name it prints the resolved Facade/Factory/Config/Provider classes, the container bindings (global + contextual), and the facade dependency tree; supports `--json` for machine output and `--tree` to limit output to the tree
 - Typed config accessors on `Config`/`AbstractConfig`: `getString()`, `getInt()`, `getFloat()`, `getBool()`, `getArray()`. Each returns a concrete type (no more `mixed` casts), uses a `null` default to mean "required", and throws `ConfigException` on a type mismatch instead of coercing (`getFloat()` accepts an int via lossless widening). Self-contained implementations: a typed read is faster than `get()` + a manual cast (single `array_key_exists`, no default sentinel comparison)
 
 ### Fixed

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -66,4 +66,20 @@ final class ConsoleFacade extends AbstractFacade
     {
         return $this->getFactory()->getContainerDependencyTree($className);
     }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getContainerBindings(): array
+    {
+        return $this->getFactory()->getContainerBindings();
+    }
+
+    /**
+     * @return array<string,array<string,string>>
+     */
+    public function getContainerContextualBindings(): array
+    {
+        return $this->getFactory()->getContainerContextualBindings();
+    }
 }

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -30,6 +30,7 @@ use SplFileInfo;
 use Symfony\Component\Console\Command\Command;
 
 use function is_dir;
+use function is_string;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
@@ -112,6 +113,39 @@ final class ConsoleFactory extends AbstractFactory
     public function getContainerDependencyTree(string $className): array
     {
         return $this->getMainContainer()->getDependencyTree($className);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getContainerBindings(): array
+    {
+        $result = [];
+        foreach (Config::getInstance()->getFactory()->createGacelaFileConfig()->getBindings() as $abstract => $concrete) {
+            $result[$abstract] = $this->stringifyBoundConcrete($concrete);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string,array<string,string>>
+     */
+    public function getContainerContextualBindings(): array
+    {
+        $result = [];
+        foreach (Config::getInstance()->getSetupGacela()->getContextualBindings() as $consumer => $needs) {
+            foreach ($needs as $abstract => $concrete) {
+                $result[$consumer][$abstract] = $this->stringifyBoundConcrete($concrete);
+            }
+        }
+
+        return $result;
+    }
+
+    private function stringifyBoundConcrete(mixed $concrete): string
+    {
+        return is_string($concrete) ? $concrete : get_debug_type($concrete);
     }
 
     /**

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -10,6 +10,7 @@ use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
 use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
 use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
 use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
 use Gacela\Console\Infrastructure\Command\DoctorCommand;
 use Gacela\Console\Infrastructure\Command\ListModulesCommand;
@@ -42,6 +43,7 @@ final class ConsoleProvider extends AbstractProvider
             new DebugConfigCommand(),
             new DebugContainerCommand(),
             new DebugDependenciesCommand(),
+            new DebugModuleCommand(),
             new DebugModulesCommand(),
             new CacheWarmCommand(),
             new CacheClearCommand(),

--- a/src/Console/Infrastructure/Command/DebugModuleCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModuleCommand.php
@@ -66,6 +66,9 @@ final class DebugModuleCommand extends Command
      */
     private function renderJson(OutputInterface $output, array $modules): int
     {
+        $bindings = $this->getFacade()->getContainerBindings();
+        $contextualBindings = $this->getFacade()->getContainerContextualBindings();
+
         $payload = [];
         foreach ($modules as $module) {
             $payload[] = [
@@ -75,8 +78,8 @@ final class DebugModuleCommand extends Command
                 'factory' => $module->factoryClass(),
                 'config' => $module->configClass(),
                 'provider' => $module->providerClass(),
-                'bindings' => $this->getFacade()->getContainerBindings(),
-                'contextualBindings' => $this->getFacade()->getContainerContextualBindings(),
+                'bindings' => $bindings,
+                'contextualBindings' => $contextualBindings,
                 'dependencyTree' => $this->getFacade()->getContainerDependencyTree($module->facadeClass()),
             ];
         }

--- a/src/Console/Infrastructure/Command/DebugModuleCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModuleCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function json_encode;
+use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+final class DebugModuleCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const NOT_FOUND = '(not found)';
+
+    protected function configure(): void
+    {
+        $this->setName('debug:module')
+            ->setDescription('Inspect a module: resolved gacela classes, container bindings, and dependency tree')
+            ->addArgument('module', InputArgument::REQUIRED, 'Module name (or a part of it)')
+            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Output machine-readable JSON')
+            ->addOption('tree', 't', InputOption::VALUE_NONE, 'Only print the dependency tree');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $moduleName = (string)$input->getArgument('module');
+        $modules = $this->getFacade()->findAllAppModules($moduleName);
+
+        if ($modules === []) {
+            $output->writeln(sprintf('<comment>No module matches "%s".</comment>', $moduleName));
+
+            return Command::FAILURE;
+        }
+
+        if ((bool)$input->getOption('json')) {
+            return $this->renderJson($output, $modules);
+        }
+
+        $treeOnly = (bool)$input->getOption('tree');
+        foreach ($modules as $module) {
+            $this->renderModule($output, $module, $treeOnly);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<AppModule> $modules
+     */
+    private function renderJson(OutputInterface $output, array $modules): int
+    {
+        $payload = [];
+        foreach ($modules as $module) {
+            $payload[] = [
+                'module' => $module->moduleName(),
+                'fullModuleName' => $module->fullModuleName(),
+                'facade' => $module->facadeClass(),
+                'factory' => $module->factoryClass(),
+                'config' => $module->configClass(),
+                'provider' => $module->providerClass(),
+                'bindings' => $this->getFacade()->getContainerBindings(),
+                'contextualBindings' => $this->getFacade()->getContainerContextualBindings(),
+                'dependencyTree' => $this->getFacade()->getContainerDependencyTree($module->facadeClass()),
+            ];
+        }
+
+        $output->writeln(json_encode(
+            $payload,
+            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function renderModule(OutputInterface $output, AppModule $module, bool $treeOnly): void
+    {
+        $output->writeln(sprintf('<info>Module: %s</info>', $module->moduleName()));
+
+        if (!$treeOnly) {
+            $this->renderResolvedClasses($output, $module);
+            $this->renderBindings($output);
+        }
+
+        $this->renderDependencyTree($output, $module);
+        $output->writeln('');
+    }
+
+    private function renderResolvedClasses(OutputInterface $output, AppModule $module): void
+    {
+        $output->writeln(sprintf('  <fg=cyan>Facade</>    → %s', $module->facadeClass()));
+        $output->writeln(sprintf('  <fg=cyan>Factory</>   → %s', $module->factoryClass() ?? self::NOT_FOUND));
+        $output->writeln(sprintf('  <fg=cyan>Config</>    → %s', $module->configClass() ?? self::NOT_FOUND));
+        $output->writeln(sprintf('  <fg=cyan>Provider</>  → %s', $module->providerClass() ?? self::NOT_FOUND));
+    }
+
+    private function renderBindings(OutputInterface $output): void
+    {
+        $bindings = $this->getFacade()->getContainerBindings();
+        $contextualBindings = $this->getFacade()->getContainerContextualBindings();
+
+        $output->writeln('  <fg=cyan>Bindings</>:');
+
+        if ($bindings === [] && $contextualBindings === []) {
+            $output->writeln('    (none)');
+
+            return;
+        }
+
+        foreach ($bindings as $abstract => $concrete) {
+            $output->writeln(sprintf('    %s => %s', $abstract, $concrete));
+        }
+
+        foreach ($contextualBindings as $consumer => $needs) {
+            foreach ($needs as $abstract => $concrete) {
+                $output->writeln(sprintf('    %s (contextual for %s) => %s', $abstract, $consumer, $concrete));
+            }
+        }
+    }
+
+    private function renderDependencyTree(OutputInterface $output, AppModule $module): void
+    {
+        $output->writeln('  <fg=cyan>Dependency tree</> (Facade):');
+
+        $dependencyTree = $this->getFacade()->getContainerDependencyTree($module->facadeClass());
+
+        if ($dependencyTree === []) {
+            $output->writeln('    (no dependencies)');
+
+            return;
+        }
+
+        foreach ($dependencyTree as $dependency) {
+            $output->writeln('    ' . $dependency);
+        }
+    }
+}

--- a/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
+++ b/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule;
+
+use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\CheckoutModuleConfig;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\CheckoutModuleFacade;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\CheckoutModuleFactory;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\CheckoutModuleProvider;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\PaymentGatewayInterface;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\StripeGateway;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\GadgetModule\GadgetModuleFacade;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+final class DebugModuleCommandTest extends TestCase
+{
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__ . '/Fixtures', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(PaymentGatewayInterface::class, StripeGateway::class);
+        });
+
+        $this->command = new CommandTester(new DebugModuleCommand());
+    }
+
+    public function test_prints_all_four_resolved_classes_bindings_and_tree(): void
+    {
+        $exitCode = $this->command->execute(['module' => 'CheckoutModule']);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('CheckoutModule', $output);
+        self::assertStringContainsString(CheckoutModuleFacade::class, $output);
+        self::assertStringContainsString(CheckoutModuleFactory::class, $output);
+        self::assertStringContainsString(CheckoutModuleConfig::class, $output);
+        self::assertStringContainsString(CheckoutModuleProvider::class, $output);
+        self::assertStringContainsString(PaymentGatewayInterface::class, $output);
+        self::assertStringContainsString(StripeGateway::class, $output);
+        self::assertStringContainsString('Dependency tree', $output);
+    }
+
+    public function test_partial_module_marks_missing_types(): void
+    {
+        $exitCode = $this->command->execute(['module' => 'GadgetModule']);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString(GadgetModuleFacade::class, $output);
+        self::assertStringContainsString('(not found)', $output);
+    }
+
+    public function test_unknown_module_prints_message_and_fails(): void
+    {
+        $exitCode = $this->command->execute(['module' => 'DoesNotExist']);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('No module matches "DoesNotExist"', $output);
+    }
+
+    public function test_json_option_emits_parseable_json(): void
+    {
+        $exitCode = $this->command->execute(['module' => 'CheckoutModule', '--json' => true]);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        /** @var list<array<string,mixed>> $decoded */
+        $decoded = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertCount(1, $decoded);
+        self::assertSame('CheckoutModule', $decoded[0]['module']);
+        self::assertSame(CheckoutModuleFacade::class, $decoded[0]['facade']);
+        self::assertSame(CheckoutModuleFactory::class, $decoded[0]['factory']);
+        self::assertArrayHasKey('bindings', $decoded[0]);
+        self::assertArrayHasKey('dependencyTree', $decoded[0]);
+    }
+
+    public function test_tree_option_limits_output_to_dependency_tree(): void
+    {
+        $exitCode = $this->command->execute(['module' => 'CheckoutModule', '--tree' => true]);
+        $output = $this->command->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dependency tree', $output);
+        self::assertStringNotContainsString('Bindings', $output);
+    }
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleConfig.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleConfig.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
+
+use Gacela\Framework\AbstractConfig;
+
+final class CheckoutModuleConfig extends AbstractConfig
+{
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleFacade.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleFacade.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<CheckoutModuleFactory>
+ */
+final class CheckoutModuleFacade extends AbstractFacade
+{
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleFactory.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
+
+use Gacela\Framework\AbstractFactory;
+
+final class CheckoutModuleFactory extends AbstractFactory
+{
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleProvider.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class CheckoutModuleProvider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/PaymentGatewayInterface.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/PaymentGatewayInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
+
+interface PaymentGatewayInterface
+{
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/StripeGateway.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/StripeGateway.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
+
+final class StripeGateway implements PaymentGatewayInterface
+{
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/GadgetModule/GadgetModuleFacade.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/GadgetModule/GadgetModuleFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\GadgetModule;
+
+use Gacela\Framework\AbstractFacade;
+
+final class GadgetModuleFacade extends AbstractFacade
+{
+}


### PR DESCRIPTION
## 📚 Description

Debugging "what does gacela resolve for my module?" required several separate commands. `debug:module <ModuleName>` prints everything in one place: the resolved Facade/Factory/Config/Provider classes, the container bindings (global and contextual), and the facade dependency tree.

## 🔖 Changes

- New `DebugModuleCommand` (`debug:module <module> [--json] [--tree]`), registered in `ConsoleProvider` so it shows up in `bin/gacela list`
- `--json` emits parseable JSON; `--tree` limits output to the dependency tree
- Unknown module prints `No module matches "..."` and exits non-zero; partial modules mark missing types with `(not found)` instead of failing
- `ConsoleFacade`/`ConsoleFactory` gained `getContainerBindings()` and `getContainerContextualBindings()` (stringified for display), reusing the existing `getContainerDependencyTree()`
- Feature test with fixture modules covering human output, `--json`, `--tree`, partial module, and the not-found path

Refactor pass done after implementation: hoisted the app-global bindings fetch out of the per-module JSON loop; nothing else to change.

Closes #453