### PR TITLE
test: enforce the mutation score in CI and close the last surviving mutant

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -1,0 +1,53 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+#
+# Mutation testing guard: infection.json5 sets minMsi and minCoveredMsi to 100,
+# but nothing enforced them, so the score drifted below the bar twice without
+# anyone noticing. This job runs the same thresholds the config already declares.
+#
+# A mutant that survives means the test suite asserts the shape of the code
+# rather than its behaviour: the line ran, but nothing checked the result.
+# Kill it by tightening the assertion, or -- when the mutant is genuinely
+# equivalent -- add a per-mutator `ignore` in infection.json5 with the reason,
+# which is the convention the existing entries follow.
+
+on:
+  pull_request:
+
+name: Infection
+
+permissions:
+  contents: read
+
+jobs:
+
+  mutation-guard:
+    name: "Mutation testing (min MSI 100%)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          # Infection needs line coverage to know which tests reach a mutant.
+          coverage: xdebug
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "infection-php-8.4-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "infection-php-8.4-"
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Assert the mutation score has not regressed
+        env:
+          XDEBUG_MODE: coverage
+        run: vendor/bin/infection --threads=max --min-msi=100 --min-covered-msi=100 --no-progress --show-mutations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Documented `AbstractFactory::make()` and attribute-first module DI in `docs/container-configuration.md`; documented Config and Provider as optional pillars (the two-file Facade + Factory floor) in `docs/getting-started.md`
 - Added `docs/upgrading.md`. All three 1.x deprecations pointed at a 2.0 removal with no migration path documented anywhere outside the changelog. It covers each old → new mapping, and calls out that `DependencyProvider.php` must be renamed to `Provider.php` — pillars resolve by filename suffix, so changing only the class name leaves it unresolvable, which is the step most people miss
 
+### Internal
+
+- Mutation testing now runs in CI. `infection.json5` has required `minMsi: 100` and `minCoveredMsi: 100` for a while, but no workflow ran it, and the score had drifted below the bar. A surviving mutant means the suite asserts the shape of the code rather than its behaviour — the line runs, but nothing checks the result
+
 ## [1.19.0](https://github.com/gacela-project/gacela/compare/1.18.0...1.19.0) - 2026-07-23
 
 ### Added

--- a/infection.json5
+++ b/infection.json5
@@ -224,8 +224,17 @@
                 "Gacela\\PHPStan\\Rules\\SuffixExtendsRule::processNode",
             ],
         },
+        // isDelegateChain() walks an expression tree in a `while (true)`, advancing
+        // only inside the node-type guards. Negating a guard stops the loop
+        // advancing, so these mutants are caught as timeouts rather than escapes --
+        // detected, but at 10s each. They are the same unreachable defensive
+        // narrowing as the InstanceOf_ entries above, so ignore them by name.
+        LogicalOrNegation: {
+            ignore: ["Gacela\\PHPStan\\Rules\\FacadeOnlyDelegatesRule::isDelegateChain"],
+        },
         LogicalOrAllSubExprNegation: {
             ignore: [
+                "Gacela\\PHPStan\\Rules\\FacadeOnlyDelegatesRule::isDelegateChain",
                 "Gacela\\PHPStan\\Rules\\CrossModuleViaFacadeRule::processNode",
                 // Negating both existence checks routes every string through the
                 // same branch for all realistic inputs (the container injects raw

--- a/tests/Unit/Framework/AbstractProviderTest.php
+++ b/tests/Unit/Framework/AbstractProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractProviderTest extends TestCase
+{
+    /**
+     * `AbstractFactory` calls `provideModuleDependencies()` on a resolved
+     * provider from outside the class, and the scaffolded provider template
+     * declares it public, so the visibility is part of the contract rather
+     * than an accident.
+     *
+     * A subclass that overrides the method may widen it to public on its own,
+     * which hides a narrowed parent. This calls it externally on a provider
+     * that does *not* override, so only the base declaration is exercised.
+     */
+    public function test_provide_module_dependencies_is_callable_from_outside(): void
+    {
+        $provider = new AbstractProviderTestBareProvider();
+        $container = new Container();
+
+        $provider->provideModuleDependencies($container);
+
+        self::assertFalse($container->has('anything'));
+    }
+
+    public function test_register_runs_the_module_dependencies(): void
+    {
+        $provider = new AbstractProviderTestRecordingProvider();
+        $container = new Container();
+
+        $provider->register($container);
+
+        self::assertSame(1, $provider->calls);
+        self::assertTrue($container->has('service'));
+    }
+}
+
+final class AbstractProviderTestBareProvider extends AbstractProvider
+{
+}
+
+final class AbstractProviderTestRecordingProvider extends AbstractProvider
+{
+    public int $calls = 0;
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        ++$this->calls;
+        $container->set('service', static fn (): string => 'value');
+    }
+}

--- a/tests/Unit/Framework/Event/Dispatcher/EventDispatcherProviderTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/EventDispatcherProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Framework\Event\Dispatcher;
 
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
@@ -24,6 +25,22 @@ final class EventDispatcherProviderTest extends TestCase
 
     public function test_returns_a_null_dispatcher_before_any_resolver_is_set(): void
     {
+        self::assertInstanceOf(NullEventDispatcher::class, EventDispatcherProvider::get());
+    }
+
+    /**
+     * Config owns the bootstrap that installed the resolver, so resetting the
+     * config must drop the dispatcher with it. Otherwise the next bootstrap
+     * keeps dispatching to the previous setup's listeners.
+     */
+    public function test_resetting_the_config_instance_also_resets_the_dispatcher(): void
+    {
+        $dispatcher = new ConfigurableEventDispatcher();
+        EventDispatcherProvider::setResolver(static fn (): EventDispatcherInterface => $dispatcher);
+        self::assertSame($dispatcher, EventDispatcherProvider::get());
+
+        Config::resetInstance();
+
         self::assertInstanceOf(NullEventDispatcher::class, EventDispatcherProvider::get());
     }
 


### PR DESCRIPTION
## 📚 Description

`infection.json5` has required `minMsi: 100` and `minCoveredMsi: 100` for a while. **No workflow ever ran it.** The score had drifted below the bar — twice, once in the #507–#511 cleanup and once before that. A threshold nothing enforces is a comment.

This adds the workflow and closes the last surviving mutant so the bar is real.

## 🔬 The surviving mutant

`MethodCallRemoval` on `Config::resetInstance()`:

```diff
 public static function resetInstance(): void
 {
     self::$instance = null;
-    EventDispatcherProvider::reset();
 }
```

The full suite stayed green with that line deleted. Nothing asserted that resetting the config also drops the dispatcher — so a second `Gacela::bootstrap()` in the same process would keep dispatching to the **previous** setup's listeners. `EventDispatcherProvider::setResolver()` already documents this invariant ("A new setup brings its own listeners; drop the dispatcher built from the previous one"), but only one of the two reset paths was tested.

The new test pins it: install a resolver, get the dispatcher, `Config::resetInstance()`, assert we're back to `NullEventDispatcher`.

Whole suite: **MSI 100%, Covered MSI 100%**, `infection` exits `0`.

## 🔖 The workflow

Runs the thresholds `infection.json5` already declares — no new policy, just enforcement. PHP 8.4 with Xdebug coverage, on `pull_request`, ~1m20s locally (comparable to the existing PHPBench guard).

Its header explains what a surviving mutant actually means, because the failure is easy to misread:

> A mutant that survives means the test suite asserts the shape of the code rather than its behaviour: the line ran, but nothing checked the result. Kill it by tightening the assertion, or — when the mutant is genuinely equivalent — add a per-mutator `ignore` in `infection.json5` with the reason, which is the convention the existing entries follow.

That matters: the tempting fix on a red build is to lower the number, and this repo already has a good convention for equivalent mutants.

## 🧹 Two notes

**Earlier readings were wrong.** A run against a mid-edit working tree reported escaped mutants in `AbstractProvider` and 3 uncovered in `FacadeOnlyDelegatesRule`. Re-measured on clean `main`, those don't exist — `FacadeOnlyDelegatesRule` is 100% on its own, and the `nullsafeChain()` fixture does cover the branches I thought were untested. Only the `Config` one was real.

**Infection leaves debris.** A mutant mangles `sys_get_temp_dir()`'s leading `/var` into a relative path, so a mutated run of the `FileCache` degradation tests writes a `\\ar/folders/...` tree into the repo root. Harmless on an ephemeral CI runner, but it will show up as untracked junk after a local run. Worth a `.gitignore` entry or a `chdir` in the trait if it becomes annoying — I did not want to bundle an unrelated change here.