### PR TITLE
feat(phpstan): shared-namespace allowlist for module boundaries + debug:graph command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `debug:graph` console command: prints the module dependency graph (which module's `use` imports point into which other module); `--format=text|mermaid|graphviz|json`, optional module filter
+- `CrossModuleViaFacadeRule` now accepts a `sharedNamespaces` argument: shared-kernel namespaces are exempt from the boundary check in both directions (references into them are allowed, classes inside them are not checked); documented in `docs/static-analysis.md`
 - `Gacela\Framework\Testing\GacelaTestCase`: PHPUnit base class for module tests — `bootstrapGacela()`/`bootstrapGacelaWithConfig()` start from a clean in-memory state, `tearDown()` drops all Gacela singletons, and every bootstrap records the lifecycle events, enabling `assertServiceResolved()`, `assertBindingRegistered()`, and `recordedGacelaEventsOf()`
 - Framework lifecycle events for observability, all allocation-guarded so they stay zero-cost when nothing listens: `GacelaBootstrapStartedEvent`/`GacelaBootstrapFinishedEvent(durationMs)`, `ConfigInitializedEvent(keyCount)`, `ConfigKeyReadEvent(key)`, `ConfigKeyNotFoundEvent(key)`, `ServiceResolvedEvent(id)` (once per container service), `BindingRegisteredEvent(id)`, `ProviderRegisteredEvent(providerClass, moduleName)`, `CacheClearedEvent(cacheFile)`, `CacheWarmedEvent(moduleCount, failedCount)`
 - `debug:module <ModuleName>` console command: given a module name it prints the resolved Facade/Factory/Config/Provider classes, the container bindings (global + contextual), and the facade dependency tree; supports `--json` for machine output and `--tree` to limit output to the tree

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -11,6 +11,34 @@ includes:
     - vendor/gacela-project/gacela/phpstan-gacela.neon
 ```
 
+### Module boundaries
+
+The bundled `CrossModuleViaFacadeRule` enforces gacela's core architecture rule
+statically: module A may only reach module B through B's Facade. It is opt-in —
+register it with your project's root namespace:
+
+```neon
+services:
+    -
+        class: Gacela\PHPStan\Rules\CrossModuleViaFacadeRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: App\Modules
+            modulePathSegments: 1     # how many segments under the root identify a module
+            sharedNamespaces:         # optional shared kernels, exempt from the check
+                - App\Modules\Shared
+```
+
+- Any `new`, static call, class-constant or static-property reference from one
+  module into another is reported unless the referenced class is a `*Facade`.
+- `sharedNamespaces` entries are exempt in both directions: references into
+  them are always allowed, and classes inside them are not checked. Matching is
+  namespace-boundary aware (`App\Modules\Shared` does not exempt
+  `App\Modules\SharedFoo`).
+
+To see the actual module dependency graph of your app, run
+`vendor/bin/gacela debug:graph` (formats: `text`, `mermaid`, `graphviz`, `json`).
+
 ## Psalm
 
 ```xml

--- a/phpstan-gacela.neon
+++ b/phpstan-gacela.neon
@@ -35,10 +35,14 @@ services:
         class: Gacela\PHPStan\Rules\FactoryDoesNotCallFacadeRule
         tags: [phpstan.rules.rule]
     # Opt-in: enable by passing your project's root namespace (and, if needed,
-    # how many segments beneath that root identify a module).
+    # how many segments beneath that root identify a module). Namespaces in
+    # sharedNamespaces are exempt shared kernels: references into them are
+    # always allowed, and classes inside them are not checked.
     # -
     #     class: Gacela\PHPStan\Rules\CrossModuleViaFacadeRule
     #     tags: [phpstan.rules.rule]
     #     arguments:
     #         rootNamespace: App\Modules
     #         modulePathSegments: 1
+    #         sharedNamespaces:
+    #             - App\Modules\Shared

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -50,6 +50,29 @@ final class ConsoleFacade extends AbstractFacade
     }
 
     /**
+     * Build the module dependency graph: module namespace => the module
+     * namespaces its `use` imports point into.
+     *
+     * @return array<string, list<string>>
+     */
+    public function buildModuleGraph(string $filter = ''): array
+    {
+        return $this->getFactory()
+            ->createModuleGraphBuilder()
+            ->build($this->findAllAppModules($filter));
+    }
+
+    /**
+     * @param array<string, list<string>> $graph
+     */
+    public function formatModuleGraph(array $graph, string $format): string
+    {
+        return $this->getFactory()
+            ->createModuleGraphFormatter($format)
+            ->format($graph);
+    }
+
+    /**
      * @return ContainerStats
      */
     public function getContainerStats(): array

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -15,6 +15,12 @@ use Gacela\Console\Domain\FileContent\FileContentGeneratorInterface;
 use Gacela\Console\Domain\FileContent\FileContentIoInterface;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizerInterface;
+use Gacela\Console\Domain\ModuleGraph\GraphFormatterInterface;
+use Gacela\Console\Domain\ModuleGraph\GraphvizGraphFormatter;
+use Gacela\Console\Domain\ModuleGraph\JsonGraphFormatter;
+use Gacela\Console\Domain\ModuleGraph\MermaidGraphFormatter;
+use Gacela\Console\Domain\ModuleGraph\ModuleGraphBuilder;
+use Gacela\Console\Domain\ModuleGraph\TextGraphFormatter;
 use Gacela\Console\Infrastructure\FileContentIo;
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\ClassResolver\Config\ConfigResolver;
@@ -86,6 +92,21 @@ final class ConsoleFactory extends AbstractFactory
             $this->createModuleScanIterator(),
             $this->createAppModuleCreator(),
         );
+    }
+
+    public function createModuleGraphBuilder(): ModuleGraphBuilder
+    {
+        return new ModuleGraphBuilder();
+    }
+
+    public function createModuleGraphFormatter(string $format): GraphFormatterInterface
+    {
+        return match ($format) {
+            'mermaid' => new MermaidGraphFormatter(),
+            'graphviz' => new GraphvizGraphFormatter(),
+            'json' => new JsonGraphFormatter(),
+            default => new TextGraphFormatter(),
+        };
     }
 
     public function createAppModuleCreator(): AppModuleCreator

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -10,6 +10,7 @@ use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
 use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
 use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
 use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
 use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
 use Gacela\Console\Infrastructure\Command\DoctorCommand;
@@ -43,6 +44,7 @@ final class ConsoleProvider extends AbstractProvider
             new DebugConfigCommand(),
             new DebugContainerCommand(),
             new DebugDependenciesCommand(),
+            new DebugGraphCommand(),
             new DebugModuleCommand(),
             new DebugModulesCommand(),
             new CacheWarmCommand(),

--- a/src/Console/Domain/ModuleGraph/GraphFormatterInterface.php
+++ b/src/Console/Domain/ModuleGraph/GraphFormatterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+interface GraphFormatterInterface
+{
+    /**
+     * @param array<string, list<string>> $graph module namespace => module namespaces it depends on
+     */
+    public function format(array $graph): string;
+}

--- a/src/Console/Domain/ModuleGraph/GraphvizGraphFormatter.php
+++ b/src/Console/Domain/ModuleGraph/GraphvizGraphFormatter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use function sprintf;
+
+final class GraphvizGraphFormatter implements GraphFormatterInterface
+{
+    public function format(array $graph): string
+    {
+        $lines = ['digraph modules {'];
+
+        foreach ($graph as $module => $dependencies) {
+            if ($dependencies === []) {
+                $lines[] = sprintf('    "%s";', $module);
+
+                continue;
+            }
+
+            foreach ($dependencies as $dependency) {
+                $lines[] = sprintf('    "%s" -> "%s";', $module, $dependency);
+            }
+        }
+
+        $lines[] = '}';
+
+        return implode("\n", $lines) . "\n";
+    }
+}

--- a/src/Console/Domain/ModuleGraph/JsonGraphFormatter.php
+++ b/src/Console/Domain/ModuleGraph/JsonGraphFormatter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+final class JsonGraphFormatter implements GraphFormatterInterface
+{
+    public function format(array $graph): string
+    {
+        return json_encode($graph, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    }
+}

--- a/src/Console/Domain/ModuleGraph/MermaidGraphFormatter.php
+++ b/src/Console/Domain/ModuleGraph/MermaidGraphFormatter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use function sprintf;
+use function str_replace;
+
+final class MermaidGraphFormatter implements GraphFormatterInterface
+{
+    public function format(array $graph): string
+    {
+        $lines = ['graph TD'];
+
+        foreach ($graph as $module => $dependencies) {
+            if ($dependencies === []) {
+                $lines[] = sprintf('    %s', self::nodeId($module));
+
+                continue;
+            }
+
+            foreach ($dependencies as $dependency) {
+                $lines[] = sprintf('    %s --> %s', self::nodeId($module), self::nodeId($dependency));
+            }
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    private static function nodeId(string $module): string
+    {
+        return str_replace('\\', '.', $module);
+    }
+}

--- a/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
+++ b/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use SplFileInfo;
+
+use function dirname;
+use function file_get_contents;
+use function is_string;
+use function preg_match_all;
+use function sort;
+use function str_starts_with;
+
+final class ModuleGraphBuilder
+{
+    /**
+     * Build the module dependency graph: which module's code declares
+     * `use` imports pointing into which other module.
+     *
+     * @param list<AppModule> $modules
+     *
+     * @return array<string, list<string>> module namespace => sorted list of module namespaces it depends on
+     */
+    public function build(array $modules): array
+    {
+        $graph = [];
+
+        foreach ($modules as $module) {
+            $graph[$module->fullModuleName()] = $this->dependenciesOf($module, $modules);
+        }
+
+        return $graph;
+    }
+
+    /**
+     * @param list<AppModule> $allModules
+     *
+     * @return list<string>
+     */
+    private function dependenciesOf(AppModule $module, array $allModules): array
+    {
+        $dependencies = [];
+
+        foreach ($this->moduleImports($module) as $import) {
+            foreach ($allModules as $candidate) {
+                if ($candidate->fullModuleName() === $module->fullModuleName()) {
+                    continue;
+                }
+
+                if (str_starts_with($import, $candidate->fullModuleName() . '\\')) {
+                    $dependencies[$candidate->fullModuleName()] = $candidate->fullModuleName();
+                }
+            }
+        }
+
+        $list = array_values($dependencies);
+        sort($list);
+
+        return $list;
+    }
+
+    /**
+     * All `use` imports declared across the module's php files.
+     *
+     * @return list<string>
+     */
+    private function moduleImports(AppModule $module): array
+    {
+        $moduleDir = $this->moduleDirectory($module);
+        if ($moduleDir === null) {
+            return [];
+        }
+
+        $imports = [];
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($moduleDir, RecursiveDirectoryIterator::SKIP_DOTS));
+
+        /** @var SplFileInfo $fileInfo */
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = file_get_contents($fileInfo->getPathname());
+            if (!is_string($contents)) {
+                continue;
+            }
+
+            preg_match_all('/^use\s+([A-Za-z0-9_\\\\]+)/m', $contents, $matches);
+            foreach ($matches[1] as $import) {
+                $imports[] = $import;
+            }
+        }
+
+        return $imports;
+    }
+
+    private function moduleDirectory(AppModule $module): ?string
+    {
+        $facadeFile = (new ReflectionClass($module->facadeClass()))->getFileName();
+
+        return is_string($facadeFile) ? dirname($facadeFile) : null;
+    }
+}

--- a/src/Console/Domain/ModuleGraph/TextGraphFormatter.php
+++ b/src/Console/Domain/ModuleGraph/TextGraphFormatter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use function count;
+use function sprintf;
+
+final class TextGraphFormatter implements GraphFormatterInterface
+{
+    public function format(array $graph): string
+    {
+        $lines = [];
+
+        foreach ($graph as $module => $dependencies) {
+            $lines[] = sprintf('%s (%d)', $module, count($dependencies));
+            foreach ($dependencies as $dependency) {
+                $lines[] = sprintf('  -> %s', $dependency);
+            }
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+final class DebugGraphCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const FORMATS = ['text', 'mermaid', 'graphviz', 'json'];
+
+    protected function configure(): void
+    {
+        $this->setName('debug:graph')
+            ->setDescription('Show the module dependency graph (which module imports which)')
+            ->addArgument('filter', InputArgument::OPTIONAL, 'Only include modules matching this filter')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format: text, mermaid, graphviz, or json', 'text');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $format = (string)$input->getOption('format');
+        if (!in_array($format, self::FORMATS, true)) {
+            $output->writeln(sprintf('<error>Unknown format "%s". Use one of: text, mermaid, graphviz, json</error>', $format));
+
+            return self::FAILURE;
+        }
+
+        $filter = (string)$input->getArgument('filter');
+        $graph = $this->getFacade()->buildModuleGraph($filter);
+
+        if ($graph === []) {
+            $output->writeln(sprintf('<comment>No modules match filter "%s".</comment>', $filter));
+
+            return self::SUCCESS;
+        }
+
+        $output->write($this->getFacade()->formatModuleGraph($graph, $format));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/PHPStan/Rules/CrossModuleViaFacadeRule.php
+++ b/src/PHPStan/Rules/CrossModuleViaFacadeRule.php
@@ -34,9 +34,16 @@ final class CrossModuleViaFacadeRule implements Rule
 {
     use ClassReflectionHelperTrait;
 
+    /**
+     * @param list<string> $sharedNamespaces namespaces exempt from the boundary
+     *                                       check (shared kernels): references
+     *                                       into them are always allowed, and
+     *                                       classes inside them are not checked
+     */
     public function __construct(
         private readonly string $rootNamespace,
         private readonly int $modulePathSegments = 1,
+        private readonly array $sharedNamespaces = [],
     ) {
     }
 
@@ -53,6 +60,10 @@ final class CrossModuleViaFacadeRule implements Rule
         }
 
         $currentClass = $classReflection->getName();
+        if ($this->isShared($currentClass)) {
+            return [];
+        }
+
         $currentModule = $this->moduleOf($currentClass);
         if ($currentModule === null) {
             return [];
@@ -91,6 +102,10 @@ final class CrossModuleViaFacadeRule implements Rule
                 continue;
             }
 
+            if ($this->isShared($referenced)) {
+                continue;
+            }
+
             $key = $currentClass . '|' . $referenced;
             if (isset($seen[$key])) {
                 continue;
@@ -108,6 +123,17 @@ final class CrossModuleViaFacadeRule implements Rule
         }
 
         return $errors;
+    }
+
+    private function isShared(string $class): bool
+    {
+        foreach ($this->sharedNamespaces as $sharedNamespace) {
+            if ($class === $sharedNamespace || str_starts_with($class, $sharedNamespace . '\\')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function moduleOf(string $class): ?string

--- a/tests/Feature/Console/DebugGraph/DebugGraphCommandTest.php
+++ b/tests/Feature/Console/DebugGraph/DebugGraphCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraph;
+
+use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function sprintf;
+
+final class DebugGraphCommandTest extends TestCase
+{
+    private const MODULE_A = 'GacelaTest\Feature\Console\DebugGraph\ModuleA';
+
+    private const MODULE_B = 'GacelaTest\Feature\Console\DebugGraph\ModuleB';
+
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $this->command = new CommandTester(new DebugGraphCommand());
+    }
+
+    public function test_text_format_lists_modules_and_edges(): void
+    {
+        $this->command->execute([]);
+
+        $display = $this->command->getDisplay();
+        self::assertStringContainsString(self::MODULE_A . ' (1)', $display);
+        self::assertStringContainsString('  -> ' . self::MODULE_B, $display);
+        self::assertStringContainsString(self::MODULE_B . ' (0)', $display);
+    }
+
+    public function test_mermaid_format(): void
+    {
+        $this->command->execute(['--format' => 'mermaid']);
+
+        $display = $this->command->getDisplay();
+        self::assertStringContainsString('graph TD', $display);
+        self::assertStringContainsString(
+            str_replace('\\', '.', self::MODULE_A) . ' --> ' . str_replace('\\', '.', self::MODULE_B),
+            $display,
+        );
+    }
+
+    public function test_graphviz_format(): void
+    {
+        $this->command->execute(['--format' => 'graphviz']);
+
+        $display = $this->command->getDisplay();
+        self::assertStringContainsString('digraph modules {', $display);
+        self::assertStringContainsString(sprintf('"%s" -> "%s";', self::MODULE_A, self::MODULE_B), $display);
+        self::assertStringContainsString('}', $display);
+    }
+
+    public function test_json_format_is_parseable(): void
+    {
+        $this->command->execute(['--format' => 'json']);
+
+        /** @var array<string, list<string>> $graph */
+        $graph = json_decode($this->command->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame([self::MODULE_B], $graph[self::MODULE_A]);
+        self::assertSame([], $graph[self::MODULE_B]);
+    }
+
+    public function test_unknown_format_fails(): void
+    {
+        $exitCode = $this->command->execute(['--format' => 'nope']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Unknown format "nope"', $this->command->getDisplay());
+    }
+
+    public function test_filter_without_matches_prints_comment(): void
+    {
+        $exitCode = $this->command->execute(['filter' => 'DoesNotExist']);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('No modules match filter "DoesNotExist"', $this->command->getDisplay());
+    }
+}

--- a/tests/Feature/Console/DebugGraph/ModuleA/Facade.php
+++ b/tests/Feature/Console/DebugGraph/ModuleA/Facade.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraph\ModuleA;
+
+use Gacela\Framework\AbstractFacade;
+use GacelaTest\Feature\Console\DebugGraph\ModuleB\Facade as ModuleBFacade;
+
+/**
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function combined(): string
+    {
+        return (new ModuleBFacade())->name() . '+a';
+    }
+}

--- a/tests/Feature/Console/DebugGraph/ModuleA/Factory.php
+++ b/tests/Feature/Console/DebugGraph/ModuleA/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraph\ModuleA;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createName(): string
+    {
+        return 'a';
+    }
+}

--- a/tests/Feature/Console/DebugGraph/ModuleB/Facade.php
+++ b/tests/Feature/Console/DebugGraph/ModuleB/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraph\ModuleB;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->createName();
+    }
+}

--- a/tests/Feature/Console/DebugGraph/ModuleB/Factory.php
+++ b/tests/Feature/Console/DebugGraph/ModuleB/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraph\ModuleB;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createName(): string
+    {
+        return 'b';
+    }
+}

--- a/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
+++ b/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
@@ -26,12 +26,14 @@ final class GacelaTestCaseTest extends GacelaTestCase
         self::assertSame(42, Config::getInstance()->getInt('an-int'));
     }
 
-    public function test_config_singleton_is_reset_between_tests(): void
+    public function test_teardown_resets_the_config_singleton(): void
     {
-        // Whatever other test ran before, tearDown() must have dropped the
-        // Config singleton; a fresh test starts unbootstrapped.
-        $this->expectException(RuntimeException::class);
+        $this->bootstrapGacela(__DIR__);
+        self::assertNotNull(Config::getInstance());
 
+        $this->tearDown();
+
+        $this->expectException(RuntimeException::class);
         Config::getInstance();
     }
 

--- a/tests/Unit/Console/Domain/ModuleGraph/GraphFormattersTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/GraphFormattersTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph;
+
+use Gacela\Console\Domain\ModuleGraph\GraphvizGraphFormatter;
+use Gacela\Console\Domain\ModuleGraph\JsonGraphFormatter;
+use Gacela\Console\Domain\ModuleGraph\MermaidGraphFormatter;
+use Gacela\Console\Domain\ModuleGraph\TextGraphFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class GraphFormattersTest extends TestCase
+{
+    private const GRAPH = [
+        'App\Checkout' => ['App\Payment', 'App\Stock'],
+        'App\Payment' => [],
+    ];
+
+    public function test_text_format(): void
+    {
+        $expected = <<<'TXT'
+App\Checkout (2)
+  -> App\Payment
+  -> App\Stock
+App\Payment (0)
+
+TXT;
+        self::assertSame($expected, (new TextGraphFormatter())->format(self::GRAPH));
+    }
+
+    public function test_mermaid_format(): void
+    {
+        $expected = <<<'TXT'
+graph TD
+    App.Checkout --> App.Payment
+    App.Checkout --> App.Stock
+    App.Payment
+
+TXT;
+        self::assertSame($expected, (new MermaidGraphFormatter())->format(self::GRAPH));
+    }
+
+    public function test_graphviz_format(): void
+    {
+        $expected = <<<'TXT'
+digraph modules {
+    "App\Checkout" -> "App\Payment";
+    "App\Checkout" -> "App\Stock";
+    "App\Payment";
+}
+
+TXT;
+        self::assertSame($expected, (new GraphvizGraphFormatter())->format(self::GRAPH));
+    }
+
+    public function test_json_format(): void
+    {
+        $decoded = json_decode((new JsonGraphFormatter())->format(self::GRAPH), true);
+
+        self::assertSame(self::GRAPH, $decoded);
+    }
+
+    public function test_empty_graph(): void
+    {
+        self::assertSame("\n", (new TextGraphFormatter())->format([]));
+        self::assertSame("graph TD\n", (new MermaidGraphFormatter())->format([]));
+        self::assertSame("digraph modules {\n}\n", (new GraphvizGraphFormatter())->format([]));
+        self::assertSame("[]\n", (new JsonGraphFormatter())->format([]));
+    }
+}

--- a/tests/Unit/PHPStan/Rules/CrossModuleViaFacadeRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/CrossModuleViaFacadeRuleTest.php
@@ -20,6 +20,9 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
 
     private int $modulePathSegments = 1;
 
+    /** @var list<string> */
+    private array $sharedNamespaces = [];
+
     public function test_reports_cross_module_new_of_non_facade(): void
     {
         $this->analyse(
@@ -147,8 +150,67 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
         self::assertNull($moduleOf->invoke($rule, self::ROOT . '\OnlyOneSegment'));
     }
 
+    public function test_reports_shared_namespace_reference_when_not_allowlisted(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/User/SharedKernelFactory.php'],
+            [
+                [
+                    'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\SharedKernelFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared). Cross-module access must go through a Facade.',
+                    9,
+                ],
+            ],
+        );
+    }
+
+    public function test_allows_reference_into_a_shared_namespace(): void
+    {
+        $this->sharedNamespaces = [self::ROOT . '\Shared'];
+
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/User/SharedKernelFactory.php'], []);
+    }
+
+    public function test_shared_namespace_must_match_a_namespace_boundary(): void
+    {
+        // "Shar" is a prefix of "Shared" but not a namespace boundary:
+        // the reference must still be reported.
+        $this->sharedNamespaces = [self::ROOT . '\Shar'];
+
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/User/SharedKernelFactory.php'],
+            [
+                [
+                    'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\SharedKernelFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared). Cross-module access must go through a Facade.',
+                    9,
+                ],
+            ],
+        );
+    }
+
+    public function test_still_reports_a_violation_after_an_allowed_shared_reference(): void
+    {
+        $this->sharedNamespaces = [self::ROOT . '\Shared'];
+
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/User/SharedThenBadFactory.php'],
+            [
+                [
+                    'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\SharedThenBadFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
+                    10,
+                ],
+            ],
+        );
+    }
+
+    public function test_class_inside_a_shared_namespace_is_not_itself_checked(): void
+    {
+        $this->sharedNamespaces = [self::ROOT . '\Shared'];
+
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/Shared/UsesOtherModule.php'], []);
+    }
+
     protected function getRule(): Rule
     {
-        return new CrossModuleViaFacadeRule($this->rootNamespace, $this->modulePathSegments);
+        return new CrossModuleViaFacadeRule($this->rootNamespace, $this->modulePathSegments, $this->sharedNamespaces);
     }
 }

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shared/Clock.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shared/Clock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared;
+
+final class Clock
+{
+    public function now(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shared/UsesOtherModule.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shared/UsesOtherModule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService;
+
+final class UsesOtherModule
+{
+    public function createIt(): ShopService
+    {
+        return new ShopService();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/User/SharedKernelFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/User/SharedKernelFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock;
+
+final class SharedKernelFactory
+{
+    public function createIt(): Clock
+    {
+        return new Clock();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/User/SharedThenBadFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/User/SharedThenBadFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock;
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService;
+
+final class SharedThenBadFactory
+{
+    public function createIt(): ShopService
+    {
+        new Clock();
+
+        return new ShopService();
+    }
+}


### PR DESCRIPTION
## 📚 Description

Implements #469 against what main actually has today: `CrossModuleViaFacadeRule` already enforces the module boundary (module A reaches module B only via its Facade), so instead of duplicating it, this PR adds the missing **shared-kernel allowlist** to that rule, plus a **`debug:graph`** command that renders the whole-app module dependency graph. (The issue's suggested `debug:dependencies` name was already taken by the per-class constructor inspector, hence `debug:graph`.)

Closes #469

## 🔖 Changes

- `CrossModuleViaFacadeRule` gains `sharedNamespaces: list<string>` (default `[]`): references into those namespaces are always allowed, classes inside them are not checked, and matching is namespace-boundary aware (`App\Shared` does not exempt `App\SharedFoo`). Opt-in example updated in `phpstan-gacela.neon`; documented in `docs/static-analysis.md` with a "Module boundaries" section.
- New `debug:graph [filter] --format=text|mermaid|graphviz|json`: builds module→module edges from each module's `use` imports (via `ModuleGraphBuilder` + four tiny formatters under `Console/Domain/ModuleGraph`), wired through `ConsoleFacade::buildModuleGraph()`/`formatModuleGraph()`.
- Flake fix (from #468, caught while running the full suite under random order): `GacelaTestCaseTest::test_config_singleton_is_reset_between_tests` assumed the previous suite test cleaned up global state — replaced with an order-independent explicit `tearDown()` assertion.

## ✅ Verification

- Rule: 18 unit tests incl. allowlist positive/negative, namespace-boundary precision (`\Shar` prefix does not exempt `\Shared`), and a shared-ref-before-violation fixture (kills the `continue`→`break` mutant).
- Command: 6 feature tests over a two-module fixture — all four formats asserted (JSON parsed back), unknown-format failure, empty-filter message. 5 formatter unit tests with exact expected output.
- Mutation testing on the touched src files: **48/48 killed — MSI 100%**.
- `composer test` (678/…) + `composer quality` green.

## 🧹 Refactor pass

Reviewed post-implementation: formatters are single-purpose finals, no dead branches, factory `match` covers all formats with text default — nothing to remove.
