### PR TITLE
test: restore the 100% mutation score on the changed framework files

### DIFF
--- a/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
+++ b/tests/Unit/Framework/Bootstrap/GacelaConfigTest.php
@@ -111,8 +111,11 @@ final class GacelaConfigTest extends TestCase
         }
 
         self::assertCount(1, $deprecations);
-        self::assertStringContainsString('addMappingInterface', $deprecations[0]);
-        self::assertStringContainsString('addBinding', $deprecations[0]);
+        self::assertSame(
+            'Since gacela-project/gacela 1.2: `' . GacelaConfig::class . '::addMappingInterface()` is deprecated '
+            . 'and will be removed in version 2.0. Use `addBinding()` instead; the arguments are unchanged.',
+            $deprecations[0],
+        );
     }
 
     public function test_add_binding_if_registers_a_default_when_absent(): void

--- a/tests/Unit/Framework/ClassResolver/DefaultGacelaClassTest.php
+++ b/tests/Unit/Framework/ClassResolver/DefaultGacelaClassTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver;
+
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ClassResolver\Config\ConfigResolver;
+use Gacela\Framework\ClassResolver\DefaultGacelaClass;
+use Gacela\Framework\ClassResolver\Facade\FacadeResolver;
+use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
+use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultGacelaClassTest extends TestCase
+{
+    public function test_facade_type_returns_an_empty_facade(): void
+    {
+        self::assertInstanceOf(AbstractFacade::class, DefaultGacelaClass::forType(FacadeResolver::TYPE));
+    }
+
+    public function test_factory_type_returns_an_empty_factory(): void
+    {
+        self::assertInstanceOf(AbstractFactory::class, DefaultGacelaClass::forType(FactoryResolver::TYPE));
+    }
+
+    public function test_config_type_returns_an_empty_config(): void
+    {
+        self::assertInstanceOf(AbstractConfig::class, DefaultGacelaClass::forType(ConfigResolver::TYPE));
+    }
+
+    /**
+     * A Provider has no meaningful empty implementation: an empty one would
+     * register nothing and silently mask a missing Provider, so the resolver
+     * reports it instead.
+     */
+    public function test_provider_type_has_no_default(): void
+    {
+        self::assertNull(DefaultGacelaClass::forType(ProviderResolver::TYPE));
+    }
+
+    public function test_unknown_type_has_no_default(): void
+    {
+        self::assertNull(DefaultGacelaClass::forType('SomeCustomType'));
+    }
+
+    public function test_each_call_returns_a_fresh_instance(): void
+    {
+        self::assertNotSame(
+            DefaultGacelaClass::forType(FacadeResolver::TYPE),
+            DefaultGacelaClass::forType(FacadeResolver::TYPE),
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Description

`infection.json5` sets `minMsi: 100` and `minCoveredMsi: 100`, but **infection does not run in any CI workflow** (`grep -rn "infection" .github/workflows/` returns nothing). So the cleanup in #507–#511 dropped the score to **97.88%** and nothing caught it.

I only found this by running the bar the project sets for itself. Both gaps were introduced by that cleanup work — this cleans up after it.

## 🔬 Before

```
284 mutations generated
    277 killed
      5 not covered by tests
      1 covered but not detected

MSI: 97%   Mutation Code Coverage: 98%   Covered Code MSI: 99%
[ERROR] The minimum required MSI percentage should be 100%, but actual is 97.88%.
```

## 🔖 The two gaps

**1. `DefaultGacelaClass` had no direct test** — 5 uncovered mutants (the `public` visibility of `forType()`, and three `MatchArmRemoval`s). It was extracted in #507 as the single source for the fallback instances, but only ever exercised *indirectly* through the resolvers, so mutating its match arms changed nothing any test observed. Given the class exists specifically to be the one place that mapping lives, the mapping is worth pinning directly: each pillar type, the two cases that deliberately return `null`, and a fresh-instance-per-call check.

**2. The `addMappingInterface()` deprecation test was too weak** — added in #509, it asserted only that the message *contained* `addMappingInterface` and `addBinding`. A `Concat` mutator survived by swapping the two halves of the sentence:

```diff
-'Since gacela-project/gacela 1.2: `%s::addMappingInterface()` is deprecated and will be '
-. 'removed in version 2.0. Use `addBinding()` instead; the arguments are unchanged.'
+'removed in version 2.0. Use `addBinding()` instead; the arguments are unchanged.'
+. 'Since gacela-project/gacela 1.2: `%s::addMappingInterface()` is deprecated and will be '
```

Both substrings are still present, so both assertions still passed on a scrambled message. It now asserts the exact string — which is the right level of strictness for a deprecation notice, since the wording *is* the contract with downstream deprecation collectors.

## ✅ After

```
MSI: 100%   Mutation Code Coverage: 100%   Covered Code MSI: 100%
```

Reproduce (filtered to the framework files this cleanup touched; `Gacela\Console\*` is globally ignored in `infection.json5`):

```bash
XDEBUG_MODE=coverage vendor/bin/infection --threads=max --min-msi=100 --min-covered-msi=100 \
  --filter=src/Framework/ClassResolver/DefaultGacelaClass.php,src/Framework/Bootstrap/GacelaConfig.php
```

Full suite: 1034 tests, 0 failures. `composer quality` green.

## 💬 Worth considering separately

A 100% MSI bar that nothing enforces will drift again — this PR is evidence it already did. Adding infection to CI would make it real, though it needs coverage-mode Xdebug and is the slowest check by some margin, so it may belong on a nightly rather than per-PR. Happy to wire that up if you want it; I did not want to add a slow blocking gate to every PR without asking.