### PR TITLE
ci: run the mutation guard on main too

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -12,6 +12,9 @@
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 name: Infection
 


### PR DESCRIPTION
## 📚 Description

Follow-up to #514. `tests.yml` and `code-style.yml` already run on both `pull_request` **and** pushes to `main`; the mutation guard only ran on `pull_request`, leaving `main` itself unguarded.

That gap is not theoretical:

- A **squash merge** produces a commit that never existed during the PR run.
- An **admin merge** can land a branch whose base has since moved.

So the score can drift on `main` without any PR ever going red — which is exactly how it drifted in the first place.

## 🔖 Changes

```diff
 on:
   pull_request:
+  push:
+    branches:
+      - main
```

## 🚫 Why not phpbench too

`phpbench.yml` stays `pull_request`-only deliberately. It checks out `github.base_ref`, benchmarks it as a baseline, then benchmarks the PR head against it. On a push there is no base to compare with, so the job has no meaning — it isn't an oversight.