### PR TITLE
test(bench): widen the ScopedCache gate past its measured noise floor

### DIFF
--- a/tests/Benchmark/Cache/ScopedCacheBench.php
+++ b/tests/Benchmark/Cache/ScopedCacheBench.php
@@ -7,6 +7,7 @@ namespace GacelaTest\Benchmark\Cache;
 use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\ScopedCache;
 use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
@@ -25,7 +26,19 @@ use function unlink;
 /**
  * ScopedCache decorator cost: put/get overhead and dependsOn() cycle-detection
  * at increasing depths, on top of a real FileCache.
+ *
+ * Gated, but with a widened tolerance: every subject here is disk-bound, and
+ * the gate compares two runs made at different moments on the same machine.
+ * `rstdev` stays under 2%, so these look stable by the README's criterion --
+ * but that measures spread *within* one run, not drift *between* runs. Two
+ * repeated runs of identical code moved `bench_invalidate_leaf` by -7.61% and
+ * then -16.36%, and CI has produced +14.70%. A +/-10% assert therefore sits
+ * below the noise floor and fails PRs that did not touch this code. The
+ * tolerance below clears the worst observed drift with headroom while still
+ * catching a real algorithmic regression, which would be far larger.
+ * See tests/Benchmark/README.md.
  */
+#[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 30%')]
 #[BeforeMethods('setUp')]
 #[AfterMethods('tearDown')]
 #[Groups(['gate', 'cache'])]

--- a/tests/Benchmark/README.md
+++ b/tests/Benchmark/README.md
@@ -26,6 +26,22 @@ Rule of thumb: if the subject's average time is below ~0.2μs, it belongs in
 would false-fail the gate on unrelated PRs. Subjects in the 0.2–1μs range can
 stay gated when their `rstdev` holds below ~3% (e.g. the warm-resolve benches).
 
+**`rstdev` is not sufficient on its own.** It measures spread *within* one run,
+but the gate compares two runs made at different moments. An I/O-bound subject
+can hold `rstdev` under 2% and still drift well past 10% run-to-run, which is
+what `ScopedCacheBench` does — repeated runs of identical code moved its mode
+by −7.61%, then −16.36%, and CI has produced +14.70%. Before gating a subject that
+touches the disk, network, or clock, run it twice against itself:
+
+```bash
+vendor/bin/phpbench run <path> --tag=selfbase --store --progress=none
+vendor/bin/phpbench run <path> --ref=selfbase --report=aggregate --progress=none
+```
+
+If unchanged code drifts near the threshold, widen that class's tolerance with
+a class-level `#[Assert]` (as `ScopedCacheBench` does) rather than leaving a
+gate that fails on PRs which never touched it.
+
 ## Sampling and warmup
 
 Defaults come from `phpbench.json`: **200 revs, 10 iterations, warmup 2**.


### PR DESCRIPTION
## 📚 Description

#507 was failed by the performance gate on `ScopedCacheBench::bench_invalidate_leaf (+14.70%)` — a PR that did not touch `src/Framework/Cache/` at all. That directory was byte-identical to `main`, and `ScopedCache` imports only PHP builtins plus filesystem calls, so a regression was impossible by construction. A rerun passed.

Rather than shrug at a flaky rerun, I measured it.

## 🔬 Evidence

Running the bench against **its own baseline — identical code, nothing changed**:

| Run | `bench_invalidate_cascade` | `bench_invalidate_leaf` | `rstdev` |
|---|---|---|---|
| 1 | −9.92% | −7.61% | ±1.57% / ±1.78% |
| 2 | −15.37% | −16.36% | ±2.89% / ±1.90% |
| CI (#507) | +8.57% | **+14.70%** | ±1.99% / ±3.09% |

The gate is `+/- 10%`. Unchanged code exceeds it in both directions.

Reproduce:

```bash
vendor/bin/phpbench run tests/Benchmark/Cache/ScopedCacheBench.php --tag=selfbase --store --progress=none
vendor/bin/phpbench run tests/Benchmark/Cache/ScopedCacheBench.php --ref=selfbase --report=aggregate --progress=none
```

## 🧠 Why `rstdev` didn't catch it

`tests/Benchmark/README.md` offers `rstdev < ~3%` as the criterion for whether a subject can be gated. **`ScopedCacheBench` passes that criterion** — it sits under 2%.

`rstdev` measures spread *within* a single run. The gate compares *two separate runs*, made minutes apart on the same machine. For a disk-bound subject those are different regimes: page cache state, competing I/O, and filesystem scheduling all shift between them. A subject can be tightly clustered within each run and still land 16% apart across runs.

So the documented criterion was necessary but not sufficient, and nothing in the repo said so.

## 🔖 Changes

- **`ScopedCacheBench`**: class-level `#[Assert(... +/- 30%)]`, the same mechanism the `micro` benches already use. It stays in the `gate` group and stays asserted — the threshold just clears the measured noise floor. 30% gives roughly 2× headroom over the worst observed drift; a genuine algorithmic regression in cascade invalidation would be far larger.
- **`tests/Benchmark/README.md`**: documents that `rstdev` alone is insufficient, and adds the two-command self-comparison to run *before* gating anything that touches disk, network, or clock.

## 🤔 Alternative considered

Moving the class to `micro` (non-blocking). Rejected — `micro` is defined as "sub-microsecond subject", and these run at 3–6 **ms**. Reusing it as a dumping ground for "noisy" would blur a group that currently has a precise meaning, and would drop the assertion entirely rather than set it correctly.

## ✅ Verification

`phpbench run --ref=selfbase --group=gate` exits `0` with the widened assert on a run that drifted −16.36%. Full suite 1028 tests, `composer quality` green.