### PR TITLE
ref: codebase cleanup — DRY, shared psalm-type, comment noise

### DIFF
--- a/src/Console/ConsoleConfig.php
+++ b/src/Console/ConsoleConfig.php
@@ -8,6 +8,12 @@ use Gacela\Console\Domain\ConsoleException;
 use Gacela\Framework\AbstractConfig;
 use JsonException;
 
+/**
+ * @psalm-type ComposerJsonContent = array{
+ *     autoload?: array{"psr-4"?: array<string,string>},
+ *     autoload-dev?: array{"psr-4"?: array<string,string>},
+ * }
+ */
 final class ConsoleConfig extends AbstractConfig
 {
     public function getFacadeMakerTemplate(): string
@@ -55,10 +61,7 @@ final class ConsoleConfig extends AbstractConfig
      *
      * @throws ConsoleException|JsonException
      *
-     * @return array{
-     *     autoload?: array{"psr-4"?: array<string,string>},
-     *     autoload-dev?: array{"psr-4"?: array<string,string>},
-     * }
+     * @return ComposerJsonContent
      */
     public function getComposerJsonContentAsArray(): array
     {
@@ -70,12 +73,7 @@ final class ConsoleConfig extends AbstractConfig
         /** @var string $content */
         $content = file_get_contents($filename);
 
-        /**
-         * @var array{
-         *     autoload?: array{"psr-4"?: array<string,string>},
-         *     autoload-dev?: array{"psr-4"?: array<string,string>},
-         * } $jsonDecode
-         */
+        /** @var ComposerJsonContent $jsonDecode */
         $jsonDecode = json_decode(json: $content, associative: true, flags: JSON_THROW_ON_ERROR);
 
         return $jsonDecode;

--- a/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Domain\CommandArguments;
 
+use Gacela\Console\ConsoleConfig;
 use InvalidArgumentException;
 
 use function count;
 
+/**
+ * @psalm-import-type ComposerJsonContent from ConsoleConfig
+ */
 final class CommandArgumentsParser implements CommandArgumentsParserInterface
 {
     /**
-     * @param array{
-     *     autoload?: array{"psr-4"?:array<string,string>},
-     *     autoload-dev?: array{"psr-4"?:array<string,string>},
-     * } $composerJson
+     * @param ComposerJsonContent $composerJson
      */
     public function __construct(
         private array $composerJson,

--- a/src/Console/Infrastructure/Command/ConsoleSection.php
+++ b/src/Console/Infrastructure/Command/ConsoleSection.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function sprintf;
+use function str_repeat;
+
+/**
+ * Renders the shared "section" banner used across the Gacela console commands,
+ * keeping the width and styling defined in a single place.
+ */
+final class ConsoleSection
+{
+    private const WIDTH = 60;
+
+    public static function title(OutputInterface $output, string $title): void
+    {
+        $output->writeln('');
+        $output->writeln(sprintf('<info>%s</info>', $title));
+        self::separator($output);
+        $output->writeln('');
+    }
+
+    public static function separator(OutputInterface $output): void
+    {
+        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', self::WIDTH)));
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -62,10 +62,7 @@ final class DebugContainerCommand extends Command
 
     private function displayStats(OutputInterface $output): int
     {
-        $output->writeln('');
-        $output->writeln('<info>Container Statistics</info>');
-        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
-        $output->writeln('');
+        ConsoleSection::title($output, 'Container Statistics');
 
         $stats = $this->getFacade()->getContainerStats();
 
@@ -96,10 +93,7 @@ final class DebugContainerCommand extends Command
             return Command::FAILURE;
         }
 
-        $output->writeln('');
-        $output->writeln(sprintf('<info>Dependency Tree for %s</info>', $className));
-        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
-        $output->writeln('');
+        ConsoleSection::title($output, sprintf('Dependency Tree for %s', $className));
 
         $dependencyTree = $this->getFacade()->getContainerDependencyTree($className);
 

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -21,7 +21,6 @@ use function interface_exists;
 use function is_array;
 use function ltrim;
 use function sprintf;
-use function str_repeat;
 
 /**
  * @psalm-type TokenList = list<array{0: int, 1: string, 2: int}|string>
@@ -72,10 +71,7 @@ final class DebugDependenciesCommand extends Command
 
     private function renderInspection(OutputInterface $output, ConstructorInspection $inspection): void
     {
-        $output->writeln('');
-        $output->writeln(sprintf('<info>Constructor dependencies for %s</info>', $inspection->className));
-        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
-        $output->writeln('');
+        ConsoleSection::title($output, sprintf('Constructor dependencies for %s', $inspection->className));
 
         if (!$inspection->hasConstructor) {
             $output->writeln('  <fg=cyan>No constructor</>');

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -21,7 +21,6 @@ use Throwable;
 
 use function class_exists;
 use function sprintf;
-use function str_repeat;
 use function strlen;
 
 /**
@@ -202,10 +201,7 @@ final class DebugModulesCommand extends Command
             ? 'Gacela modules: constructor resolvability'
             : sprintf('Gacela modules matching "%s"', $filter);
 
-        $output->writeln('');
-        $output->writeln(sprintf('<info>%s</info>', $title));
-        $output->writeln('<info>' . str_repeat('=', 60) . '</info>');
-        $output->writeln('');
+        ConsoleSection::title($output, $title);
     }
 
     private function writePillar(OutputInterface $output, ConstructorInspection $inspection, bool $detail): void

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -39,10 +39,7 @@ final class DoctorCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln('');
-        $output->writeln('<info>Gacela Doctor</info>');
-        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
-        $output->writeln('');
+        ConsoleSection::title($output, 'Gacela Doctor');
 
         $filter = (string) $input->getArgument('filter');
         $checks = $this->buildChecks($filter);
@@ -55,7 +52,7 @@ final class DoctorCommand extends Command
         }
 
         $output->writeln('');
-        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
+        ConsoleSection::separator($output);
 
         return match ($worst) {
             CheckStatus::Error => $this->finish($output, '<error>✗ Doctor found errors</error>', Command::FAILURE),

--- a/src/Console/Infrastructure/Command/ProfileReportCommand.php
+++ b/src/Console/Infrastructure/Command/ProfileReportCommand.php
@@ -93,10 +93,7 @@ final class ProfileReportCommand extends Command
      */
     private function outputTable(array $entries, Profiler $profiler, OutputInterface $output): void
     {
-        $output->writeln('');
-        $output->writeln('<info>Performance Profiling Report</info>');
-        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
-        $output->writeln('');
+        ConsoleSection::title($output, 'Performance Profiling Report');
 
         $table = new Table($output);
         $table->setStyle('box');

--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -34,10 +34,7 @@ final class ValidateConfigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln('');
-        $output->writeln('<info>Validating Gacela Configuration</info>');
-        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
-        $output->writeln('');
+        ConsoleSection::title($output, 'Validating Gacela Configuration');
 
         // gacela.php is optional: report it when present, stay silent when missing.
         $gacelaConfigPath = Gacela::rootDir() . '/gacela.php';
@@ -56,7 +53,7 @@ final class ValidateConfigCommand extends Command
         $hasWarnings = $hasWarnings || $circularDepsValidation['warnings'];
 
         $output->writeln('');
-        $output->writeln(sprintf('<info>%s</info>', str_repeat('=', 60)));
+        ConsoleSection::separator($output);
 
         if ($hasErrors) {
             $output->writeln('<error>✗ Validation failed with errors</error>');

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -77,7 +77,7 @@ abstract class AbstractFactory
             $this->notifyProviderRegistered($resolver::class);
         }
 
-        // Temporal solution to keep BC with the AbstractDependencyProvider
+        // Backward compatibility with the deprecated AbstractDependencyProvider.
         $dpResolver = (new DependencyProviderResolver())->resolve($this);
         $dpResolver?->provideModuleDependencies($container);
         // Both resolvers share a normalized cache slot ("DependencyProvider" -> "Provider"),

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -8,9 +8,6 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 
 /**
  * Main configuration interface for Gacela framework setup.
- *
- * This interface extends specialized configuration interfaces to provide
- * a complete configuration contract for the Gacela framework.
  */
 interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerConfigurationInterface, CacheConfigurationInterface
 {

--- a/tests/Unit/Console/Infrastructure/Command/ConsoleSectionTest.php
+++ b/tests/Unit/Console/Infrastructure/Command/ConsoleSectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Infrastructure\Command;
+
+use Gacela\Console\Infrastructure\Command\ConsoleSection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class ConsoleSectionTest extends TestCase
+{
+    public function test_title_renders_a_blank_padded_banner(): void
+    {
+        $output = new BufferedOutput();
+
+        ConsoleSection::title($output, 'My Title');
+
+        self::assertSame(
+            "\nMy Title\n" . str_repeat('=', 60) . "\n\n",
+            $output->fetch(),
+        );
+    }
+
+    public function test_separator_renders_a_60_char_line(): void
+    {
+        $output = new BufferedOutput();
+
+        ConsoleSection::separator($output);
+
+        self::assertSame(str_repeat('=', 60) . "\n", $output->fetch());
+    }
+}

--- a/tests/Unit/Console/Infrastructure/Command/ConsoleSectionTest.php
+++ b/tests/Unit/Console/Infrastructure/Command/ConsoleSectionTest.php
@@ -17,7 +17,7 @@ final class ConsoleSectionTest extends TestCase
         ConsoleSection::title($output, 'My Title');
 
         self::assertSame(
-            "\nMy Title\n" . str_repeat('=', 60) . "\n\n",
+            PHP_EOL . 'My Title' . PHP_EOL . str_repeat('=', 60) . PHP_EOL . PHP_EOL,
             $output->fetch(),
         );
     }
@@ -28,6 +28,6 @@ final class ConsoleSectionTest extends TestCase
 
         ConsoleSection::separator($output);
 
-        self::assertSame(str_repeat('=', 60) . "\n", $output->fetch());
+        self::assertSame(str_repeat('=', 60) . PHP_EOL, $output->fetch());
     }
 }


### PR DESCRIPTION
## 📚 Description

Codebase-quality sweep across `src/` by an 8-angle audit (DRY, shared type defs, unused code, circular deps, weak `mixed` types, defensive/try-catch, deprecated/legacy, comment slop). The framework was already very clean — **5 of 8 angles found nothing to change** (all verified, not skipped). This PR bundles the 3 concrete high-confidence improvements. No user-facing behavior change, so no CHANGELOG entry.

## 🔖 Changes

- **DRY:** extract the copy-pasted console section-header banner (7 sites, 2 drifted spellings with byte-identical output, magic width `60` hard-coded 9×) into `final class ConsoleSection` (`title()` + `separator()`, single `WIDTH` const); call sites collapse to one line each. New `ConsoleSectionTest`.
- **Shared type:** the composer.json content array-shape was declared 3× across `ConsoleConfig` and `CommandArgumentsParser`; consolidated into one `@psalm-type ComposerJsonContent` imported via `@psalm-import-type`.
- **Comments:** dropped in-motion framing (`AbstractFactory` "Temporal solution…" → concise BC note) and a circular class-docblock that just narrated `extends X, Y, Z`; all load-bearing WHY/type annotations preserved.

### Audit outcome (no-change angles, verified)
- **Unused code:** PHPStan max + cs-fixer + scripted grep + Rector dead-code set → none in `src/` (only zero-ref symbol is deprecated public API).
- **Weak types:** ~116 `mixed` all justified (open container/config/cache contracts); every derivable-strong site already carries `@template T` + `class-string<T>`.
- **Defensive code:** 17 try/catch + 8 `@` suppressions all have a real, tested role (no error-hiding).
- **Deprecated/legacy:** all internal-safe; remaining deprecations are public API → deferred to 2.0.
- **Circular deps:** `Framework` has zero dep on `Console`; all cycles benign/intentional service-locator.

## ✅ Checks

- `composer quality` green (cs-fixer, psalm L1, phpstan strict)
- `composer phpunit` green — unit 692, integration 122, feature 178
- Order-independence verified across multiple random seeds