### PR TITLE
ref(config): single APP_ENV source, reader-aware read cache, simpler loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- The application environment (`APP_ENV`) is now read from a single source (`AppEnv::current()`) for both the env-suffixed config file lookup and the merged-config cache filename, so they can no longer disagree when the env var changes mid-process
+- `ConfigLoader`'s per-load read cache is now keyed by reader as well as path: two config items pointing the same file at different readers no longer share a cache entry
 - `Gacela::resetCache()` now also clears the glob-result cache (`PathFinder`), so config files added or removed on disk are picked up by the next bootstrap in the same process (long-running workers, multi-bootstrap tests); previously the file list was cached for the process lifetime
 - `ProviderRegisteredEvent` is no longer dispatched twice for a modern `AbstractProvider`: the BC `DependencyProvider` resolver returns the same cached provider instance and no longer re-reports it
 - `Config::getEventDispatcher()` no longer throws when called before bootstrap; it returns a no-op dispatcher so guarded dispatch sites (e.g. cache-file deletion) stay silent

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,18 @@ return static function (GacelaConfig $config): void {
 };
 ```
 
+### Config precedence
+
+When the same key appears in several places, later sources win:
+
+1. default config files matching the pattern (e.g. `config/app.php`)
+2. environment-suffixed files (`config/app-{APP_ENV}.php`, using the `APP_ENV` env var)
+3. the local file (second argument of `addAppConfig(...)`, conventionally `config/local.php`; not env-suffixed, meant for per-machine overrides)
+4. values set in code via `GacelaConfig::addAppConfigKeyValue(s)`
+
+On the first boot the merged result is cached to a single PHP file (per `APP_ENV`
+and app root), so warm boots skip the file scan entirely; `cache:clear` drops it.
+
 ## 3. Add your first module
 
 ```

--- a/infection.json5
+++ b/infection.json5
@@ -56,6 +56,10 @@
             '.*resolvedServiceIds\\[\\$id\\] = true;.*',
             // The candidate list feeds implode(); reindexing cannot change the message.
             '.*array_values\\(array_unique\\(\\$candidates\\)\\).*',
+            // Cache-key separator: collisions require crafting spl_object_id values,
+            // which are runtime-assigned and untestable; any separator variant behaves
+            // identically for real ids/paths.
+            '.*spl_object_id\\(\\$configItem->reader\\(\\)\\).*',
         ],
         // flock()-based locking and opcache invalidation are not observable in-process.
         FunctionCallRemoval: {

--- a/src/Framework/Config/AppEnv.php
+++ b/src/Framework/Config/AppEnv.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+use function getenv;
+
+/**
+ * Single source of truth for the application environment name, so the
+ * env-suffixed config file lookup and the merged-config cache filename can
+ * never disagree within one bootstrap.
+ */
+final class AppEnv
+{
+    public static function current(): string
+    {
+        return getenv('APP_ENV') ?: '';
+    }
+}

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -415,11 +415,9 @@ final class Config implements ConfigInterface
 
     private function createMergedConfigCache(): MergedConfigCache
     {
-        $env = getenv('APP_ENV');
-
         return new MergedConfigCache(
             $this->getCacheDir(),
-            is_string($env) ? $env : '',
+            AppEnv::current(),
             $this->getAppRootDir(),
         );
     }

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -109,7 +109,7 @@ final class ConfigFactory extends AbstractFactory
 
     private function env(): string
     {
-        return getenv('APP_ENV') ?: '';
+        return AppEnv::current();
     }
 
     private function createPathFinder(): PathFinderInterface

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -28,7 +28,13 @@ final class ConfigLoader
 
         foreach ($this->gacelaConfigFile->getConfigItems() as $configItem) {
             $allConfigs[] = $this->loadConfigsFromPatterns($configItem);
-            $allConfigs[] = $this->loadLocalConfig($configItem);
+            // The local file is merged last, so it always overrides the
+            // default and env values; the read cache guarantees it is read
+            // only once even when it also matches a pattern above.
+            $allConfigs[] = $this->readConfigWithCache(
+                $this->pathNormalizer->normalizePathLocal($configItem),
+                $configItem,
+            );
         }
 
         return array_merge(...$allConfigs);
@@ -44,13 +50,10 @@ final class ConfigLoader
             $this->pathNormalizer->normalizePathPatternWithEnvironment($configItem),
         ];
 
-        $localPath = $this->pathNormalizer->normalizePathLocal($configItem);
         $mergedConfigs = [];
 
         foreach ($patterns as $pattern) {
-            $configPaths = $this->getMatchingConfigPaths($pattern, $localPath);
-
-            foreach ($configPaths as $absolutePath) {
+            foreach ($this->pathFinder->matchingPattern($pattern) as $absolutePath) {
                 $mergedConfigs[] = $this->readConfigWithCache($absolutePath, $configItem);
             }
         }
@@ -61,30 +64,16 @@ final class ConfigLoader
     /**
      * @return array<string,mixed>
      */
-    private function loadLocalConfig(GacelaConfigItem $configItem): array
-    {
-        $localPath = $this->pathNormalizer->normalizePathLocal($configItem);
-        return $configItem->reader()->read($localPath);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function getMatchingConfigPaths(string $pattern, string $excludePath): array
-    {
-        $matchingPaths = $this->pathFinder->matchingPattern($pattern);
-        return array_diff($matchingPaths, [$excludePath]);
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
     private function readConfigWithCache(string $absolutePath, GacelaConfigItem $configItem): array
     {
-        if (!isset($this->cachedConfigs[$absolutePath])) {
-            $this->cachedConfigs[$absolutePath] = $configItem->reader()->read($absolutePath);
+        // Key by reader too: different config items may point to the same
+        // path with different readers, which must not share a cache entry.
+        $cacheKey = spl_object_id($configItem->reader()) . '|' . $absolutePath;
+
+        if (!isset($this->cachedConfigs[$cacheKey])) {
+            $this->cachedConfigs[$cacheKey] = $configItem->reader()->read($absolutePath);
         }
 
-        return $this->cachedConfigs[$absolutePath];
+        return $this->cachedConfigs[$cacheKey];
     }
 }

--- a/tests/Unit/Framework/Config/AppEnvTest.php
+++ b/tests/Unit/Framework/Config/AppEnvTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Config\AppEnv;
+use PHPUnit\Framework\TestCase;
+
+use function getenv;
+use function putenv;
+
+final class AppEnvTest extends TestCase
+{
+    private ?string $originalAppEnv = null;
+
+    protected function setUp(): void
+    {
+        $env = getenv('APP_ENV');
+        $this->originalAppEnv = $env === false ? null : $env;
+    }
+
+    protected function tearDown(): void
+    {
+        putenv($this->originalAppEnv === null ? 'APP_ENV' : 'APP_ENV=' . $this->originalAppEnv);
+    }
+
+    public function test_returns_the_app_env_value(): void
+    {
+        putenv('APP_ENV=prod');
+
+        self::assertSame('prod', AppEnv::current());
+    }
+
+    public function test_returns_empty_string_when_unset(): void
+    {
+        putenv('APP_ENV');
+
+        self::assertSame('', AppEnv::current());
+    }
+
+    public function test_returns_empty_string_when_set_to_empty(): void
+    {
+        putenv('APP_ENV=');
+
+        self::assertSame('', AppEnv::current());
+    }
+}

--- a/tests/Unit/Framework/Config/ConfigLoaderReadCountTest.php
+++ b/tests/Unit/Framework/Config/ConfigLoaderReadCountTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Config\ConfigLoader;
+use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use Gacela\Framework\Config\PathFinderInterface;
+use Gacela\Framework\Config\PathNormalizerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigLoaderReadCountTest extends TestCase
+{
+    /** @var array<string,int> */
+    private array $readsPerPath = [];
+
+    public function test_each_config_file_is_read_at_most_once_per_load(): void
+    {
+        $reader = $this->createCountingReader([
+            '/app/config/default.php' => ['a' => 1],
+            '/app/config/local.php' => ['b' => 2],
+        ]);
+
+        $configItem = new GacelaConfigItem('config/*.php', 'config/local.php', $reader);
+
+        $pathFinder = $this->createStub(PathFinderInterface::class);
+        // The local file also matches the glob pattern: it must still be
+        // read only once (excluded from the pattern phase, read as local).
+        $pathFinder->method('matchingPattern')
+            ->willReturn(['/app/config/default.php', '/app/config/local.php']);
+
+        $normalizer = $this->createStub(PathNormalizerInterface::class);
+        $normalizer->method('normalizePathPattern')->willReturn('/app/config/*.php');
+        $normalizer->method('normalizePathPatternWithEnvironment')->willReturn('/app/config/*-dev.php');
+        $normalizer->method('normalizePathLocal')->willReturn('/app/config/local.php');
+
+        $loader = new ConfigLoader(
+            (new GacelaConfigFile())->setConfigItems([$configItem]),
+            $pathFinder,
+            $normalizer,
+        );
+
+        self::assertSame(['a' => 1, 'b' => 2], $loader->loadAll());
+        self::assertSame(1, $this->readsPerPath['/app/config/default.php']);
+        self::assertSame(1, $this->readsPerPath['/app/config/local.php']);
+    }
+
+    /**
+     * @param array<string,array<string,mixed>> $contentByPath
+     */
+    private function createCountingReader(array $contentByPath): ConfigReaderInterface
+    {
+        $this->readsPerPath = [];
+
+        return new class($contentByPath, $this->readsPerPath) implements ConfigReaderInterface {
+            /**
+             * @param array<string,array<string,mixed>> $contentByPath
+             * @param array<string,int> $readsPerPath
+             */
+            public function __construct(
+                private readonly array $contentByPath,
+                private array &$readsPerPath,
+            ) {
+            }
+
+            public function read(string $absolutePath): array
+            {
+                $this->readsPerPath[$absolutePath] = ($this->readsPerPath[$absolutePath] ?? 0) + 1;
+
+                return $this->contentByPath[$absolutePath] ?? [];
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 📚 Description

Cold-path polish of the config loading flow, per #475's three findings — plus one latent bug the refactor surfaced and fixed.

Closes #475

## 🔖 Changes

- **Single `APP_ENV` source**: new `AppEnv::current()` used by both the env-suffixed file lookup (`ConfigFactory`) and the merged-config cache filename (`Config::createMergedConfigCache()`), so a mid-process `putenv` can no longer split cache key vs file suffixes. `grep getenv('APP_ENV')` now hits exactly one place.
- **Reader-aware read cache** (latent bug found while routing the local read through the cache): `ConfigLoader`'s per-load cache was keyed by path only — two config items pointing the same file at *different readers* shared a cache entry (caught red by the existing `ConfigInitTest::test_read_multiple_config`). Now keyed by `spl_object_id(reader) . '|' . path`.
- **Simpler loader**: local path normalized once; the local read goes through the same cache; with dedupe in place the `array_diff` local-exclusion became provably redundant (precedence is preserved by merging local last) — deleted, along with `getMatchingConfigPaths()`.
- **Precedence documented** in `docs/getting-started.md`: `default files < *-{APP_ENV} < local file < addAppConfigKeyValue(s)`, plus a note on the merged-config warm cache.
- Explicit non-goal honored (per issue): the two-glob shape stays — it is what keeps env switching cache-correct in `PathFinder`.

## ✅ Verification

- New `ConfigLoaderReadCountTest` (counting spy reader): every file read at most once per `loadAll()`, including a local file that also matches the glob pattern.
- New `AppEnvTest`: set/unset/empty `APP_ENV`.
- Mutation testing on `ConfigLoader.php` + `AppEnv.php`: **MSI 100%** (cache-key separator mutants documented as untestable ignores — `spl_object_id` values are runtime-assigned).
- Random-order runs across 3 seeds green; `composer test` (682 + suites) + `composer quality` green.

## 🧹 Refactor pass

The refactor pass happened in-line: the mutation run drove the deletion of the now-redundant `array_diff` exclusion and its helper method. Nothing further to remove.
