### PR TITLE
ref: fail loudly on health check container resolution errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - The opcache preload script (`resources/gacela-preload.php`) now requires PHP 8.1, matching the framework's `>=8.1`, instead of advertising and guarding an obsolete PHP 7.4 floor
+- Health-check resolution no longer swallows container errors: a registered check whose container resolution throws now surfaces the real exception instead of silently falling back to a default instance and hiding the misconfiguration
 
 ### Documentation
 

--- a/src/Framework/Health/HealthCheckRegistry.php
+++ b/src/Framework/Health/HealthCheckRegistry.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Framework\Health;
 
 use Gacela\Framework\Container\Container;
-use Throwable;
 
 /**
  * Tracks health checks registered through GacelaConfig::addHealthCheck()
@@ -74,14 +73,10 @@ final class HealthCheckRegistry
     private static function instantiate(string $className, ?Container $container): ?ModuleHealthCheckInterface
     {
         if ($container instanceof Container) {
-            try {
-                /** @var mixed $instance */
-                $instance = $container->get($className);
-                if ($instance instanceof ModuleHealthCheckInterface) {
-                    return $instance;
-                }
-            } catch (Throwable) {
-                // fall through to direct instantiation
+            /** @var mixed $instance */
+            $instance = $container->get($className);
+            if ($instance instanceof ModuleHealthCheckInterface) {
+                return $instance;
             }
         }
 

--- a/tests/Unit/Framework/Health/HealthCheckRegistryTest.php
+++ b/tests/Unit/Framework/Health/HealthCheckRegistryTest.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use stdClass;
 
 final class HealthCheckRegistryTest extends TestCase
@@ -130,6 +131,28 @@ final class HealthCheckRegistryTest extends TestCase
             $report = HealthCheckRegistry::createHealthChecker(Gacela::container())->checkAll();
 
             self::assertArrayHasKey('default', $report->getResults());
+        } finally {
+            Gacela::resetCache();
+        }
+    }
+
+    public function test_container_resolution_error_propagates_instead_of_being_swallowed(): void
+    {
+        try {
+            Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+                $config->addFactory(
+                    HealthCheckRegistryConfigurableFake::class,
+                    static function (): HealthCheckRegistryConfigurableFake {
+                        throw new RuntimeException('boom from factory');
+                    },
+                );
+            });
+            HealthCheckRegistry::register(HealthCheckRegistryConfigurableFake::class);
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('boom from factory');
+
+            HealthCheckRegistry::createHealthChecker(Gacela::container());
         } finally {
             Gacela::resetCache();
         }


### PR DESCRIPTION
## 📚 Description

Found by an 8-angle cleanup sweep of the code added since #479. Seven angles were no-op (the recent code is clean); this is the one real finding — an error-hiding `try/catch` in the health-check registry.

`HealthCheckRegistry::instantiate()` wrapped `$container->get($className)` in `catch (Throwable) { /* fall through to direct instantiation */ }`. But the injected container already **autowires** unbound-yet-resolvable classes, so the catch only fired on a *genuine* resolution failure — and the `new $className()` fall-through then either rethrew a vaguer error or, for a no-arg class, **silently substituted a default instance**, masking the misconfiguration (e.g. a bound health-check factory that throws a real bug). This is exactly the error-hiding fallback pattern we want gone.

## 🔖 Changes

- Removed the `try/catch (Throwable)` swallow in `HealthCheckRegistry::instantiate()` (and the now-unused `use Throwable`). Container resolution errors propagate; the non-check → direct-instantiation and `null`-container paths are unchanged.
- New test `test_container_resolution_error_propagates_instead_of_being_swallowed` locks the fail-loud contract (a throwing bound factory now surfaces instead of being replaced by a default).

## ✅ Checks

- `composer quality` green (cs-fixer, psalm L1, phpstan strict)
- `composer phpunit` green — unit 706 (+1), integration 122, feature 178
- `composer infection` on `HealthCheckRegistry.php`: **MSI 100%** (12 mutants killed)
- Behavior change documented under CHANGELOG → Fixed

## Note

The other 7 sweep angles (DRY, shared types, unused code, circular deps, weak types, legacy, comments) found nothing in the post-#479 delta — the code shipped through PRs #491/#492/#494/#495 is clean.