### PR TITLE
fix(config): scope merged-config cache filename per app root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `Config::getEventDispatcher()` no longer throws when called before bootstrap; it returns a no-op dispatcher so guarded dispatch sites (e.g. cache-file deletion) stay silent
 - Re-bootstrapping now rebuilds the event dispatcher from the new setup; previously a dispatcher cached by a prior bootstrap kept serving stale listeners unless the in-memory cache was reset
+- The merged-config cache filename now embeds a hash of the app root dir, so apps sharing a cache directory (the default is the system temp dir when `setFileCache(true)` is used without a directory) no longer read each other's merged config. Cache files written under the old name become stale; they are removed by `cache:clear` / `clearMergedConfigCache()` and are otherwise ignored
 
 ### Documentation
 

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -420,6 +420,7 @@ final class Config implements ConfigInterface
         return new MergedConfigCache(
             $this->getCacheDir(),
             is_string($env) ? $env : '',
+            $this->getAppRootDir(),
         );
     }
 

--- a/src/Framework/Config/MergedConfigCache.php
+++ b/src/Framework/Config/MergedConfigCache.php
@@ -6,6 +6,9 @@ namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Cache\FileCache;
 
+use function sha1;
+use function substr;
+
 final class MergedConfigCache
 {
     public const FILENAME_PREFIX = 'gacela-merged-config';
@@ -15,6 +18,7 @@ final class MergedConfigCache
     public function __construct(
         private readonly string $cacheDir,
         private readonly string $env = '',
+        private readonly string $appRootDir = '',
     ) {
     }
 
@@ -49,16 +53,39 @@ final class MergedConfigCache
     public function clear(): void
     {
         FileCache::delete($this->filename());
+
+        // Also drop a cache written before filenames were app-scoped, so
+        // clearing leaves no stale pre-#465 file behind in a shared dir.
+        $legacyFilename = $this->buildFilename('');
+        if ($legacyFilename !== $this->filename()) {
+            FileCache::delete($legacyFilename);
+        }
     }
 
+    /**
+     * The cache dir can be shared between apps (it defaults to the system
+     * temp dir), so the filename embeds a hash of the app root: without it,
+     * every app using the shared default read and wrote the same file and
+     * silently served another app's merged config.
+     */
     public function filename(): string
     {
-        $suffix = $this->env !== '' ? '-' . $this->env : '';
+        $appSuffix = $this->appRootDir !== ''
+            ? '-' . substr(sha1($this->appRootDir), 0, 12)
+            : '';
+
+        return $this->buildFilename($appSuffix);
+    }
+
+    private function buildFilename(string $appSuffix): string
+    {
+        $envSuffix = $this->env !== '' ? '-' . $this->env : '';
 
         return $this->cacheDir
             . DIRECTORY_SEPARATOR
             . self::FILENAME_PREFIX
-            . $suffix
+            . $appSuffix
+            . $envSuffix
             . self::FILENAME_EXTENSION;
     }
 }

--- a/tests/Integration/Framework/Bootstrap/ReadOnlyAppRootTest.php
+++ b/tests/Integration/Framework/Bootstrap/ReadOnlyAppRootTest.php
@@ -81,7 +81,8 @@ final class ReadOnlyAppRootTest extends TestCase
             $cacheDir = $dir . '/.gacela/cache';
             mkdir($cacheDir, 0o755, true);
             file_put_contents(
-                $cacheDir . '/' . MergedConfigCache::FILENAME_PREFIX . MergedConfigCache::FILENAME_EXTENSION,
+                // Filenames are scoped per app root (#465).
+                (new MergedConfigCache($cacheDir, '', $dir))->filename(),
                 sprintf('<?php return %s;', var_export(['ro_key' => 'from_prewarmed_cache'], true)),
             );
             chmod($cacheDir, 0o555);

--- a/tests/Integration/Framework/Config/MergedConfigCacheIntegrationTest.php
+++ b/tests/Integration/Framework/Config/MergedConfigCacheIntegrationTest.php
@@ -198,6 +198,23 @@ final class MergedConfigCacheIntegrationTest extends TestCase
         self::assertSame('missing', Config::getInstance()->get('env_marker', 'missing'));
     }
 
+    public function test_apps_sharing_a_cache_dir_do_not_read_each_others_merged_config(): void
+    {
+        // App A (the AutoWarmFixtures root) warms its merged config into the shared dir.
+        Gacela::bootstrap($this->fixtureDir, $this->autoWarmConfig());
+        self::assertSame('warm_value', Config::getInstance()->get('warm_key'));
+
+        // App B (this dir, no config files) boots against the same cache dir:
+        // it must not be served app A's merged config.
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->setFileCache(true, $cacheDir);
+            $config->resetInMemoryCache();
+        });
+
+        self::assertSame('missing', Config::getInstance()->get('warm_key', 'missing'));
+    }
+
     private function autoWarmConfig(): Closure
     {
         $cacheDir = $this->cacheDir;
@@ -218,12 +235,8 @@ final class MergedConfigCacheIntegrationTest extends TestCase
             mkdir($this->cacheDir, 0777, true);
         }
 
-        $suffix = $env !== '' ? '-' . $env : '';
-        $filename = $this->cacheDir
-            . DIRECTORY_SEPARATOR
-            . MergedConfigCache::FILENAME_PREFIX
-            . $suffix
-            . MergedConfigCache::FILENAME_EXTENSION;
+        // Filenames are scoped per app root (#465); every test here boots __DIR__.
+        $filename = (new MergedConfigCache($this->cacheDir, $env, __DIR__))->filename();
 
         file_put_contents($filename, sprintf('<?php return %s;', var_export($data, true)));
     }

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -136,6 +136,59 @@ final class MergedConfigCacheTest extends TestCase
         self::assertSame(['app' => 'dev'], $dev->load());
     }
 
+    public function test_different_app_roots_produce_isolated_cache_files_in_a_shared_dir(): void
+    {
+        $appA = new MergedConfigCache($this->cacheDir, '', '/srv/app-a');
+        $appB = new MergedConfigCache($this->cacheDir, '', '/srv/app-b');
+
+        $appA->write(['app' => 'a']);
+        $appB->write(['app' => 'b']);
+
+        self::assertNotSame($appA->filename(), $appB->filename());
+        self::assertSame(['app' => 'a'], $appA->load());
+        self::assertSame(['app' => 'b'], $appB->load());
+    }
+
+    public function test_same_app_root_produces_a_stable_filename(): void
+    {
+        $first = new MergedConfigCache($this->cacheDir, '', '/srv/app-a');
+        $second = new MergedConfigCache($this->cacheDir, '', '/srv/app-a');
+
+        self::assertSame($first->filename(), $second->filename());
+    }
+
+    public function test_filename_keeps_legacy_name_without_app_root(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir);
+
+        self::assertStringEndsWith(
+            MergedConfigCache::FILENAME_PREFIX . MergedConfigCache::FILENAME_EXTENSION,
+            $cache->filename(),
+        );
+    }
+
+    public function test_app_scoped_filename_keeps_env_suffix(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir, 'prod', '/srv/app-a');
+
+        self::assertStringEndsWith('-prod' . MergedConfigCache::FILENAME_EXTENSION, $cache->filename());
+        self::assertStringContainsString(MergedConfigCache::FILENAME_PREFIX . '-', $cache->filename());
+    }
+
+    public function test_clear_also_removes_a_legacy_unscoped_cache_file(): void
+    {
+        $legacy = new MergedConfigCache($this->cacheDir);
+        $legacy->write(['stale' => 'legacy']);
+
+        $scoped = new MergedConfigCache($this->cacheDir, '', '/srv/app-a');
+        $scoped->write(['fresh' => 'scoped']);
+
+        $scoped->clear();
+
+        self::assertFalse($scoped->exists());
+        self::assertFalse($legacy->exists());
+    }
+
     public function test_write_creates_cache_directory_when_missing(): void
     {
         $cache = new MergedConfigCache($this->cacheDir);


### PR DESCRIPTION
## 📚 Description

With `setFileCache(true)` and no explicit directory, the cache dir falls back to `sys_get_temp_dir()` and the merged-config filename carried no app discrimination — every app or test run on the machine read and wrote the same `gacela-merged-config.php`, silently serving another app's merged config (or failing with missing config keys). Found while stabilizing the benchmark suite in #464.

## 🔖 Changes

- `MergedConfigCache::filename()` now embeds a short `sha1` hash of the app root dir (`gacela-merged-config-<hash>{-env}.php`); `Config` passes its app root when building the cache
- `clear()` also deletes a cache written under the legacy unscoped name, so `cache:clear` / `clearMergedConfigCache()` leave no stale pre-fix file behind in a shared dir
- Regression test: two apps sharing one cache dir no longer read each other's merged config; unit tests cover per-app isolation, filename stability, env suffixes, and legacy cleanup
- Pre-seeding tests updated to build the app-scoped filename

Migration note: previously written cache files become stale; they are cleaned by `cache:clear` and otherwise ignored (the first boot re-warms under the new name).

Refactor pass done after implementation: filename construction already flows through one `buildFilename()` helper; nothing to change.

Closes #465