### PR TITLE
fix(preload): require PHP 8.1 to match framework floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- The opcache preload script (`resources/gacela-preload.php`) now requires PHP 8.1, matching the framework's `>=8.1`, instead of advertising and guarding an obsolete PHP 7.4 floor
+
 ## [1.18.0](https://github.com/gacela-project/gacela/compare/1.17.0...1.18.0) - 2026-07-20
 
 ### Added

--- a/resources/gacela-preload.php
+++ b/resources/gacela-preload.php
@@ -16,23 +16,23 @@
  *   - Faster bootstrap time
  *
  * Requirements:
- *   - PHP 7.4 or higher
+ *   - PHP 8.1 or higher
  *   - Opcache enabled
  *   - Production environment (not recommended for development)
  */
 
 declare(strict_types=1);
 
-if (PHP_VERSION_ID < 70400) {
-    throw new RuntimeException('Opcache preloading requires PHP 7.4 or higher');
+if (PHP_VERSION_ID < 80100) {
+    throw new RuntimeException('Opcache preloading requires PHP 8.1 or higher');
 }
 
-if (!function_exists('opcache_compile_file')) {
+if (!\function_exists('opcache_compile_file')) {
     throw new RuntimeException('Opcache is not enabled or opcache_compile_file is not available');
 }
 
 // Get the Gacela root directory (vendor/gacela-project/gacela)
-$gacelaRoot = dirname(__DIR__);
+$gacelaRoot = \dirname(__DIR__);
 
 // Core framework files that should be preloaded
 $coreFiles = [
@@ -115,11 +115,11 @@ if ($userPreloadFile && file_exists($userPreloadFile)) {
 }
 
 // Log preloading statistics
-if (function_exists('error_log')) {
-    error_log(sprintf(
+if (\function_exists('error_log')) {
+    error_log(\sprintf(
         'Gacela Opcache Preload: %d files preloaded successfully, %d failed',
         $preloadedCount,
-        count($failedFiles)
+        \count($failedFiles),
     ));
 
     if ($failedFiles !== []) {


### PR DESCRIPTION
## 📚 Description

The opcache preload script (`resources/gacela-preload.php`) advertised and enforced a PHP **7.4** floor, contradicting the framework's `>=8.1` requirement and `docs/opcache-preload.md` (already documents 8.1+).

## 🔖 Changes

- Bump the docblock requirement to PHP 8.1
- Bump the runtime guard to `PHP_VERSION_ID < 80100` with a matching message

No behavior change on supported runtimes: the guard only fires below 8.1, which the framework already rejects. No test added — there is no logic to exercise on a `>=8.1` runtime; a string-match assertion would only be coverage optics. Touched file needs no refactor (mechanical constant + comment).

Closes #484