### PR TITLE
feat(console): make:module --minimal and document Config/Provider as optional pillars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- `make:module --minimal` (or `--template=minimal`): scaffolds only the Facade and Factory pillars. Config and Provider are optional — the runtime tolerates their absence — so add them only when the module reads config or wires external dependencies. `basic` (four pillars) and `service` are unchanged
+- Documented Config and Provider as optional pillars (the two-file Facade + Factory floor) in `docs/getting-started.md`
+
 ## [1.19.0](https://github.com/gacela-project/gacela/compare/1.18.0...1.19.0) - 2026-07-23
 
 ### Added

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,29 @@ final class Factory extends AbstractFactory
 
 > Using `singleton()` the factory keeps instances in memory.
 
+### Config and Provider are optional pillars
+
+A Gacela module has four pillars — **Facade**, **Factory**, **Config**, and
+**Provider** — but only the **Facade** and **Factory** are required. The
+runtime tolerates the other two being absent: Config falls back to an anonymous
+default, and a module whose Factory never calls `getProvidedDependency()` never
+needs a Provider. So the two-file module above already resolves and runs.
+
+Add the optional pillars only when you actually need them:
+
+- **Config** — when the module reads configuration values.
+- **Provider** — when the module wires external dependencies (services from
+  other modules or third-party libraries) into its container.
+
+Scaffold just the two-file floor with the CLI:
+
+```bash
+vendor/bin/gacela make:module App/Hello --minimal
+```
+
+Use `make:module App/Hello` (or `--template=basic`) for the full four-pillar
+shape, or `--template=service` for a module wired to a `Domain` service.
+
 `src/Hello/Greeter.php`
 ```php
 <?php

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -24,7 +24,7 @@ final class MakeModuleCommand extends Command
 {
     use ServiceResolverAwareTrait;
 
-    private const TEMPLATES = ['basic', 'service'];
+    private const TEMPLATES = ['basic', 'service', 'minimal'];
 
     protected function configure(): void
     {
@@ -32,15 +32,24 @@ final class MakeModuleCommand extends Command
             ->setDescription('Generate a basic module with an empty ' . $this->getExpectedFilenames())
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
             ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name')
-            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Module template: basic, or service (Facade wired to a Domain service)', 'basic')
+            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Module template: basic, service (Facade wired to a Domain service), or minimal (Facade + Factory only)', 'basic')
+            ->addOption('minimal', null, InputOption::VALUE_NONE, 'Scaffold only the Facade and Factory pillars (shorthand for --template=minimal)')
             ->addOption('with-tests', null, InputOption::VALUE_NONE, 'Also scaffold a facade test (service template only)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $template = (string)$input->getOption('template');
+        if ((bool)$input->getOption('minimal')) {
+            $template = 'minimal';
+        }
+
         if (!in_array($template, self::TEMPLATES, true)) {
-            $output->writeln(sprintf('<error>Unknown template "%s". Use one of: basic, service</error>', $template));
+            $output->writeln(sprintf(
+                '<error>Unknown template "%s". Use one of: %s</error>',
+                $template,
+                implode(', ', self::TEMPLATES),
+            ));
 
             return self::FAILURE;
         }
@@ -52,6 +61,8 @@ final class MakeModuleCommand extends Command
 
         if ($template === 'service') {
             $this->generateServiceModule($commandArguments, $shortName, (bool)$input->getOption('with-tests'), $output);
+        } elseif ($template === 'minimal') {
+            $this->generateMinimalModule($commandArguments, $shortName, $output);
         } else {
             foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
                 $fullPath = $this->getFacade()->generateFileContent(
@@ -92,6 +103,26 @@ final class MakeModuleCommand extends Command
                 $filename,
                 $shortName,
                 $subDirectory,
+            );
+            $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
+        }
+    }
+
+    /**
+     * The `minimal` template scaffolds only the Facade and Factory pillars.
+     * Config and Provider are optional: add them when the module actually
+     * reads config or wires external dependencies.
+     */
+    private function generateMinimalModule(
+        CommandArguments $commandArguments,
+        bool $shortName,
+        OutputInterface $output,
+    ): void {
+        foreach ([FilenameSanitizer::FACADE, FilenameSanitizer::FACTORY] as $filename) {
+            $fullPath = $this->getFacade()->generateFileContent(
+                $commandArguments,
+                $filename,
+                $shortName,
             );
             $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
         }

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Console\CodeGenerator;
 
 use Gacela\Console\Infrastructure\ConsoleBootstrap;
+use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
@@ -23,6 +24,9 @@ final class MakeModuleCommandTest extends TestCase
     {
         DirectoryUtil::removeDir(self::CACHE_DIR);
         DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'ServiceModule');
+        DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'MinimalModule');
+        DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'MinimalTemplateModule');
+        DirectoryUtil::removeDir('.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'MinimalRunModule');
     }
 
     protected function setUp(): void
@@ -133,6 +137,96 @@ OUT;
         $execute = [new $facadeClass(), 'execute'];
         self::assertIsCallable($execute);
         self::assertSame('Hello from ServiceModuleService!', $execute());
+    }
+
+    public function test_make_module_minimal_generates_only_facade_and_factory(): void
+    {
+        $input = new StringInput('make:module Psr4CodeGeneratorData/MinimalModule --minimal');
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run($input, $output);
+
+        $expectedOutput = <<<OUT
+> Path 'data/MinimalModule/MinimalModuleFacade.php' created successfully
+> Path 'data/MinimalModule/MinimalModuleFactory.php' created successfully
+Module 'MinimalModule' created successfully
+OUT;
+
+        if (strcasecmp(substr(PHP_OS, 0, 3), 'WIN') === 0) {
+            $expectedOutput = str_replace("\n", PHP_EOL, $expectedOutput);
+        }
+
+        self::assertSame($expectedOutput, trim($output->fetch()));
+
+        $moduleDir = getcwd() . '/data/MinimalModule';
+        self::assertFileExists($moduleDir . '/MinimalModuleFacade.php');
+        self::assertFileExists($moduleDir . '/MinimalModuleFactory.php');
+
+        // Config and Provider are optional pillars: the minimal template omits them.
+        self::assertFileDoesNotExist($moduleDir . '/MinimalModuleConfig.php');
+        self::assertFileDoesNotExist($moduleDir . '/MinimalModuleProvider.php');
+    }
+
+    public function test_make_module_template_minimal_is_equivalent_to_the_flag(): void
+    {
+        $input = new StringInput('make:module Psr4CodeGeneratorData/MinimalTemplateModule --template=minimal');
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $exitCode = $bootstrap->run($input, $output);
+
+        self::assertSame(0, $exitCode);
+
+        $moduleDir = getcwd() . '/data/MinimalTemplateModule';
+        self::assertFileExists($moduleDir . '/MinimalTemplateModuleFacade.php');
+        self::assertFileExists($moduleDir . '/MinimalTemplateModuleFactory.php');
+        self::assertFileDoesNotExist($moduleDir . '/MinimalTemplateModuleConfig.php');
+        self::assertFileDoesNotExist($moduleDir . '/MinimalTemplateModuleProvider.php');
+    }
+
+    public function test_make_module_minimal_module_resolves_and_runs_without_config_or_provider(): void
+    {
+        $input = new StringInput('make:module Psr4CodeGeneratorData/MinimalRunModule --minimal');
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run($input, $output);
+
+        $moduleDir = getcwd() . '/data/MinimalRunModule';
+        $facadeFile = $moduleDir . '/MinimalRunModuleFacade.php';
+        $factoryFile = $moduleDir . '/MinimalRunModuleFactory.php';
+
+        // Only the two pillars exist; no Config/Provider on disk.
+        self::assertFileExists($facadeFile);
+        self::assertFileExists($factoryFile);
+        self::assertFileDoesNotExist($moduleDir . '/MinimalRunModuleConfig.php');
+        self::assertFileDoesNotExist($moduleDir . '/MinimalRunModuleProvider.php');
+
+        // Every generated file must be valid PHP.
+        foreach ([$facadeFile, $factoryFile] as $file) {
+            exec(sprintf('php -l %s 2>&1', escapeshellarg($file)), $lintOutput, $lintExit);
+            self::assertSame(0, $lintExit, implode("\n", $lintOutput));
+        }
+
+        // The Psr4CodeGeneratorData namespace is only mapped in the fixture
+        // composer.json, so load the generated files explicitly.
+        require_once $facadeFile;
+        require_once $factoryFile;
+
+        $facadeClass = 'Psr4CodeGeneratorData\MinimalRunModule\MinimalRunModuleFacade';
+        $factoryClass = 'Psr4CodeGeneratorData\MinimalRunModule\MinimalRunModuleFactory';
+        self::assertTrue(class_exists($facadeClass));
+
+        // The module resolves and runs: the Facade resolves its own generated
+        // Factory through the framework with no Config or Provider present (no
+        // exception thrown, and not the anonymous fallback factory).
+        $factory = (new $facadeClass())->getFactory();
+        self::assertInstanceOf(AbstractFactory::class, $factory);
+        self::assertSame($factoryClass, $factory::class);
     }
 
     public function test_make_module_with_unknown_template_fails(): void


### PR DESCRIPTION
## 📚 Description

The minimum module today scaffolds four files (`Facade`, `Factory`, `Config`, `Provider`), yet Config and Provider are frequently empty. The runtime already tolerates their absence: a module whose Factory never calls `getProvidedDependency()` never triggers `ProviderNotFoundException`, and Config falls back to an anonymous default when the pillar class is missing. So the empty files are scaffolder ceremony, not a runtime requirement.

This adds a two-file floor to the scaffolder and documents Config + Provider as optional pillars.

Closes #501

## 🔖 Changes

- `make:module --minimal` (and the equivalent `--template=minimal`) scaffolds only the Facade and Factory pillars, reusing the existing basic facade/factory templates. `basic` (four pillars) and `service` are unchanged
- The unknown-template error now lists all available templates dynamically
- Feature tests:
  - `test_make_module_minimal_generates_only_facade_and_factory`: asserts exactly `FooFacade` + `FooFactory` are written and no Config/Provider
  - `test_make_module_template_minimal_is_equivalent_to_the_flag`: `--template=minimal` parity
  - `test_make_module_minimal_module_resolves_and_runs_without_config_or_provider`: fixture-based — the generated module's Facade resolves its own generated Factory through the framework with no Config/Provider present (asserts the concrete Factory class, not the anonymous fallback)
- `docs/getting-started.md`: new "Config and Provider are optional pillars" section documenting the two-file floor and the `--minimal` scaffolder
- `CHANGELOG.md`: `### Added` entry

## Notes

- No runtime/`AbstractFactory.php` changes — the framework already tolerates a missing Config/Provider when unused.