### PR TITLE
fix: report an unresolvable health check instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `GacelaConfig::addMappingInterface()` now emits an `E_USER_DEPRECATED` notice. It has carried a `@deprecated` docblock since 1.2.0 — over three years and 17 minor releases — but nothing surfaced it at runtime, so an app could not discover it was on a path scheduled for removal in 2.0. Use `addBinding()`; the arguments are unchanged. `DocBlockResolverAwareTrait` stays documentation-only: PHP offers no hook for "a trait was used"
 - Scaffolding commands (`make:module`, `make:file`) now fail loudly when a generated file cannot be written. `FileContentIo::filePutContents()` discarded the result of `file_put_contents()`, so a read-only target, a permission error, or a full disk produced a success message, an exit code of `0`, and no file on disk. It now throws a `RuntimeException` naming the path, matching how the neighbouring `mkdir()` has always behaved. This only changes behaviour on runs that were already failing silently
+- A health check registered by class-string that cannot be resolved now throws `HealthCheckNotResolvableException` instead of being dropped from the report. A typo in `addHealthCheck(SomeCheck::class)`, or a class that does not implement `ModuleHealthCheckInterface`, previously produced a report that looked healthy while the check silently never ran — the exact failure mode health checks exist to surface. This completes the direction 1.19.0 started, where health-check container-resolution errors stopped being swallowed
 
 ### Removed
 

--- a/src/Framework/Health/HealthCheckNotResolvableException.php
+++ b/src/Framework/Health/HealthCheckNotResolvableException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Health;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class HealthCheckNotResolvableException extends RuntimeException
+{
+    public static function classNotFound(string $className): self
+    {
+        return new self(sprintf(
+            'The health check "%s" was registered but the class does not exist. '
+            . 'Check the class-string passed to GacelaConfig::addHealthCheck().',
+            $className,
+        ));
+    }
+
+    public static function notAHealthCheck(string $className): self
+    {
+        return new self(sprintf(
+            'The health check "%s" does not implement %s.',
+            $className,
+            ModuleHealthCheckInterface::class,
+        ));
+    }
+}

--- a/src/Framework/Health/HealthCheckRegistry.php
+++ b/src/Framework/Health/HealthCheckRegistry.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Gacela\Framework\Health;
 
 use Gacela\Framework\Container\Container;
+use ReflectionClass;
+
+use function class_exists;
 
 /**
  * Tracks health checks registered through GacelaConfig::addHealthCheck()
@@ -58,19 +61,23 @@ final class HealthCheckRegistry
                 continue;
             }
 
-            $instance = self::instantiate($check, $container);
-            if ($instance instanceof ModuleHealthCheckInterface) {
-                $resolved[] = $instance;
-            }
+            $resolved[] = self::instantiate($check, $container);
         }
 
         return $resolved;
     }
 
     /**
-     * @param class-string<ModuleHealthCheckInterface> $className
+     * The registry stores whatever `addHealthCheck()` was handed. Its
+     * `class-string<ModuleHealthCheckInterface>` annotation is a promise from
+     * the caller, not a verified fact, so this takes a bare `class-string` and
+     * checks both halves of that promise at runtime.
+     *
+     * @param class-string $className
+     *
+     * @throws HealthCheckNotResolvableException
      */
-    private static function instantiate(string $className, ?Container $container): ?ModuleHealthCheckInterface
+    private static function instantiate(string $className, ?Container $container): ModuleHealthCheckInterface
     {
         if ($container instanceof Container) {
             /** @var mixed $instance */
@@ -81,9 +88,14 @@ final class HealthCheckRegistry
         }
 
         if (!class_exists($className)) {
-            return null;
+            throw HealthCheckNotResolvableException::classNotFound($className);
         }
 
-        return new $className();
+        $instance = (new ReflectionClass($className))->newInstance();
+        if (!$instance instanceof ModuleHealthCheckInterface) {
+            throw HealthCheckNotResolvableException::notAHealthCheck($className);
+        }
+
+        return $instance;
     }
 }

--- a/tests/Integration/Architecture/NoCircularDependenciesTest.php
+++ b/tests/Integration/Architecture/NoCircularDependenciesTest.php
@@ -49,6 +49,16 @@ final class NoCircularDependenciesTest extends TestCase
         // is what unpicks this component. That is a BC break on a public method, so
         // it is deferred; until then the whole component is listed.
         //
+        // A second, smaller edge for the same 2.0 pass: `SetupGacelaInterface`
+        // declares `merge(SetupGacela $other)`, naming its own implementation in
+        // its own contract, which no other implementation could satisfy. Dropping
+        // it from the interface needs `ConfigFactory` and
+        // `GacelaConfigUsingGacelaPhpFileFactory` to type-hint the concrete
+        // `SetupGacela`; both are public non-@internal constructors, so it cannot
+        // be done in a minor. Deprecating it early was tried and reverted: nothing
+        // in Gacela itself could satisfy the deprecation, so it only produced a
+        // warning no caller could act on.
+        //
         // Two sub-clusters inside it are cohesive on their own merits and are
         // expected to survive even after the knot is cut:
         //   - SetupGacela + its Setup\* strategy helpers: an aggregate and the

--- a/tests/Unit/Framework/Health/HealthCheckRegistryTest.php
+++ b/tests/Unit/Framework/Health/HealthCheckRegistryTest.php
@@ -6,12 +6,15 @@ namespace GacelaTest\Unit\Framework\Health;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use Gacela\Framework\Health\HealthCheckNotResolvableException;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\HealthStatus;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
+
+use function sprintf;
 
 final class HealthCheckRegistryTest extends TestCase
 {
@@ -87,15 +90,40 @@ final class HealthCheckRegistryTest extends TestCase
         self::assertArrayHasKey('SecondFake', $report->getResults());
     }
 
-    public function test_unresolvable_class_string_is_skipped(): void
+    /**
+     * A registered check that cannot be resolved is a misconfiguration, not a
+     * reason to report a healthy system: skipping it silently would hide the
+     * very problem health checks exist to surface.
+     */
+    public function test_unresolvable_class_string_reports_the_misconfiguration(): void
     {
         /** @var class-string<ModuleHealthCheckInterface> $bogus */
         $bogus = 'GacelaTest\NotExisting\HealthCheck';
         HealthCheckRegistry::register($bogus);
 
-        $checker = HealthCheckRegistry::createHealthChecker();
+        $this->expectException(HealthCheckNotResolvableException::class);
+        $this->expectExceptionMessage(
+            'The health check "GacelaTest\NotExisting\HealthCheck" was registered but the class does not exist. '
+            . 'Check the class-string passed to GacelaConfig::addHealthCheck().',
+        );
 
-        self::assertSame(0, $checker->count());
+        HealthCheckRegistry::createHealthChecker();
+    }
+
+    public function test_class_that_is_not_a_health_check_reports_the_misconfiguration(): void
+    {
+        /** @var class-string<ModuleHealthCheckInterface> $notACheck */
+        $notACheck = HealthCheckRegistryNotACheck::class;
+        HealthCheckRegistry::register($notACheck);
+
+        $this->expectException(HealthCheckNotResolvableException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The health check "%s" does not implement %s.',
+            HealthCheckRegistryNotACheck::class,
+            ModuleHealthCheckInterface::class,
+        ));
+
+        HealthCheckRegistry::createHealthChecker();
     }
 
     public function test_container_provided_instance_is_preferred_over_direct_instantiation(): void
@@ -201,4 +229,8 @@ final class HealthCheckRegistryConfigurableFake implements ModuleHealthCheckInte
     {
         return $this->name;
     }
+}
+
+final class HealthCheckRegistryNotACheck
+{
 }


### PR DESCRIPTION
## 📚 Description

Closes the last of the audit findings that needed a judgement call, and the changelog already made the call — 1.19.0 shipped:

> Health-check resolution no longer swallows container errors: a registered check whose container resolution throws now surfaces the real exception **instead of silently falling back to a default instance and hiding the misconfiguration**

The `class_exists()` branch right next to it was the same bug, left in place. A health check registered by class-string that could not be resolved was skipped, so:

```php
$config->addHealthCheck(SomCheck::class); // typo
```

produced a report that looked **healthy** while the check never ran — the exact failure mode health checks exist to surface. `bin/gacela doctor` would print `✓ All checks passed`.

## 🔖 Changes

- Unresolvable class-string → `HealthCheckNotResolvableException` naming the class and pointing at `addHealthCheck()`.
- Class exists but does not implement `ModuleHealthCheckInterface` → same exception, different message.
- `instantiate()` now takes a bare `class-string` rather than `class-string<ModuleHealthCheckInterface>`. That narrower annotation is a *promise from the caller*, not a verified fact; taking it at face value made PHPStan (correctly) rule the interface check dead code. Construction goes through `ReflectionClass` so the result is honestly `object` until checked.

## ⚠️ Behaviour change

An app that registers a health check it cannot resolve now fails loudly where it previously reported healthy. That is the point, but it belongs in release notes — a misconfigured check that has been quietly absent could surface on upgrade.

## 🚫 What I did *not* do, and why

I also drafted deprecating `SetupGacelaInterface::merge()` — the other open finding, worth 4 classes off the architecture cycle. **I reverted it.**

Its signature is `merge(SetupGacela $other)`: an interface method naming its own implementation, which nothing else can satisfy. Dropping it needs `ConfigFactory` and `GacelaConfigUsingGacelaPhpFileFactory` to type-hint the concrete `SetupGacela` — and **both are public, non-`@internal` constructors**, so that is a BC break, not a minor.

Deprecating it early failed on its own merits: Psalm immediately flagged Gacela's own call site, and there was no non-breaking way to fix it. A deprecation that the library itself cannot satisfy is just a warning nobody can act on, and it teaches people to ignore deprecation notices.

So the reasoning is recorded where the 2.0 work will actually hit it — the architecture test's allow-list comment, beside the existing note about inverting `Container::withConfig()`.

## ✅ Verification

- `composer quality` exit 0 (cs-fixer, psalm level 1, phpstan max, phpstan-tests).
- Full suite 1035 tests, 2143 assertions, 0 failures.
- Infection on the changed files: **MSI 100%, Covered MSI 100%**. The first pass came back 88% — my own exception messages weren't pinned tightly enough and `Concat` mutators escaped, the same gap #512 fixed elsewhere. Tests now assert the exact messages.