### PR TITLE
fix(config): clear PathFinder glob cache in Gacela::resetCache()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- `Gacela::resetCache()` now also clears the glob-result cache (`PathFinder`), so config files added or removed on disk are picked up by the next bootstrap in the same process (long-running workers, multi-bootstrap tests); previously the file list was cached for the process lifetime
 - `ProviderRegisteredEvent` is no longer dispatched twice for a modern `AbstractProvider`: the BC `DependencyProvider` resolver returns the same cached provider instance and no longer re-reports it
 - `Config::getEventDispatcher()` no longer throws when called before bootstrap; it returns a no-op dispatcher so guarded dispatch sites (e.g. cache-file deletion) stay silent
 - Re-bootstrapping now rebuilds the event dispatcher from the new setup; previously a dispatcher cached by a prior bootstrap kept serving stale listeners unless the in-memory cache was reset

--- a/src/Framework/Config/PathFinder.php
+++ b/src/Framework/Config/PathFinder.php
@@ -13,6 +13,14 @@ final class PathFinder implements PathFinderInterface
     private static array $cache = [];
 
     /**
+     * @internal drop all cached glob results, so a re-bootstrap re-scans the filesystem
+     */
+    public static function resetCache(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
      * @return string[]
      */
     public function matchingPattern(string $pattern): array

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -18,6 +18,7 @@ use Gacela\Framework\ClassResolver\ClassResolverCache;
 use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\ConfigFactory;
+use Gacela\Framework\Config\PathFinder;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Container\Locator;
 use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
@@ -202,6 +203,7 @@ final class Gacela
         DocBlockResolverCache::resetCache();
         ClassResolverCache::resetCache();
         ConfigFactory::resetCache();
+        PathFinder::resetCache();
         Config::resetInstance();
         Locator::resetInstance();
     }

--- a/tests/Benchmark/Bootstrap/BootstrapBench.php
+++ b/tests/Benchmark/Bootstrap/BootstrapBench.php
@@ -43,7 +43,13 @@ final class BootstrapBench
         $this->bootstrapWarm();
     }
 
-    public function bench_bootstrap_cold(): void
+    /**
+     * Renamed from bench_bootstrap_cold when Gacela::resetCache() started
+     * clearing the glob cache (#474): the old numbers measured bootstraps
+     * that reused a stale glob file list, so they are not comparable — a
+     * cold boot now genuinely re-scans the config files every rev.
+     */
+    public function bench_bootstrap_cold_rescan(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();

--- a/tests/Integration/Framework/Config/PathFinderResetTest.php
+++ b/tests/Integration/Framework/Config/PathFinderResetTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Config;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Testing\GacelaTestCase;
+
+use function file_put_contents;
+use function mkdir;
+
+final class PathFinderResetTest extends GacelaTestCase
+{
+    public function test_config_files_added_after_a_reset_are_visible_to_the_next_bootstrap(): void
+    {
+        $appRootDir = $this->containerTempDir();
+        mkdir($appRootDir . '/config');
+        file_put_contents($appRootDir . '/config/first.php', '<?php return ["first-key" => 1];');
+
+        $this->bootstrapWithConfigDir($appRootDir);
+        self::assertSame(1, Config::getInstance()->getInt('first-key'));
+        self::assertSame('fallback', Config::getInstance()->getString('second-key', 'fallback'));
+
+        // A file added on disk after the first bootstrap must be visible to a
+        // re-bootstrap: resetContainer() (Gacela::resetCache()) has to drop the
+        // glob results too, not only the resolver/config singletons.
+        file_put_contents($appRootDir . '/config/second.php', '<?php return ["second-key" => 2];');
+        $this->bootstrapWithConfigDir($appRootDir);
+
+        self::assertSame(1, Config::getInstance()->getInt('first-key'));
+        self::assertSame(2, Config::getInstance()->getInt('second-key'));
+    }
+
+    private function bootstrapWithConfigDir(string $appRootDir): void
+    {
+        $this->bootstrapGacela($appRootDir, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+            $config->addAppConfig('config/*.php');
+        });
+    }
+}


### PR DESCRIPTION
## 📚 Description

`PathFinder` cached glob results in a static map with no reset path — the only config-layer cache outside the `Gacela::resetCache()` contract. Config files added or removed on disk after the first glob stayed invisible for the entire process: long-running workers (Swoole/RoadRunner/queue consumers) that re-bootstrap never picked up config changes, multi-bootstrap tests read stale file lists, and `GacelaTestCase`'s isolation promise had a hole.

Closes #474

## 🔖 Changes

- `PathFinder::resetCache()` (mirrors the other static caches' naming) + wired into `Gacela::resetCache()`.
- Per-bootstrap glob dedupe is preserved — only the cross-bootstrap staleness is gone.
- Not affected (and verified by the existing behavior): switching `APP_ENV` between bootstraps was already safe, since the env suffix is part of the cached pattern key.
- CHANGELOG under Fixed.

## ✅ Verification

- **Failing-first** integration test (`PathFinderResetTest`, built on `GacelaTestCase` + `containerTempDir()`): bootstrap a temp app, add a second config file on disk, re-bootstrap → new key must be visible. Red on main, green with the fix.
- Mutation testing on `PathFinder.php`: **MSI 100%** (the test kills the `resetCache()` removal mutant — it is exactly the bug scenario).
- Random-order runs across 3 seeds green; `composer test` (678 + suites) + `composer quality` green.

## 🧹 Refactor pass

Two-line fix + test; reviewed the touched files — nothing to dedupe or remove.
