### PR TITLE
ref: consolidate repeated intra-file array shapes into local psalm-types

### DIFF
--- a/src/Framework/Attribute/ProvidesScanner.php
+++ b/src/Framework/Attribute/ProvidesScanner.php
@@ -15,10 +15,12 @@ use ReflectionNamedType;
  * method into the given Container as a lazy service factory.
  *
  * @internal
+ *
+ * @psalm-type ProvidesEntry = array{id: string, method: ReflectionMethod, needsContainer: bool}
  */
 final class ProvidesScanner
 {
-    /** @var array<class-string<AbstractProvider>, list<array{id:string, method:ReflectionMethod, needsContainer:bool}>> */
+    /** @var array<class-string<AbstractProvider>, list<ProvidesEntry>> */
     private static array $cache = [];
 
     public static function scan(AbstractProvider $provider, Container $container): void
@@ -35,7 +37,7 @@ final class ProvidesScanner
     }
 
     /**
-     * @return list<array{id:string, method:ReflectionMethod, needsContainer:bool}>
+     * @return list<ProvidesEntry>
      */
     private static function resolveEntries(AbstractProvider $provider): array
     {

--- a/src/Framework/Profiler/Profiler.php
+++ b/src/Framework/Profiler/Profiler.php
@@ -9,6 +9,9 @@ use function hrtime;
 use function memory_get_usage;
 use function round;
 
+/**
+ * @psalm-type OperationStats = array{count: int, total_duration: float, avg_duration: float}
+ */
 final class Profiler
 {
     private static ?self $instance = null;
@@ -109,7 +112,7 @@ final class Profiler
      *     total_duration: float,
      *     avg_duration: float,
      *     peak_memory: int,
-     *     by_operation: array<string, array{count: int, total_duration: float, avg_duration: float}>
+     *     by_operation: array<string, OperationStats>
      * }
      */
     public function getStats(): array
@@ -131,7 +134,7 @@ final class Profiler
             $tally[$entry->operation]['total_duration'] += $entry->duration;
         }
 
-        /** @var array<string, array{count: int, total_duration: float, avg_duration: float}> $byOperation */
+        /** @var array<string, OperationStats> $byOperation */
         $byOperation = [];
         foreach ($tally as $operation => $stats) {
             $byOperation[$operation] = [

--- a/src/Framework/Testing/ContainerSnapshot.php
+++ b/src/Framework/Testing/ContainerSnapshot.php
@@ -12,13 +12,15 @@ namespace Gacela\Framework\Testing;
  * (scalars, arrays, and cache-dir roots). It does not attempt to capture
  * object instances from the container because those may hold non-serializable
  * resources (closures, file handles, PDO connections, etc.).
+ *
+ * @psalm-type InMemoryCacheSnapshot = array<string, array<string, string>>
  */
 final class ContainerSnapshot
 {
     /**
-     * @param  array<string, array<string, string>>  $inMemoryCache
-     * @param  array<string, mixed>                  $config
-     * @param  array<string, mixed>                  $extras
+     * @param  InMemoryCacheSnapshot  $inMemoryCache
+     * @param  array<string, mixed>   $config
+     * @param  array<string, mixed>   $extras
      */
     public function __construct(
         private readonly array $inMemoryCache = [],
@@ -31,7 +33,7 @@ final class ContainerSnapshot
 
     /**
      * @return array{
-     *     inMemoryCache: array<string, array<string, string>>,
+     *     inMemoryCache: InMemoryCacheSnapshot,
      *     config: array<string, mixed>,
      *     appRootDir: ?string,
      *     cacheDir: ?string,
@@ -51,7 +53,7 @@ final class ContainerSnapshot
 
     /**
      * @param  array{
-     *     inMemoryCache?: array<string, array<string, string>>,
+     *     inMemoryCache?: InMemoryCacheSnapshot,
      *     config?: array<string, mixed>,
      *     appRootDir?: ?string,
      *     cacheDir?: ?string,
@@ -73,7 +75,7 @@ final class ContainerSnapshot
     }
 
     /**
-     * @return array<string, array<string, string>>
+     * @return InMemoryCacheSnapshot
      */
     public function inMemoryCache(): array
     {


### PR DESCRIPTION
## 📚 Description

Deeper cleanup pass (angle #2, type consolidation). Three array shapes were each written out multiple times **within a single file** — a local `@psalm-type` alias gives each shape one definition, so future edits change one place. Annotation-only; no runtime, behavior, or API change.

## 🔖 Changes

- `ProvidesScanner` — `@psalm-type ProvidesEntry` (was spelled 2×: the `$cache` property + `resolveEntries()` return)
- `ContainerSnapshot` — `@psalm-type InMemoryCacheSnapshot` (was spelled 4×: ctor param, `__serialize`/`__unserialize` shapes, `inMemoryCache()` return)
- `Profiler` — `@psalm-type OperationStats` (was spelled 2×: `getStats()` return `by_operation` + the `$byOperation` local)

## ✅ Checks

- `composer quality` green (cs-fixer, psalm L1, phpstan strict — both resolve the local aliases)
- `composer phpunit` green — unit, integration 122, feature 178

## Context

Follow-up to the 8-angle cleanup sweeps. These are the genuine intra-file consolidations the earlier passes deferred under a "don't alias a cross-file one-use shape" rule — but a shape repeated 2–4× in one file is a legitimate single-definition win. No CHANGELOG entry (internal annotations only).