### PR TITLE
test(bench): harden and expand the PHPBench suite now that it gates CI

### DIFF
--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -1,9 +1,14 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 #
 # Performance regression guard: benchmarks the PR base branch, then benchmarks
-# the PR head against that stored baseline. The suite-wide assertion configured
-# in phpbench.json (mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%)
+# the PR head against that stored baseline. The assertion configured in
+# phpbench.json (mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%)
 # fails the job when a benchmarked path regresses by more than 10%.
+#
+# Only the `gate` group blocks the merge: those are the stable macro benches.
+# The `micro` group (sub-microsecond subjects, where timer quantization alone
+# moves the mode by ~10%) runs afterwards as a non-blocking informational
+# report. See tests/Benchmark/README.md for the group taxonomy.
 
 on:
   pull_request:
@@ -53,5 +58,9 @@ jobs:
       - name: Install PR head dependencies
         run: composer install --no-interaction --no-progress
 
-      - name: Assert no >10% regression against the base baseline
-        run: vendor/bin/phpbench run --ref=base --report=aggregate --progress=none
+      - name: Assert no >10% regression against the base baseline (gate group)
+        run: vendor/bin/phpbench run --ref=base --group=gate --report=aggregate --progress=none
+
+      - name: Report micro benches against the base baseline (informational, non-blocking)
+        continue-on-error: true
+        run: vendor/bin/phpbench run --ref=base --group=micro --report=aggregate --progress=none

--- a/tests/Benchmark/Bootstrap/BootstrapBench.php
+++ b/tests/Benchmark/Bootstrap/BootstrapBench.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Bootstrap;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PhpBench\Attributes\AfterClassMethods;
+use PhpBench\Attributes\BeforeClassMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+use function glob;
+use function unlink;
+
+/**
+ * Gacela::bootstrap() itself, isolated from module resolution — the dominant
+ * cost of real-app startup. Cold boots re-read the config files every rev;
+ * warm boots load the merged-config file cache written by the first boot.
+ */
+#[BeforeClassMethods('removeCacheFiles')]
+#[AfterClassMethods('removeCacheFiles')]
+#[Groups(['gate', 'bootstrap'])]
+#[Revs(20)]
+#[Iterations(5)]
+final class BootstrapBench
+{
+    private const CACHE_DIR = __DIR__ . '/.gacela/cache';
+
+    public static function removeCacheFiles(): void
+    {
+        foreach (glob(self::CACHE_DIR . '/*.php') ?: [] as $file) {
+            unlink($file);
+        }
+    }
+
+    public function warmMergedConfigCache(): void
+    {
+        self::removeCacheFiles();
+        $this->bootstrapWarm();
+    }
+
+    public function bench_bootstrap_cold(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php');
+            $config->setFileCache(false);
+        });
+    }
+
+    #[BeforeMethods('warmMergedConfigCache')]
+    public function bench_bootstrap_warm(): void
+    {
+        $this->bootstrapWarm();
+    }
+
+    private function bootstrapWarm(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php');
+            $config->enableFileCache(self::CACHE_DIR);
+        });
+    }
+}

--- a/tests/Benchmark/Bootstrap/config/default.php
+++ b/tests/Benchmark/Bootstrap/config/default.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'app-name' => 'bootstrap-bench',
+    'debug' => false,
+    'retries' => 3,
+    'timeout-seconds' => 1.5,
+    'feature-flags' => [
+        'flag-a' => true,
+        'flag-b' => false,
+        'flag-c' => true,
+    ],
+    'endpoints' => [
+        'primary' => 'https://example.test/api',
+        'fallback' => 'https://fallback.example.test/api',
+    ],
+];

--- a/tests/Benchmark/Cache/ScopedCacheBench.php
+++ b/tests/Benchmark/Cache/ScopedCacheBench.php
@@ -6,6 +6,11 @@ namespace GacelaTest\Benchmark\Cache;
 
 use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\ScopedCache;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 
 use function bin2hex;
 use function is_dir;
@@ -18,14 +23,14 @@ use function sys_get_temp_dir;
 use function unlink;
 
 /**
- * @BeforeMethods({"setUp"})
- *
- * @AfterMethods({"tearDown"})
- *
- * @Revs(50)
- *
- * @Iterations(5)
+ * ScopedCache decorator cost: put/get overhead and dependsOn() cycle-detection
+ * at increasing depths, on top of a real FileCache.
  */
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+#[Groups(['gate', 'cache'])]
+#[Revs(50)]
+#[Iterations(5)]
 final class ScopedCacheBench
 {
     private string $cacheDir;

--- a/tests/Benchmark/ClassResolver/ClassInfo/ClassInfoBench.php
+++ b/tests/Benchmark/ClassResolver/ClassInfo/ClassInfoBench.php
@@ -8,26 +8,45 @@ use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\ClassResolver\ClassInfo;
 use GacelaTest\Fixtures\ClassInfoTestingFacade;
 use PhpBench\Attributes\Assert;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 
 /**
+ * Measures ClassInfo::from() alone: the caller objects are constructed once in
+ * setUp so the subjects don't mix allocation cost into the measurement.
+ *
  * Informational, not gated: these subjects run at sub-microsecond scale, where
  * timer quantization moves the mode by ~10% between runs, so a strict +/-10%
  * baseline assert false-fails unrelated PRs. The widened tolerance keeps the
  * numbers reported/compared without letting noise break CI. See #458.
  */
 #[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
+#[BeforeMethods('setUp')]
+#[Groups(['micro', 'resolve'])]
+#[Revs(1000)]
+#[Iterations(5)]
 final class ClassInfoBench
 {
+    private AbstractFacade $anonymousFacade;
+
+    private ClassInfoTestingFacade $realFacade;
+
+    public function setUp(): void
+    {
+        $this->anonymousFacade = new class() extends AbstractFacade {
+        };
+        $this->realFacade = new ClassInfoTestingFacade();
+    }
+
     public function bench_anonymous_class(): void
     {
-        $facade = new class() extends AbstractFacade {
-        };
-        ClassInfo::from($facade, 'Factory');
+        ClassInfo::from($this->anonymousFacade, 'Factory');
     }
 
     public function bench_real_class(): void
     {
-        $facade = new ClassInfoTestingFacade();
-        ClassInfo::from($facade, 'Factory');
+        ClassInfo::from($this->realFacade, 'Factory');
     }
 }

--- a/tests/Benchmark/ClassResolver/EventDispatchBench.php
+++ b/tests/Benchmark/ClassResolver/EventDispatchBench.php
@@ -7,20 +7,27 @@ namespace GacelaTest\Benchmark\ClassResolver;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameNotFoundEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
 use GacelaTest\Benchmark\ModuleExample\ModuleExampleFacade;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 
 use function dirname;
 
 /**
- * Warm-resolve throughput of the guarded event dispatch on the
- * class-resolution hot path: every rev is a cache-hit resolve, which is
- * exactly the ResolvedClassCachedEvent dispatch site.
- *
- * @Revs(1000)
- *
- * @Iterations(5)
+ * Event-dispatch overhead on the class-resolution hot path: every rev is a
+ * cache-hit resolve, which is exactly the ResolvedClassCachedEvent dispatch
+ * site. Three states: nothing listens (guard short-circuits, no allocation),
+ * an unrelated specific listener (guard still short-circuits for this event),
+ * and a generic listener (event allocated and dispatched every resolve).
+ * Guards the zero-cost dispatch work from #449/#450.
  */
+#[Groups(['gate', 'resolve'])]
+#[Revs(1000)]
+#[Iterations(5)]
 final class EventDispatchBench
 {
     public function setUpWithoutListeners(): void
@@ -42,18 +49,30 @@ final class EventDispatchBench
         $this->warmResolverCache();
     }
 
-    /**
-     * @BeforeMethods("setUpWithoutListeners")
-     */
+    public function setUpWithGenericListener(): void
+    {
+        Gacela::bootstrap(dirname(__DIR__) . '/ModuleExample', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->registerGenericListener(static function (GacelaEventInterface $event): void {});
+        });
+
+        $this->warmResolverCache();
+    }
+
+    #[BeforeMethods('setUpWithoutListeners')]
     public function bench_warm_resolve_without_listeners(): void
     {
         (new FactoryResolver())->resolve(ModuleExampleFacade::class);
     }
 
-    /**
-     * @BeforeMethods("setUpWithUnrelatedListener")
-     */
+    #[BeforeMethods('setUpWithUnrelatedListener')]
     public function bench_warm_resolve_with_unrelated_specific_listener(): void
+    {
+        (new FactoryResolver())->resolve(ModuleExampleFacade::class);
+    }
+
+    #[BeforeMethods('setUpWithGenericListener')]
+    public function bench_warm_resolve_with_generic_listener(): void
     {
         (new FactoryResolver())->resolve(ModuleExampleFacade::class);
     }

--- a/tests/Benchmark/ClassResolver/ResolverCacheHitBench.php
+++ b/tests/Benchmark/ClassResolver/ResolverCacheHitBench.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\ClassResolver;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
+use Gacela\Framework\Gacela;
+use GacelaTest\Benchmark\ModuleExample\ModuleExampleFacade;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+use function dirname;
+
+/**
+ * The hottest steady-state path in the framework: every facade access after
+ * warmup goes through AbstractClassResolver::doResolve() and is served from
+ * the in-memory instance cache. Each rev is exactly one cache-hit resolve
+ * with no listeners registered.
+ */
+#[BeforeMethods('setUp')]
+#[Groups(['gate', 'resolve'])]
+#[Revs(1000)]
+#[Iterations(5)]
+final class ResolverCacheHitBench
+{
+    public function setUp(): void
+    {
+        Gacela::bootstrap(dirname(__DIR__) . '/ModuleExample', static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        // Warm the resolver cache so every measured rev is a cache hit.
+        (new FactoryResolver())->resolve(ModuleExampleFacade::class);
+    }
+
+    public function bench_resolver_cache_hit(): void
+    {
+        (new FactoryResolver())->resolve(ModuleExampleFacade::class);
+    }
+}

--- a/tests/Benchmark/Config/ConfigInit/config/default.php
+++ b/tests/Benchmark/Config/ConfigInit/config/default.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'app-name' => 'config-init-bench',
+    'debug' => false,
+    'retries' => 3,
+    'timeout-seconds' => 1.5,
+    'feature-flags' => [
+        'flag-a' => true,
+        'flag-b' => false,
+        'flag-c' => true,
+    ],
+    'endpoints' => [
+        'primary' => 'https://example.test/api',
+        'fallback' => 'https://fallback.example.test/api',
+    ],
+];

--- a/tests/Benchmark/Config/ConfigInitBench.php
+++ b/tests/Benchmark/Config/ConfigInitBench.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Config;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use PhpBench\Attributes\AfterClassMethods;
+use PhpBench\Attributes\BeforeClassMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+use function glob;
+use function unlink;
+
+/**
+ * Config::init() — building the merged configuration. Cold globs and parses
+ * the config files on every call; warm loads the persisted merged-config
+ * file cache instead.
+ */
+#[BeforeClassMethods('removeCacheFiles')]
+#[AfterClassMethods('removeCacheFiles')]
+#[Groups(['gate', 'config'])]
+#[Revs(50)]
+#[Iterations(5)]
+final class ConfigInitBench
+{
+    private const APP_ROOT = __DIR__ . '/ConfigInit';
+
+    private const CACHE_DIR = self::APP_ROOT . '/.gacela/cache';
+
+    public static function removeCacheFiles(): void
+    {
+        foreach (glob(self::CACHE_DIR . '/*.php') ?: [] as $file) {
+            unlink($file);
+        }
+    }
+
+    public function setUpCold(): void
+    {
+        Gacela::bootstrap(self::APP_ROOT, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php');
+            $config->setFileCache(false);
+        });
+    }
+
+    public function setUpWarm(): void
+    {
+        self::removeCacheFiles();
+
+        Gacela::bootstrap(self::APP_ROOT, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfig('config/*.php');
+            $config->enableFileCache(self::CACHE_DIR);
+        });
+
+        // First init persists the merged-config cache; measured revs load it.
+        Config::getInstance()->init();
+    }
+
+    #[BeforeMethods('setUpCold')]
+    public function bench_config_init_cold(): void
+    {
+        Config::getInstance()->init();
+    }
+
+    #[BeforeMethods('setUpWarm')]
+    public function bench_config_init_warm(): void
+    {
+        Config::getInstance()->init();
+    }
+}

--- a/tests/Benchmark/Config/ConfigTypedAccessBench.php
+++ b/tests/Benchmark/Config/ConfigTypedAccessBench.php
@@ -8,10 +8,14 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use PhpBench\Attributes\Assert;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 
 /**
  * Tracks the runtime cost of the typed config accessors against the raw
- * get()+cast they replace. The typed getters are self-contained (single
+ * get()+cast they replace (bench_get_int_raw_cast is the documented
+ * comparison witness). The typed getters are self-contained (single
  * array_key_exists, null-default compare, no get() delegation) and should
  * stay at least as fast as get()+cast.
  *
@@ -19,11 +23,14 @@ use PhpBench\Attributes\Assert;
  * quantization alone moves the mode by ~10% between runs, so a strict +/-10%
  * baseline assert false-fails unrelated PRs. The class-level assertion widens
  * the tolerance so the numbers are still reported and compared, but noise can't
- * break CI. The gate/informational split is tracked in #458.
+ * break CI. See tests/Benchmark/README.md.
  *
  * @BeforeMethods("setUp")
  */
 #[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
+#[Groups(['micro', 'config'])]
+#[Revs(1000)]
+#[Iterations(5)]
 final class ConfigTypedAccessBench
 {
     private Config $config;

--- a/tests/Benchmark/Container/ContainerResolutionBench.php
+++ b/tests/Benchmark/Container/ContainerResolutionBench.php
@@ -11,7 +11,17 @@ use GacelaTest\Benchmark\Container\Fixtures\DeepD;
 use GacelaTest\Benchmark\Container\Fixtures\InjectConsumer;
 use GacelaTest\Benchmark\Container\Fixtures\ServiceInterface;
 use GacelaTest\Benchmark\Container\Fixtures\SimpleClass;
+use PhpBench\Attributes\Groups;
 
+/**
+ * Cold container resolution: each subject deliberately constructs a fresh
+ * Container so it measures first-resolution cost (reflection, attribute
+ * lookup, binding lookup) — the container allocation is part of the
+ * documented path, not incidental noise.
+ *
+ * Sampling: inherits the phpbench.json defaults — see tests/Benchmark/README.md.
+ */
+#[Groups(['gate', 'container'])]
 final class ContainerResolutionBench
 {
     /**

--- a/tests/Benchmark/FileCache/BatchWriteBench.php
+++ b/tests/Benchmark/FileCache/BatchWriteBench.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache;
 
 use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 
 use function bin2hex;
 use function is_dir;
@@ -15,14 +20,14 @@ use function sys_get_temp_dir;
 use function unlink;
 
 /**
- * @BeforeMethods({"setUp"})
- *
- * @AfterMethods({"tearDown"})
- *
- * @Revs(50)
- *
- * @Iterations(5)
+ * Batched vs unbatched file-cache writes: 200 puts as one atomic write per
+ * commit versus one full-file rewrite per put.
  */
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+#[Groups(['gate', 'cache'])]
+#[Revs(50)]
+#[Iterations(5)]
 final class BatchWriteBench
 {
     private string $cacheDir;

--- a/tests/Benchmark/FileCache/FileCacheBench.php
+++ b/tests/Benchmark/FileCache/FileCacheBench.php
@@ -5,27 +5,39 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
-use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
+use PhpBench\Attributes\AfterClassMethods;
+use PhpBench\Attributes\BeforeClassMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+use function glob;
+use function unlink;
 
 /**
- * @BeforeClassMethods("removeFiles")
+ * Full bootstrap + resolution of seven modules, with the file cache disabled
+ * vs enabled. The cache directory is explicit and wiped around the run:
+ * relying on the implicit default (sys_get_temp_dir()) made the bench pick up
+ * merged-config cache files written by unrelated test runs on the same
+ * machine, which poisoned the enabled-cache path with foreign config values.
  */
+#[BeforeClassMethods('removeCacheFiles')]
+#[AfterClassMethods('removeCacheFiles')]
+#[Groups(['gate', 'bootstrap'])]
+#[Revs(50)]
+#[Iterations(5)]
 final class FileCacheBench
 {
-    public static function removeFiles(): void
+    private const CACHE_DIR = __DIR__ . '/.gacela/cache';
+
+    public static function removeCacheFiles(): void
     {
-        $removeFile = static function (string $filename): void {
-            $filenameFullPath = __DIR__ . '/.gacela/cache/' . $filename;
-            if (file_exists($filenameFullPath)) {
-                unlink($filenameFullPath);
-            }
-        };
-        $removeFile(ClassNamePhpCache::FILENAME);
-        $removeFile(CustomServicesPhpCache::FILENAME);
+        foreach (glob(self::CACHE_DIR . '/*.php') ?: [] as $file) {
+            unlink($file);
+        }
     }
 
     public function bench_without_cache(): void
@@ -45,7 +57,12 @@ final class FileCacheBench
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheEnabled): void {
             $config->resetInMemoryCache();
             $config->addAppConfig('config/*.php');
-            $config->setFileCache($cacheEnabled);
+
+            if ($cacheEnabled) {
+                $config->enableFileCache(self::CACHE_DIR);
+            } else {
+                $config->setFileCache(false);
+            }
 
             $config->addBinding(StringValueInterface::class, new StringValue('testing-string'));
 

--- a/tests/Benchmark/GacelaGlobalBench.php
+++ b/tests/Benchmark/GacelaGlobalBench.php
@@ -10,10 +10,19 @@ use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
 
 /**
- * @BeforeMethods("setUp")
+ * Warm facade access through anonymous classes registered via
+ * Gacela::addGlobal() (facade -> factory -> config + provider). Complements
+ * ModuleExampleBench, which covers the same flow for a conventional on-disk
+ * module discovered by naming convention.
+ *
+ * Sampling: inherits the phpbench.json defaults — see tests/Benchmark/README.md.
  */
+#[BeforeMethods('setUp')]
+#[Groups(['gate', 'resolve'])]
 final class GacelaGlobalBench
 {
     private AbstractFacade $facade;

--- a/tests/Benchmark/ModuleExample/ModuleExampleBench.php
+++ b/tests/Benchmark/ModuleExample/ModuleExampleBench.php
@@ -5,14 +5,20 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\ModuleExample;
 
 use Gacela\Framework\Gacela;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
 
 /**
- * @Revs(50)
+ * Warm facade access through a conventional on-disk module (Facade, Factory,
+ * Config, Provider classes discovered by naming convention). Complements
+ * GacelaGlobalBench, which covers the same flow for anonymous classes
+ * registered via Gacela::addGlobal().
  *
- * @Iterations(3)
- *
- * @BeforeMethods("setUp")
+ * Sampling: inherits the phpbench.json defaults (200 revs, 10 iterations,
+ * warmup) — see tests/Benchmark/README.md.
  */
+#[BeforeMethods('setUp')]
+#[Groups(['gate', 'resolve'])]
 final class ModuleExampleBench
 {
     private ModuleExampleFacade $facade;

--- a/tests/Benchmark/README.md
+++ b/tests/Benchmark/README.md
@@ -1,0 +1,96 @@
+# Benchmarks
+
+This suite is a **blocking CI gate** (`.github/workflows/phpbench.yml`): every PR
+benchmarks its base branch, then its head, and fails when a gated subject
+regresses by more than the `phpbench.json` assertion
+(`mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%`). Because the gate
+blocks merges, every bench must be **stable** (low `rstdev`) and **intentional**
+(measures one documented path).
+
+## Groups
+
+Every subject must carry a `#[Groups([...])]` with exactly one gating group and
+one domain group:
+
+| Group | Meaning |
+|---|---|
+| `gate` | Stable macro bench. Asserted by CI with the strict ±10% rule. |
+| `micro` | Sub-microsecond subject. Reported by CI (non-blocking); carries a widened class-level `#[Assert]` so full local runs can't false-fail either. |
+| `bootstrap` \| `resolve` \| `config` \| `container` \| `cache` | Domain, for running subsets locally. |
+
+CI runs `phpbench run --ref=base --group=gate` as the blocking step and
+`--group=micro` as a `continue-on-error` informational step.
+
+Rule of thumb: if the subject's average time is below ~0.2μs, it belongs in
+`micro` — at that scale timer quantization alone moves the mode by ~10%, which
+would false-fail the gate on unrelated PRs. Subjects in the 0.2–1μs range can
+stay gated when their `rstdev` holds below ~3% (e.g. the warm-resolve benches).
+
+## Sampling and warmup
+
+Defaults come from `phpbench.json`: **200 revs, 10 iterations, warmup 2**.
+Inheriting them is fine and preferred; annotate only to deviate:
+
+- `micro` subjects: at least `#[Revs(1000)]`, `#[Iterations(5)]`.
+- Bootstrap-heavy subjects (each rev runs `Gacela::bootstrap()` or module
+  loading): lower revs are fine (`#[Revs(20..50)]`, `#[Iterations(5)]`) to keep
+  the suite fast; never below 5 iterations.
+
+After changing a bench, check its `rstdev` in the aggregate report: gated
+subjects should stay below ~3%.
+
+## Purity
+
+A subject body must contain only the path it documents. Hoist incidental
+allocation and setup into `#[BeforeMethods]` / `#[BeforeClassMethods]`
+(see `ClassInfoBench`). When an allocation *is* the measured path (e.g.
+`ContainerResolutionBench` constructs a fresh container to measure cold
+resolution), say so in the class docblock.
+
+## State isolation
+
+Benches share one process per subject, and the repository shares one machine:
+
+- Reset global state in setup (`resetInMemoryCache()`, `Config::resetInstance()`,
+  `DocBlockResolverCache::resetCache()`, ...) so subjects don't leak into each
+  other.
+- **Never enable the file cache without an explicit directory.** With no
+  directory the cache falls back to `sys_get_temp_dir()`, which is shared with
+  every other test run on the machine — stale `gacela-merged-config.php` files
+  from unrelated runs will poison the bench. Use
+  `enableFileCache(__DIR__ . '/.gacela/cache')` and wipe it in
+  `#[BeforeClassMethods]` / `#[AfterClassMethods]` (see `FileCacheBench`).
+
+## Adding a bench
+
+1. One class per measured concern, `*Bench.php`, under the matching domain dir.
+2. Class docblock: what path it measures and why it matters.
+3. `#[Groups([...])]`: `gate` or `micro`, plus a domain group.
+4. Explicit revs/iterations only when deviating from the defaults (per above).
+5. `micro` subjects additionally get the widened class-level assert:
+   `#[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]`.
+6. Run locally before pushing:
+   ```bash
+   composer phpbench                                  # full suite
+   vendor/bin/phpbench run --group=gate --report=aggregate
+   vendor/bin/phpbench run --tag=base --store         # simulate the CI guard
+   vendor/bin/phpbench run --ref=base --group=gate
+   ```
+
+## Current inventory
+
+| Bench | Groups | Measures |
+|---|---|---|
+| `Bootstrap/BootstrapBench` | gate, bootstrap | `Gacela::bootstrap()` cold vs merged-config-cache warm |
+| `FileCache/FileCacheBench` | gate, bootstrap | bootstrap + 7-module load, file cache off vs on |
+| `GacelaGlobalBench` | gate, resolve | warm facade access via `Gacela::addGlobal()` anonymous classes |
+| `ModuleExample/ModuleExampleBench` | gate, resolve | warm facade access via a conventional on-disk module |
+| `ClassResolver/ResolverCacheHitBench` | gate, resolve | single `doResolve()` cache hit — the hottest steady-state path |
+| `ClassResolver/EventDispatchBench` | gate, resolve | cache-hit resolve with events off / unrelated listener / generic listener |
+| `ServiceResolver/DocBlockResolverBench` | gate, resolve | attribute vs phpdoc service resolution, single + cached-repeated |
+| `Container/ContainerResolutionBench` | gate, container | cold container resolution: no-deps / `#[Inject]` / bindings / deep chain |
+| `Config/ConfigInitBench` | gate, config | `Config::init()` cold vs merged-config-cache load |
+| `Cache/ScopedCacheBench` | gate, cache | ScopedCache put/get + dependsOn cycle detection |
+| `FileCache/BatchWriteBench` | gate, cache | 200 cache puts batched vs unbatched |
+| `ClassResolver/ClassInfo/ClassInfoBench` | micro, resolve | `ClassInfo::from()` for anonymous vs real classes |
+| `Config/ConfigTypedAccessBench` | micro, config | typed config getters vs raw `get()`+cast witness |

--- a/tests/Benchmark/ServiceResolver/DocBlockResolverBench.php
+++ b/tests/Benchmark/ServiceResolver/DocBlockResolverBench.php
@@ -6,12 +6,19 @@ namespace GacelaTest\Benchmark\ServiceResolver;
 
 use Gacela\Framework\Gacela;
 use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
 
 /**
- * @BeforeMethods("setUp")
+ * Attribute-based vs phpdoc-based service resolution, single and repeated
+ * (repeated variants exercise the DocBlockResolverCache).
  *
- * @AfterMethods("tearDown")
+ * Sampling: inherits the phpbench.json defaults — see tests/Benchmark/README.md.
  */
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+#[Groups(['gate', 'resolve'])]
 final class DocBlockResolverBench
 {
     public function setUp(): void


### PR DESCRIPTION
## 📚 Description

The PHPBench suite gates merges since #457, so it must be broad enough to catch real regressions and stable enough not to flake the ±10% gate. This splits gated from informational benches, fixes purity/isolation problems, adds the missing high-value coverage, and documents the pattern.

## 🔖 Changes

- **Group taxonomy + CI gating**: every subject carries `gate` or `micro` plus a domain group; the workflow asserts only `--group=gate` (27 subjects) and reports `--group=micro` (8 sub-0.2μs subjects) as a non-blocking step
- **Purity**: `ClassInfoBench` no longer allocates inside the subject body (callers hoisted to setUp)
- **Isolation**: `FileCacheBench` now uses an explicit, wiped cache dir — with `setFileCache(true)` and no dir, the cache defaults to the shared `sys_get_temp_dir()`, where stale `gacela-merged-config.php` files from unrelated test runs poisoned the enabled-cache path (reproduced locally; CI only passed because its tmp dir is fresh)
- **Sampling normalized**: micro ≥1000 revs / 5 its; bootstrap-heavy benches 20–50 revs / 5 its; the ad-hoc `@Revs(50)/@Iterations(3)` on `ModuleExampleBench` now inherits the defaults (`runner.warmup: 2` was already in place)
- **New coverage**: `BootstrapBench` (cold vs merged-config-cache warm), `ResolverCacheHitBench` (hottest steady-state path), `ConfigInitBench` (cold vs cache load), plus a generic-listener state in `EventDispatchBench` (0.262μs off → 0.284μs unrelated → 0.419μs generic)
- **Docs**: `tests/Benchmark/README.md` with the taxonomy, sampling floors, purity/isolation rules, and current inventory; `ModuleExampleBench` vs `GacelaGlobalBench` intents documented (conventional module vs anonymous globals)

Verified locally: full suite green (35 subjects, rstdev ≤3%); `--group=gate`/`--group=micro` select the right subsets; simulated the CI guard (`--tag=base --store` then `--ref=base --group=gate` → exit 0; forced `* 0.5` assert → non-zero, so the gate still bites).

Note for a follow-up: the shared-tmp merged-config collision is a framework-level footgun (`getDefaultCacheDir()` → `sys_get_temp_dir()` with an app-root-agnostic filename); this PR only isolates the bench.

Closes #458