### PR TITLE
feat(console): scaffolder provider template uses #[Provides] (attribute-first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `make:module` provider template is now attribute-first: the scaffolded provider demonstrates a typed `#[Provides]` method (a `clock(): DateTimeImmutable` example) as the primary registration path, while keeping the imperative `provideModuleDependencies(Container $container)` available for edge cases (no BC break)
+
 ## [1.19.0](https://github.com/gacela-project/gacela/compare/1.18.0...1.19.0) - 2026-07-23
 
 ### Added

--- a/src/Console/Infrastructure/Template/Command/provider-maker.txt
+++ b/src/Console/Infrastructure/Template/Command/provider-maker.txt
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace $NAMESPACE$;
 
+use DateTimeImmutable;
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 
 /**
@@ -12,6 +14,23 @@ use Gacela\Framework\Container\Container;
  */
 final class $CLASS_NAME$ extends AbstractProvider
 {
+    public const CLOCK = 'CLOCK';
+
+    /**
+     * Attribute-first: a typed #[Provides] method registers a lazy service
+     * under the given id. Resolve it from the Factory with
+     * $this->getProvidedDependency(self::CLOCK).
+     */
+    #[Provides(self::CLOCK)]
+    public function clock(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+
+    /**
+     * Imperative registration is still available for edge cases; register
+     * services with $container->set('id', static fn () => ...).
+     */
     public function provideModuleDependencies(Container $container): void
     {
     }

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -23,6 +23,7 @@ final class MakeModuleCommandTest extends TestCase
     {
         DirectoryUtil::removeDir(self::CACHE_DIR);
         DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'ServiceModule');
+        DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'ProvidesModule');
     }
 
     protected function setUp(): void
@@ -133,6 +134,37 @@ OUT;
         $execute = [new $facadeClass(), 'execute'];
         self::assertIsCallable($execute);
         self::assertSame('Hello from ServiceModuleService!', $execute());
+    }
+
+    public function test_make_module_provider_demonstrates_provides_attribute(): void
+    {
+        $input = new StringInput('make:module Psr4CodeGeneratorData/ProvidesModule');
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run($input, $output);
+
+        $providerFile = getcwd() . '/data/ProvidesModule/ProvidesModuleProvider.php';
+        self::assertFileExists($providerFile);
+
+        $contents = (string)file_get_contents($providerFile);
+
+        // Attribute-first: the scaffolded provider demonstrates a typed #[Provides]
+        // method as the primary registration path.
+        self::assertStringContainsString('use Gacela\Framework\Attribute\Provides;', $contents);
+        self::assertStringContainsString('#[Provides(', $contents);
+        self::assertStringContainsString('public function clock(): DateTimeImmutable', $contents);
+
+        // ...while keeping the imperative provideModuleDependencies() available (no BC break).
+        self::assertStringContainsString(
+            'public function provideModuleDependencies(Container $container): void',
+            $contents,
+        );
+
+        // The generated provider must be valid PHP.
+        exec(sprintf('php -l %s 2>&1', escapeshellarg($providerFile)), $lintOutput, $lintExit);
+        self::assertSame(0, $lintExit, implode("\n", $lintOutput));
     }
 
     public function test_make_module_with_unknown_template_fails(): void


### PR DESCRIPTION
## 📚 Description

The `#[Provides]` attribute + `ProvidesScanner` already let a provider register typed, lazy services without the stringly `$container->set('key', fn () => ...)` body. The 2.0 direction is attribute-first, but the `make:module` provider template still emitted an empty imperative `provideModuleDependencies(Container $c)`.

This updates the scaffolded provider to demonstrate `#[Provides]` as the primary registration path — a typed method returning the service — while keeping `provideModuleDependencies()` available for imperative/edge cases (no BC break).

Closes #502

## 🔖 Changes

- `provider-maker.txt`: emit a typed `#[Provides(self::CLOCK)] public function clock(): DateTimeImmutable` example (self-contained, resolves at runtime) plus a retained empty `provideModuleDependencies()` for imperative wiring
- The template is shared by both the `basic` and `service` module templates, so both now scaffold attribute-first
- Feature test `test_make_module_provider_demonstrates_provides_attribute()` asserts the generated provider imports `Provides`, uses `#[Provides(`, exposes the typed `clock()` method, keeps `provideModuleDependencies()`, and is valid PHP (`php -l`)
- `CHANGELOG.md`: `### Changed` entry