### PR TITLE
test: reach 100% MSI and lock mutation floors at 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- `ProviderRegisteredEvent` is no longer dispatched twice for a modern `AbstractProvider`: the BC `DependencyProvider` resolver returns the same cached provider instance and no longer re-reports it
 - `Config::getEventDispatcher()` no longer throws when called before bootstrap; it returns a no-op dispatcher so guarded dispatch sites (e.g. cache-file deletion) stay silent
 - Re-bootstrapping now rebuilds the event dispatcher from the new setup; previously a dispatcher cached by a prior bootstrap kept serving stale listeners unless the in-memory cache was reset
 

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
             "@rector"
         ],
         "infection": [
-            "XDEBUG_MODE=coverage ./vendor/bin/infection --show-mutations --threads=max --min-msi=75 --min-covered-msi=75",
+            "XDEBUG_MODE=coverage ./vendor/bin/infection --show-mutations --threads=max --min-msi=100 --min-covered-msi=100",
             "@static-clear-cache"
         ],
         "metrics-report": [

--- a/infection.json5
+++ b/infection.json5
@@ -16,8 +16,8 @@
             'src'
         ]
     },
-    minMsi: 65,
-    minCoveredMsi: 65,
+    minMsi: 100,
+    minCoveredMsi: 100,
     mutators: {
         '@default': true,
         "global-ignore": [
@@ -45,6 +45,17 @@
             '.*\\$seen = \\[\\$\\w+ => true\\];.*',
             // commitBatch() writes for every key of $dirty regardless of value.
             '.*\\$dirty\\[static::class\\] = true;.*',
+            // Memoization guards: rebuilding the cached instance every call is
+            // observationally identical (idempotent construction), only slower.
+            '.*!self::\\$container instanceof Container.*',
+            '.*\\$this->gacelaFileConfig instanceof GacelaConfigFileInterface.*',
+            '.*self::\\$eventDispatcher instanceof EventDispatcherInterface.*',
+            // A fresh no-op dispatcher per pre-bootstrap call is identical.
+            '.*preBootstrapDispatcher \\?\\?= new NullEventDispatcher.*',
+            // Dedup bookkeeping: isset() treats `false` like `true`.
+            '.*resolvedServiceIds\\[\\$id\\] = true;.*',
+            // The candidate list feeds implode(); reindexing cannot change the message.
+            '.*array_values\\(array_unique\\(\\$candidates\\)\\).*',
         ],
         // flock()-based locking and opcache invalidation are not observable in-process.
         FunctionCallRemoval: {
@@ -169,8 +180,14 @@
             ignore: ["Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get"],
         },
         // hrtime(true) is an int; dividing by a float yields a float either way.
+        // Same for the bootstrap-duration event, and getFloat()'s widening
+        // return: int-to-float applies via the float return type anyway.
         CastFloat: {
             ignore: ["Gacela\\Framework\\Profiler\\Profiler::getCurrentTime"],
+            ignoreSourceCodeByRegex: [
+                '.*return \\(float\\) \\$value;.*',
+                '.*\\(float\\) \\(hrtime\\(true\\) - \\$startTime\\).*',
+            ],
         },
         // Keys never carry a leading backslash outside the normalization itself.
         UnwrapLtrim: {
@@ -190,6 +207,10 @@
         // unreachable defensive narrowing.
         InstanceOf_: {
             ignore: [
+                // instantiate(): both instanceof mutants collapse into the same
+                // catch(Throwable)+fallback path (null->get() Error, or the
+                // strict return type throwing TypeError): identical outcome.
+                "Gacela\\Framework\\Health\\HealthCheckRegistry::instantiate",
                 "Gacela\\PHPStan\\Rules\\CrossModuleViaFacadeRule::processNode",
                 "Gacela\\PHPStan\\Rules\\FacadeOnlyDelegatesRule::processNode",
                 "Gacela\\PHPStan\\Rules\\FacadeOnlyDelegatesRule::isDelegateStatement",

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -80,7 +80,9 @@ abstract class AbstractFactory
         // Temporal solution to keep BC with the AbstractDependencyProvider
         $dpResolver = (new DependencyProviderResolver())->resolve($this);
         $dpResolver?->provideModuleDependencies($container);
-        if ($dpResolver !== null) {
+        // Both resolvers share a normalized cache slot ("DependencyProvider" -> "Provider"),
+        // so a modern provider comes back from both; only notify when it is a distinct one.
+        if ($dpResolver !== null && $dpResolver !== $resolver) {
             $this->notifyProviderRegistered($dpResolver::class);
         }
 

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/LifecycleEventsTest.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/LifecycleEventsTest.php
@@ -13,6 +13,8 @@ use Gacela\Framework\Event\Container\ServiceResolvedEvent;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
 use Gacela\Framework\Gacela;
+use GacelaTest\Fixtures\CustomClass;
+use GacelaTest\Fixtures\CustomInterface;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
 use PHPUnit\Framework\TestCase;
@@ -29,6 +31,11 @@ final class LifecycleEventsTest extends TestCase
         Gacela::bootstrap(__DIR__, function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
             $config->addBinding(StringValueInterface::class, StringValue::class);
+            $config->addFactory('a-factory', static fn (): StringValue => new StringValue('factory'));
+            $config->addProtected('a-protected', static fn (): string => 'protected');
+            $config->addAlias('an-alias', StringValueInterface::class);
+            $config->addLazy('a-lazy', static fn (): StringValue => new StringValue('lazy'));
+            $config->when(StringValue::class)->needs(CustomInterface::class)->give(CustomClass::class);
 
             $config->registerGenericListener(function (GacelaEventInterface $event): void {
                 $this->events[] = $event;
@@ -64,6 +71,32 @@ final class LifecycleEventsTest extends TestCase
 
         self::assertInstanceOf(GacelaBootstrapFinishedEvent::class, $finished);
         self::assertGreaterThan(0.0, $finished->durationMs());
+        // Upper bound guards the duration math: a broken hrtime diff or a wrong
+        // ns->ms conversion yields an astronomically large number.
+        self::assertLessThan(60_000.0, $finished->durationMs());
+    }
+
+    public function test_every_binding_flavor_dispatches_binding_registered_event(): void
+    {
+        // Force the main container to be built, which registers bindings,
+        // factories, protected services, aliases, contextual bindings,
+        // and lazy services.
+        self::assertInstanceOf(StringValue::class, Gacela::get('a-factory'));
+
+        $bindingIds = array_map(
+            static fn (BindingRegisteredEvent $event): string => $event->id(),
+            array_values(array_filter(
+                $this->events,
+                static fn (GacelaEventInterface $event): bool => $event instanceof BindingRegisteredEvent,
+            )),
+        );
+
+        self::assertContains(StringValueInterface::class, $bindingIds, 'plain binding');
+        self::assertContains('a-factory', $bindingIds, 'factory binding');
+        self::assertContains('a-protected', $bindingIds, 'protected binding');
+        self::assertContains('an-alias', $bindingIds, 'alias binding');
+        self::assertContains('a-lazy', $bindingIds, 'lazy binding');
+        self::assertContains(CustomInterface::class, $bindingIds, 'contextual binding');
     }
 
     public function test_resolving_a_module_dispatches_provider_binding_and_service_events(): void
@@ -72,10 +105,15 @@ final class LifecycleEventsTest extends TestCase
 
         self::assertSame('hello lifecycle', $facade->greet());
 
-        $provider = $this->firstEventOf(ProviderRegisteredEvent::class);
-        self::assertInstanceOf(ProviderRegisteredEvent::class, $provider);
-        self::assertSame(Module\Provider::class, $provider->providerClass());
-        self::assertSame('Module', $provider->moduleName());
+        $providerEvents = array_values(array_filter(
+            $this->events,
+            static fn (GacelaEventInterface $event): bool => $event instanceof ProviderRegisteredEvent,
+        ));
+        // Exactly one: the BC DependencyProvider resolver returns the same cached
+        // provider instance and must not re-report it.
+        self::assertCount(1, $providerEvents);
+        self::assertSame(Module\Provider::class, $providerEvents[0]->providerClass());
+        self::assertSame('Module', $providerEvents[0]->moduleName());
 
         $binding = $this->firstEventOf(BindingRegisteredEvent::class);
         self::assertInstanceOf(BindingRegisteredEvent::class, $binding);
@@ -89,6 +127,20 @@ final class LifecycleEventsTest extends TestCase
             )),
         );
         self::assertContains(Module\Provider::GREETING, $serviceIds);
+    }
+
+    public function test_bc_dependency_provider_dispatches_provider_registered_event(): void
+    {
+        self::assertSame('hello bc lifecycle', (new ModuleBc\Facade())->greet());
+
+        $providerClasses = array_map(
+            static fn (ProviderRegisteredEvent $event): string => $event->providerClass(),
+            array_values(array_filter(
+                $this->events,
+                static fn (GacelaEventInterface $event): bool => $event instanceof ProviderRegisteredEvent,
+            )),
+        );
+        self::assertContains(ModuleBc\DependencyProvider::class, $providerClasses);
     }
 
     /**

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/ModuleBc/DependencyProvider.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/ModuleBc/DependencyProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle\ModuleBc;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+final class DependencyProvider extends AbstractDependencyProvider
+{
+    public const GREETING = 'lifecycle-bc-greeting';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::GREETING, static fn (): string => 'hello bc lifecycle');
+    }
+}

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/ModuleBc/Facade.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/ModuleBc/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle\ModuleBc;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function greet(): string
+    {
+        return $this->getFactory()->createGreeting();
+    }
+}

--- a/tests/Feature/Framework/ListeningEvents/Lifecycle/ModuleBc/Factory.php
+++ b/tests/Feature/Framework/ListeningEvents/Lifecycle/ModuleBc/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ListeningEvents\Lifecycle\ModuleBc;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createGreeting(): string
+    {
+        return (string)$this->getProvidedDependency(DependencyProvider::GREETING);
+    }
+}

--- a/tests/Integration/Framework/Config/AutoWarmFixtures/config/config.php
+++ b/tests/Integration/Framework/Config/AutoWarmFixtures/config/config.php
@@ -4,4 +4,5 @@ declare(strict_types=1);
 
 return [
     'warm_key' => 'warm_value',
+    'second_warm_key' => 'second_warm_value',
 ];

--- a/tests/Integration/Framework/Config/MergedConfigCacheIntegrationTest.php
+++ b/tests/Integration/Framework/Config/MergedConfigCacheIntegrationTest.php
@@ -81,6 +81,8 @@ final class MergedConfigCacheIntegrationTest extends TestCase
 
         self::assertTrue(is_file($filename), 'merged config cache should be auto-warmed on miss');
         self::assertSame('warm_value', Config::getInstance()->get('warm_key'));
+        // A multi-key merged config must survive the cache-miss path intact.
+        self::assertSame('second_warm_value', Config::getInstance()->get('second_warm_key'));
     }
 
     public function test_does_not_auto_warm_when_file_cache_disabled(): void

--- a/tests/Unit/Framework/Config/TypedConfigAccessTest.php
+++ b/tests/Unit/Framework/Config/TypedConfigAccessTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Framework\Config;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Exception\ConfigException;
 use Gacela\Framework\Gacela;
@@ -96,7 +97,84 @@ final class TypedConfigAccessTest extends TestCase
     {
         self::assertSame('fallback', Config::getInstance()->getString('missing-key', 'fallback'));
         self::assertSame(7, Config::getInstance()->getInt('missing-key', 7));
+        self::assertSame(1.5, Config::getInstance()->getFloat('missing-key', 1.5));
         self::assertFalse(Config::getInstance()->getBool('missing-key', false));
         self::assertSame([], Config::getInstance()->getArray('missing-key', []));
+    }
+
+    public function test_missing_key_multi_item_array_default_is_returned_unchanged(): void
+    {
+        self::assertSame(
+            ['a' => 1, 'b' => 2],
+            Config::getInstance()->getArray('missing-key', ['a' => 1, 'b' => 2]),
+        );
+    }
+
+    public function test_get_float_throws_on_wrong_type(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('expected "float"');
+
+        Config::getInstance()->getFloat('a-string');
+    }
+
+    public function test_get_array_throws_on_wrong_type(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('expected "array"');
+
+        Config::getInstance()->getArray('an-int');
+    }
+
+    public function test_get_int_missing_key_without_default_throws(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        Config::getInstance()->getInt('missing-key');
+    }
+
+    public function test_get_float_missing_key_without_default_throws(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        Config::getInstance()->getFloat('missing-key');
+    }
+
+    public function test_get_bool_missing_key_without_default_throws(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        Config::getInstance()->getBool('missing-key');
+    }
+
+    public function test_get_array_missing_key_without_default_throws(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        Config::getInstance()->getArray('missing-key');
+    }
+
+    public function test_typed_getters_initialize_config_on_first_access(): void
+    {
+        // Fresh Config with no prior init(): each typed getter must trigger the
+        // lazy initialization itself, otherwise the key would not be found.
+        foreach ([['getString', 'hello'], ['getInt', 42], ['getFloat', 3.14], ['getBool', true], ['getArray', ['x' => 1]]] as [$getter, $expected]) {
+            Config::resetInstance();
+            $config = Config::createWithSetup(
+                (new SetupGacela())
+                    ->setFileCacheEnabled(false)
+                    ->setConfigKeyValues([
+                        'a-string' => 'hello',
+                        'an-int' => 42,
+                        'a-float' => 3.14,
+                        'a-bool' => true,
+                        'an-array' => ['x' => 1],
+                    ]),
+            );
+            $config->setAppRootDir(__DIR__);
+
+            $key = ['getString' => 'a-string', 'getInt' => 'an-int', 'getFloat' => 'a-float', 'getBool' => 'a-bool', 'getArray' => 'an-array'][$getter];
+            self::assertSame($expected, $config->{$getter}($key), "first access via {$getter}()");
+        }
     }
 }


### PR DESCRIPTION
## 📚 Description

Takes mutation testing from **MSI 97% to 100%** (covered MSI 98% → 100%, mutation coverage 99% → 100%) and locks the floors at 100 so it cannot silently regress. Before: 26 escaped + 12 uncovered mutants; after: **0 escaped, 0 uncovered** (1727 killed, 54 documented equivalents ignored).

## 🔖 Changes

**Tests (kill real gaps)**
- `TypedConfigAccessTest`: missing-key throws for all typed getters, wrong-type throws for `getFloat`/`getArray`, `getFloat` default, multi-item array default, and a lazy-init test where a typed getter is the first-ever config access.
- `LifecycleEventsTest`: bootstrap duration upper bound (kills broken hrtime-diff / ns→ms math mutants); every binding flavor (plain/factory/protected/alias/lazy/contextual) asserted to dispatch `BindingRegisteredEvent`; new `ModuleBc` fixture covering the BC `AbstractDependencyProvider` → `ProviderRegisteredEvent` path.
- `MergedConfigCacheIntegrationTest`: auto-warm fixture now has two keys, so the cache-miss path proves a multi-key merged config survives intact.

**Bug found by a mutant 🐛**
- `ProviderRegisteredEvent` fired **twice** for modern `AbstractProvider`s: both resolvers share a normalized cache slot (`DependencyProvider` → `Provider` in `ResolvableType`), so the BC resolver returned the same cached instance and re-reported it. Now it only notifies a distinct provider; test asserts exactly one event. (CHANGELOG under Fixed.)

**Equivalent mutants — documented ignores (infection.json5, per-reason comments)**
- Memoization guards (`instanceof` rebuild-idempotent): resolver container, gacela file config, event dispatcher.
- `??=` no-op pre-bootstrap dispatcher; `isset()`-based dedup (`= true` vs `= false`); `array_values(array_unique())` feeding `implode()`; `(float)` casts where int→float widening applies anyway; `HealthCheckRegistry::instantiate` instanceof mutants that collapse into the same catch+fallback.

**Floors**
- `infection.json5`: `minMsi`/`minCoveredMsi` 65 → **100**; composer `infection` script `--min-msi`/`--min-covered-msi` 75 → **100**.

## ✅ Verification

- Full infection run: `1787 mutations, 1727 killed, 54 ignored, 0 escaped, 0 uncovered — MSI 100%`.
- Mutant #1 (provider notify removal) verified killed by manually applying it → test fails.
- `composer test` (940 tests) + `composer quality` green. PHPStan caught (and I fixed) a same-namespace `::class` import bug in the new test along the way.
