### PR TITLE
feat(container): add AbstractFactory::make() to route domain construction through the module container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `AbstractFactory::make(class-string, params)`: resolve a domain object through the module container with autowiring, so a `create*()` method can build it by type instead of hand-wiring each constructor argument. The container DI attributes (`#[Inject]`/`#[Singleton]`/`#[Factory]`) are honored on the resolved class, and optional runtime `params` override constructor arguments by name (fresh instance). Additive and opt-in — existing `getProvidedDependency()` and hand-wired `create*()` methods keep working
+
 ## [1.19.0](https://github.com/gacela-project/gacela/compare/1.18.0...1.19.0) - 2026-07-23
 
 ### Added

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -266,6 +266,38 @@ Notes:
 - Constructor params of attribute-annotated classes still go through the normal
   resolution order (bindings, contextual bindings, `#[Inject]`).
 
+### Resolving domain objects by type with `make()`
+
+`AbstractFactory::make()` gives a `create*()` method a typed, autowiring
+construction path through the same module container — so a factory can resolve a
+domain object by type instead of hand-`new`ing it and wiring each argument:
+
+```php
+final class CheckoutFactory extends AbstractFactory
+{
+    public function createCheckoutService(): CheckoutService
+    {
+        // Constructor autowired; #[Inject]/#[Singleton]/#[Factory] honored.
+        return $this->make(CheckoutService::class);
+    }
+}
+```
+
+- The return type is inferred from the class-string, so no `/** @var */` is
+  needed at the call site (unlike `getProvidedDependency()`, which returns
+  `mixed`).
+- Pass runtime overrides by parameter name to override specific constructor
+  arguments; the instance is then always built fresh:
+
+  ```php
+  $this->make(CheckoutService::class, ['currency' => 'EUR']);
+  ```
+
+  Scalars/config are best expressed as contextual bindings
+  (`when()->needs('$currency')->give(...)`) rather than string locator keys.
+- Additive and opt-in: existing `getProvidedDependency()` and hand-wired
+  `create*()` methods keep working unchanged.
+
 ## Quick Reference
 
 | Type | Behavior | Use Case |

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -56,6 +56,27 @@ abstract class AbstractFactory
         return $this->getContainer()->get($key);
     }
 
+    /**
+     * Resolve a class through the module container with autowiring, so its
+     * constructor dependencies and the container DI attributes (#[Inject],
+     * #[Singleton], #[Factory]) are honored — letting a create*() method
+     * resolve a domain object by type instead of hand-wiring it.
+     *
+     * Pass $params to override constructor arguments by name (top level only);
+     * the instance is then always built fresh.
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     * @param array<string, mixed> $params
+     *
+     * @return T
+     */
+    protected function make(string $className, array $params = []): object
+    {
+        return $this->getContainer()->make($className, $params);
+    }
+
     private function getContainer(): Container
     {
         $containerKey = static::class;

--- a/tests/Feature/Container/ModuleAttributes/FactoryMakeTest.php
+++ b/tests/Feature/Container/ModuleAttributes/FactoryMakeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Container\ModuleAttributes;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\DefaultGreeting;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\GreetingInterface;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\SpecialGreeting;
+use PHPUnit\Framework\TestCase;
+
+final class FactoryMakeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(GreetingInterface::class, DefaultGreeting::class);
+        });
+    }
+
+    public function test_make_autowires_a_plain_typed_dependency(): void
+    {
+        $greeter = (new Module\Factory())->makePlainGreeter();
+
+        self::assertInstanceOf(DefaultGreeting::class, $greeter->greeting);
+        self::assertSame('hello from the binding', $greeter->greeting->greet());
+    }
+
+    public function test_make_returns_the_same_instance_for_a_singleton_attribute(): void
+    {
+        $factory = new Module\Factory();
+
+        $first = $factory->makeSingletonCounter();
+        $second = $factory->makeSingletonCounter();
+
+        self::assertSame($first, $second);
+
+        $first->increment();
+        self::assertSame(1, $second->count);
+    }
+
+    public function test_make_returns_fresh_instances_for_a_factory_attribute(): void
+    {
+        $factory = new Module\Factory();
+
+        self::assertNotSame(
+            $factory->makeFreshPrinter(),
+            $factory->makeFreshPrinter(),
+        );
+    }
+
+    public function test_make_honors_the_inject_attribute_override(): void
+    {
+        $greeter = (new Module\Factory())->makeGreeterWithInject();
+
+        self::assertInstanceOf(SpecialGreeting::class, $greeter->greeting);
+        self::assertSame('hello from the #[Inject] override', $greeter->greeting->greet());
+    }
+
+    public function test_make_applies_runtime_parameter_overrides(): void
+    {
+        $override = new SpecialGreeting();
+
+        $greeter = (new Module\Factory())->makePlainGreeterWith($override);
+
+        self::assertSame($override, $greeter->greeting);
+    }
+}

--- a/tests/Feature/Container/ModuleAttributes/Module/Factory.php
+++ b/tests/Feature/Container/ModuleAttributes/Module/Factory.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractFactory;
 use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\CounterServiceSingleton;
 use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\FreshPrinter;
 use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\GreeterWithInject;
+use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\GreetingInterface;
 use GacelaTest\Feature\Container\ModuleAttributes\Module\Domain\PlainGreeter;
 
 final class Factory extends AbstractFactory
@@ -34,5 +35,30 @@ final class Factory extends AbstractFactory
     {
         /** @var PlainGreeter */
         return $this->getProvidedDependency(PlainGreeter::class);
+    }
+
+    public function makeSingletonCounter(): CounterServiceSingleton
+    {
+        return $this->make(CounterServiceSingleton::class);
+    }
+
+    public function makeFreshPrinter(): FreshPrinter
+    {
+        return $this->make(FreshPrinter::class);
+    }
+
+    public function makeGreeterWithInject(): GreeterWithInject
+    {
+        return $this->make(GreeterWithInject::class);
+    }
+
+    public function makePlainGreeter(): PlainGreeter
+    {
+        return $this->make(PlainGreeter::class);
+    }
+
+    public function makePlainGreeterWith(GreetingInterface $greeting): PlainGreeter
+    {
+        return $this->make(PlainGreeter::class, ['greeting' => $greeting]);
     }
 }

--- a/tests/Unit/Framework/Factory/Make/Factory.php
+++ b/tests/Unit/Framework/Factory/Make/Factory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Factory\Make;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createWidget(): Widget
+    {
+        return $this->make(Widget::class);
+    }
+
+    public function createNamedWidget(string $name): Widget
+    {
+        return $this->make(Widget::class, ['name' => $name]);
+    }
+}

--- a/tests/Unit/Framework/Factory/Make/Provider.php
+++ b/tests/Unit/Framework/Factory/Make/Provider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Factory\Make;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class Provider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/tests/Unit/Framework/Factory/Make/Widget.php
+++ b/tests/Unit/Framework/Factory/Make/Widget.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Factory\Make;
+
+final class Widget
+{
+    public function __construct(
+        public readonly string $name = 'autowired',
+    ) {
+    }
+}

--- a/tests/Unit/Framework/Factory/MakeTest.php
+++ b/tests/Unit/Framework/Factory/MakeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Factory;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class MakeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+    }
+
+    public function test_make_autowires_a_class_by_type(): void
+    {
+        $widget = (new Make\Factory())->createWidget();
+
+        self::assertSame('autowired', $widget->name);
+    }
+
+    public function test_make_overrides_constructor_arguments_by_name(): void
+    {
+        $widget = (new Make\Factory())->createNamedWidget('custom');
+
+        self::assertSame('custom', $widget->name);
+    }
+
+    public function test_make_builds_a_fresh_instance_when_params_are_given(): void
+    {
+        $factory = new Make\Factory();
+
+        self::assertNotSame(
+            $factory->createNamedWidget('same'),
+            $factory->createNamedWidget('same'),
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adds `AbstractFactory::make()` — a typed, autowiring construction path that resolves domain objects **through** the per-module container. Until now, module domain objects were hand-`new`'d inside factory `create*()` methods, so they never passed through the container and the DI attributes `#[Inject]` / `#[Singleton]` / `#[Factory]` were effectively inert for application code (deps arrived via the stringly-typed `getProvidedDependency('key')` locator returning `mixed`).

A factory can now write:

```php
public function createCheckoutService(): CheckoutService
{
    return $this->make(CheckoutService::class);
}
```

instead of hand-wiring each constructor argument. The return type is inferred from the class-string (no `/** @var */` needed), the constructor is autowired, and the container DI attributes fire on the resolved class. Optional runtime `params` override constructor arguments by name (fresh instance); scalars/config still flow via contextual bindings.

Additive and opt-in — existing `getProvidedDependency()` and hand-wired `create*()` methods keep working, **no BC break**. Targets `1.20`.

Closes #499

## 🔖 Changes

- `AbstractFactory::make(class-string<T>, array $params = []): T` delegating to the module container's autowiring `make()` (honors `#[Inject]`/`#[Singleton]`/`#[Factory]`; `$params` override constructor args by name → fresh instance).
- Feature test `FactoryMakeTest` through a real Factory (extends #452's fixtures): plain typed dep autowired, `#[Singleton]` → same instance, `#[Factory]` → fresh, `#[Inject]` → override injected, runtime param override applied.
- Focused unit test `MakeTest` (+ minimal `Make/` fixture module): autowiring by type, param override by name, fresh instance when params given.
- Docs: new `make()` subsection in `docs/container-configuration.md`.
- `CHANGELOG.md` `## Unreleased` → `### Added` entry.

### Quality gates
- `composer quality` (cs-fixer, psalm level 1, phpstan strict src + tests): green
- `composer test-unit` (709), `composer test-feature` (183), `composer test-integration` (124): green
- Infection on `src/Framework/AbstractFactory.php`: 24/24 mutants killed, **MSI 100% / Covered MSI 100%**
