### PR TITLE
feat(container): adopt container 0.10 conditional bindings; decide the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `GacelaConfig::addBindingIf(key, value)`: register a binding only when the key is not already bound, so plugins can ship an overridable default (register-unless-overridden)
+
 ### Changed
 
 - Confirmed PHP 8.5 support by adding it to the CI test matrix (the `>=8.1` requirement already permitted it)

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -47,6 +47,28 @@ $container->get(LoggerInterface::class);
 $container->get('logger');
 ```
 
+## Conditional Bindings
+
+Register a binding only when the key is not already bound — a default that the
+application (or an earlier binding) can override. Useful for plugins that want to
+ship a sensible default without clobbering a host application's choice.
+
+```php
+return static function (GacelaConfig $config): void {
+    // App opts into its own logger.
+    $config->addBinding(LoggerInterface::class, JsonLogger::class);
+
+    // A plugin provides a fallback; skipped because the key is already bound.
+    $config->addBindingIf(LoggerInterface::class, NullLogger::class);
+};
+
+// Resolves to JsonLogger.
+$container->get(LoggerInterface::class);
+```
+
+`addBindingIf()` compares against the bindings already declared in the same config.
+If no binding exists for the key, it behaves exactly like `addBinding()`.
+
 ## Contextual Bindings
 
 Provide different implementations based on which class is requesting a dependency.
@@ -249,6 +271,7 @@ Notes:
 | Type | Behavior | Use Case |
 |------|----------|----------|
 | Regular (binding) | Singleton | Stateless services, repositories |
+| Conditional (`addBindingIf`) | Binds only if unbound | Plugin defaults that apps can override |
 | Factory | New instance each call | Stateful services, request-scoped |
 | Protected | Returns closure as-is | Lazy initialization, callable configs |
 | Alias | Points to another service | Backward compatibility, short names |
@@ -276,3 +299,22 @@ return static function (GacelaConfig $config): void {
     $config->addAlias('db', Database::class);
 };
 ```
+
+## Underlying container features gacela does not expose
+
+The `gacela-project/container` package offers a few capabilities that gacela
+deliberately keeps internal, to avoid two ways of doing the same thing:
+
+- **Service tagging** (`tag()` / `tagged()`): use [`addHandlerRegistry()`](events.md)
+  instead. Handler registries are a superset — lazily resolved, keyed dispatch
+  tables, frozen after boot — so a flat tag group would only duplicate a weaker
+  version of the same idea.
+- **`afterResolving()` hooks**: use the [`ServiceResolvedEvent`](events.md) instead.
+  It is the gacela-native, zero-cost-when-unused way to react to resolution.
+- **`make()` with runtime parameters**: kept internal. One-off construction with
+  ad-hoc overrides encourages service location; resolve through your module's
+  Factory instead.
+- **Compiled constructor plans**: measured on gacela's instance-cached resolution,
+  the reflection saved is sub-microsecond per class, so the cache-file lifecycle is
+  not worth its complexity today. May be revisited if bootstrap reflection ever
+  shows up as a real hotspot for large applications.

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -188,6 +188,20 @@ final class GacelaConfig
     }
 
     /**
+     * Bind a key only when it is not already bound in this config, so plugins can
+     * register a default that the application (or an earlier binding) can override.
+     *
+     * @param class-string $key
+     * @param class-string|object|callable $value
+     */
+    public function addBindingIf(string $key, string|object|callable $value): self
+    {
+        $this->bindingsBuilder->bindIf($key, $value);
+
+        return $this;
+    }
+
+    /**
      * Useful to pass services while bootstrapping Gacela to the gacela.php config file.
      *
      * @param class-string|object|callable $value

--- a/src/Framework/Config/GacelaConfigBuilder/BindingsBuilder.php
+++ b/src/Framework/Config/GacelaConfigBuilder/BindingsBuilder.php
@@ -26,6 +26,21 @@ final class BindingsBuilder
     }
 
     /**
+     * Bind a value only when the key is not already bound (register-unless-overridden).
+     *
+     * @param class-string $key
+     * @param callable|object|class-string $value
+     */
+    public function bindIf(string $key, callable|object|string $value): self
+    {
+        if (!isset($this->mapping[$key])) {
+            $this->mapping[$key] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
      * @return BindingsMap
      */
     public function build(): array

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -90,6 +90,31 @@ final class GacelaConfigTest extends TestCase
         );
     }
 
+    public function test_add_binding_if_registers_a_default_when_absent(): void
+    {
+        $config = new GacelaConfig();
+
+        $config->addBindingIf('App\\Port', 'App\\Adapter');
+
+        self::assertSame(
+            ['App\\Port' => 'App\\Adapter'],
+            $config->toTransfer()->bindingsBuilder->build(),
+        );
+    }
+
+    public function test_add_binding_if_does_not_override_an_existing_binding(): void
+    {
+        $config = new GacelaConfig();
+
+        $config->addBinding('App\\Port', 'App\\Existing');
+        $config->addBindingIf('App\\Port', 'App\\Override');
+
+        self::assertSame(
+            ['App\\Port' => 'App\\Existing'],
+            $config->toTransfer()->bindingsBuilder->build(),
+        );
+    }
+
     public function test_add_health_check_collects_class_string(): void
     {
         $config = new GacelaConfig();

--- a/tests/Unit/Framework/Config/GacelaConfigBuilder/BindingsBuilderTest.php
+++ b/tests/Unit/Framework/Config/GacelaConfigBuilder/BindingsBuilderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\GacelaConfigBuilder;
+
+use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class BindingsBuilderTest extends TestCase
+{
+    public function test_bind_registers_a_value_under_its_key(): void
+    {
+        $builder = new BindingsBuilder();
+
+        $builder->bind('App\\Port', 'App\\Adapter');
+
+        self::assertSame(['App\\Port' => 'App\\Adapter'], $builder->build());
+    }
+
+    public function test_bind_overwrites_an_existing_key(): void
+    {
+        $builder = new BindingsBuilder();
+
+        $builder->bind('App\\Port', 'App\\First');
+        $builder->bind('App\\Port', 'App\\Second');
+
+        self::assertSame(['App\\Port' => 'App\\Second'], $builder->build());
+    }
+
+    public function test_bind_if_registers_when_the_key_is_absent(): void
+    {
+        $builder = new BindingsBuilder();
+
+        $builder->bindIf('App\\Port', 'App\\Adapter');
+
+        self::assertSame(['App\\Port' => 'App\\Adapter'], $builder->build());
+    }
+
+    public function test_bind_if_does_not_overwrite_an_already_bound_key(): void
+    {
+        $builder = new BindingsBuilder();
+
+        $builder->bind('App\\Port', 'App\\Existing');
+        $builder->bindIf('App\\Port', 'App\\Override');
+
+        self::assertSame(['App\\Port' => 'App\\Existing'], $builder->build());
+    }
+
+    public function test_bind_if_is_chainable(): void
+    {
+        $builder = new BindingsBuilder();
+
+        self::assertSame($builder, $builder->bindIf('App\\Port', 'App\\Adapter'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

Closes #478. Evaluates the five remaining `gacela-project/container` 0.10 capabilities and gives each a decision. One is adopted; the rest are documented (three rejected to avoid overlapping ways to do the same thing, one deferred with a measurement).

## 🔖 Changes

**Adopted — conditional bindings**
- `GacelaConfig::addBindingIf(key, value)` (+ `BindingsBuilder::bindIf()`): register a binding only when the key is not already bound — plugins ship an overridable default (register-unless-overridden). Compares against bindings declared in the same config; behaves like `addBinding()` when absent.

**Decisions on the rest** (documented in `docs/container-configuration.md` so they aren't re-litigated)
- **Tagging (`tag`/`tagged`) → rejected.** `addHandlerRegistry()` is a superset (lazily resolved, keyed dispatch, frozen after boot); a flat tag group would only duplicate a weaker version.
- **`afterResolving()` → rejected.** `ServiceResolvedEvent` is the gacela-native, zero-cost-when-unused equivalent.
- **`make()` + runtime params → kept internal.** Ad-hoc override construction encourages service location; resolve through a module Factory instead.
- **Compiled constructor plans → deferred (#493).** Spike measured **24% faster cold resolution but only 0.64 µs/resolve absolute**; gacela instance-caches resolved services, so the per-request ceiling is sub-millisecond — not worth the cache-file lifecycle now. #493 tracks revisiting if bootstrap reflection ever profiles as a hotspot.

## ✅ Checks

- `composer quality` green (cs-fixer, psalm L1, phpstan strict)
- `composer phpunit` green — unit 705 (+7), integration 122, feature 178
- `composer infection` on the changed files: **MSI 100% / covered 100%**
- Docs (`container-configuration.md`: Conditional Bindings + "features gacela does not expose") + CHANGELOG updated