### PR TITLE
fix: provider double-registration and silent console failures; cleanup pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 ### Changed
 
 - `make:module` provider template is now attribute-first: the scaffolded provider demonstrates a typed `#[Provides]` method as the primary registration path, keeping the imperative `provideModuleDependencies()` available (no BC break)
+- The deprecation notice for `AbstractDependencyProvider` is now emitted whether or not `symfony/deprecation-contracts` is installed. It was previously routed through `trigger_deprecation()` and skipped when that function was unavailable — which is most apps, since the package is not a runtime dependency of Gacela. The message keeps the contract's `Since <package> <version>: ` format, so deprecation collectors group it exactly as before. Apps still using `AbstractDependencyProvider` will start seeing the deprecation; migrate to `AbstractProvider`
+
+- Scaffolding commands (`make:module`, `make:file`) now fail loudly when a generated file cannot be written. `FileContentIo::filePutContents()` discarded the result of `file_put_contents()`, so a read-only target, a permission error, or a full disk produced a success message, an exit code of `0`, and no file on disk. It now throws a `RuntimeException` naming the path, matching how the neighbouring `mkdir()` has always behaved. This only changes behaviour on runs that were already failing silently
+
+### Removed
+
+- `Gacela\Framework\Container\Locator::addSingleton()`, which had no production caller. `Locator` is `@internal`; seed services through a `Container` and `Locator::getInstance($container)` instead
+
+### Fixed
+
+- A module's `provideModuleDependencies()` is no longer invoked twice. The `AbstractDependencyProvider` backward-compatibility path in `AbstractFactory` resolved the same provider instance through both `ProviderResolver` and `DependencyProviderResolver` (they share a normalized cache slot, because `DependencyProvider` ends with `Provider`) and then registered it once via `register()` and again directly. Providers whose body is not idempotent — counters, external registrations, logging — ran their side effects twice
+- `validate:config` now actually reports circular dependencies. The check caught every resolution error and then searched the message text for the lowercase word `circular`, but the container throws `CircularDependencyException` whose message begins `Circular dependency detected:` — capital `C`, and `str_contains()` is case-sensitive, so the branch never once matched. A genuinely cyclic configuration printed `✓ No circular dependencies detected` and exited `0`. The command now catches `CircularDependencyException` by type and prints the full `A -> B -> A` chain. Configurations that were always cyclic will now fail validation (exit code `1`) where they previously passed — if `validate:config` runs in your CI pipeline, expect it to surface pre-existing cycles on the first run after upgrading. Every other binding-resolution failure, previously discarded in silence by the same `catch`, is now reported as a warning naming the binding and the error
 
 ### Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "ergebnis/composer-normalize": "^2.50",
         "friendsofphp/php-cs-fixer": "^3.95",
         "infection/infection": "^0.29",
+        "nikic/php-parser": "^5.0",
         "phpbench/phpbench": "^1.4",
         "phpmetrics/phpmetrics": "^2.9",
         "phpstan/phpstan": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c3f118cf3e6b01bf34d83b4a637deeb",
+    "content-hash": "bdd440a10432096e9f131f460508c62f",
     "packages": [
         {
             "name": "gacela-project/container",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,9 +11,28 @@ parameters:
         maximumNumberOfProcesses: 4
     excludePaths:
         - '**/gacela-class-names.php'
+    strictRules:
+        # `glob(...) ?: []` / `getenv(...) ?: ''` is the idiomatic false-coalesce here.
+        # Scoped to this one rule so a short ternary hiding a real type confusion
+        # (e.g. strrpos() returning a falsy 0) still shows up as an opt-out.
+        disallowedShortTernary: false
     ignoreErrors:
-        - '#Method Gacela\\.*::.* should return class-string.*but returns string#'
-        - '#Method Gacela\\.*::.* should return array<.*> but returns array#'
-        - '#Cannot cast mixed to string.#'
-        - '#Short ternary operator is not allowed.#'
-        - '#Method .* should return list<.*> but returns array.#'
+        # The resolver caches store class names that were validated before being
+        # put(), but CacheInterface::get() is a plain string map shared with the
+        # generic service caches, so the class-string-ness cannot be proven here.
+        # Fixing this properly means typing the cache storage (and the on-disk
+        # payload it is rehydrated from) as class-string maps.
+        -
+            message: '#should return class-string\|null but returns string#'
+            path: src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php
+            count: 1
+        -
+            message: '#should return class-string but returns string#'
+            path: src/Framework/ServiceResolver/DocBlockResolver.php
+            count: 1
+        # The constructor takes a class-string and only re-normalizes its leading
+        # backslash, but the result is computed, so it cannot be proven.
+        -
+            message: '#should return class-string but returns string#'
+            path: src/Framework/ServiceResolver/DocBlockResolvable.php
+            count: 1

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,9 +31,5 @@
     <include>
       <directory suffix=".php">src</directory>
     </include>
-    <exclude>
-      <directory prefix="CodeGenerator">src/CodeGenerator</directory>
-      <directory suffix=".php">src/CodeGenerator/Infrastructure</directory>
-    </exclude>
   </source>
 </phpunit>

--- a/src/Console/Application/CacheWarm/CacheWarmService.php
+++ b/src/Console/Application/CacheWarm/CacheWarmService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Console\Application\CacheWarm;
 
 use Exception;
-use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\Config\ConfigResolver;
@@ -17,6 +16,7 @@ use Gacela\Framework\ServiceResolver\ReflectionClassPool;
 use ReflectionMethod;
 
 use function array_filter;
+use function array_values;
 use function class_exists;
 use function str_contains;
 
@@ -24,11 +24,6 @@ final class CacheWarmService
 {
     /** @var list<AbstractClassResolver>|null */
     private ?array $classResolvers = null;
-
-    public function __construct(
-        private readonly ConsoleFacade $facade,
-    ) {
-    }
 
     /**
      * Eagerly resolve a module's Factory, Config, and Provider through Gacela's
@@ -55,21 +50,13 @@ final class CacheWarmService
     }
 
     /**
-     * @return list<AppModule>
-     */
-    public function discoverModules(): array
-    {
-        return $this->facade->findAllAppModules();
-    }
-
-    /**
      * @param list<AppModule> $modules
      *
      * @return list<AppModule>
      */
     public function filterProductionModules(array $modules): array
     {
-        return array_filter($modules, static function (\Gacela\Console\Domain\AllAppModules\AppModule $module): bool {
+        return array_values(array_filter($modules, static function (\Gacela\Console\Domain\AllAppModules\AppModule $module): bool {
             $className = $module->facadeClass();
             // Anchor to whole namespace segments (like \Fixtures\ / \Benchmark\); an unanchored
             // 'Test' substring dropped legitimate modules such as App\Testimonial\TestimonialFacade.
@@ -77,7 +64,7 @@ final class CacheWarmService
                 && !str_contains($className, '\\Tests\\')
                 && !str_contains($className, '\\Fixtures\\')
                 && !str_contains($className, '\\Benchmark\\');
-        });
+        }));
     }
 
     /**

--- a/src/Console/Application/Doctor/Check/ModuleHealthCheck.php
+++ b/src/Console/Application/Doctor/Check/ModuleHealthCheck.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Framework\Health\HealthLevel;
+use Gacela\Framework\Health\HealthStatus;
+
+use function is_scalar;
+use function sprintf;
+
+/**
+ * Adapts a module's {@see HealthStatus} to the doctor command's check contract.
+ */
+final class ModuleHealthCheck implements HealthCheck
+{
+    public function __construct(
+        private readonly string $moduleName,
+        private readonly HealthStatus $status,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return $this->moduleName;
+    }
+
+    public function run(): CheckResult
+    {
+        $title = sprintf('module health: %s', $this->moduleName);
+        $detail = $this->status->message;
+        $details = [$detail, ...$this->formatMetadata()];
+
+        return match ($this->status->level) {
+            HealthLevel::HEALTHY => CheckResult::ok($title, $detail),
+            HealthLevel::DEGRADED => CheckResult::warn($title, $details),
+            HealthLevel::UNHEALTHY => CheckResult::error($title, $details),
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function formatMetadata(): array
+    {
+        $lines = [];
+
+        /** @var mixed $value */
+        foreach ($this->status->metadata as $key => $value) {
+            $lines[] = sprintf('%s: %s', $key, is_scalar($value) ? (string) $value : get_debug_type($value));
+        }
+
+        return $lines;
+    }
+}

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -58,12 +58,19 @@ final class ConsoleFactory extends AbstractFactory
 {
     /**
      * @return list<Command>
-     *
-     * @psalm-suppress MixedReturnTypeCoercion
      */
     public function getConsoleCommands(): array
     {
-        return (array)$this->getProvidedDependency(ConsoleProvider::COMMANDS);
+        $commands = [];
+
+        /** @var mixed $command */
+        foreach ((array)$this->getProvidedDependency(ConsoleProvider::COMMANDS) as $command) {
+            if ($command instanceof Command) {
+                $commands[] = $command;
+            }
+        }
+
+        return $commands;
     }
 
     public function createCommandArgumentsParser(): CommandArgumentsParserInterface
@@ -240,23 +247,40 @@ final class ConsoleFactory extends AbstractFactory
     }
 
     /**
-     * @psalm-suppress MixedReturnTypeCoercion
-     *
      * @return array<string,string>
      */
     private function getTemplateByFilenameMap(): array
     {
-        return (array)$this->getProvidedDependency(ConsoleProvider::TEMPLATE_BY_FILENAME_MAP);
+        return $this->stringMapDependency(ConsoleProvider::TEMPLATE_BY_FILENAME_MAP);
     }
 
     /**
-     * @psalm-suppress MixedReturnTypeCoercion
-     *
      * @return array<string,string>
      */
     private function getServiceTemplateByFilenameMap(): array
     {
-        return (array)$this->getProvidedDependency(ConsoleProvider::SERVICE_TEMPLATE_BY_FILENAME_MAP);
+        return $this->stringMapDependency(ConsoleProvider::SERVICE_TEMPLATE_BY_FILENAME_MAP);
+    }
+
+    /**
+     * Narrow a provided dependency to a string map, dropping any entry that is
+     * not a string-keyed string. Providers are user-supplied, so the container
+     * cannot guarantee the shape on its own.
+     *
+     * @return array<string,string>
+     */
+    private function stringMapDependency(string $key): array
+    {
+        $map = [];
+
+        /** @var mixed $value */
+        foreach ((array)$this->getProvidedDependency($key) as $name => $value) {
+            if (is_string($name) && is_string($value)) {
+                $map[$name] = $value;
+            }
+        }
+
+        return $map;
     }
 
     private function getMainContainer(): Container

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -21,6 +21,7 @@ use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * @extends AbstractProvider<ConsoleConfig>
@@ -34,7 +35,7 @@ final class ConsoleProvider extends AbstractProvider
     public const SERVICE_TEMPLATE_BY_FILENAME_MAP = 'SERVICE_TEMPLATE_FILENAME_MAP';
 
     /**
-     * @return list<object>
+     * @return list<Command>
      */
     #[Provides(self::COMMANDS)]
     public function commands(): array

--- a/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
+++ b/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
@@ -44,10 +44,13 @@ final class AllAppModulesFinder
 
     private function createAppModule(SplFileInfo $fileInfo, string $filter): ?AppModule
     {
-        if (!$fileInfo->isFile()
+        $realPath = $fileInfo->getRealPath();
+
+        if ($realPath === false
+            || !$fileInfo->isFile()
             || $fileInfo->getExtension() !== 'php'
             || str_starts_with($fileInfo->getFilename(), '.')
-            || str_contains($fileInfo->getRealPath(), 'vendor' . DIRECTORY_SEPARATOR)
+            || str_contains($realPath, 'vendor' . DIRECTORY_SEPARATOR)
         ) {
             return null;
         }
@@ -81,7 +84,12 @@ final class AllAppModulesFinder
 
     private function getNamespace(SplFileInfo $fileInfo): string
     {
-        $fileContent = file_get_contents($fileInfo->getRealPath());
+        $realPath = $fileInfo->getRealPath();
+        if ($realPath === false) {
+            return '';
+        }
+
+        $fileContent = file_get_contents($realPath);
         if ($fileContent === false) {
             return '';
         }

--- a/src/Console/Domain/AllAppModules/AppModule.php
+++ b/src/Console/Domain/AllAppModules/AppModule.php
@@ -6,6 +6,12 @@ namespace Gacela\Console\Domain\AllAppModules;
 
 final class AppModule
 {
+    /**
+     * @param class-string $facadeClass
+     * @param ?class-string $factoryClass
+     * @param ?class-string $configClass
+     * @param ?class-string $providerClass
+     */
     public function __construct(
         private readonly string $fullModuleName,
         private readonly string $moduleName,

--- a/src/Console/Domain/AllAppModules/AppModuleCreator.php
+++ b/src/Console/Domain/AllAppModules/AppModuleCreator.php
@@ -42,7 +42,10 @@ final class AppModuleCreator
      */
     private function fullModuleName(string $facadeClass): string
     {
-        $moduleNameIndex = strrpos($facadeClass, '\\') ?: strlen($facadeClass);
+        // Not `?:` — a class in the root namespace yields position 0, which is a
+        // valid separator index but falsy, and would fall through to strlen().
+        $separatorIndex = strrpos($facadeClass, '\\');
+        $moduleNameIndex = $separatorIndex === false ? strlen($facadeClass) : $separatorIndex;
 
         return substr($facadeClass, 0, $moduleNameIndex);
     }
@@ -61,6 +64,8 @@ final class AppModuleCreator
 
     /**
      * @param class-string $facadeClass
+     *
+     * @return ?class-string
      */
     private function findFactory(string $facadeClass): ?string
     {
@@ -69,6 +74,8 @@ final class AppModuleCreator
 
     /**
      * @param class-string $facadeClass
+     *
+     * @return ?class-string
      */
     private function findConfig(string $facadeClass): ?string
     {
@@ -77,6 +84,8 @@ final class AppModuleCreator
 
     /**
      * @param class-string $facadeClass
+     *
+     * @return ?class-string
      */
     private function findProvider(string $facadeClass): ?string
     {
@@ -89,6 +98,8 @@ final class AppModuleCreator
      * or falls back to an anonymous default class).
      *
      * @param class-string $facadeClass
+     *
+     * @return ?class-string
      */
     private function resolveClassName(AbstractClassResolver $resolver, string $facadeClass): ?string
     {

--- a/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
+++ b/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
@@ -27,6 +27,14 @@ final class FilenameSanitizer implements FilenameSanitizerInterface
     ];
 
     /**
+     * The expected filenames rendered for console help text.
+     */
+    public static function expectedFilenamesAsText(): string
+    {
+        return implode(', ', self::EXPECTED_FILENAMES);
+    }
+
+    /**
      * @return list<string>
      */
     public function getExpectedFilenames(): array

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -48,7 +48,7 @@ final class CacheWarmCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $cacheManager = new CacheManager();
-        $cacheWarmService = new CacheWarmService($this->getFacade());
+        $cacheWarmService = new CacheWarmService();
         $formatter = new CacheWarmOutputFormatter($output);
         $metrics = new PerformanceMetrics();
 
@@ -63,7 +63,7 @@ final class CacheWarmCommand extends Command
             $formatter->writeCacheCleared();
         }
 
-        $modules = $this->discoverModules($cacheWarmService, $formatter);
+        $modules = $this->discoverModules($formatter);
         $modules = $cacheWarmService->filterProductionModules($modules);
 
         $formatter->writeModulesFound($modules);
@@ -110,11 +110,10 @@ final class CacheWarmCommand extends Command
      * @return list<AppModule>
      */
     private function discoverModules(
-        CacheWarmService $cacheWarmService,
         CacheWarmOutputFormatter $formatter,
     ): array {
         try {
-            return $cacheWarmService->discoverModules();
+            return $this->getFacade()->findAllAppModules();
         } catch (Throwable $throwable) {
             $formatter->writeModuleDiscoveryWarning($throwable->getMessage());
             return [];

--- a/src/Console/Infrastructure/Command/ConsoleInput.php
+++ b/src/Console/Infrastructure/Command/ConsoleInput.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+use function is_string;
+
+/**
+ * Reads console arguments and options as strings.
+ *
+ * Symfony types getArgument()/getOption() as `mixed` because an input
+ * definition may declare array or boolean values. The Gacela commands only
+ * declare scalar, optional arguments and options, so a non-string value means
+ * "absent" and collapses to the empty string, keeping the call sites free of
+ * unchecked `(string)` casts on `mixed`.
+ */
+final class ConsoleInput
+{
+    public static function argument(InputInterface $input, string $name): string
+    {
+        return self::asString($input->getArgument($name));
+    }
+
+    public static function option(InputInterface $input, string $name): string
+    {
+        return self::asString($input->getOption($name));
+    }
+
+    private static function asString(mixed $value): string
+    {
+        return is_string($value) ? $value : '';
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugConfigCommand.php
+++ b/src/Console/Infrastructure/Command/DebugConfigCommand.php
@@ -40,7 +40,7 @@ final class DebugConfigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $filter = (string)$input->getArgument('filter');
+        $filter = ConsoleInput::argument($input, 'filter');
 
         $values = Config::getInstance()->getAllValues();
         ksort($values);

--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -52,7 +52,6 @@ final class DebugContainerCommand extends Command
             return Command::FAILURE;
         }
 
-        // If class provided without --tree flag, assume --tree
         if ($className !== null) {
             return $this->displayDependencyTree($output, $className);
         }
@@ -124,7 +123,6 @@ final class DebugContainerCommand extends Command
 
     private function getIndentLevel(string $dependency): int
     {
-        // Count leading spaces to determine depth
         $matches = [];
         if (preg_match('/^(\s*)/', $dependency, $matches) === 1) {
             return (int)(strlen($matches[1]) / 2);

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -34,14 +34,14 @@ final class DebugGraphCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $format = (string)$input->getOption('format');
+        $format = ConsoleInput::option($input, 'format');
         if (!in_array($format, self::FORMATS, true)) {
             $output->writeln(sprintf('<error>Unknown format "%s". Use one of: text, mermaid, graphviz, json</error>', $format));
 
             return self::FAILURE;
         }
 
-        $filter = (string)$input->getArgument('filter');
+        $filter = ConsoleInput::argument($input, 'filter');
         $graph = $this->getFacade()->buildModuleGraph($filter);
 
         if ($graph === []) {

--- a/src/Console/Infrastructure/Command/DebugModuleCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModuleCommand.php
@@ -40,7 +40,7 @@ final class DebugModuleCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $moduleName = (string)$input->getArgument('module');
+        $moduleName = ConsoleInput::argument($input, 'module');
         $modules = $this->getFacade()->findAllAppModules($moduleName);
 
         if ($modules === []) {

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
+use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
 use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\CheckStatus;
@@ -13,15 +14,12 @@ use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Health\HealthCheckRegistry;
-use Gacela\Framework\Health\HealthLevel;
-use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function is_scalar;
 use function sprintf;
 
 /**
@@ -42,7 +40,7 @@ final class DoctorCommand extends Command
     {
         ConsoleSection::title($output, 'Gacela Doctor');
 
-        $filter = (string) $input->getArgument('filter');
+        $filter = ConsoleInput::argument($input, 'filter');
         $checks = $this->buildChecks($filter);
         $worst = CheckStatus::Ok;
 
@@ -77,53 +75,10 @@ final class DoctorCommand extends Command
         ];
 
         foreach (HealthCheckRegistry::createHealthChecker(Gacela::container())->checkAll()->getResults() as $moduleName => $status) {
-            $checks[] = $this->toHealthCheck($moduleName, $status);
+            $checks[] = new ModuleHealthCheck($moduleName, $status);
         }
 
         return $checks;
-    }
-
-    private function toHealthCheck(string $moduleName, HealthStatus $status): HealthCheck
-    {
-        return new class($moduleName, $status) implements HealthCheck {
-            public function __construct(
-                private readonly string $moduleName,
-                private readonly HealthStatus $status,
-            ) {
-            }
-
-            public function name(): string
-            {
-                return $this->moduleName;
-            }
-
-            public function run(): CheckResult
-            {
-                $title = sprintf('module health: %s', $this->moduleName);
-                $detail = $this->status->message;
-                $metadata = $this->formatMetadata();
-
-                return match ($this->status->level) {
-                    HealthLevel::HEALTHY => CheckResult::ok($title, $detail),
-                    HealthLevel::DEGRADED => CheckResult::warn($title, $metadata === [] ? [$detail] : [$detail, ...$metadata]),
-                    HealthLevel::UNHEALTHY => CheckResult::error($title, $metadata === [] ? [$detail] : [$detail, ...$metadata]),
-                };
-            }
-
-            /**
-             * @return list<string>
-             */
-            private function formatMetadata(): array
-            {
-                $lines = [];
-                /** @var mixed $value */
-                foreach ($this->status->metadata as $key => $value) {
-                    $lines[] = sprintf('%s: %s', $key, is_scalar($value) ? (string) $value : get_debug_type($value));
-                }
-
-                return $lines;
-            }
-        };
     }
 
     private function renderResult(CheckResult $result, OutputInterface $output): void

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -42,7 +42,7 @@ final class ListModulesCommand extends Command
     {
         $this->output = $output;
 
-        $filter = (string)$input->getArgument('filter');
+        $filter = ConsoleInput::argument($input, 'filter');
         $modules = $this->getFacade()->findAllAppModules($filter);
 
         if ($modules === []) {

--- a/src/Console/Infrastructure/Command/MakeFileCommand.php
+++ b/src/Console/Infrastructure/Command/MakeFileCommand.php
@@ -25,9 +25,9 @@ final class MakeFileCommand extends Command
     protected function configure(): void
     {
         $this->setName('make:file')
-            ->setDescription('Generate a ' . $this->getExpectedFilenames())
+            ->setDescription('Generate a ' . FilenameSanitizer::expectedFilenamesAsText())
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
-            ->addArgument('filenames', InputArgument::REQUIRED | InputArgument::IS_ARRAY, $this->getExpectedFilenames())
+            ->addArgument('filenames', InputArgument::REQUIRED | InputArgument::IS_ARRAY, FilenameSanitizer::expectedFilenamesAsText())
             ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
     }
 
@@ -56,10 +56,5 @@ final class MakeFileCommand extends Command
         }
 
         return self::SUCCESS;
-    }
-
-    private function getExpectedFilenames(): string
-    {
-        return implode(', ', FilenameSanitizer::EXPECTED_FILENAMES);
     }
 }

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -29,7 +29,7 @@ final class MakeModuleCommand extends Command
     protected function configure(): void
     {
         $this->setName('make:module')
-            ->setDescription('Generate a basic module with an empty ' . $this->getExpectedFilenames())
+            ->setDescription('Generate a basic module with an empty ' . FilenameSanitizer::expectedFilenamesAsText())
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
             ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name')
             ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Module template: basic, service (Facade wired to a Domain service), or minimal (Facade + Factory only)', 'basic')
@@ -39,7 +39,7 @@ final class MakeModuleCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $template = (string)$input->getOption('template');
+        $template = ConsoleInput::option($input, 'template');
         if ((bool)$input->getOption('minimal')) {
             $template = 'minimal';
         }
@@ -128,8 +128,4 @@ final class MakeModuleCommand extends Command
         }
     }
 
-    private function getExpectedFilenames(): string
-    {
-        return implode(', ', FilenameSanitizer::EXPECTED_FILENAMES);
-    }
 }

--- a/src/Console/Infrastructure/Command/ProfileReportCommand.php
+++ b/src/Console/Infrastructure/Command/ProfileReportCommand.php
@@ -58,8 +58,8 @@ final class ProfileReportCommand extends Command
             return self::SUCCESS;
         }
 
-        $format = (string)$input->getOption('format');
-        $sortBy = (string)$input->getOption('sort');
+        $format = ConsoleInput::option($input, 'format');
+        $sortBy = ConsoleInput::option($input, 'sort');
 
         $entries = $this->sortEntries($entries, $sortBy);
 

--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Infrastructure\Command;
 
+use Gacela\Container\Exception\CircularDependencyException;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
 use Symfony\Component\Console\Command\Command;
@@ -164,13 +165,21 @@ final class ValidateConfigCommand extends Command
 
                 if (class_exists($value)) {
                     try {
-                        // Resolving the binding surfaces circular/recursive dependency errors.
+                        // Resolving the binding surfaces circular dependency errors.
                         $container->get($key);
+                    } catch (CircularDependencyException $exception) {
+                        $output->writeln(sprintf('  <error>✗ Circular dependency detected:</> %s', $key));
+                        $output->writeln(sprintf('      chain: %s', $this->cycleChain($exception)));
+                        $hasErrors = true;
                     } catch (Throwable $throwable) {
-                        if (str_contains($throwable->getMessage(), 'circular') || str_contains($throwable->getMessage(), 'recursive')) {
-                            $output->writeln(sprintf('  <error>✗ Circular dependency detected:</> %s', $key));
-                            $hasErrors = true;
-                        }
+                        // Any other resolution failure is a real problem the developer
+                        // needs to see; reporting it is the whole point of this command.
+                        $output->writeln(sprintf(
+                            '  <fg=yellow>⚠ Warning: Could not resolve binding:</> %s (%s)',
+                            $key,
+                            $throwable->getMessage(),
+                        ));
+                        $hasWarnings = true;
                     }
                 }
             }
@@ -186,6 +195,20 @@ final class ValidateConfigCommand extends Command
         $output->writeln('');
 
         return ['errors' => $hasErrors, 'warnings' => $hasWarnings];
+    }
+
+    /**
+     * Pull the `A -> B -> A` chain out of the exception headline, so the
+     * developer sees exactly which classes close the loop.
+     */
+    private function cycleChain(CircularDependencyException $exception): string
+    {
+        /** @var non-empty-list<string> $lines */
+        $lines = explode("\n", $exception->getMessage());
+        $headline = $lines[0];
+        $colonPos = strpos($headline, ':');
+
+        return $colonPos === false ? $headline : trim(substr($headline, $colonPos + 1));
     }
 
     private function describeTypeChain(string $className): string

--- a/src/Console/Infrastructure/FileContentIo.php
+++ b/src/Console/Infrastructure/FileContentIo.php
@@ -33,6 +33,8 @@ final class FileContentIo implements FileContentIoInterface
 
     public function filePutContents(string $path, string $fileContent): void
     {
-        file_put_contents($path, $fileContent);
+        if (file_put_contents($path, $fileContent) === false) {
+            throw new RuntimeException(sprintf('File "%s" was not written', $path));
+        }
     }
 }

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -99,11 +99,12 @@ abstract class AbstractFactory
         }
 
         // Backward compatibility with the deprecated AbstractDependencyProvider.
-        $dpResolver = (new DependencyProviderResolver())->resolve($this);
-        $dpResolver?->provideModuleDependencies($container);
         // Both resolvers share a normalized cache slot ("DependencyProvider" -> "Provider"),
-        // so a modern provider comes back from both; only notify when it is a distinct one.
+        // so a modern provider comes back from both; register and notify only when it is a
+        // distinct one, otherwise `register()` above already provided its dependencies.
+        $dpResolver = (new DependencyProviderResolver())->resolve($this);
         if ($dpResolver !== null && $dpResolver !== $resolver) {
+            $dpResolver->provideModuleDependencies($container);
             $this->notifyProviderRegistered($dpResolver::class);
         }
 

--- a/src/Framework/Attribute/ProvidesScanner.php
+++ b/src/Framework/Attribute/ProvidesScanner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Attribute;
 
-use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use ReflectionClass;
 use ReflectionMethod;
@@ -20,10 +19,10 @@ use ReflectionNamedType;
  */
 final class ProvidesScanner
 {
-    /** @var array<class-string<AbstractProvider>, list<ProvidesEntry>> */
+    /** @var array<class-string, list<ProvidesEntry>> */
     private static array $cache = [];
 
-    public static function scan(AbstractProvider $provider, Container $container): void
+    public static function scan(object $provider, Container $container): void
     {
         foreach (self::resolveEntries($provider) as $entry) {
             $method = $entry['method'];
@@ -39,7 +38,7 @@ final class ProvidesScanner
     /**
      * @return list<ProvidesEntry>
      */
-    private static function resolveEntries(AbstractProvider $provider): array
+    private static function resolveEntries(object $provider): array
     {
         $class = $provider::class;
 

--- a/src/Framework/Bootstrap/BuilderConfigurationInterface.php
+++ b/src/Framework/Bootstrap/BuilderConfigurationInterface.php
@@ -9,29 +9,17 @@ use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 
 /**
- * Provides configuration builders for Gacela framework setup.
- *
- * This interface defines the contract for building application configuration,
- * service bindings, and suffix types used by the class resolver.
- *
  * @psalm-type ExternalServicesMap = array<string, class-string|object|callable>
  */
 interface BuilderConfigurationInterface
 {
     /**
      * Define different config sources.
-     *
-     * This method allows customization of how configuration files are loaded
-     * and processed. You can add config readers, set paths, and configure
-     * the configuration loading behavior.
      */
     public function buildAppConfig(AppConfigBuilder $builder): AppConfigBuilder;
 
     /**
-     * Define the mapping between interfaces and concretions.
-     *
-     * This allows Gacela services to auto-resolve dependencies automatically
-     * by binding interfaces to their concrete implementations.
+     * Define the mapping between interfaces and concretions, so Gacela services will auto-resolve them automatically.
      *
      * @param ExternalServicesMap $externalServices
      */
@@ -41,19 +29,11 @@ interface BuilderConfigurationInterface
     ): BindingsBuilder;
 
     /**
-     * Allow overriding Gacela resolvable types.
-     *
-     * Customize the suffix patterns used by Gacela's class resolver
-     * (e.g., Factory, Config, DependencyProvider).
+     * Allow overriding gacela resolvable types.
      */
     public function buildSuffixTypes(SuffixTypesBuilder $builder): SuffixTypesBuilder;
 
     /**
-     * Get external services available for dependency injection.
-     *
-     * External services are objects or class names that can be injected
-     * into Gacela managed classes.
-     *
      * @return ExternalServicesMap
      */
     public function externalServices(): array;

--- a/src/Framework/Bootstrap/CacheConfigurationInterface.php
+++ b/src/Framework/Bootstrap/CacheConfigurationInterface.php
@@ -4,35 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap;
 
-/**
- * Provides cache configuration for the Gacela framework.
- *
- * This interface defines the contract for configuring both in-memory
- * and file-based caching behavior.
- */
 interface CacheConfigurationInterface
 {
-    /**
-     * Check if file-based caching is enabled.
-     *
-     * When enabled, resolved class names and other data will be cached
-     * to disk for faster subsequent loads.
-     */
     public function isFileCacheEnabled(): bool;
 
-    /**
-     * Get the directory path for file cache storage.
-     *
-     * Returns the absolute path where cache files should be stored.
-     */
     public function getFileCacheDirectory(): string;
 
-    /**
-     * Check if in-memory cache should be reset on bootstrap.
-     *
-     * When true, static in-memory caches will be cleared during
-     * Gacela initialization. This is useful for testing or when
-     * you need to ensure a clean state.
-     */
     public function shouldResetInMemoryCache(): bool;
 }

--- a/src/Framework/Bootstrap/ContainerConfigurationInterface.php
+++ b/src/Framework/Bootstrap/ContainerConfigurationInterface.php
@@ -8,13 +8,10 @@ use Closure;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 /**
- * Provides configuration for the dependency injection container.
- *
- * This interface defines the contract for configuring services, factories,
- * aliases, and contextual bindings within the DI container.
- *
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
  *
+ * @psalm-type ServiceFactoryMap = array<string, Closure>
+ * @psalm-type ServiceAliasMap = array<string, string>
  * @psalm-type ServicesToExtendMap = array<string, list<Closure>>
  * @psalm-type HandlerRegistriesMap = array<string, array<string|int, class-string>>
  * @psalm-type ContextualBindingsMap = array<string, array<string, mixed>>
@@ -22,60 +19,46 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 interface ContainerConfigurationInterface
 {
     /**
-     * Get services that should be extended with decorators.
-     *
      * @return ServicesToExtendMap
      */
     public function getServicesToExtend(): array;
 
     /**
-     * Get factory definitions for creating services.
-     *
-     * @return array<string,Closure>
+     * @return ServiceFactoryMap
      */
     public function getFactories(): array;
 
     /**
-     * Get services that should be protected (not shared/singleton).
+     * Closures stored as-is: the container returns them uninvoked, and they cannot be extended.
      *
-     * @return array<string,Closure>
+     * @return ServiceFactoryMap
      */
     public function getProtectedServices(): array;
 
     /**
-     * Get service ID aliases.
-     *
-     * @return array<string,string>
+     * @return ServiceAliasMap
      */
     public function getAliases(): array;
 
     /**
-     * Get contextual bindings for dependency resolution.
-     *
-     * Contextual bindings allow different implementations to be injected
-     * based on the context (which class is requesting the dependency).
+     * Bindings selected by which class is requesting the dependency.
      *
      * @return ContextualBindingsMap
      */
     public function getContextualBindings(): array;
 
     /**
-     * Get handler registry declarations (build-time dispatch tables).
-     *
-     * Each entry maps a registry identifier to the declared handler classes.
-     * The registry is resolvable from the container under that identifier.
+     * Build-time dispatch tables: each entry maps a registry identifier to its
+     * declared handler classes, and is resolvable from the container under that identifier.
      *
      * @return HandlerRegistriesMap
      */
     public function getHandlerRegistries(): array;
 
     /**
-     * Get lazy-loaded service definitions.
+     * Services instantiated on first access rather than at container build.
      *
-     * Lazy services are only instantiated when first accessed,
-     * improving startup performance for expensive services.
-     *
-     * @return array<string,Closure>
+     * @return ServiceFactoryMap
      */
     public function getLazyServices(): array;
 }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -23,6 +23,9 @@ use function sprintf;
 /**
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
  * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
+ * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
+ * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
+ * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
@@ -48,7 +51,7 @@ final class GacelaConfig
     /** @var list<string> */
     private ?array $appModulePaths = null;
 
-    /** @var array<string,mixed> */
+    /** @var ConfigKeyValues */
     private ?array $configKeyValues = null;
 
     private ?bool $areEventListenersEnabled = null;
@@ -68,13 +71,13 @@ final class GacelaConfig
     /** @var ServicesToExtendMap */
     private array $servicesToExtend = [];
 
-    /** @var array<string,Closure> */
+    /** @var ServiceFactoryMap */
     private array $factories = [];
 
-    /** @var array<string,Closure> */
+    /** @var ServiceFactoryMap */
     private array $protectedServices = [];
 
-    /** @var array<string,string> */
+    /** @var ServiceAliasMap */
     private array $aliases = [];
 
     /** @var ContextualBindingsMap */
@@ -83,7 +86,7 @@ final class GacelaConfig
     /** @var HandlerRegistriesMap */
     private array $handlerRegistries = [];
 
-    /** @var array<string,Closure> */
+    /** @var ServiceFactoryMap */
     private array $lazyServices = [];
 
     /**
@@ -306,7 +309,7 @@ final class GacelaConfig
     /**
      * Add/replace a list of existent configuration keys with a specific value.
      *
-     * @param array<string, mixed> $config
+     * @param ConfigKeyValues $config
      */
     public function addAppConfigKeyValues(array $config): self
     {
@@ -366,8 +369,7 @@ final class GacelaConfig
      * Unlike regular services (which are singletons), factory services return
      * a new instance every time they are resolved from the container.
      *
-     * @param string $id The service identifier (usually a class name or interface)
-     * @param Closure $factory The factory closure that creates the service instance
+     * The `$id` is usually a class name or interface.
      *
      * @return $this
      */
@@ -383,9 +385,6 @@ final class GacelaConfig
      * Protected services are stored as closures and won't be invoked by the container,
      * making them useful for storing callable configurations.
      *
-     * @param string $id The service identifier
-     * @param Closure $service The closure to protect
-     *
      * @return $this
      */
     public function addProtected(string $id, Closure $service): self
@@ -399,9 +398,6 @@ final class GacelaConfig
      * Create an alias for a service.
      * This allows you to reference the same service with different names.
      *
-     * @param string $alias The alias name
-     * @param string $id The actual service identifier
-     *
      * @return $this
      */
     public function addAlias(string $alias, string $id): self
@@ -412,9 +408,8 @@ final class GacelaConfig
     }
 
     /**
-     * Register a lazy-loaded service that is only instantiated when first accessed.
-     * This improves startup performance by deferring expensive service creation
-     * until they are actually needed.
+     * Register a lazy-loaded service that is only instantiated when first accessed,
+     * deferring expensive service creation until it is actually needed.
      *
      * Example:
      * ```php

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap\Setup;
 
-use Closure;
 use Gacela\Framework\Bootstrap\BuilderConfigurationInterface;
 use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
@@ -16,9 +16,12 @@ use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 /**
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
  * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
+ * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
+ * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
+ * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type SpecificListenersMap from ConfigurableEventDispatcher
  */
 final class GacelaConfigTransfer
@@ -27,18 +30,18 @@ final class GacelaConfigTransfer
      * @param ?ExternalServicesMap $externalServices
      * @param ?list<string> $projectNamespaces
      * @param ?list<string> $appModulePaths
-     * @param ?array<string,mixed> $configKeyValues
+     * @param ?ConfigKeyValues $configKeyValues
      * @param ?list<callable> $genericListeners
      * @param ?SpecificListenersMap $specificListeners
      * @param ?list<class-string> $gacelaConfigsToExtend
      * @param ?list<class-string|callable> $plugins
      * @param ?ServicesToExtendMap $servicesToExtend
-     * @param array<string,Closure> $factories
-     * @param array<string,Closure> $protectedServices
-     * @param array<string,string> $aliases
+     * @param ServiceFactoryMap $factories
+     * @param ServiceFactoryMap $protectedServices
+     * @param ServiceAliasMap $aliases
      * @param ContextualBindingsMap $contextualBindings
      * @param HandlerRegistriesMap $handlerRegistries
-     * @param array<string,Closure> $lazyServices
+     * @param ServiceFactoryMap $lazyServices
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap\Setup;
 
-use Closure;
 use Gacela\Framework\Bootstrap\BuilderConfigurationInterface;
 use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
@@ -19,9 +19,12 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
  *
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
  * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
+ * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
+ * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
+ * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type SpecificListenersMap from ConfigurableEventDispatcher
  */
 final class Properties
@@ -56,7 +59,7 @@ final class Properties
     /** @var ?list<string> */
     public ?array $appModulePaths = null;
 
-    /** @var ?array<string,mixed> */
+    /** @var ?ConfigKeyValues */
     public ?array $configKeyValues = null;
 
     public ?bool $areEventListenersEnabled = null;
@@ -72,19 +75,19 @@ final class Properties
     /** @var ?ServicesToExtendMap */
     public ?array $servicesToExtend = null;
 
-    /** @var ?array<string,Closure> */
+    /** @var ?ServiceFactoryMap */
     public ?array $factories = null;
 
-    /** @var ?array<string,Closure> */
+    /** @var ?ServiceFactoryMap */
     public ?array $protectedServices = null;
 
-    /** @var ?array<string,string> */
+    /** @var ?ServiceAliasMap */
     public ?array $aliases = null;
 
     /** @var ?ContextualBindingsMap */
     public ?array $contextualBindings = null;
 
-    /** @var ?array<string,Closure> */
+    /** @var ?ServiceFactoryMap */
     public ?array $lazyServices = null;
 
     /** @var ?list<class-string> */

--- a/src/Framework/Bootstrap/Setup/PropertyChangeTracker.php
+++ b/src/Framework/Bootstrap/Setup/PropertyChangeTracker.php
@@ -23,12 +23,4 @@ final class PropertyChangeTracker
     {
         return $this->changedProperties[$propertyName] ?? false;
     }
-
-    /**
-     * @return array<string,bool>
-     */
-    public function getAll(): array
-    {
-        return $this->changedProperties;
-    }
 }

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap\Setup;
 
-use Closure;
 use Gacela\Framework\Bootstrap\BuilderConfigurationInterface;
 use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
 use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 use function array_merge;
@@ -18,8 +18,11 @@ use function array_unique;
  *
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
  * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
+ * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
+ * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
+ * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  */
 final class PropertyMerger
 {
@@ -47,7 +50,7 @@ final class PropertyMerger
     }
 
     /**
-     * @param array<string,mixed> $list
+     * @param ConfigKeyValues $list
      */
     public function mergeConfigKeyValues(array $list): void
     {
@@ -76,7 +79,7 @@ final class PropertyMerger
     }
 
     /**
-     * @param array<string,Closure> $list
+     * @param ServiceFactoryMap $list
      */
     public function mergeFactories(array $list): void
     {
@@ -85,7 +88,7 @@ final class PropertyMerger
     }
 
     /**
-     * @param array<string,Closure> $list
+     * @param ServiceFactoryMap $list
      */
     public function mergeProtectedServices(array $list): void
     {
@@ -94,7 +97,7 @@ final class PropertyMerger
     }
 
     /**
-     * @param array<string,string> $list
+     * @param ServiceAliasMap $list
      */
     public function mergeAliases(array $list): void
     {
@@ -123,7 +126,7 @@ final class PropertyMerger
     }
 
     /**
-     * @param array<string,Closure> $list
+     * @param ServiceFactoryMap $list
      */
     public function mergeLazyServices(array $list): void
     {

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap\Setup;
 
+use Closure;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 
@@ -21,62 +22,37 @@ final class SetupMerger
 
     public function merge(SetupGacela $other): SetupGacela
     {
-        $this->overrideResetInMemoryCache($other);
-        $this->overrideFileCacheSettings($other);
+        $this->whenChanged($other, SetupGacela::shouldResetInMemoryCache, fn () => $this->original->setShouldResetInMemoryCache($other->shouldResetInMemoryCache()));
+        $this->whenChanged($other, SetupGacela::fileCacheEnabled, fn () => $this->original->setFileCacheEnabled($other->isFileCacheEnabled()));
+        $this->whenChanged($other, SetupGacela::fileCacheDirectory, fn () => $this->original->setFileCacheDirectory($other->getFileCacheDirectory()));
 
-        $this->mergeExternalServices($other);
-        $this->mergeProjectNamespaces($other);
-        $this->mergeConfigKeyValues($other);
+        $this->whenChanged($other, SetupGacela::externalServices, fn () => $this->original->mergeExternalServices($other->externalServices()));
+        $this->whenChanged($other, SetupGacela::projectNamespaces, fn () => $this->original->mergeProjectNamespaces($other->getProjectNamespaces()));
+        $this->whenChanged($other, SetupGacela::configKeyValues, fn () => $this->original->mergeConfigKeyValues($other->getConfigKeyValues()));
         $this->mergeEventDispatcher($other);
         $this->mergeServicesToExtend($other);
-        $this->mergeFactories($other);
-        $this->mergeProtectedServices($other);
-        $this->mergeAliases($other);
-        $this->mergeContextualBindings($other);
-        $this->mergeHandlerRegistries($other);
-        $this->mergeLazyServices($other);
-        $this->mergePlugins($other);
-        $this->mergeGacelaConfigsToExtend($other);
+        $this->whenChanged($other, SetupGacela::factories, fn () => $this->original->mergeFactories($other->getFactories()));
+        $this->whenChanged($other, SetupGacela::protectedServices, fn () => $this->original->mergeProtectedServices($other->getProtectedServices()));
+        $this->whenChanged($other, SetupGacela::aliases, fn () => $this->original->mergeAliases($other->getAliases()));
+        $this->whenChanged($other, SetupGacela::contextualBindings, fn () => $this->original->mergeContextualBindings($other->getContextualBindings()));
+        $this->whenChanged($other, SetupGacela::handlerRegistries, fn () => $this->original->mergeHandlerRegistries($other->getHandlerRegistries()));
+        $this->whenChanged($other, SetupGacela::lazyServices, fn () => $this->original->mergeLazyServices($other->getLazyServices()));
+        $this->whenChanged($other, SetupGacela::plugins, fn () => $this->original->mergePlugins($other->getPlugins()));
+        $this->whenChanged($other, SetupGacela::gacelaConfigsToExtend, fn () => $this->original->mergeGacelaConfigsToExtend($other->getGacelaConfigsToExtend()));
 
         return $this->original;
     }
 
-    private function overrideResetInMemoryCache(SetupGacela $other): void
+    /**
+     * Apply $merge only when $other explicitly set $property, so an untouched
+     * property on the incoming setup never overwrites the original's value.
+     *
+     * @param Closure():mixed $merge
+     */
+    private function whenChanged(SetupGacela $other, string $property, Closure $merge): void
     {
-        if ($other->isPropertyChanged(SetupGacela::shouldResetInMemoryCache)) {
-            $this->original->setShouldResetInMemoryCache($other->shouldResetInMemoryCache());
-        }
-    }
-
-    private function overrideFileCacheSettings(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::fileCacheEnabled)) {
-            $this->original->setFileCacheEnabled($other->isFileCacheEnabled());
-        }
-
-        if ($other->isPropertyChanged(SetupGacela::fileCacheDirectory)) {
-            $this->original->setFileCacheDirectory($other->getFileCacheDirectory());
-        }
-    }
-
-    private function mergeExternalServices(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::externalServices)) {
-            $this->original->mergeExternalServices($other->externalServices());
-        }
-    }
-
-    private function mergeProjectNamespaces(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::projectNamespaces)) {
-            $this->original->mergeProjectNamespaces($other->getProjectNamespaces());
-        }
-    }
-
-    private function mergeConfigKeyValues(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::configKeyValues)) {
-            $this->original->mergeConfigKeyValues($other->getConfigKeyValues());
+        if ($other->isPropertyChanged($property)) {
+            $merge();
         }
     }
 
@@ -110,62 +86,6 @@ final class SetupMerger
             foreach ($other->getServicesToExtend() as $serviceId => $otherServiceToExtend) {
                 $this->original->addServicesToExtend($serviceId, $otherServiceToExtend);
             }
-        }
-    }
-
-    private function mergePlugins(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::plugins)) {
-            $this->original->mergePlugins($other->getPlugins());
-        }
-    }
-
-    private function mergeGacelaConfigsToExtend(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::gacelaConfigsToExtend)) {
-            $this->original->mergeGacelaConfigsToExtend($other->getGacelaConfigsToExtend());
-        }
-    }
-
-    private function mergeFactories(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::factories)) {
-            $this->original->mergeFactories($other->getFactories());
-        }
-    }
-
-    private function mergeProtectedServices(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::protectedServices)) {
-            $this->original->mergeProtectedServices($other->getProtectedServices());
-        }
-    }
-
-    private function mergeAliases(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::aliases)) {
-            $this->original->mergeAliases($other->getAliases());
-        }
-    }
-
-    private function mergeContextualBindings(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::contextualBindings)) {
-            $this->original->mergeContextualBindings($other->getContextualBindings());
-        }
-    }
-
-    private function mergeHandlerRegistries(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::handlerRegistries)) {
-            $this->original->mergeHandlerRegistries($other->getHandlerRegistries());
-        }
-    }
-
-    private function mergeLazyServices(SetupGacela $other): void
-    {
-        if ($other->isPropertyChanged(SetupGacela::lazyServices)) {
-            $this->original->mergeLazyServices($other->getLazyServices());
         }
     }
 }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -27,6 +27,9 @@ use function sprintf;
  *
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
  * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
+ * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
+ * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
+ * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
@@ -269,7 +272,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return array<string,mixed>
+     * @return ConfigKeyValues
      */
     public function getConfigKeyValues(): array
     {
@@ -290,7 +293,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return array<string,Closure>
+     * @return ServiceFactoryMap
      */
     public function getFactories(): array
     {
@@ -298,7 +301,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return array<string,Closure>
+     * @return ServiceFactoryMap
      */
     public function getProtectedServices(): array
     {
@@ -306,7 +309,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return array<string,string>
+     * @return ServiceAliasMap
      */
     public function getAliases(): array
     {
@@ -330,7 +333,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @return array<string,Closure>
+     * @return ServiceFactoryMap
      */
     public function getLazyServices(): array
     {
@@ -355,7 +358,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param ?array<string,mixed> $configKeyValues
+     * @param ?ConfigKeyValues $configKeyValues
      */
     public function setConfigKeyValues(?array $configKeyValues): self
     {
@@ -429,7 +432,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,mixed> $list
+     * @param ConfigKeyValues $list
      */
     public function mergeConfigKeyValues(array $list): void
     {
@@ -453,7 +456,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,Closure> $list
+     * @param ServiceFactoryMap $list
      */
     public function mergeFactories(array $list): void
     {
@@ -461,7 +464,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,Closure> $list
+     * @param ServiceFactoryMap $list
      */
     public function mergeProtectedServices(array $list): void
     {
@@ -469,7 +472,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,string> $list
+     * @param ServiceAliasMap $list
      */
     public function mergeAliases(array $list): void
     {
@@ -485,7 +488,7 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
-     * @param array<string,Closure> $list
+     * @param ServiceFactoryMap $list
      */
     public function mergeLazyServices(array $list): void
     {
@@ -581,7 +584,7 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @internal Used by SetupInitializer - do not call directly
      *
-     * @param ?array<string,Closure> $list
+     * @param ?ServiceFactoryMap $list
      */
     public function setFactories(?array $list): self
     {
@@ -597,7 +600,7 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @internal Used by SetupInitializer - do not call directly
      *
-     * @param ?array<string,Closure> $list
+     * @param ?ServiceFactoryMap $list
      */
     public function setProtectedServices(?array $list): self
     {
@@ -613,7 +616,7 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @internal Used by SetupInitializer - do not call directly
      *
-     * @param ?array<string,string> $list
+     * @param ?ServiceAliasMap $list
      */
     public function setAliases(?array $list): self
     {
@@ -661,7 +664,7 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @internal Used by SetupInitializer - do not call directly
      *
-     * @param ?array<string,Closure> $list
+     * @param ?ServiceFactoryMap $list
      */
     public function setLazyServices(?array $list): self
     {

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -8,6 +8,8 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 
 /**
  * Main configuration interface for Gacela framework setup.
+ *
+ * @psalm-type ConfigKeyValues = array<string, mixed>
  */
 interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerConfigurationInterface, CacheConfigurationInterface
 {
@@ -29,7 +31,7 @@ interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerC
     /**
      * Get the list of key:value configuration.
      *
-     * @return array<string,mixed>
+     * @return ConfigKeyValues
      */
     public function getConfigKeyValues(): array;
 

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -119,7 +119,7 @@ abstract class AbstractPhpFileCache implements CacheInterface
      */
     public function getAll(): array
     {
-        return self::$cache[static::class];
+        return static::all();
     }
 
     public function put(string $cacheKey, string $className): void

--- a/src/Framework/ClassResolver/Cache/InMemoryCache.php
+++ b/src/Framework/ClassResolver/Cache/InMemoryCache.php
@@ -47,7 +47,7 @@ final class InMemoryCache implements CacheInterface
      */
     public function getAll(): array
     {
-        return self::$cache[$this->key] ?? [];
+        return self::getAllFromKey($this->key);
     }
 
     public function has(string $cacheKey): bool

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -7,7 +7,6 @@ namespace Gacela\Framework\ClassResolver;
 use function array_slice;
 use function count;
 use function is_object;
-use function is_string;
 use function sprintf;
 
 final class ClassInfo implements ClassInfoInterface
@@ -81,10 +80,9 @@ final class ClassInfo implements ClassInfoInterface
             return self::$callerClassCache[$callerClass][$resolvableType];
         }
 
-        /** @var list<string> $callerClassParts */
+        /** @var non-empty-list<string> $callerClassParts */
         $callerClassParts = explode('\\', ltrim($callerClass, '\\'));
-        $lastCallerClassPart = end($callerClassParts);
-        $filepath = is_string($lastCallerClassPart) ? $lastCallerClassPart : '';
+        $filepath = end($callerClassParts);
         $filename = self::normalizeFilename($filepath);
 
         if (str_contains($callerClass, 'anonymous')) {

--- a/src/Framework/ClassResolver/ClassNameFinder/ClassValidatorInterface.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/ClassValidatorInterface.php
@@ -6,5 +6,11 @@ namespace Gacela\Framework\ClassResolver\ClassNameFinder;
 
 interface ClassValidatorInterface
 {
+    /**
+     * Narrows a speculative class candidate to a loadable class name, so the
+     * caller can treat it as a `class-string` only after this returns true.
+     *
+     * @phpstan-assert-if-true class-string $className
+     */
     public function isClassNameValid(string $className): bool;
 }

--- a/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleInterface.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleInterface.php
@@ -9,7 +9,10 @@ use Gacela\Framework\ClassResolver\ClassInfo;
 interface FinderRuleInterface
 {
     /**
-     * @return class-string
+     * Builds a speculative class name. The candidate is not guaranteed to name
+     * an existing class; validate it before treating it as a `class-string`.
+     *
+     * @return non-empty-string
      */
     public function buildClassCandidate(string $projectNamespace, string $resolvableType, ClassInfo $classInfo): string;
 }

--- a/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefix.php
+++ b/src/Framework/ClassResolver/ClassNameFinder/Rule/FinderRuleWithModulePrefix.php
@@ -11,7 +11,7 @@ use function sprintf;
 final class FinderRuleWithModulePrefix implements FinderRuleInterface
 {
     /**
-     * @return class-string
+     * @return non-empty-string
      */
     public function buildClassCandidate(string $projectNamespace, string $resolvableType, ClassInfo $classInfo): string
     {

--- a/src/Framework/ClassResolver/DefaultGacelaClass.php
+++ b/src/Framework/ClassResolver/DefaultGacelaClass.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\ClassResolver;
+
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ClassResolver\Config\ConfigResolver;
+use Gacela\Framework\ClassResolver\Facade\FacadeResolver;
+use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
+
+/**
+ * Fallback instances used when no class could be resolved for a caller.
+ *
+ * Keyed on the resolvable type rather than on the resolver's class identity, so
+ * the fixed resolvers and the dynamically-typed {@see \Gacela\Framework\ClassResolver\DocBlockService\DocBlockServiceResolver}
+ * share one definition. Types without a meaningful empty implementation
+ * (Provider, DependencyProvider, custom types) resolve to null.
+ *
+ * @internal
+ */
+final class DefaultGacelaClass
+{
+    public static function forType(string $resolvableType): ?object
+    {
+        return match ($resolvableType) {
+            FacadeResolver::TYPE => new /**
+             * @extends AbstractFacade<AbstractFactory>
+             */ class() extends AbstractFacade {},
+            FactoryResolver::TYPE => new /**
+             * @extends AbstractFactory<AbstractConfig>
+             */ class() extends AbstractFactory {},
+            ConfigResolver::TYPE => new class() extends AbstractConfig {},
+            default => null,
+        };
+    }
+}

--- a/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
+++ b/src/Framework/ClassResolver/GlobalInstance/AnonymousGlobal.php
@@ -102,12 +102,10 @@ final class AnonymousGlobal
         }
 
         $callerClass = $context::class;
-        /** @var list<string> $callerClassParts */
+        /** @var non-empty-list<string> $callerClassParts */
         $callerClassParts = explode('\\', $callerClass);
 
-        $lastCallerClassParts = end($callerClassParts);
-
-        return is_string($lastCallerClassParts) ? $lastCallerClassParts : '';
+        return end($callerClassParts);
     }
 
     private static function validateTypeForAnonymousGlobalRegistration(string $type): void

--- a/src/Framework/ClassResolver/Provider/DependencyProviderResolver.php
+++ b/src/Framework/ClassResolver/Provider/DependencyProviderResolver.php
@@ -9,7 +9,9 @@ use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\ClassResolver\AbstractClassResolver;
 use Gacela\Framework\ClassResolver\ClassInfo;
 
-use function function_exists;
+use function sprintf;
+
+use const E_USER_DEPRECATED;
 
 /**
  * @psalm-suppress DeprecatedClass
@@ -26,16 +28,21 @@ final class DependencyProviderResolver extends AbstractClassResolver
         /** @var ?AbstractDependencyProvider $resolved */
         $resolved = $this->doResolve($caller);
 
-        // `trigger_deprecation()` comes from symfony/deprecation-contracts, which is not a
-        // runtime dependency of gacela; skip the notice when the function is unavailable.
-        if ($resolved instanceof AbstractDependencyProvider && function_exists('trigger_deprecation')) {
-            trigger_deprecation(
-                'gacela-project/gacela',
-                '1.8',
-                "`%s` is deprecated and will be removed in version 2.0.\nUse `%s` instead. Where? Check your module `%s`",
-                AbstractDependencyProvider::class,
-                AbstractProvider::class,
-                ClassInfo::from($caller, self::TYPE)->getModuleName(),
+        if ($resolved instanceof AbstractDependencyProvider) {
+            // Emitted directly rather than through `trigger_deprecation()`: that function comes
+            // from symfony/deprecation-contracts, which is not a runtime dependency of gacela, so
+            // guarding on it silenced this notice for everyone without symfony installed. The
+            // message keeps the contract's "Since <package> <version>: " format, so deprecation
+            // collectors group it exactly as before.
+            @trigger_error(
+                sprintf(
+                    "Since gacela-project/gacela 1.8: `%s` is deprecated and will be removed in version 2.0.\n"
+                    . 'Use `%s` instead. Where? Check your module `%s`',
+                    AbstractDependencyProvider::class,
+                    AbstractProvider::class,
+                    ClassInfo::from($caller, self::TYPE)->getModuleName(),
+                ),
+                E_USER_DEPRECATED,
             );
         }
 

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
-use Gacela\Framework\AbstractConfig;
-use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigFromBootstrapFactory;
 use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigUsingGacelaPhpFileFactory;
@@ -17,9 +15,13 @@ use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
 use function sprintf;
 
 /**
- * @extends AbstractFactory<AbstractConfig>
+ * Assembles the configuration during bootstrap, before any module exists.
+ *
+ * Deliberately not an AbstractFactory: that base is for module factories and
+ * pulls in the container, the config resolver and the provider resolvers —
+ * none of which are available (or needed) this early.
  */
-final class ConfigFactory extends AbstractFactory
+final class ConfigFactory
 {
     private const GACELA_PHP_CONFIG_FILENAME = 'gacela';
 

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFileAssembler.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFileAssembler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\GacelaFileConfig\Factory;
+
+use Gacela\Framework\Bootstrap\BuilderConfigurationInterface;
+use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
+use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+
+/**
+ * Runs a setup's three builder hooks and assembles the resulting config file.
+ *
+ * Every builder hook is invoked before any of them is materialized with
+ * `build()`, so a hook can still observe the state a previous hook left behind.
+ *
+ * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
+ */
+final class GacelaConfigFileAssembler
+{
+    /**
+     * @param ExternalServicesMap $externalServices
+     */
+    public static function assemble(
+        BuilderConfigurationInterface $setup,
+        array $externalServices = [],
+    ): GacelaConfigFileInterface {
+        $configBuilder = $setup->buildAppConfig(new AppConfigBuilder());
+        $bindingsBuilder = $setup->buildBindings(new BindingsBuilder(), $externalServices);
+        $suffixTypesBuilder = $setup->buildSuffixTypes(new SuffixTypesBuilder());
+
+        return (new GacelaConfigFile())
+            ->setConfigItems($configBuilder->build())
+            ->setBindings($bindingsBuilder->build())
+            ->setSuffixTypes($suffixTypesBuilder->build());
+    }
+}

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigFromBootstrapFactory.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config\GacelaFileConfig\Factory;
 
 use Gacela\Framework\Bootstrap\BuilderConfigurationInterface;
-use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
-use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
 final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryInterface
@@ -21,28 +17,6 @@ final class GacelaConfigFromBootstrapFactory implements GacelaConfigFileFactoryI
 
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $configBuilder = $this->createConfigBuilder();
-        $bindingsBuilder = $this->createBindingsBuilder();
-        $suffixTypesBuilder = $this->createSuffixTypesBuilder();
-
-        return (new GacelaConfigFile())
-            ->setConfigItems($configBuilder->build())
-            ->setBindings($bindingsBuilder->build())
-            ->setSuffixTypes($suffixTypesBuilder->build());
-    }
-
-    private function createConfigBuilder(): AppConfigBuilder
-    {
-        return $this->bootstrapSetup->buildAppConfig(new AppConfigBuilder());
-    }
-
-    private function createBindingsBuilder(): BindingsBuilder
-    {
-        return $this->bootstrapSetup->buildBindings(new BindingsBuilder(), []);
-    }
-
-    private function createSuffixTypesBuilder(): SuffixTypesBuilder
-    {
-        return $this->bootstrapSetup->buildSuffixTypes(new SuffixTypesBuilder());
+        return GacelaConfigFileAssembler::assemble($this->bootstrapSetup);
     }
 }

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -4,16 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config\GacelaFileConfig\Factory;
 
-use Gacela\Framework\Bootstrap\BuilderConfigurationInterface;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\FileIoInterface;
-use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
-use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaConfigFileFactoryInterface;
-use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use RuntimeException;
 
@@ -35,14 +30,10 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
 
         $this->bootstrapSetup->merge($projectSetupGacela);
 
-        $configBuilder = $this->createConfigBuilder($projectSetupGacela);
-        $bindingsBuilder = $this->createBindingsBuilder($projectSetupGacela);
-        $suffixTypesBuilder = $this->createSuffixTypesBuilder($projectSetupGacela);
-
-        return (new GacelaConfigFile())
-            ->setConfigItems($configBuilder->build())
-            ->setBindings($bindingsBuilder->build())
-            ->setSuffixTypes($suffixTypesBuilder->build());
+        return GacelaConfigFileAssembler::assemble(
+            $projectSetupGacela,
+            $this->bootstrapSetup->externalServices(),
+        );
     }
 
     private function createGacelaConfig(): GacelaConfig
@@ -59,20 +50,5 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         $configFn($gacelaConfig);
 
         return $gacelaConfig;
-    }
-
-    private function createConfigBuilder(BuilderConfigurationInterface $setupGacela): AppConfigBuilder
-    {
-        return $setupGacela->buildAppConfig(new AppConfigBuilder());
-    }
-
-    private function createBindingsBuilder(BuilderConfigurationInterface $setupGacela): BindingsBuilder
-    {
-        return $setupGacela->buildBindings(new BindingsBuilder(), $this->bootstrapSetup->externalServices());
-    }
-
-    private function createSuffixTypesBuilder(BuilderConfigurationInterface $setupGacela): SuffixTypesBuilder
-    {
-        return $setupGacela->buildSuffixTypes(new SuffixTypesBuilder());
     }
 }

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -100,7 +100,6 @@ final class Container extends GacelaContainer implements ContainerInterface
             );
         }
 
-        // Register lazy services - wrapped as factories that instantiate on first access
         foreach ($containerConfig->getLazyServices() as $id => $lazyFactory) {
             $container->set($id, $container->factory(static fn (): mixed => $lazyFactory($container)));
             self::notifyBindingRegistered($id);

--- a/src/Framework/Container/Locator.php
+++ b/src/Framework/Container/Locator.php
@@ -30,17 +30,6 @@ final class Locator implements LocatorInterface
     /**
      * @template T
      *
-     * @param class-string<T> $key
-     * @param T $value
-     */
-    public static function addSingleton(string $key, mixed $value): void
-    {
-        self::getInstance()->add($key, $value);
-    }
-
-    /**
-     * @template T
-     *
      * @param class-string<T> $className
      *
      * @return T|null

--- a/src/Framework/Profiler/Profiler.php
+++ b/src/Framework/Profiler/Profiler.php
@@ -175,6 +175,6 @@ final class Profiler
 
     private function getCurrentTime(): float
     {
-        return (float)hrtime(true) / 1e9; // Convert nanoseconds to seconds
+        return (float)hrtime(true) / 1e9;
     }
 }

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -11,7 +11,6 @@ use Gacela\Framework\ClassResolver\DocBlockService\UseBlockParser;
 use ReflectionAttribute;
 use ReflectionClass;
 
-use function is_string;
 use function sprintf;
 
 final class DocBlockResolver
@@ -160,13 +159,9 @@ final class DocBlockResolver
 
     private function normalizeResolvableType(string $resolvableType): string
     {
-        /** @var list<string> $resolvableTypeParts */
+        /** @var non-empty-list<string> $resolvableTypeParts */
         $resolvableTypeParts = explode('\\', $resolvableType);
-        $normalizedResolvableType = end($resolvableTypeParts);
-
-        $result = is_string($normalizedResolvableType)
-            ? $normalizedResolvableType
-            : $resolvableType;
+        $result = end($resolvableTypeParts);
 
         foreach (self::SPECIAL_RESOLVABLE_TYPES as $specialName) {
             if (str_contains($result, $specialName)) {

--- a/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
+++ b/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
@@ -84,13 +84,11 @@ final class CacheWarmCommandTest extends TestCase
 
     public function test_cache_warm_with_clear_option(): void
     {
-        // Ensure cache directory exists
         $cacheDir = dirname($this->cacheFile);
         if (!is_dir($cacheDir)) {
             mkdir($cacheDir, 0777, true);
         }
 
-        // Create a cache file first
         file_put_contents($this->cacheFile, '<?php return [];');
         self::assertFileExists($this->cacheFile);
 
@@ -108,7 +106,6 @@ final class CacheWarmCommandTest extends TestCase
 
         $output = $this->command->getDisplay();
 
-        // Should find at least the test facade in this directory
         self::assertStringContainsString('Found', $output);
         self::assertStringContainsString('modules', $output);
     }
@@ -119,7 +116,6 @@ final class CacheWarmCommandTest extends TestCase
 
         $output = $this->command->getDisplay();
 
-        // Check for statistics
         self::assertMatchesRegularExpression('/Modules processed:\s+\d+/', $output);
         self::assertMatchesRegularExpression('/Classes resolved:\s+\d+/', $output);
         self::assertMatchesRegularExpression('/Classes skipped:\s+\d+/', $output);

--- a/tests/Feature/Console/CodeGenerator/MakeFileCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeFileCommandTest.php
@@ -39,14 +39,12 @@ final class MakeFileCommandTest extends TestCase
 
         $description = $command->getDescription();
 
-        // Test that the description contains 'Generate a ' followed by the expected filenames
         self::assertStringContainsString('Generate a ', $description);
         self::assertStringContainsString('Facade', $description);
         self::assertStringContainsString('Factory', $description);
         self::assertStringContainsString('Config', $description);
         self::assertStringContainsString('Provider', $description);
 
-        // Ensure it's in the correct order (not reversed)
         self::assertStringStartsWith('Generate a ', $description);
     }
 
@@ -72,7 +70,6 @@ final class MakeFileCommandTest extends TestCase
         yield 'config' => ['config', 'TestModuleConfig', false];
         yield 'dependency provider' => ['dependency-provider', 'TestModuleProvider', false];
 
-        // Short name flag
         yield 'facade -s' => ['facade', 'Facade', true];
         yield 'factory -s' => ['factory', 'Factory', true];
         yield 'config -s' => ['config', 'Config', true];

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -45,14 +45,12 @@ final class MakeModuleCommandTest extends TestCase
 
         $description = $command->getDescription();
 
-        // Test that the description contains 'Generate a basic module with an empty ' followed by the expected filenames
         self::assertStringContainsString('Generate a basic module with an empty ', $description);
         self::assertStringContainsString('Facade', $description);
         self::assertStringContainsString('Factory', $description);
         self::assertStringContainsString('Config', $description);
         self::assertStringContainsString('Provider', $description);
 
-        // Ensure it's in the correct order (not reversed or partial)
         self::assertStringStartsWith('Generate a basic module with an empty ', $description);
     }
 

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -53,7 +53,6 @@ TXT;
         self::assertStringContainsString('TestModule3Facade', $output);
         self::assertStringContainsString('TestModule1Factory', $output);
 
-        // Test that modules are numbered starting from 1 (not 0 or 2)
         self::assertStringContainsString('1.-', $output);
         self::assertStringContainsString('2.-', $output);
         self::assertStringContainsString('3.-', $output);

--- a/tests/Feature/Console/ValidateConfig/Fixtures/CyclicA.php
+++ b/tests/Feature/Console/ValidateConfig/Fixtures/CyclicA.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ValidateConfig\Fixtures;
+
+/**
+ * Half of a deliberate constructor-injection cycle: A needs B, B needs A.
+ * Resolving it makes the container throw a CircularDependencyException.
+ */
+final class CyclicA implements CyclicContract
+{
+    public function __construct(
+        public readonly CyclicB $b,
+    ) {
+    }
+}

--- a/tests/Feature/Console/ValidateConfig/Fixtures/CyclicB.php
+++ b/tests/Feature/Console/ValidateConfig/Fixtures/CyclicB.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ValidateConfig\Fixtures;
+
+/**
+ * The other half of the cycle declared by {@see CyclicA}.
+ */
+final class CyclicB
+{
+    public function __construct(
+        public readonly CyclicA $a,
+    ) {
+    }
+}

--- a/tests/Feature/Console/ValidateConfig/Fixtures/CyclicContract.php
+++ b/tests/Feature/Console/ValidateConfig/Fixtures/CyclicContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ValidateConfig\Fixtures;
+
+interface CyclicContract
+{
+}

--- a/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
+++ b/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
@@ -7,6 +7,8 @@ namespace GacelaTest\Feature\Console\ValidateConfig;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\ValidateConfig\Fixtures\CyclicA;
+use GacelaTest\Feature\Console\ValidateConfig\Fixtures\CyclicContract;
 use GacelaTest\Feature\Console\ValidateConfig\Fixtures\SomeContract;
 use GacelaTest\Feature\Console\ValidateConfig\Fixtures\UnrelatedImplementation;
 use PHPUnit\Framework\TestCase;
@@ -70,6 +72,24 @@ final class ValidateConfigCommandTest extends TestCase
         $output = $this->command->getDisplay();
 
         self::assertStringContainsString('Checking for circular dependencies...', $output);
+    }
+
+    public function test_validate_config_reports_a_real_circular_dependency(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(CyclicContract::class, CyclicA::class);
+        });
+
+        $command = new CommandTester(new ValidateConfigCommand());
+        $exitCode = $command->execute([]);
+
+        $output = $command->getDisplay();
+
+        self::assertStringContainsString('Circular dependency detected', $output);
+        self::assertStringContainsString(CyclicContract::class, $output);
+        self::assertStringNotContainsString('No circular dependencies detected', $output);
+        self::assertSame(1, $exitCode);
     }
 
     public function test_validate_config_explains_binding_mismatch(): void

--- a/tests/Integration/Architecture/DependencyGraph.php
+++ b/tests/Integration/Architecture/DependencyGraph.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function array_filter;
+use function array_keys;
+use function array_pop;
+use function array_values;
+use function count;
+use function file_get_contents;
+use function implode;
+use function in_array;
+use function min;
+use function sort;
+use function str_starts_with;
+use function strrpos;
+use function substr;
+
+/**
+ * Builds the intra-`src/` dependency graph and reports its cycles.
+ *
+ * The graph comes from the parsed AST rather than from `use` statements: a class
+ * referencing another class in the *same* namespace needs no import, so an
+ * import-based graph silently drops every same-namespace edge — around a quarter
+ * of this tree — and reports far smaller cycles than actually exist.
+ *
+ * Every reference that creates a compile- or run-time coupling is an edge:
+ * extends, implements, trait use, new, static calls, class constants, `::class`,
+ * instanceof, catch, attributes, and parameter/return/property types.
+ */
+final class DependencyGraph
+{
+    /**
+     * @param array<string, list<string>> $classEdges
+     * @param array<string, list<string>> $namespaceEdges
+     */
+    private function __construct(
+        private readonly array $classEdges,
+        private readonly array $namespaceEdges,
+    ) {
+    }
+
+    public static function fromDirectory(string $directory): self
+    {
+        $collector = self::collect($directory);
+        $classEdges = self::internalEdges($collector);
+
+        return new self($classEdges, self::aggregateToNamespaces($classEdges));
+    }
+
+    /**
+     * Each cycle is the sorted list of its members joined by ' | '.
+     *
+     * @return list<string>
+     */
+    public function classCycles(): array
+    {
+        return self::cyclesOf($this->classEdges);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function namespaceCycles(): array
+    {
+        return self::cyclesOf($this->namespaceEdges);
+    }
+
+    /**
+     * @param array<string, list<string>> $edges
+     *
+     * @return list<string>
+     */
+    private static function cyclesOf(array $edges): array
+    {
+        $cycles = [];
+
+        foreach (self::stronglyConnectedComponents($edges) as $component) {
+            if (count($component) < 2) {
+                continue;
+            }
+            sort($component);
+            $cycles[] = implode(' | ', $component);
+        }
+        sort($cycles);
+
+        return $cycles;
+    }
+
+    private static function collect(string $directory): NodeVisitorAbstract
+    {
+        $collector = new class() extends NodeVisitorAbstract {
+            /** @var array<string, list<string>> */
+            public array $edges = [];
+
+            /** @var array<string, true> */
+            public array $defined = [];
+
+            /** @var list<string> */
+            private array $stack = [];
+
+            public function enterNode(Node $node): null
+            {
+                if ($node instanceof Node\Stmt\ClassLike) {
+                    $this->enterClassLike($node);
+
+                    return null;
+                }
+
+                $current = $this->current();
+                if ($current === null) {
+                    return null;
+                }
+
+                foreach (self::referencesOf($node) as $reference) {
+                    $this->addEdge($current, $reference);
+                }
+
+                return null;
+            }
+
+            public function leaveNode(Node $node): null
+            {
+                if ($node instanceof Node\Stmt\ClassLike && $node->namespacedName !== null) {
+                    array_pop($this->stack);
+                }
+
+                return null;
+            }
+
+            /**
+             * @return list<string>
+             */
+            private static function referencesOf(Node $node): array
+            {
+                if ($node instanceof Node\Stmt\TraitUse) {
+                    return self::names($node->traits);
+                }
+                if ($node instanceof Node\Stmt\Catch_) {
+                    return self::names($node->types);
+                }
+                if ($node instanceof Node\Attribute) {
+                    return [$node->name->toString()];
+                }
+                if ($node instanceof Node\Expr\New_
+                    || $node instanceof Node\Expr\StaticCall
+                    || $node instanceof Node\Expr\StaticPropertyFetch
+                    || $node instanceof Node\Expr\ClassConstFetch
+                    || $node instanceof Node\Expr\Instanceof_
+                ) {
+                    return $node->class instanceof Node\Name ? [$node->class->toString()] : [];
+                }
+                if ($node instanceof Node\Param) {
+                    return self::typeNames($node->type);
+                }
+                if ($node instanceof Node\Stmt\Property) {
+                    return self::typeNames($node->type);
+                }
+                if ($node instanceof Node\FunctionLike) {
+                    return self::typeNames($node->getReturnType());
+                }
+
+                return [];
+            }
+
+            /**
+             * @param array<Node\Name> $names
+             *
+             * @return list<string>
+             */
+            private static function names(array $names): array
+            {
+                $out = [];
+                foreach ($names as $name) {
+                    $out[] = $name->toString();
+                }
+
+                return $out;
+            }
+
+            /**
+             * @return list<string>
+             */
+            private static function typeNames(?Node $type): array
+            {
+                if ($type instanceof Node\Name) {
+                    return [$type->toString()];
+                }
+                if ($type instanceof Node\NullableType) {
+                    return self::typeNames($type->type);
+                }
+                if ($type instanceof Node\UnionType || $type instanceof Node\IntersectionType) {
+                    $out = [];
+                    foreach ($type->types as $inner) {
+                        foreach (self::typeNames($inner) as $name) {
+                            $out[] = $name;
+                        }
+                    }
+
+                    return $out;
+                }
+
+                return [];
+            }
+
+            private function enterClassLike(Node\Stmt\ClassLike $node): void
+            {
+                if ($node->namespacedName === null) {
+                    return;
+                }
+
+                $fqn = $node->namespacedName->toString();
+                $this->stack[] = $fqn;
+                $this->defined[$fqn] = true;
+                $this->edges[$fqn] ??= [];
+
+                if ($node instanceof Node\Stmt\Class_ && $node->extends instanceof Node\Name) {
+                    $this->addEdge($fqn, $node->extends->toString());
+                }
+                if ($node instanceof Node\Stmt\Interface_) {
+                    foreach (self::names($node->extends) as $name) {
+                        $this->addEdge($fqn, $name);
+                    }
+                }
+                if ($node instanceof Node\Stmt\Class_ || $node instanceof Node\Stmt\Enum_) {
+                    foreach (self::names($node->implements) as $name) {
+                        $this->addEdge($fqn, $name);
+                    }
+                }
+            }
+
+            private function current(): ?string
+            {
+                return $this->stack === [] ? null : $this->stack[count($this->stack) - 1];
+            }
+
+            private function addEdge(string $from, string $to): void
+            {
+                if ($from === $to || !str_starts_with($to, 'Gacela\\')) {
+                    return;
+                }
+                if (in_array($to, $this->edges[$from] ?? [], true)) {
+                    return;
+                }
+                $this->edges[$from][] = $to;
+            }
+        };
+
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+        /** @var iterable<SplFileInfo> $files */
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+        );
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $traverser = new NodeTraverser();
+            $traverser->addVisitor(new NameResolver());
+            $traverser->addVisitor($collector);
+            $traverser->traverse($parser->parse((string) file_get_contents($file->getPathname())) ?? []);
+        }
+
+        return $collector;
+    }
+
+    /**
+     * Drops references to classes outside `src/` (vendor, PHP core) so the graph
+     * only contains edges this repository can actually change.
+     *
+     * @return array<string, list<string>>
+     */
+    private static function internalEdges(NodeVisitorAbstract $collector): array
+    {
+        /** @var array<string, list<string>> $rawEdges */
+        $rawEdges = $collector->edges;
+        /** @var array<string, true> $defined */
+        $defined = $collector->defined;
+
+        $edges = [];
+        foreach ($rawEdges as $from => $targets) {
+            $edges[$from] = array_values(array_filter(
+                $targets,
+                static fn (string $to): bool => isset($defined[$to]),
+            ));
+        }
+
+        return $edges;
+    }
+
+    /**
+     * @param array<string, list<string>> $classEdges
+     *
+     * @return array<string, list<string>>
+     */
+    private static function aggregateToNamespaces(array $classEdges): array
+    {
+        $edges = [];
+
+        foreach ($classEdges as $from => $targets) {
+            $fromNamespace = self::namespaceOf($from);
+            $edges[$fromNamespace] ??= [];
+
+            foreach ($targets as $to) {
+                $toNamespace = self::namespaceOf($to);
+                if ($fromNamespace === $toNamespace || in_array($toNamespace, $edges[$fromNamespace], true)) {
+                    continue;
+                }
+                $edges[$fromNamespace][] = $toNamespace;
+            }
+        }
+
+        return $edges;
+    }
+
+    private static function namespaceOf(string $fqn): string
+    {
+        $position = strrpos($fqn, '\\');
+
+        return $position === false ? $fqn : substr($fqn, 0, $position);
+    }
+
+    /**
+     * Tarjan's strongly-connected-components algorithm (iterative).
+     *
+     * @param array<string, list<string>> $edges
+     *
+     * @return list<list<string>>
+     */
+    private static function stronglyConnectedComponents(array $edges): array
+    {
+        $index = [];
+        $low = [];
+        $onStack = [];
+        $stack = [];
+        $result = [];
+        $counter = 0;
+
+        foreach (array_keys($edges) as $start) {
+            if (isset($index[$start])) {
+                continue;
+            }
+
+            // Iterative DFS: each frame tracks the node and how far through its edges we are.
+            $work = [[$start, 0]];
+
+            while ($work !== []) {
+                [$node, $edgePointer] = $work[count($work) - 1];
+
+                if ($edgePointer === 0) {
+                    $index[$node] = $counter;
+                    $low[$node] = $counter;
+                    ++$counter;
+                    $stack[] = $node;
+                    $onStack[$node] = true;
+                }
+
+                $recursed = false;
+                $neighbors = $edges[$node] ?? [];
+                for ($i = $edgePointer; $i < count($neighbors); ++$i) {
+                    $next = $neighbors[$i];
+                    if (!isset($edges[$next])) {
+                        continue;
+                    }
+                    if (!isset($index[$next])) {
+                        $work[count($work) - 1] = [$node, $i + 1];
+                        $work[] = [$next, 0];
+                        $recursed = true;
+                        break;
+                    }
+                    if (($onStack[$next] ?? false) === true) {
+                        $low[$node] = min($low[$node], $index[$next]);
+                    }
+                }
+
+                if ($recursed) {
+                    continue;
+                }
+
+                if ($low[$node] === $index[$node]) {
+                    $component = [];
+                    do {
+                        $w = array_pop($stack);
+                        $onStack[$w] = false;
+                        $component[] = $w;
+                    } while ($w !== $node);
+                    $result[] = $component;
+                }
+
+                array_pop($work);
+                if ($work !== []) {
+                    $parent = $work[count($work) - 1][0];
+                    $low[$parent] = min($low[$parent], $low[$node]);
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Integration/Architecture/DependencyGraph.php
+++ b/tests/Integration/Architecture/DependencyGraph.php
@@ -110,7 +110,7 @@ final class DependencyGraph
             /** @var list<string> */
             private array $stack = [];
 
-            public function enterNode(Node $node): null
+            public function enterNode(Node $node): ?Node
             {
                 if ($node instanceof Node\Stmt\ClassLike) {
                     $this->enterClassLike($node);
@@ -130,7 +130,7 @@ final class DependencyGraph
                 return null;
             }
 
-            public function leaveNode(Node $node): null
+            public function leaveNode(Node $node): ?Node
             {
                 if ($node instanceof Node\Stmt\ClassLike && $node->namespacedName !== null) {
                     array_pop($this->stack);

--- a/tests/Integration/Architecture/NoCircularDependenciesTest.php
+++ b/tests/Integration/Architecture/NoCircularDependenciesTest.php
@@ -5,31 +5,26 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Architecture;
 
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use SplFileInfo;
 
-use function array_keys;
-use function count;
-use function file_get_contents;
+use function array_diff;
+use function array_values;
 use function implode;
-use function preg_match;
-use function preg_match_all;
-use function sort;
 use function sprintf;
 
 /**
- * Guards the source tree against circular dependencies between classes.
+ * Guards the source tree against circular dependencies, at both the class and
+ * the namespace (package) level.
  *
- * The graph is built from fully-qualified `use Gacela\{Framework,Console,PHPStan}\...`
- * imports (short-name matching would conflate the framework `Container` with the vendor
- * `Gacela\Container\Container`), then Tarjan's algorithm reports every strongly connected
- * component larger than one node.
+ * The graph is built from the AST — see {@see DependencyGraph} for why an
+ * import-based graph is not good enough — and Tarjan's algorithm reports every
+ * strongly connected component larger than one node.
  *
- * Two benign cycles are allow-listed: cohesive aggregate/helper clusters where the
- * back-edge is a constructor dependency or a parameter type, and where inverting the
- * dependency would add indirection without decoupling anything real. Any *new* cycle
- * fails the test.
+ * Cycles that are cohesive by design are allow-listed below with a rationale.
+ * Any *new* cycle fails the test.
+ *
+ * Note the allow-list forgives a whole component: while a component is listed,
+ * new edges *among its existing members* are not detected. That is the cost of
+ * listing the large bootstrap component, and a reason to keep shrinking it.
  */
 final class NoCircularDependenciesTest extends TestCase
 {
@@ -40,182 +35,171 @@ final class NoCircularDependenciesTest extends TestCase
      *
      * @var list<string>
      */
-    private const ALLOWED_CYCLES = [
-        'Gacela\Framework\AbstractProvider | Gacela\Framework\Attribute\ProvidesScanner',
-        'Gacela\Framework\Bootstrap\SetupGacela | Gacela\Framework\Bootstrap\Setup\PropertyMerger'
-            . ' | Gacela\Framework\Bootstrap\Setup\SetupInitializer | Gacela\Framework\Bootstrap\Setup\SetupMerger',
+    private const ALLOWED_CLASS_CYCLES = [
+        // The bootstrap knot. Config needs a ConfigFactory to read `gacela.php`, that
+        // file produces a SetupGacela, setup resolves extenders and health checks
+        // through the Container, and the Container reads its bindings back off Config:
+        //
+        //   Config -> ConfigFactory -> GacelaConfigUsingGacelaPhpFileFactory
+        //     -> SetupGacela -> {GacelaConfigExtender, HealthCheckRegistry}
+        //     -> Container -> Config
+        //
+        // `Container::withConfig(Config)` is the single edge every path returns
+        // through, and inverting it (Config builds the Container, not the reverse)
+        // is what unpicks this component. That is a BC break on a public method, so
+        // it is deferred; until then the whole component is listed.
+        //
+        // Two sub-clusters inside it are cohesive on their own merits and are
+        // expected to survive even after the knot is cut:
+        //   - SetupGacela + its Setup\* strategy helpers: an aggregate and the
+        //     strategies extracted from it; the back-edges are parameter/return
+        //     types, and SetupMerger alone reads 17 of its constants.
+        //   - Container + Locator: a container and its service locator, both
+        //     @internal, one concept split across two classes.
+        'Gacela\Framework\Bootstrap\AbstractSetupGacela'
+            . ' | Gacela\Framework\Bootstrap\GacelaConfig'
+            . ' | Gacela\Framework\Bootstrap\SetupEventDispatcher'
+            . ' | Gacela\Framework\Bootstrap\SetupGacela'
+            . ' | Gacela\Framework\Bootstrap\SetupGacelaInterface'
+            . ' | Gacela\Framework\Bootstrap\Setup\GacelaConfigExtender'
+            . ' | Gacela\Framework\Bootstrap\Setup\PropertyMerger'
+            . ' | Gacela\Framework\Bootstrap\Setup\SetupInitializer'
+            . ' | Gacela\Framework\Bootstrap\Setup\SetupMerger'
+            . ' | Gacela\Framework\ClassResolver\Cache\GacelaFileCache'
+            . ' | Gacela\Framework\Config\Config'
+            . ' | Gacela\Framework\Config\ConfigFactory'
+            . ' | Gacela\Framework\Config\ConfigInterface'
+            . ' | Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigUsingGacelaPhpFileFactory'
+            . ' | Gacela\Framework\Container\Container'
+            . ' | Gacela\Framework\Container\Locator'
+            . ' | Gacela\Framework\Health\HealthCheckRegistry',
     ];
 
-    public function test_source_tree_has_no_unexpected_circular_dependencies(): void
+    /**
+     * Package-level cycles. These are looser than class cycles by nature: a
+     * namespace pair is cyclic as soon as any one class on each side points at
+     * the other, so a framework that configures itself is cyclic here almost by
+     * construction — resolving a config class needs the class resolver, and the
+     * class resolver needs config to know where to look.
+     *
+     * Both entries are accepted for 1.x. Splitting them needs classes moved
+     * between namespaces, which is a BC break for a public library.
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_NAMESPACE_CYCLES = [
+        // One component covering most of Gacela\Framework. It is the package-level
+        // shadow of the class cycle allow-listed above, widened by two things that
+        // are cyclic only at namespace granularity:
+        //   - the module-facing API (AbstractFacade/Factory/Config/Provider) and the
+        //     resolvers that construct it — each base class names its resolver, and
+        //     each resolver returns the matching base class;
+        //   - the #[Provides] attribute scanner, which reads provider objects that
+        //     the framework root defines.
+        //
+        // Cutting the class cycle above shrinks this but does not remove it: a
+        // namespace pair is cyclic as soon as any one class on each side points at
+        // the other, so a framework that configures itself is cyclic here almost by
+        // construction. Splitting it needs classes moved between namespaces, which
+        // is a BC break on a public library. Accepted for 1.x.
+        'Gacela\Framework'
+            . ' | Gacela\Framework\Attribute'
+            . ' | Gacela\Framework\Bootstrap'
+            . ' | Gacela\Framework\Bootstrap\Setup'
+            . ' | Gacela\Framework\ClassResolver'
+            . ' | Gacela\Framework\ClassResolver\Cache'
+            . ' | Gacela\Framework\ClassResolver\ClassNameFinder'
+            . ' | Gacela\Framework\ClassResolver\ClassNameFinder\Rule'
+            . ' | Gacela\Framework\ClassResolver\Config'
+            . ' | Gacela\Framework\ClassResolver\DocBlockService'
+            . ' | Gacela\Framework\ClassResolver\Facade'
+            . ' | Gacela\Framework\ClassResolver\Factory'
+            . ' | Gacela\Framework\ClassResolver\GlobalInstance'
+            . ' | Gacela\Framework\ClassResolver\Provider'
+            . ' | Gacela\Framework\Config'
+            . ' | Gacela\Framework\Config\ConfigReader'
+            . ' | Gacela\Framework\Config\GacelaConfigBuilder'
+            . ' | Gacela\Framework\Config\GacelaFileConfig'
+            . ' | Gacela\Framework\Config\GacelaFileConfig\Factory'
+            . ' | Gacela\Framework\Config\PathNormalizer'
+            . ' | Gacela\Framework\Container'
+            . ' | Gacela\Framework\Event\ClassResolver'
+            . ' | Gacela\Framework\Event\ClassResolver\ClassNameFinder'
+            . ' | Gacela\Framework\Health'
+            . ' | Gacela\Framework\ServiceResolver',
+    ];
+
+    public function test_source_tree_has_no_unexpected_class_cycles(): void
     {
-        $edges = $this->buildDependencyGraph();
+        self::assertNoUnexpectedCycles(
+            DependencyGraph::fromDirectory(self::SRC)->classCycles(),
+            self::ALLOWED_CLASS_CYCLES,
+            'class',
+        );
+    }
 
-        $cycles = [];
-        foreach ($this->stronglyConnectedComponents($edges) as $component) {
-            if (count($component) < 2) {
-                continue;
-            }
-            sort($component);
-            $cycles[] = implode(' | ', $component);
-        }
-        sort($cycles);
+    public function test_source_tree_has_no_unexpected_namespace_cycles(): void
+    {
+        self::assertNoUnexpectedCycles(
+            DependencyGraph::fromDirectory(self::SRC)->namespaceCycles(),
+            self::ALLOWED_NAMESPACE_CYCLES,
+            'namespace',
+        );
+    }
 
-        $unexpected = array_values(array_diff($cycles, self::ALLOWED_CYCLES));
+    public function test_allow_listed_class_cycles_still_exist(): void
+    {
+        self::assertAllowListIsNotStale(
+            DependencyGraph::fromDirectory(self::SRC)->classCycles(),
+            self::ALLOWED_CLASS_CYCLES,
+            'ALLOWED_CLASS_CYCLES',
+        );
+    }
+
+    public function test_allow_listed_namespace_cycles_still_exist(): void
+    {
+        self::assertAllowListIsNotStale(
+            DependencyGraph::fromDirectory(self::SRC)->namespaceCycles(),
+            self::ALLOWED_NAMESPACE_CYCLES,
+            'ALLOWED_NAMESPACE_CYCLES',
+        );
+    }
+
+    /**
+     * @param list<string> $found
+     * @param list<string> $allowed
+     */
+    private static function assertNoUnexpectedCycles(array $found, array $allowed, string $level): void
+    {
+        $unexpected = array_values(array_diff($found, $allowed));
 
         self::assertSame(
             [],
             $unexpected,
             sprintf(
-                "Unexpected dependency cycle(s) introduced:\n- %s\n\nBreak the cycle, or (if genuinely benign) add it to ALLOWED_CYCLES with a rationale.",
+                "Unexpected %s dependency cycle(s) introduced:\n- %s\n\n"
+                . 'Break the cycle, or (if genuinely cohesive) add it to the allow-list with a rationale.',
+                $level,
                 implode("\n- ", $unexpected),
             ),
         );
     }
 
-    public function test_allow_listed_cycles_still_exist(): void
+    /**
+     * A cycle that no longer exists must leave the allow-list, otherwise the list
+     * grows stale and starts forgiving components nobody has looked at in years.
+     *
+     * @param list<string> $found
+     * @param list<string> $allowed
+     */
+    private static function assertAllowListIsNotStale(array $found, array $allowed, string $constant): void
     {
-        $edges = $this->buildDependencyGraph();
-
-        $found = [];
-        foreach ($this->stronglyConnectedComponents($edges) as $component) {
-            if (count($component) < 2) {
-                continue;
-            }
-            sort($component);
-            $found[] = implode(' | ', $component);
-        }
-
-        foreach (self::ALLOWED_CYCLES as $allowed) {
+        foreach ($allowed as $cycle) {
             self::assertContains(
-                $allowed,
+                $cycle,
                 $found,
-                sprintf('Allow-listed cycle no longer exists; remove it from ALLOWED_CYCLES: %s', $allowed),
+                sprintf('Cycle no longer exists; remove it from %s: %s', $constant, $cycle),
             );
         }
-    }
-
-    /**
-     * @return array<string, list<string>> adjacency list of intra-source class dependencies
-     */
-    private function buildDependencyGraph(): array
-    {
-        /** @var array<string, list<string>> $rawEdges */
-        $rawEdges = [];
-        $defined = [];
-
-        /** @var iterable<SplFileInfo> $iterator */
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator(self::SRC, RecursiveDirectoryIterator::SKIP_DOTS),
-        );
-
-        foreach ($iterator as $file) {
-            if ($file->getExtension() !== 'php') {
-                continue;
-            }
-
-            $code = (string) file_get_contents($file->getPathname());
-            if (preg_match('/^namespace\s+([^;]+);/m', $code, $ns) !== 1) {
-                continue;
-            }
-            if (preg_match('/^(?:final\s+|abstract\s+)?(?:class|interface|trait|enum)\s+(\w+)/m', $code, $type) !== 1) {
-                continue;
-            }
-
-            $fqn = trim($ns[1]) . '\\' . trim($type[1]);
-            $defined[$fqn] = true;
-
-            preg_match_all('/^use\s+(Gacela\\\\(?:Framework|Console|PHPStan)\\\\[^;\s]+?)(?:\s+as\s+\w+)?;/m', $code, $uses);
-            /** @var list<string> $imports */
-            $imports = $uses[1];
-            $rawEdges[$fqn] = $imports;
-        }
-
-        $edges = [];
-        foreach ($rawEdges as $from => $tos) {
-            $edges[$from] = array_values(array_filter(
-                $tos,
-                static fn (string $to): bool => isset($defined[$to]) && $to !== $from,
-            ));
-        }
-
-        return $edges;
-    }
-
-    /**
-     * Tarjan's strongly-connected-components algorithm (iterative).
-     *
-     * @param array<string, list<string>> $edges
-     *
-     * @return list<list<string>>
-     */
-    private function stronglyConnectedComponents(array $edges): array
-    {
-        $index = [];
-        $low = [];
-        $onStack = [];
-        $stack = [];
-        $result = [];
-        $counter = 0;
-
-        /** @var array<string, int> $nodes */
-        $nodes = array_fill_keys(array_keys($edges), 0);
-
-        foreach (array_keys($nodes) as $start) {
-            if (isset($index[$start])) {
-                continue;
-            }
-
-            // Iterative DFS: each frame tracks the node and how far through its edges we are.
-            $work = [[$start, 0]];
-
-            while ($work !== []) {
-                [$node, $edgePointer] = $work[count($work) - 1];
-
-                if ($edgePointer === 0) {
-                    $index[$node] = $counter;
-                    $low[$node] = $counter;
-                    ++$counter;
-                    $stack[] = $node;
-                    $onStack[$node] = true;
-                }
-
-                $recursed = false;
-                $neighbors = $edges[$node] ?? [];
-                for ($i = $edgePointer; $i < count($neighbors); ++$i) {
-                    $next = $neighbors[$i];
-                    if (!isset($index[$next])) {
-                        $work[count($work) - 1] = [$node, $i + 1];
-                        $work[] = [$next, 0];
-                        $recursed = true;
-                        break;
-                    }
-                    if (($onStack[$next] ?? false) === true) {
-                        $low[$node] = min($low[$node], $index[$next]);
-                    }
-                }
-
-                if ($recursed) {
-                    continue;
-                }
-
-                if ($low[$node] === $index[$node]) {
-                    $component = [];
-                    do {
-                        $w = array_pop($stack);
-                        $onStack[$w] = false;
-                        $component[] = $w;
-                    } while ($w !== $node);
-                    $result[] = $component;
-                }
-
-                array_pop($work);
-                if ($work !== []) {
-                    $parent = $work[count($work) - 1][0];
-                    $low[$parent] = min($low[$parent], $low[$node]);
-                }
-            }
-        }
-
-        return $result;
     }
 }

--- a/tests/Integration/Console/CacheWarm/CacheWarmServiceTest.php
+++ b/tests/Integration/Console/CacheWarm/CacheWarmServiceTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Console\CacheWarm;
 
 use Gacela\Console\Application\CacheWarm\CacheWarmService;
-use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
@@ -45,7 +44,7 @@ final class CacheWarmServiceTest extends TestCase
 
     public function test_warm_class_resolution_populates_factory_config_and_provider_entries(): void
     {
-        $service = new CacheWarmService(new ConsoleFacade());
+        $service = new CacheWarmService();
 
         $service->warmClassResolution(Module1Facade::class);
 
@@ -58,7 +57,7 @@ final class CacheWarmServiceTest extends TestCase
 
     public function test_warm_class_resolution_is_idempotent(): void
     {
-        $service = new CacheWarmService(new ConsoleFacade());
+        $service = new CacheWarmService();
 
         $service->warmClassResolution(Module1Facade::class);
 
@@ -72,7 +71,7 @@ final class CacheWarmServiceTest extends TestCase
 
     public function test_warm_class_resolution_skips_when_facade_class_missing(): void
     {
-        $service = new CacheWarmService(new ConsoleFacade());
+        $service = new CacheWarmService();
 
         /** @var class-string $fake */
         $fake = 'Non\\Existing\\MissingFacade';
@@ -83,7 +82,7 @@ final class CacheWarmServiceTest extends TestCase
 
     public function test_filter_production_modules_only_drops_test_fixture_and_benchmark_namespace_segments(): void
     {
-        $service = new CacheWarmService(new ConsoleFacade());
+        $service = new CacheWarmService();
 
         $modules = array_map(
             static fn (string $facade): AppModule => new AppModule($facade, 'name', $facade),

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
@@ -7,7 +7,6 @@ namespace GacelaTest\Integration\Console\CacheWarm;
 use Gacela\Console\Application\CacheWarm\CacheWarmOutputFormatter;
 use Gacela\Console\Application\CacheWarm\CacheWarmService;
 use Gacela\Console\Application\CacheWarm\ModuleWarmer;
-use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
@@ -52,7 +51,7 @@ final class ModuleWarmerFacadeWarmTest extends TestCase
     public function test_a_php_error_warming_one_module_facade_does_not_abort_the_remaining_modules(): void
     {
         $warmer = new ModuleWarmer(
-            new CacheWarmService(new ConsoleFacade()),
+            new CacheWarmService(),
             new CacheWarmOutputFormatter($output = new BufferedOutput()),
         );
 

--- a/tests/Integration/Framework/Bootstrap/Setup/GacelaPhpFileMergeTest.php
+++ b/tests/Integration/Framework/Bootstrap/Setup/GacelaPhpFileMergeTest.php
@@ -97,16 +97,13 @@ PHP;
 
         $container = Container::withConfig(\Gacela\Framework\Config\Config::getInstance());
 
-        // Test factory
         $factory1 = $container->get('my-factory');
         $factory2 = $container->get('my-factory');
         self::assertNotSame($factory1, $factory2);
 
-        // Test protected
         $protected = $container->get('my-protected');
         self::assertSame($protectedCallable, $protected);
 
-        // Test alias
         $aliased = $container->get('my-alias');
         self::assertInstanceOf(stdClass::class, $aliased);
     }

--- a/tests/Integration/Framework/ClassResolver/Provider/LegacyModule/DependencyProvider.php
+++ b/tests/Integration/Framework/ClassResolver/Provider/LegacyModule/DependencyProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\Provider\LegacyModule;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Guards the backward-compatibility path for the deprecated AbstractDependencyProvider.
+ * Delete together with AbstractDependencyProvider in version 2.0.
+ */
+final class DependencyProvider extends AbstractDependencyProvider
+{
+    public const GREETING = 'legacy-dependency-provider-greeting';
+
+    public static int $provideCallCount = 0;
+
+    public static function resetCallCount(): void
+    {
+        self::$provideCallCount = 0;
+    }
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        ++self::$provideCallCount;
+
+        $container->set(self::GREETING, static fn (): string => 'hello from the legacy dependency provider');
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/Provider/LegacyModule/Factory.php
+++ b/tests/Integration/Framework/ClassResolver/Provider/LegacyModule/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\Provider\LegacyModule;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function getGreeting(): string
+    {
+        return $this->getProvidedDependency(DependencyProvider::GREETING);
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/Provider/ModernModule/Factory.php
+++ b/tests/Integration/Framework/ClassResolver/Provider/ModernModule/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\Provider\ModernModule;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function getGreeting(): string
+    {
+        return $this->getProvidedDependency(Provider::GREETING);
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/Provider/ModernModule/Provider.php
+++ b/tests/Integration/Framework/ClassResolver/Provider/ModernModule/Provider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\Provider\ModernModule;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Counts how often Gacela invokes `provideModuleDependencies()`, so a test can
+ * assert a module's provider body runs exactly once per container build.
+ */
+final class Provider extends AbstractProvider
+{
+    public const GREETING = 'modern-provider-greeting';
+
+    public static int $provideCallCount = 0;
+
+    public static function resetCallCount(): void
+    {
+        self::$provideCallCount = 0;
+    }
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        ++self::$provideCallCount;
+
+        $container->set(self::GREETING, static fn (): string => 'hello from the modern provider');
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/Provider/ProviderRegistrationTest.php
+++ b/tests/Integration/Framework/ClassResolver/Provider/ProviderRegistrationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\Provider;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\ClassResolver\Provider\DependencyProviderResolver;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\ClassResolver\Provider\LegacyModule\DependencyProvider;
+use GacelaTest\Integration\Framework\ClassResolver\Provider\LegacyModule\Factory as LegacyFactory;
+use GacelaTest\Integration\Framework\ClassResolver\Provider\ModernModule\Factory as ModernFactory;
+use GacelaTest\Integration\Framework\ClassResolver\Provider\ModernModule\Provider;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+use const E_USER_DEPRECATED;
+
+final class ProviderRegistrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetGacela();
+
+        Provider::resetCallCount();
+        DependencyProvider::resetCallCount();
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetGacela();
+
+        Provider::resetCallCount();
+        DependencyProvider::resetCallCount();
+    }
+
+    /**
+     * `ProviderResolver` and `DependencyProviderResolver` share one normalized cache
+     * slot ("DependencyProvider" -> "Provider"), so a modern provider is returned by
+     * both. It must still be registered only once, otherwise every non-idempotent
+     * provider body runs its side effects twice.
+     */
+    public function test_modern_provider_is_registered_exactly_once(): void
+    {
+        (new ModernFactory())->getGreeting();
+
+        self::assertSame(1, Provider::$provideCallCount);
+    }
+
+    public function test_modern_provider_provides_its_dependencies(): void
+    {
+        self::assertSame('hello from the modern provider', (new ModernFactory())->getGreeting());
+    }
+
+    public function test_legacy_dependency_provider_is_registered_exactly_once(): void
+    {
+        (new LegacyFactory())->getGreeting();
+
+        self::assertSame(1, DependencyProvider::$provideCallCount);
+    }
+
+    public function test_legacy_dependency_provider_still_provides_its_dependencies(): void
+    {
+        self::assertSame(
+            'hello from the legacy dependency provider',
+            (new LegacyFactory())->getGreeting(),
+        );
+    }
+
+    /**
+     * The notice is emitted without symfony/deprecation-contracts installed, but keeps that
+     * contract's "Since <package> <version>: " format so deprecation collectors group it
+     * unchanged. Locked here because the format is the part consumers' tooling depends on.
+     */
+    public function test_legacy_dependency_provider_triggers_a_deprecation_in_the_contract_format(): void
+    {
+        $captured = [];
+        set_error_handler(
+            static function (int $errno, string $message) use (&$captured): bool {
+                $captured[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            (new DependencyProviderResolver())->resolve(new LegacyFactory());
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame([sprintf(
+            "Since gacela-project/gacela 1.8: `%s` is deprecated and will be removed in version 2.0.\n"
+            . 'Use `%s` instead. Where? Check your module `LegacyModule`',
+            AbstractDependencyProvider::class,
+            AbstractProvider::class,
+        )], $captured);
+    }
+
+    private function resetGacela(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        InMemoryCache::resetCache();
+    }
+}

--- a/tests/Integration/Framework/ServiceResolverAware/ServiceResolverCustomServicesAwareTest.php
+++ b/tests/Integration/Framework/ServiceResolverAware/ServiceResolverCustomServicesAwareTest.php
@@ -48,13 +48,11 @@ final class ServiceResolverCustomServicesAwareTest extends TestCase
 
     public function test_existing_service_cached(): void
     {
-        // First call should populate the cache
         $dummy = new DummyServiceResolverAware();
         $dummy->getRepository()->findName();
 
         self::assertCount(1, CustomServicesPhpCache::all());
 
-        // Subsequent calls should reuse the cache without adding new entries
         $dummy->getRepository()->findName();
         $dummy->getRepository()->findName();
 

--- a/tests/Unit/Framework/Bootstrap/Setup/PropertyChangeTrackerTest.php
+++ b/tests/Unit/Framework/Bootstrap/Setup/PropertyChangeTrackerTest.php
@@ -33,12 +33,13 @@ final class PropertyChangeTrackerTest extends TestCase
         self::assertFalse($tracker->isChanged('prop'));
     }
 
-    public function test_get_all_reports_both_changed_and_unchanged_entries(): void
+    public function test_properties_are_tracked_independently(): void
     {
         $tracker = new PropertyChangeTracker();
         $tracker->markAsChanged('a');
         $tracker->markAsUnchanged('b');
 
-        self::assertSame(['a' => true, 'b' => false], $tracker->getAll());
+        self::assertTrue($tracker->isChanged('a'));
+        self::assertFalse($tracker->isChanged('b'));
     }
 }

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheBatchTest.php
@@ -90,9 +90,9 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
         $cache1->put('persisted', 'ClassP');
         TestPhpFileCache::clearStaticCache();
 
-        $cache2 = new TestPhpFileCache($this->cacheDir);
+        new TestPhpFileCache($this->cacheDir);
 
-        self::assertSame(['persisted' => 'ClassP'], $cache2->getAll());
+        self::assertSame(['persisted' => 'ClassP'], TestPhpFileCache::all());
     }
 
     public function test_constructor_loads_every_persisted_entry_not_just_the_first(): void
@@ -103,11 +103,11 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
         $cache1->put('third', 'ClassThree');
         TestPhpFileCache::clearStaticCache();
 
-        $cache2 = new TestPhpFileCache($this->cacheDir);
+        new TestPhpFileCache($this->cacheDir);
 
         self::assertSame(
             ['first' => 'ClassOne', 'second' => 'ClassTwo', 'third' => 'ClassThree'],
-            $cache2->getAll(),
+            TestPhpFileCache::all(),
         );
     }
 
@@ -138,7 +138,7 @@ final class AbstractPhpFileCacheBatchTest extends TestCase
 
         $cache = new TestPhpFileCache($dir);
 
-        self::assertSame(['warm' => 'ClassW'], $cache->getAll());
+        self::assertSame(['warm' => 'ClassW'], TestPhpFileCache::all());
 
         $warnings = $this->collectWarnings(static fn () => $cache->put('fresh', 'ClassF'));
 

--- a/tests/Unit/Framework/ClassResolver/Cache/InMemoryCacheTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/InMemoryCacheTest.php
@@ -25,11 +25,11 @@ final class InMemoryCacheTest extends TestCase
         $cache->put('A', 'ResolvedA');
         $cache->put('B', 'ResolvedB');
 
-        self::assertSame(['A' => 'ResolvedA', 'B' => 'ResolvedB'], $cache->getAll());
+        self::assertSame(['A' => 'ResolvedA', 'B' => 'ResolvedB'], InMemoryCache::getAllFromKey('some-key'));
     }
 
     public function test_get_all_is_empty_for_untouched_key(): void
     {
-        self::assertSame([], (new InMemoryCache('fresh-key'))->getAll());
+        self::assertSame([], InMemoryCache::getAllFromKey('fresh-key'));
     }
 }

--- a/tests/Unit/Framework/Container/LocatorTest.php
+++ b/tests/Unit/Framework/Container/LocatorTest.php
@@ -37,15 +37,6 @@ final class LocatorTest extends TestCase
         self::assertNull($nullValue);
     }
 
-    public function test_get_existing_singleton(): void
-    {
-        Locator::addSingleton(StringValue::class, new StringValue('str'));
-
-        $singleton = Locator::getSingleton(StringValue::class);
-
-        self::assertEquals(new StringValue('str'), $singleton);
-    }
-
     public function test_get_existing_singleton_from_container(): void
     {
         $container = new Container(bindings: [
@@ -75,18 +66,11 @@ final class LocatorTest extends TestCase
 
     public function test_get_required_returns_existing_service(): void
     {
-        Locator::addSingleton(StringValue::class, new StringValue('required'));
+        $container = new Container(bindings: [
+            StringValue::class => new StringValue('required'),
+        ]);
 
-        $singleton = Locator::getInstance()->getRequired(StringValue::class);
-
-        self::assertEquals(new StringValue('required'), $singleton);
-    }
-
-    public function test_get_required_singleton_returns_existing_service(): void
-    {
-        Locator::addSingleton(StringValue::class, new StringValue('required'));
-
-        $singleton = Locator::getRequiredSingleton(StringValue::class);
+        $singleton = Locator::getInstance($container)->getRequired(StringValue::class);
 
         self::assertEquals(new StringValue('required'), $singleton);
     }

--- a/tests/Unit/Framework/Profiler/ProfilerTest.php
+++ b/tests/Unit/Framework/Profiler/ProfilerTest.php
@@ -49,7 +49,7 @@ final class ProfilerTest extends TestCase
     public function test_profiler_tracks_operations(): void
     {
         $this->profiler->start('test_operation', 'test_subject');
-        usleep(1000); // Sleep for 1ms
+        usleep(1000);
         $this->profiler->stop('test_operation', 'test_subject');
 
         $entries = $this->profiler->getEntries();
@@ -120,7 +120,7 @@ final class ProfilerTest extends TestCase
         $this->profiler->start('operation1', 'subject1');
         // Intentionally not stopping
 
-        $this->profiler->stop('operation2', 'subject2'); // Stop different operation
+        $this->profiler->stop('operation2', 'subject2');
 
         self::assertCount(0, $this->profiler->getEntries());
     }


### PR DESCRIPTION
## 📚 Description

An 8-workstream cleanup pass over `src/`. Two of the findings turned out to be live bugs rather than style issues, so this is not a pure refactor.

Every commit was verified green in isolation, and the pre-commit hook ran cs-fixer + psalm (level 1) + phpstan (level max) + phpstan-tests + all three suites on each. Final: **1026 tests, 2131 assertions, 0 failures**.

## 🔖 Changes

### Bugs fixed

- **A module's `provideModuleDependencies()` ran twice.** `ProviderResolver` and `DependencyProviderResolver` share a normalized cache slot (`DependencyProvider` ends with `Provider`), so a modern provider came back from both, and the backward-compatibility path called `provideModuleDependencies()` on an object `register()` had already run. A distinctness guard existed but only gated the event notification. Providers whose body is not idempotent — counters, external registrations, logging — ran their side effects twice. Regression test asserts a counter of exactly 1; it fails on `main` with 2.
- **`validate:config` could never detect a circular dependency.** It caught every resolution error, then searched the message for the lowercase word `circular`; the container throws `CircularDependencyException` whose message begins `Circular dependency detected:`. `str_contains()` is case-sensitive, so the branch never fired — cyclic config printed a green checkmark and exited `0`. Now caught by type, with the full `A -> B -> A` chain reported.
- **`make:module` / `make:file` failed silently.** `FileContentIo::filePutContents()` discarded the `file_put_contents()` result, so a read-only target or full disk produced a success message, exit `0`, and no file.
- **The `AbstractDependencyProvider` deprecation notice was invisible to most apps** — routed only through `trigger_deprecation()`, which needs `symfony/deprecation-contracts`, not a runtime dependency of Gacela. Now falls back to `trigger_error(E_USER_DEPRECATED)`.

### Architecture guard

The `NoCircularDependenciesTest` added in #498 built its graph from `use` statements — but a class referencing another in the same namespace needs no import. **134 real edges were invisible (26% of the graph)**, and it reported a largest cycle of 4 where the truth was 31. It now walks the AST via `nikic/php-parser`, and asserts at both class and namespace granularity.

Three edges were then removed: `ConfigFactory` no longer extends `AbstractFactory`, `ProvidesScanner` accepts any provider object, and `CacheWarmService` resolves modules directly instead of calling back through its own Facade. The remaining `Config <-> Container <-> Bootstrap` component is intrinsic to a self-configuring DI framework and is allow-listed with a rationale until inverting `Container::withConfig()` becomes possible.

### Types, duplication, dead code

- Finishes the alias consolidation `a316df56` started and left half-done, where consecutive properties alternated between aliased and raw shapes.
- `phpstan.neon`'s five blanket `ignoreErrors` wildcards → three path-scoped entries with stated reasons.
- `FinderRuleInterface::buildClassCandidate()` declares `non-empty-string` instead of claiming a `class-string` it cannot guarantee; the validator carries `@phpstan-assert-if-true`.
- Single source for the default gacela class (was built in four places); shared assembly for the two `GacelaConfigFile` factories; `SetupMerger`'s twelve byte-identical guards collapsed.
- Three `is_string(end(explode(...)))` guards were unreachable — a widening `@var` annotation was what made the analysers think otherwise.
- Removed `Locator::addSingleton()` (`@internal`, no callers) and a `phpunit.xml` exclude pointing at `src/CodeGenerator`, which does not exist.

### Deliberately not done

- **`CacheInterface::getAll()` is kept.** It looks dead, but the interface is not `@internal` while its replacement `all()` is — and `all()` returns a different shape on `InMemoryCache`. Removing it would be a BC break in a minor.
- `Config`'s typed accessors were left duplicated: they were deliberately un-DRYed by `3729ccbf` for measured performance, with a benchmark behind it.
- `ConsoleFacade`'s pass-throughs were left alone: collapsing them would violate the project's own `FacadeOnlyDelegatesRule`.

## ⚠️ Behaviour changes worth calling out in release notes

- Configurations that were always cyclic will now **fail** `validate:config` (exit `1`) where they previously passed. If it runs in CI, expect it to surface pre-existing cycles on the first run.
- Apps still on `AbstractDependencyProvider` will start seeing the deprecation notice.
- Scaffolding now throws instead of failing silently — only on runs that were already broken.

`nikic/php-parser` added to **require-dev** only; runtime dependencies remain `php` + `gacela-project/container`.