### PR TITLE
ref: decouple event dispatch from Config via EventDispatcherProvider

### DIFF
--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -9,8 +9,8 @@ use Gacela\Framework\Event\Config\ConfigInitializedEvent;
 use Gacela\Framework\Event\Config\ConfigKeyNotFoundEvent;
 use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
-use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
 use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
 
@@ -27,10 +27,6 @@ final class Config implements ConfigInterface
     use EventDispatchingCapabilities;
 
     private static ?self $instance = null;
-
-    private static ?EventDispatcherInterface $eventDispatcher = null;
-
-    private static ?NullEventDispatcher $preBootstrapDispatcher = null;
 
     private ?ConfigFactory $configFactory = null;
 
@@ -53,8 +49,7 @@ final class Config implements ConfigInterface
     public static function createWithSetup(SetupGacelaInterface $setup): self
     {
         self::$instance = new self($setup);
-        // A new setup brings its own listeners; drop the dispatcher built from the previous one.
-        self::$eventDispatcher = null;
+        EventDispatcherProvider::setResolver(static fn (): EventDispatcherInterface => $setup->getEventDispatcher());
 
         return self::$instance;
     }
@@ -74,26 +69,12 @@ final class Config implements ConfigInterface
     public static function resetInstance(): void
     {
         self::$instance = null;
-        self::$eventDispatcher = null;
+        EventDispatcherProvider::reset();
     }
 
     public static function getEventDispatcher(): EventDispatcherInterface
     {
-        if (self::$eventDispatcher instanceof EventDispatcherInterface) {
-            return self::$eventDispatcher;
-        }
-
-        // Dispatch sites can run before bootstrap (e.g. clearing cache files);
-        // without a Config instance there is nothing to listen, so stay silent.
-        if (!self::$instance instanceof self) {
-            return self::$preBootstrapDispatcher ??= new NullEventDispatcher();
-        }
-
-        self::$eventDispatcher = self::$instance
-            ->getSetupGacela()
-            ->getEventDispatcher();
-
-        return self::$eventDispatcher;
+        return EventDispatcherProvider::get();
     }
 
     /**

--- a/src/Framework/Event/Dispatcher/EventDispatcherProvider.php
+++ b/src/Framework/Event/Dispatcher/EventDispatcherProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Dispatcher;
+
+/**
+ * Holds the currently active event dispatcher so the {@see EventDispatchingCapabilities}
+ * mixin can dispatch without depending on Config. Config pushes a lazy resolver at
+ * bootstrap; every dispatch site reads through here. Before bootstrap (no resolver),
+ * a shared NullEventDispatcher keeps dispatch sites silent.
+ */
+final class EventDispatcherProvider
+{
+    private static ?EventDispatcherInterface $dispatcher = null;
+
+    private static ?NullEventDispatcher $preBootstrapDispatcher = null;
+
+    /** @var (callable(): EventDispatcherInterface)|null */
+    private static $resolver = null;
+
+    /**
+     * @param callable(): EventDispatcherInterface $resolver
+     */
+    public static function setResolver(callable $resolver): void
+    {
+        self::$resolver = $resolver;
+        // A new setup brings its own listeners; drop the dispatcher built from the previous one.
+        self::$dispatcher = null;
+    }
+
+    public static function get(): EventDispatcherInterface
+    {
+        if (self::$dispatcher instanceof EventDispatcherInterface) {
+            return self::$dispatcher;
+        }
+
+        // Dispatch sites can run before bootstrap (e.g. clearing cache files);
+        // without a resolver there is nothing to listen, so stay silent.
+        if (self::$resolver === null) {
+            return self::$preBootstrapDispatcher ??= new NullEventDispatcher();
+        }
+
+        return self::$dispatcher = (self::$resolver)();
+    }
+
+    public static function reset(): void
+    {
+        self::$dispatcher = null;
+        self::$resolver = null;
+    }
+}

--- a/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
+++ b/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Event\Dispatcher;
 
-use Gacela\Framework\Config\Config;
 use Gacela\Framework\Event\GacelaEventInterface;
 
 trait EventDispatchingCapabilities
@@ -17,11 +16,11 @@ trait EventDispatchingCapabilities
      */
     private static function shouldDispatch(string $eventClass): bool
     {
-        return Config::getEventDispatcher()->hasListeners($eventClass);
+        return EventDispatcherProvider::get()->hasListeners($eventClass);
     }
 
     private static function dispatchEvent(GacelaEventInterface $event): void
     {
-        Config::getEventDispatcher()->dispatch($event);
+        EventDispatcherProvider::get()->dispatch($event);
     }
 }

--- a/tests/Unit/Framework/Event/Dispatcher/EventDispatcherProviderTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/EventDispatcherProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Dispatcher;
+
+use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use PHPUnit\Framework\TestCase;
+
+final class EventDispatcherProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        EventDispatcherProvider::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        EventDispatcherProvider::reset();
+    }
+
+    public function test_returns_a_null_dispatcher_before_any_resolver_is_set(): void
+    {
+        self::assertInstanceOf(NullEventDispatcher::class, EventDispatcherProvider::get());
+    }
+
+    public function test_memoises_the_pre_bootstrap_null_dispatcher(): void
+    {
+        self::assertSame(EventDispatcherProvider::get(), EventDispatcherProvider::get());
+    }
+
+    public function test_resolves_the_dispatcher_from_the_pushed_resolver(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+        EventDispatcherProvider::setResolver(static fn (): EventDispatcherInterface => $dispatcher);
+
+        self::assertSame($dispatcher, EventDispatcherProvider::get());
+    }
+
+    public function test_resolver_is_called_lazily_only_on_first_get(): void
+    {
+        $calls = 0;
+        EventDispatcherProvider::setResolver(static function () use (&$calls): EventDispatcherInterface {
+            ++$calls;
+            return new ConfigurableEventDispatcher();
+        });
+
+        self::assertSame(0, $calls, 'resolver must not run until get() is called');
+
+        $first = EventDispatcherProvider::get();
+        $second = EventDispatcherProvider::get();
+
+        self::assertSame(1, $calls, 'resolver must run once and memoise');
+        self::assertSame($first, $second);
+    }
+
+    public function test_setting_a_new_resolver_drops_the_previously_memoised_dispatcher(): void
+    {
+        $first = new ConfigurableEventDispatcher();
+        $second = new ConfigurableEventDispatcher();
+
+        EventDispatcherProvider::setResolver(static fn (): EventDispatcherInterface => $first);
+        self::assertSame($first, EventDispatcherProvider::get());
+
+        EventDispatcherProvider::setResolver(static fn (): EventDispatcherInterface => $second);
+        self::assertSame($second, EventDispatcherProvider::get());
+    }
+
+    public function test_reset_returns_to_the_pre_bootstrap_null_dispatcher(): void
+    {
+        EventDispatcherProvider::setResolver(static fn (): EventDispatcherInterface => new ConfigurableEventDispatcher());
+        self::assertInstanceOf(ConfigurableEventDispatcher::class, EventDispatcherProvider::get());
+
+        EventDispatcherProvider::reset();
+
+        self::assertInstanceOf(NullEventDispatcher::class, EventDispatcherProvider::get());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Closes #481. Breaks the benign-but-coupling `Config` ↔ `EventDispatchingCapabilities` service-locator cycle found by the circular-dependency audit. The dispatch mixin (used by 11 kernel classes) no longer calls back into `Config`; it reads the active dispatcher from a dedicated `EventDispatcherProvider` holder. `Config` pushes a lazy resolver at bootstrap.

No public API or behavior change — `Config::getEventDispatcher()` stays as a thin delegator, so the integration test and any consumer keep working. Pure internal decoupling → no CHANGELOG entry.

## 🔖 Changes

- **New** `src/Framework/Event/Dispatcher/EventDispatcherProvider.php` — holds the current dispatcher; lazy `setResolver()` (memoises, dropped on new setup), `get()` (pre-bootstrap `NullEventDispatcher` fallback), `reset()`.
- `EventDispatchingCapabilities` trait reads `EventDispatcherProvider::get()` instead of `Config::getEventDispatcher()` → drops its `Config` import (**cycle broken**; trait is same-namespace as the holder so no new import).
- `Config`: `createWithSetup()` pushes the resolver; `resetInstance()` resets the holder; `getEventDispatcher()` delegates; removed the now-unused `$eventDispatcher`/`$preBootstrapDispatcher` fields (state moved into the holder).
- New `EventDispatcherProviderTest` (6 cases: pre-bootstrap null, memoisation, lazy single-call resolve, new-resolver invalidation, reset).

## ✅ Checks

- `composer quality` green (cs-fixer, psalm L1, phpstan strict)
- `composer phpunit` green — unit 698 (+6), integration 122, feature 178
- Order-independent across random seeds
- Verified: trait has zero `Config` references (cycle gone); pre-/post-bootstrap dispatch timing + zero-cost `shouldDispatch()` guard preserved