### PR TITLE
docs: link the upgrade guide from the docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [Cacheable methods](cacheable-methods.md) — cache facade method results with `#[Cacheable]`
 - [Opcache preload](opcache-preload.md) — production performance tuning
 - [Production performance](production-performance.md) — full checklist to run Gacela fast in production
+- [Upgrading](upgrading.md) — what is deprecated in 1.x, and what to replace it with
 
 ## RFCs
 


### PR DESCRIPTION
## 📚 Description

Follow-up to #509, fixing my own miss.

`docs/upgrading.md` was added because the three 1.x deprecations were documented nowhere outside the changelog — a discoverability problem. But the guide was never linked from `docs/README.md`, so it had exactly the problem it was written to solve: reachable only if you already knew the filename.

## 🔖 Changes

One line in `docs/README.md`, in the existing list, after Production performance.

```diff
+- [Upgrading](upgrading.md) — what is deprecated in 1.x, and what to replace it with
```