### PR TITLE
docs: add an upgrade guide and surface the addMappingInterface deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `make:module` provider template is now attribute-first: the scaffolded provider demonstrates a typed `#[Provides]` method as the primary registration path, keeping the imperative `provideModuleDependencies()` available (no BC break)
 - The deprecation notice for `AbstractDependencyProvider` is now emitted whether or not `symfony/deprecation-contracts` is installed. It was previously routed through `trigger_deprecation()` and skipped when that function was unavailable — which is most apps, since the package is not a runtime dependency of Gacela. The message keeps the contract's `Since <package> <version>: ` format, so deprecation collectors group it exactly as before. Apps still using `AbstractDependencyProvider` will start seeing the deprecation; migrate to `AbstractProvider`
 
+- `GacelaConfig::addMappingInterface()` now emits an `E_USER_DEPRECATED` notice. It has carried a `@deprecated` docblock since 1.2.0 — over three years and 17 minor releases — but nothing surfaced it at runtime, so an app could not discover it was on a path scheduled for removal in 2.0. Use `addBinding()`; the arguments are unchanged. `DocBlockResolverAwareTrait` stays documentation-only: PHP offers no hook for "a trait was used"
 - Scaffolding commands (`make:module`, `make:file`) now fail loudly when a generated file cannot be written. `FileContentIo::filePutContents()` discarded the result of `file_put_contents()`, so a read-only target, a permission error, or a full disk produced a success message, an exit code of `0`, and no file on disk. It now throws a `RuntimeException` naming the path, matching how the neighbouring `mkdir()` has always behaved. This only changes behaviour on runs that were already failing silently
 
 ### Removed
@@ -26,6 +27,7 @@
 ### Documentation
 
 - Documented `AbstractFactory::make()` and attribute-first module DI in `docs/container-configuration.md`; documented Config and Provider as optional pillars (the two-file Facade + Factory floor) in `docs/getting-started.md`
+- Added `docs/upgrading.md`. All three 1.x deprecations pointed at a 2.0 removal with no migration path documented anywhere outside the changelog. It covers each old → new mapping, and calls out that `DependencyProvider.php` must be renamed to `Provider.php` — pillars resolve by filename suffix, so changing only the class name leaves it unresolvable, which is the step most people miss
 
 ## [1.19.0](https://github.com/gacela-project/gacela/compare/1.18.0...1.19.0) - 2026-07-23
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,80 @@
+# Upgrading
+
+Everything deprecated in the 1.x line still works. Each entry below is scheduled
+for removal in 2.0, so migrating now is optional but keeps the 2.0 upgrade
+mechanical.
+
+## Deprecated in 1.x, removed in 2.0
+
+| Deprecated | Replacement | Since |
+|---|---|---|
+| `AbstractDependencyProvider` | `AbstractProvider` | 1.8.0 |
+| `GacelaConfig::addMappingInterface()` | `GacelaConfig::addBinding()` | 1.2.0 |
+| `DocBlockResolverAwareTrait` | `ServiceResolverAwareTrait` | 1.12.0 |
+
+Each emits an `E_USER_DEPRECATED` notice at runtime, except
+`DocBlockResolverAwareTrait` — PHP gives no hook for "a trait was used", so that
+one is documented only. Grep for it directly:
+
+```bash
+grep -rn "DocBlockResolverAwareTrait" src/
+```
+
+To see the others while running your test suite, make PHP report them:
+
+```php
+error_reporting(E_ALL);
+```
+
+### `AbstractDependencyProvider` → `AbstractProvider`
+
+Change the parent class and rename the method:
+
+```diff
+-final class DependencyProvider extends AbstractDependencyProvider
++final class Provider extends AbstractProvider
+ {
+     public function provideModuleDependencies(Container $container): void
+     {
+         $container->set(SomeService::class, static fn () => new SomeService());
+     }
+ }
+```
+
+**Rename the file too.** `DependencyProvider.php` must become `Provider.php` —
+Gacela resolves module pillars by filename suffix, so a class named `Provider`
+sitting in `DependencyProvider.php` will not be found. This is the step most
+people miss.
+
+`provideModuleDependencies()` keeps working on `AbstractProvider`. If you would
+rather register by attribute, `#[Provides]` is the attribute-first path:
+
+```php
+final class Provider extends AbstractProvider
+{
+    #[Provides]
+    public function someService(): SomeService
+    {
+        return new SomeService();
+    }
+}
+```
+
+### `addMappingInterface()` → `addBinding()`
+
+A straight rename; the arguments are identical.
+
+```diff
+-$config->addMappingInterface(SomeInterface::class, SomeImplementation::class);
++$config->addBinding(SomeInterface::class, SomeImplementation::class);
+```
+
+### `DocBlockResolverAwareTrait` → `ServiceResolverAwareTrait`
+
+`DocBlockResolverAwareTrait` is now nothing but `use ServiceResolverAwareTrait;`,
+so swapping it changes no behaviour.
+
+```diff
+-use DocBlockResolverAwareTrait;
++use ServiceResolverAwareTrait;
+```

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -174,6 +174,15 @@ final class GacelaConfig
      */
     public function addMappingInterface(string $key, string|object|callable $value): self
     {
+        @trigger_error(
+            sprintf(
+                'Since gacela-project/gacela 1.2: `%s::addMappingInterface()` is deprecated and will be '
+                . 'removed in version 2.0. Use `addBinding()` instead; the arguments are unchanged.',
+                self::class,
+            ),
+            E_USER_DEPRECATED,
+        );
+
         return $this->addBinding($key, $value);
     }
 
@@ -560,4 +569,5 @@ final class GacelaConfig
             $this->lazyServices,
         );
     }
+
 }

--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -90,6 +90,31 @@ final class GacelaConfigTest extends TestCase
         );
     }
 
+    public function test_add_mapping_interface_emits_a_deprecation(): void
+    {
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                if ($errno === E_USER_DEPRECATED) {
+                    $deprecations[] = $errstr;
+                }
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            (new GacelaConfig())->addMappingInterface('App\\Port', 'App\\Adapter');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertCount(1, $deprecations);
+        self::assertStringContainsString('addMappingInterface', $deprecations[0]);
+        self::assertStringContainsString('addBinding', $deprecations[0]);
+    }
+
     public function test_add_binding_if_registers_a_default_when_absent(): void
     {
         $config = new GacelaConfig();


### PR DESCRIPTION
## 📚 Description

Stacked on #508 (which is stacked on #507). GitHub retargets automatically as each merges.

Gacela has been disciplined about deprecations — the changelog shows ~10 deprecate→remove cycles actually completed. The gap is **communication**, not policy:

- `grep -ri "deprecat|AbstractDependencyProvider|addMappingInterface|DocBlockResolverAwareTrait" docs/ README.md` returns **nothing**. All three live deprecations point at a 2.0 removal with no documented migration path anywhere outside the changelog.
- Of the three, only `AbstractDependencyProvider` emitted a runtime notice. `addMappingInterface()` has carried a `@deprecated` docblock since **1.2.0 — over three years and 17 minor releases** — with nothing at runtime, so an app had no way to discover it was on a removal path.

## 🔖 Changes

- **`docs/upgrading.md`** — a table of the three old → new mappings plus a worked diff for each.
- **`addMappingInterface()` now emits `E_USER_DEPRECATED`**, matching how `AbstractDependencyProvider` reports itself. Behaviour is otherwise unchanged; it still delegates to `addBinding()`.

## ⚠️ The step people miss

The guide calls this out explicitly, because it is silent when you get it wrong:

> **Rename the file too.** `DependencyProvider.php` must become `Provider.php` — Gacela resolves module pillars by filename suffix, so a class named `Provider` sitting in `DependencyProvider.php` will not be found.

Renaming only the class leaves the module unresolvable with no obvious cause.

## 🚫 Deliberately not done

`DocBlockResolverAwareTrait` gets **no** runtime notice. PHP offers no hook for "a trait was used" — there is no constructor and no resolution step to hang it off. Rather than fake it, the guide documents it and gives a `grep` command. Called out here so it does not look like an oversight.

## ✅ Tests

`test_add_mapping_interface_emits_a_deprecation` — installs an `E_USER_DEPRECATED` handler, asserts exactly one notice naming both the old and new method. The existing `test_add_mapping_interface_is_an_alias_of_add_binding` is untouched and still green.

Full suite: 1028 tests, 0 failures. `composer quality` green.

## 💬 Open question for you

Deprecating for three years with no removal date is its own kind of debt. If 2.0 has no timeline, it may be worth either committing to one or dropping the "will be removed in 2.0" wording — the guide currently repeats that promise. Happy to follow up either way.