### PR TITLE
feat(console): add gacela init to scaffold a project's gacela.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `doctor` now reports pillar classes whose file is named differently from the class. Gacela resolves pillars by *filename* suffix, so a class renamed without its file stops resolving with nothing pointing at the cause — the step people miss migrating `AbstractDependencyProvider` to `AbstractProvider`, where `DependencyProvider.php` must also become `Provider.php`
 - `doctor --strict` exits non-zero on warnings as well as errors, so it can gate CI
+- `gacela init` scaffolds a project's `gacela.php`. It was the one file you had to hand-write from the docs before anything ran; `composer require` → `gacela init` → `make:module` now gets you to working code. Refuses to overwrite an existing file unless `--force`
 
 ## [1.20.0](https://github.com/gacela-project/gacela/compare/1.19.0...1.20.0) - 2026-07-25
 

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -14,6 +14,7 @@ use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
 use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
 use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
 use Gacela\Console\Infrastructure\Command\DoctorCommand;
+use Gacela\Console\Infrastructure\Command\InitCommand;
 use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\MakeFileCommand;
 use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
@@ -21,6 +22,7 @@ use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Config\Config;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -55,6 +57,7 @@ final class ConsoleProvider extends AbstractProvider
             new ValidateConfigCommand(),
             new ProfileReportCommand(),
             new DoctorCommand(),
+            new InitCommand(Config::getInstance()->getAppRootDir()),
         ];
     }
 

--- a/src/Console/Infrastructure/Command/InitCommand.php
+++ b/src/Console/Infrastructure/Command/InitCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function is_file;
+use function sprintf;
+
+/**
+ * Scaffolds the `gacela.php` a project needs before anything else works.
+ *
+ * Takes the app root as a constructor argument rather than reading it from a
+ * bootstrapped Config: this command runs *before* the project has a gacela.php,
+ * so there is nothing to bootstrap from yet.
+ */
+final class InitCommand extends Command
+{
+    private const FILENAME = 'gacela.php';
+
+    private const TEMPLATE = __DIR__ . '/../Template/Command/gacela-php.txt';
+
+    public function __construct(
+        private readonly string $appRootDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('init')
+            ->setDescription('Create a gacela.php config file in the project root')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite an existing gacela.php');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $target = $this->appRootDir . DIRECTORY_SEPARATOR . self::FILENAME;
+
+        if (is_file($target) && $input->getOption('force') !== true) {
+            $output->writeln(sprintf('<error>%s already exists.</error>', self::FILENAME));
+            $output->writeln('Pass <comment>--force</comment> to overwrite it.');
+
+            return self::FAILURE;
+        }
+
+        $template = file_get_contents(self::TEMPLATE);
+        if ($template === false) {
+            throw new RuntimeException(sprintf('Template "%s" could not be read', self::TEMPLATE));
+        }
+
+        if (file_put_contents($target, $template) === false) {
+            throw new RuntimeException(sprintf('File "%s" was not written', $target));
+        }
+
+        $output->writeln(sprintf('<fg=green>✓</> Created %s', $target));
+        $output->writeln('');
+        $output->writeln('Next: <comment>bin/gacela make:module App/YourModule --minimal</comment>');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Infrastructure/Template/Command/gacela-php.txt
+++ b/src/Console/Infrastructure/Template/Command/gacela-php.txt
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    // Where Gacela reads your configuration from. The local file wins, so keep
+    // it out of version control for machine-specific overrides.
+    $config->addAppConfig('config/*.php', 'config/local.php');
+
+    // Namespaces Gacela scans when resolving a module's pillars.
+    $config->setProjectNamespaces(['App']);
+
+    // Always pass an explicit directory. Without one the cache falls back to
+    // the system temp directory, which is shared with every other app on the
+    // machine — you would be reading someone else's stale entries.
+    $config->setFileCache(false, __DIR__ . '/data/cache');
+};

--- a/tests/Feature/Console/Init/InitCommandTest.php
+++ b/tests/Feature/Console/Init/InitCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\Init;
+
+use Gacela\Console\Infrastructure\Command\InitCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function bin2hex;
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class InitCommandTest extends TestCase
+{
+    private string $appRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->appRoot = sys_get_temp_dir() . '/gacela-init-test-' . bin2hex(random_bytes(4));
+        mkdir($this->appRoot, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->appRoot . '/gacela.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+
+        if (is_dir($this->appRoot)) {
+            rmdir($this->appRoot);
+        }
+    }
+
+    public function test_writes_a_gacela_php_that_returns_a_callable(): void
+    {
+        $command = new CommandTester(new InitCommand($this->appRoot));
+
+        $exitCode = $command->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertFileExists($this->appRoot . '/gacela.php');
+
+        $returned = require $this->appRoot . '/gacela.php';
+        self::assertIsCallable($returned);
+    }
+
+    public function test_generated_file_is_valid_for_bootstrap(): void
+    {
+        (new CommandTester(new InitCommand($this->appRoot)))->execute([]);
+
+        $contents = (string)file_get_contents($this->appRoot . '/gacela.php');
+
+        self::assertStringContainsString('declare(strict_types=1);', $contents);
+        self::assertStringContainsString('GacelaConfig', $contents);
+    }
+
+    public function test_refuses_to_overwrite_an_existing_file(): void
+    {
+        file_put_contents($this->appRoot . '/gacela.php', '<?php // mine');
+
+        $command = new CommandTester(new InitCommand($this->appRoot));
+        $exitCode = $command->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('already exists', $command->getDisplay());
+        self::assertSame('<?php // mine', file_get_contents($this->appRoot . '/gacela.php'));
+    }
+
+    public function test_force_overwrites_an_existing_file(): void
+    {
+        file_put_contents($this->appRoot . '/gacela.php', '<?php // mine');
+
+        $command = new CommandTester(new InitCommand($this->appRoot));
+        $exitCode = $command->execute(['--force' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringNotContainsString('// mine', (string)file_get_contents($this->appRoot . '/gacela.php'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

Closes #517.

`make:module` and `make:file` scaffold *inside* an existing project, but the first file — `gacela.php` — had to be hand-written from the docs. That is the highest-friction moment in the framework: the package is installed and there is nothing to run.

`composer require gacela-project/gacela` → `gacela init` → `make:module --minimal` now gets you to working code.

## 🔖 Changes

- **`InitCommand`** (`gacela init`) writes `gacela.php` into the project root and points at the next command.
- **`--force`** to overwrite; without it an existing `gacela.php` is left untouched and the command exits `FAILURE`. Clobbering someone's config by accident is the one thing this command must not do.
- **`gacela-php.txt`** template, alongside the existing maker templates.

## 🧩 Two decisions worth calling out

**The template sets an explicit file cache directory.** Not cosmetic — with no directory the cache falls back to `sys_get_temp_dir()`, shared with every other Gacela app on the machine. That is not hypothetical: while writing the `doctor --strict` test in #519, `CacheStalenessCheck` reported ~30 stale entries belonging to an entirely different project (`\Phel\Console\Factory`, `\Phel\Run\RunFacade`…). A scaffolded project should not start out sharing a cache with the machine.

**`InitCommand` takes the app root as a constructor argument** rather than reading a bootstrapped `Config`. It runs *before* the project has a `gacela.php` to bootstrap from, so depending on bootstrap state would be backwards. It also makes the command testable against a temp directory without touching global state.

## ✅ Verification

Unit/feature: 4 tests covering write, content validity, refuse-to-overwrite, and `--force`.

Verified end-to-end with the real binary rather than only through `CommandTester` — in a fresh temp directory:

```
$ php bin/gacela init
✓ Created /tmp/…/gacela.php

Next: bin/gacela make:module App/YourModule --minimal

$ php bin/gacela list:modules
No modules match filter "".      # exit 0 — the generated file bootstraps
```

`composer quality` exit 0 · 1049 tests, 0 failures · full-suite MSI 100%.