### PR TITLE
docs: correct #[Cacheable] backtrace cost + add CacheableBench guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Documentation
 
 - New `docs/production-performance.md`: a single checklist for running Gacela fast in production (file cache, `cache:warm`, opcache preload, autoloader optimisation, disabling unused event listeners, cross-request `#[Cacheable]` storage, `GACELA_CACHE_DIR`)
+- Corrected the `#[Cacheable]` backtrace-cost note (measured ~0.08 µs/call on a warm hit, not 1–5 µs) and now recommend explicit `$method`/`$args` as the pattern for hot, cheap methods; added `CacheableBench` to guard the delta
 
 ## [1.18.0](https://github.com/gacela-project/gacela/compare/1.17.0...1.18.0) - 2026-07-20
 

--- a/docs/cacheable-methods.md
+++ b/docs/cacheable-methods.md
@@ -126,9 +126,9 @@ The override applies on the next `set()`; existing entries keep their original e
 
 ## Opting out of backtrace
 
-`cached()` calls `debug_backtrace()` (limit 2) to infer the method name and arguments. Cost is 1–5 µs — unmeasurable for typical "expensive" methods (DB, HTTP). Pass `$method` and `$args` explicitly when:
+`cached()` calls `debug_backtrace()` (limit 2) to infer the method name and arguments. The overhead is ~0.08 µs per call on a warm cache hit (`CacheableBench`) — negligible for typical "expensive" methods (DB, HTTP), where it is lost in the noise of the work being cached. Pass `$method` and `$args` explicitly when:
 
-- The cached operation itself is very fast and the overhead matters.
+- **The method is hot and its work is cheap** — the recommended pattern for tight, frequently-hit lookups where every fraction of a microsecond counts.
 - The method takes very large arguments (frame-construction cost scales with arg count).
 - `cached()` is called from a private helper rather than the attributed method itself (backtrace would pick the helper, find no attribute, and skip caching).
 

--- a/tests/Benchmark/Attribute/CacheableBench.php
+++ b/tests/Benchmark/Attribute/CacheableBench.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Benchmark\Attribute;
+
+use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableConfig;
+use Gacela\Framework\Attribute\CacheableTrait;
+use Gacela\Framework\Attribute\InMemoryCacheStorage;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+/**
+ * Quantifies the cost the default #[Cacheable] path pays for inferring the method
+ * name + arguments from the caller's stack frame (debug_backtrace) versus passing
+ * them explicitly. Both benches measure a warm cache hit (the repeated hot path).
+ *
+ * Informational only (not in the `gate` group): the delta is sub-microsecond and
+ * well within CI timer noise, so it must not fail the performance regression guard.
+ */
+#[BeforeMethods('setUp')]
+#[Groups(['cacheable'])]
+#[Revs(1000)]
+#[Iterations(5)]
+final class CacheableBench
+{
+    private CacheableBenchFacade $facade;
+
+    public function setUp(): void
+    {
+        CacheableConfig::reset();
+        CacheableConfig::setStorage(new InMemoryCacheStorage());
+        $this->facade = new CacheableBenchFacade();
+
+        // Warm both entries so every measured rev is a cache hit.
+        $this->facade->inferredFromBacktrace(7);
+        $this->facade->explicitArgs(7);
+    }
+
+    public function bench_cache_hit_inferred_via_backtrace(): void
+    {
+        $this->facade->inferredFromBacktrace(7);
+    }
+
+    public function bench_cache_hit_with_explicit_args(): void
+    {
+        $this->facade->explicitArgs(7);
+    }
+}
+
+final class CacheableBenchFacade
+{
+    use CacheableTrait;
+
+    #[Cacheable(ttl: 3600)]
+    public function inferredFromBacktrace(int $id): int
+    {
+        return $this->cached(static fn (): int => $id * 2);
+    }
+
+    #[Cacheable(ttl: 3600)]
+    public function explicitArgs(int $id): int
+    {
+        return $this->cached(static fn (): int => $id * 2, __METHOD__, [$id]);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Closes #486. Investigated the `#[Cacheable]` default path's `debug_backtrace()` cost, measured it, and resolved the issue with a guard bench + corrected docs. No runtime change — the measurement showed a hot-path reorder would be net-negative.

## 🔖 Changes

- **`CacheableBench`** (informational, non-`gate` group): measures a warm cache hit via backtrace inference vs. explicit `$method`/`$args`, quantifying and guarding the delta.
- **Docs** (`cacheable-methods.md`): the note claimed "1–5 µs"; corrected to the measured **~0.08 µs/call** on a warm hit, and elevated explicit `$method`/`$args` from a footnote to the recommended pattern for hot, cheap methods.
- **CHANGELOG**: Documentation entry.

## 🔬 Measurement

Raw `debug_backtrace` (200k iters, 3 args incl. 1KB object): `0`→0.148 µs, `IGNORE_ARGS`→0.106 µs (arg capture = 0.043 µs). On the real `cached()` warm hit: **0.589 µs (backtrace) vs 0.512 µs (explicit), ~0.077 µs / ~13%**.

**Why no reorder:** the default per-argument cache key needs the backtrace args, so they can only be skipped for zero-param methods — and deciding that needs a cheap name-only backtrace first, making the common has-args path do *two* backtraces (regression) to save 0.04 µs on zero-arg methods. Sub-0.1 µs, dominated by cache-key hashing + storage. Full rationale in the issue thread.

## ♻️ Refactor pass

New code is a single small bench class + a fixture facade; no dead branches, unused params, or naming drift. Nothing to clean.

## ✅ Checks

- `composer quality` green (cs-fixer, psalm L1, phpstan strict)
- `composer phpunit` green — unit 705, integration 122, feature 178
- `CacheableBench` runs clean; not in the `gate` group (sub-µs, CI-noise-safe)