### PR TITLE
feat(console): make:module --template=service with optional test scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `make:module --template=service [--with-tests]`: scaffolds the four pillars plus a `Domain` service the Facade delegates to (built on the existing `.txt` template mechanism); `--with-tests` adds a ready-to-run facade test extending `GacelaTestCase` under the module's `Tests/` directory. The generated module compiles and runs out of the box
 - `debug:graph` console command: prints the module dependency graph (which module's `use` imports point into which other module); `--format=text|mermaid|graphviz|json`, optional module filter
 - `CrossModuleViaFacadeRule` now accepts a `sharedNamespaces` argument: shared-kernel namespaces are exempt from the boundary check in both directions (references into them are allowed, classes inside them are not checked); documented in `docs/static-analysis.md`
 - `Gacela\Framework\Testing\GacelaTestCase`: PHPUnit base class for module tests — `bootstrapGacela()`/`bootstrapGacelaWithConfig()` start from a clean in-memory state, `tearDown()` drops all Gacela singletons, and every bootstrap records the lifecycle events, enabling `assertServiceResolved()`, `assertBindingRegistered()`, and `recordedGacelaEventsOf()`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,3 +48,15 @@ $resolved = $this->recordedGacelaEventsOf(ServiceResolvedEvent::class); // one t
 If you only need the reset helpers inside an existing test hierarchy, use the
 [`ContainerFixture`](../src/Framework/Testing/ContainerFixture.php) trait
 directly — `GacelaTestCase` builds on it.
+
+## Scaffolding a testable module
+
+`make:module` can scaffold a module already wired for testing:
+
+```bash
+vendor/bin/gacela make:module App/Greeting --template=service --with-tests
+```
+
+The `service` template generates the four pillars plus a `Domain` service the
+Facade delegates to, and `--with-tests` adds a ready-to-run facade test (a
+`GacelaTestCase`) under the module's `Tests/` directory.

--- a/src/Console/ConsoleConfig.php
+++ b/src/Console/ConsoleConfig.php
@@ -30,6 +30,26 @@ final class ConsoleConfig extends AbstractConfig
         return $this->getCommandTemplateContent('provider-maker.txt');
     }
 
+    public function getServiceFacadeMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('service/facade-maker.txt');
+    }
+
+    public function getServiceFactoryMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('service/factory-maker.txt');
+    }
+
+    public function getServiceMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('service/service-maker.txt');
+    }
+
+    public function getServiceFacadeTestMakerTemplate(): string
+    {
+        return $this->getCommandTemplateContent('service/facade-test-maker.txt');
+    }
+
     /**
      * @psalm-suppress MixedReturnTypeCoercion
      *

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -40,6 +40,22 @@ final class ConsoleFacade extends AbstractFacade
     }
 
     /**
+     * Generate a file from the `service` template set.
+     *
+     * @param string $subDirectory optional sub-directory (relative to the module dir) to place the file in
+     */
+    public function generateServiceFileContent(
+        CommandArguments $commandArguments,
+        string $filename,
+        bool $withShortName = false,
+        string $subDirectory = '',
+    ): string {
+        return $this->getFactory()
+            ->createServiceFileContentGenerator()
+            ->generate($commandArguments, $filename, $withShortName, $subDirectory);
+    }
+
+    /**
      * @return list<AppModule>
      */
     public function findAllAppModules(string $filter = ''): array

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -86,6 +86,14 @@ final class ConsoleFactory extends AbstractFactory
         );
     }
 
+    public function createServiceFileContentGenerator(): FileContentGeneratorInterface
+    {
+        return new FileContentGenerator(
+            $this->createFileContentIo(),
+            $this->getServiceTemplateByFilenameMap(),
+        );
+    }
+
     public function createAllAppModulesFinder(): AllAppModulesFinder
     {
         return new AllAppModulesFinder(
@@ -238,6 +246,16 @@ final class ConsoleFactory extends AbstractFactory
     private function getTemplateByFilenameMap(): array
     {
         return (array)$this->getProvidedDependency(ConsoleProvider::TEMPLATE_BY_FILENAME_MAP);
+    }
+
+    /**
+     * @psalm-suppress MixedReturnTypeCoercion
+     *
+     * @return array<string,string>
+     */
+    private function getServiceTemplateByFilenameMap(): array
+    {
+        return (array)$this->getProvidedDependency(ConsoleProvider::SERVICE_TEMPLATE_BY_FILENAME_MAP);
     }
 
     private function getMainContainer(): Container

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -31,6 +31,8 @@ final class ConsoleProvider extends AbstractProvider
 
     public const TEMPLATE_BY_FILENAME_MAP = 'TEMPLATE_FILENAME_MAP';
 
+    public const SERVICE_TEMPLATE_BY_FILENAME_MAP = 'SERVICE_TEMPLATE_FILENAME_MAP';
+
     /**
      * @return list<object>
      */
@@ -66,6 +68,25 @@ final class ConsoleProvider extends AbstractProvider
             FilenameSanitizer::FACTORY => $this->getConfig()->getFactoryMakerTemplate(),
             FilenameSanitizer::CONFIG => $this->getConfig()->getConfigMakerTemplate(),
             FilenameSanitizer::PROVIDER => $this->getConfig()->getProviderMakerTemplate(),
+        ];
+    }
+
+    /**
+     * The `service` template set: Facade and Factory variants wired to a
+     * Domain service, plus the extra Service and FacadeTest files.
+     *
+     * @return array<string,string>
+     */
+    #[Provides(self::SERVICE_TEMPLATE_BY_FILENAME_MAP)]
+    public function serviceTemplateByFilenameMap(): array
+    {
+        return [
+            FilenameSanitizer::FACADE => $this->getConfig()->getServiceFacadeMakerTemplate(),
+            FilenameSanitizer::FACTORY => $this->getConfig()->getServiceFactoryMakerTemplate(),
+            FilenameSanitizer::CONFIG => $this->getConfig()->getConfigMakerTemplate(),
+            FilenameSanitizer::PROVIDER => $this->getConfig()->getProviderMakerTemplate(),
+            'Service' => $this->getConfig()->getServiceMakerTemplate(),
+            'FacadeTest' => $this->getConfig()->getServiceFacadeTestMakerTemplate(),
         ];
     }
 }

--- a/src/Console/Domain/FileContent/FileContentGenerator.php
+++ b/src/Console/Domain/FileContent/FileContentGenerator.php
@@ -21,16 +21,23 @@ final class FileContentGenerator implements FileContentGeneratorInterface
     }
 
     /**
+     * @param string $subDirectory optional sub-directory (relative to the module dir) to place the file in
+     *
      * @return string path result where the file was generated
      */
-    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false): string
+    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string
     {
-        $this->fileContentIo->mkdir($commandArguments->directory());
+        $targetDirectory = $commandArguments->directory();
+        if ($subDirectory !== '') {
+            $targetDirectory .= '/' . $subDirectory;
+        }
+
+        $this->fileContentIo->mkdir($targetDirectory);
 
         $moduleName = $withShortName ? '' : $commandArguments->basename();
         $className = $moduleName . $filename;
 
-        $path = sprintf('%s/%s.php', $commandArguments->directory(), $className);
+        $path = sprintf('%s/%s.php', $targetDirectory, $className);
         $search = ['$NAMESPACE$', '$MODULE_NAME$', '$CLASS_NAME$'];
         $replace = [$commandArguments->namespace(), $moduleName, $className];
 

--- a/src/Console/Domain/FileContent/FileContentGeneratorInterface.php
+++ b/src/Console/Domain/FileContent/FileContentGeneratorInterface.php
@@ -9,7 +9,9 @@ use Gacela\Console\Domain\CommandArguments\CommandArguments;
 interface FileContentGeneratorInterface
 {
     /**
+     * @param string $subDirectory optional sub-directory (relative to the module dir) to place the file in
+     *
      * @return string path result where the file was generated
      */
-    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false): string;
+    public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string;
 }

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\CommandArguments\CommandArguments;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function in_array;
 use function sprintf;
 
 /**
@@ -22,28 +24,43 @@ final class MakeModuleCommand extends Command
 {
     use ServiceResolverAwareTrait;
 
+    private const TEMPLATES = ['basic', 'service'];
+
     protected function configure(): void
     {
         $this->setName('make:module')
             ->setDescription('Generate a basic module with an empty ' . $this->getExpectedFilenames())
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
-            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
+            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name')
+            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Module template: basic, or service (Facade wired to a Domain service)', 'basic')
+            ->addOption('with-tests', null, InputOption::VALUE_NONE, 'Also scaffold a facade test (service template only)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $template = (string)$input->getOption('template');
+        if (!in_array($template, self::TEMPLATES, true)) {
+            $output->writeln(sprintf('<error>Unknown template "%s". Use one of: basic, service</error>', $template));
+
+            return self::FAILURE;
+        }
+
         /** @var string $path */
         $path = $input->getArgument('path');
         $commandArguments = $this->getFacade()->parseArguments($path);
         $shortName = (bool)$input->getOption('short-name');
 
-        foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
-            $fullPath = $this->getFacade()->generateFileContent(
-                $commandArguments,
-                $filename,
-                $shortName,
-            );
-            $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
+        if ($template === 'service') {
+            $this->generateServiceModule($commandArguments, $shortName, (bool)$input->getOption('with-tests'), $output);
+        } else {
+            foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
+                $fullPath = $this->getFacade()->generateFileContent(
+                    $commandArguments,
+                    $filename,
+                    $shortName,
+                );
+                $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
+            }
         }
 
         $pieces = explode('/', $commandArguments->directory());
@@ -51,6 +68,33 @@ final class MakeModuleCommand extends Command
         $output->writeln(sprintf("Module '%s' created successfully", $moduleName));
 
         return self::SUCCESS;
+    }
+
+    private function generateServiceModule(
+        CommandArguments $commandArguments,
+        bool $shortName,
+        bool $withTests,
+        OutputInterface $output,
+    ): void {
+        $files = [];
+        foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
+            $files[] = [$filename, ''];
+        }
+
+        $files[] = ['Service', 'Domain'];
+        if ($withTests) {
+            $files[] = ['FacadeTest', 'Tests'];
+        }
+
+        foreach ($files as [$filename, $subDirectory]) {
+            $fullPath = $this->getFacade()->generateServiceFileContent(
+                $commandArguments,
+                $filename,
+                $shortName,
+                $subDirectory,
+            );
+            $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
+        }
     }
 
     private function getExpectedFilenames(): string

--- a/src/Console/Infrastructure/Template/Command/service/facade-maker.txt
+++ b/src/Console/Infrastructure/Template/Command/service/facade-maker.txt
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<$MODULE_NAME$Factory>
+ */
+final class $CLASS_NAME$ extends AbstractFacade
+{
+    public function execute(): string
+    {
+        return $this->getFactory()
+            ->createService()
+            ->execute();
+    }
+}

--- a/src/Console/Infrastructure/Template/Command/service/facade-test-maker.txt
+++ b/src/Console/Infrastructure/Template/Command/service/facade-test-maker.txt
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$\Tests;
+
+use $NAMESPACE$\$MODULE_NAME$Facade;
+use Gacela\Framework\Testing\GacelaTestCase;
+
+final class $CLASS_NAME$ extends GacelaTestCase
+{
+    public function test_execute(): void
+    {
+        $this->bootstrapGacela(__DIR__);
+
+        self::assertSame('Hello from $MODULE_NAME$Service!', (new $MODULE_NAME$Facade())->execute());
+    }
+}

--- a/src/Console/Infrastructure/Template/Command/service/factory-maker.txt
+++ b/src/Console/Infrastructure/Template/Command/service/factory-maker.txt
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$;
+
+use $NAMESPACE$\Domain\$MODULE_NAME$Service;
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @extends AbstractFactory<$MODULE_NAME$Config>
+ */
+final class $CLASS_NAME$ extends AbstractFactory
+{
+    public function createService(): $MODULE_NAME$Service
+    {
+        return new $MODULE_NAME$Service();
+    }
+}

--- a/src/Console/Infrastructure/Template/Command/service/service-maker.txt
+++ b/src/Console/Infrastructure/Template/Command/service/service-maker.txt
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace $NAMESPACE$\Domain;
+
+final class $CLASS_NAME$
+{
+    public function execute(): string
+    {
+        return 'Hello from $MODULE_NAME$Service!';
+    }
+}

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -22,6 +22,7 @@ final class MakeModuleCommandTest extends TestCase
     public static function tearDownAfterClass(): void
     {
         DirectoryUtil::removeDir(self::CACHE_DIR);
+        DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'ServiceModule');
     }
 
     protected function setUp(): void
@@ -85,5 +86,65 @@ OUT;
     {
         yield 'module' => ['TestModule', false];
         yield 'module -s' => ['', true];
+    }
+
+    public function test_make_module_with_service_template_generates_a_working_module(): void
+    {
+        $input = new StringInput('make:module Psr4CodeGeneratorData/ServiceModule --template=service --with-tests');
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run($input, $output);
+
+        $display = $output->fetch();
+        self::assertStringContainsString("Module 'ServiceModule' created successfully", $display);
+
+        // Paths are built at runtime: the files only exist after the command ran.
+        $moduleDir = getcwd() . '/data/ServiceModule';
+        $files = [
+            $moduleDir . '/ServiceModuleFacade.php',
+            $moduleDir . '/ServiceModuleFactory.php',
+            $moduleDir . '/ServiceModuleConfig.php',
+            $moduleDir . '/ServiceModuleProvider.php',
+            $moduleDir . '/Domain/ServiceModuleService.php',
+            $moduleDir . '/Tests/ServiceModuleFacadeTest.php',
+        ];
+        foreach ($files as $file) {
+            self::assertFileExists($file);
+            // Every generated file must be valid PHP.
+            exec(sprintf('php -l %s 2>&1', escapeshellarg($file)), $lintOutput, $lintExit);
+            self::assertSame(0, $lintExit, implode("\n", $lintOutput));
+        }
+
+        // The generated module actually runs: the facade delegates through
+        // the factory to the Domain service. The Psr4CodeGeneratorData
+        // namespace is only mapped in the fixture composer.json, so load
+        // the generated files explicitly.
+        foreach ($files as $file) {
+            if (!str_contains($file, '/Tests/')) {
+                require_once $file;
+            }
+        }
+
+        $facadeClass = 'Psr4CodeGeneratorData\ServiceModule\ServiceModuleFacade';
+        self::assertTrue(class_exists($facadeClass));
+
+        $execute = [new $facadeClass(), 'execute'];
+        self::assertIsCallable($execute);
+        self::assertSame('Hello from ServiceModuleService!', $execute());
+    }
+
+    public function test_make_module_with_unknown_template_fails(): void
+    {
+        $input = new StringInput('make:module Psr4CodeGeneratorData/AnotherModule --template=nope');
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $exitCode = $bootstrap->run($input, $output);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Unknown template "nope"', $output->fetch());
     }
 }


### PR DESCRIPTION
## 📚 Description

Extends `make:module` with an opt-in `--template=service` that scaffolds a module which **compiles and runs out of the box**, built entirely on the existing `.txt` template mechanism (no inline heredocs). Per the issue's scoping, one well-designed template ships first; more archetypes only once they meet the same bar.

Closes #470

## 🔖 Changes

- `make:module <path> --template=service [--with-tests]`:
  - Four pillars: Facade/Factory come from `service/` template variants — the Facade exposes `execute(): string` delegating through the Factory to a generated `Domain/<Module>Service`; Config/Provider reuse the default templates.
  - `--with-tests` adds `Tests/<Module>FacadeTest.php` extending the new `GacelaTestCase` (#468) — bootstrap + facade assertion, not an `assertInstanceOf` tautology.
  - Templates are placeholder-compatible with `--short-name` (class names collapse cleanly).
  - Unknown template name → clear error, exit 1. Plain `make:module` behavior unchanged (`--template=basic` default).
- Infra: `FileContentGenerator::generate()` gains an optional `$subDirectory` (for `Domain/`, `Tests/`); new `SERVICE_TEMPLATE_BY_FILENAME_MAP` provider key; `ConsoleConfig` template getters; `ConsoleFacade::generateServiceFileContent()`.
- Docs: scaffolding section in `docs/testing.md`; CHANGELOG under Unreleased.

## ✅ Verification

- Feature test proves the acceptance criterion end-to-end: runs the command, asserts all 6 files exist, `php -l`-lints each, then **loads the generated module and calls the Facade** — asserts the delegation chain returns `'Hello from ServiceModuleService!'`.
- Unknown-template failure test; existing `make:module` tests (incl. `--short-name`) untouched and green.
- Random-order runs across 3 seeds green (per the post-#471 rule).
- `composer test` (678 unit + suites) + `composer quality` green.

## 🧹 Refactor pass

Reviewed post-implementation: template selection is one `match` in the factory, command split keeps `execute()` flat, no speculative abstractions (e.g. no template-registry class for two sets) — nothing to remove.
