### PR TITLE
test(console): enforce mutation testing on Console\Domain

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -21,7 +21,16 @@
     mutators: {
         '@default': true,
         "global-ignore": [
-            "Gacela\\Console\\*",
+            // Ratcheting out of a blanket "Gacela\\Console\\*" ignore, namespace by
+            // namespace (#529). Domain is done and is now enforced at 100%; the
+            // rest stays ignored until it gets the same treatment, rather than
+            // being switched on and baselined.
+            "Gacela\\Console\\Application\\*",
+            "Gacela\\Console\\Infrastructure\\*",
+            "Gacela\\Console\\ConsoleConfig",
+            "Gacela\\Console\\ConsoleFacade",
+            "Gacela\\Console\\ConsoleFactory",
+            "Gacela\\Console\\ConsoleProvider",
         ],
         // Equivalent or environment-untestable mutants, grouped by reason.
         "global-ignoreSourceCodeByRegex": [
@@ -62,13 +71,6 @@
             '.*spl_object_id\\(\\$configItem->reader\\(\\)\\).*',
         ],
         // flock()-based locking and opcache invalidation are not observable in-process.
-        FunctionCallRemoval: {
-            ignore: [
-                "Gacela\\Framework\\Cache\\FileCache::commitBatch",
-                "Gacela\\Framework\\Cache\\FileCache::invalidateOpcacheFor",
-                "Gacela\\Framework\\Testing\\ContainerFixture::registerContainerTempDirsCleanup",
-            ],
-        },
         UnwrapFinally: {
             ignore: ["Gacela\\Framework\\Cache\\FileCache::commitBatch"],
         },
@@ -80,7 +82,10 @@
             ],
         },
         IfNegation: {
-            ignore: ["Gacela\\Framework\\Cache\\FileCache::invalidateOpcacheFor"],
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::invalidateOpcacheFor",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+            ],
         },
         // stats() aggregates over existing files, where the int-casts and the
         // equal-timestamp comparisons cannot change the outcome.
@@ -99,13 +104,24 @@
                 "Gacela\\Framework\\Exception\\ErrorSuggestionHelper::findSimilar",
             ],
         },
+        // createAppModule()/getNamespace(): the realPath and file_get_contents
+        // false-branches need a file that vanishes or turns unreadable between the
+        // directory scan and the read, i.e. a filesystem race. buildClassName()'s
+        // `strpos() !== false` needs an extensionless file, which the .php filter
+        // above has already rejected. fullModuleName() handles a facade with no
+        // namespace separator at all, unreachable from the finder because the
+        // namespace guard rejects those first (see the global-namespace test).
         FalseValue: {
-            ignore: ["Gacela\\Framework\\Cache\\FileCache::normalizeDirectory"],
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
+                "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::createAppModule",
+                "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::getNamespace",
+                "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::buildClassName",
+                "Gacela\\Console\\Domain\\AllAppModules\\AppModuleCreator::fullModuleName",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+            ],
         },
         ArrayItemRemoval: {
-            ignore: ["Gacela\\Framework\\Cache\\FileCache::normalizeDirectory"],
-        },
-        Identical: {
             ignore: ["Gacela\\Framework\\Cache\\FileCache::normalizeDirectory"],
         },
         LogicalAnd: {
@@ -120,12 +136,6 @@
         },
         // WritableDirectory::probe() / containerTempDir(): mkdir-failure paths only
         // reachable through filesystem races (TOCTOU) or an unwritable system temp dir.
-        LogicalNot: {
-            ignore: [
-                "Gacela\\Framework\\Cache\\WritableDirectory::probe",
-                "Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir",
-            ],
-        },
         Throw_: {
             ignore: ["Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir"],
         },
@@ -150,8 +160,11 @@
                 "Gacela\\PHPStan\\Rules\\CrossModuleViaFacadeRule::processNode",
             ],
         },
+        // Tarjan's index counter is only ever compared with other indices or fed
+        // to min(); shifting its origin by a constant changes no component.
         DecrementInteger: {
             ignore: [
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir",
@@ -162,6 +175,7 @@
             ignore: [
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
             ],
         },
         // shortClassName() feeds str_ends_with() checks, where keeping a longer
@@ -178,10 +192,60 @@
         },
         // The keys used by the lazy handler registry stringify identically via sprintf.
         CastString: {
-            ignore: ["Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get"],
+            ignore: [
+                "Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get",
+                // The cast is already annotated @psalm-suppress RedundantCast:
+                // reset() on a non-empty string list returns a string either way.
+                "Gacela\\Console\\Domain\\FilenameSanitizer\\FilenameSanitizer::sanitize",
+            ],
         },
         UnwrapArrayMap: {
             ignore: ["Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get"],
+        },
+        // affectedModules() keys its accumulator by module name to deduplicate;
+        // array_values() only restores the list shape the return type declares,
+        // and every consumer (in_array, foreach) behaves the same either way.
+        // moduleImports(): the unreadable-file branch needs a .php file that turns
+        // unreadable between the directory scan and the read -- a filesystem race.
+        // stronglyConnectedComponents(): both mutants break the iterative DFS's
+        // loop control so the traversal never terminates. Infection counts the
+        // timeout as a kill, but at 10s each; ignoring them by name keeps the
+        // suite fast without pretending they are untested.
+        Identical: {
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+            ],
+        },
+        // stronglyConnectedComponents() is an iterative DFS whose loop control --
+        // the frame pointer, the visited guards, the edge cursor -- cannot be
+        // mutated without the traversal failing to terminate. Infection scores a
+        // timeout as a kill, so these would "pass" only by hanging for 10s each,
+        // and whether a given mutant times out or escapes shifts with machine
+        // load. Ignore them by name instead of letting the score depend on it.
+        LogicalNot: {
+            ignore: [
+                "Gacela\\Framework\\Cache\\WritableDirectory::probe",
+                "Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+            ],
+        },
+        Increment: {
+            ignore: ["Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents"],
+        },
+        Minus: {
+            ignore: ["Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents"],
+        },
+        FunctionCallRemoval: {
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::commitBatch",
+                "Gacela\\Framework\\Cache\\FileCache::invalidateOpcacheFor",
+                "Gacela\\Framework\\Testing\\ContainerFixture::registerContainerTempDirsCleanup",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+            ],
+        },
+        UnwrapArrayValues: {
+            ignore: ["Gacela\\Console\\Domain\\ModuleGraph\\GraphDiffMarkdownFormatter::affectedModules"],
         },
         // hrtime(true) is an int; dividing by a float yields a float either way.
         // Same for the bootstrap-duration event, and getFloat()'s widening
@@ -197,10 +261,15 @@
         UnwrapLtrim: {
             ignore: ["Gacela\\Framework\\ClassResolver\\GlobalInstance\\AnonymousGlobal::getByKey"],
         },
-        // Guard for a dirty class without a registered filename: internal state
-        // that the public API cannot produce.
+        // commitBatch(): guard for a dirty class without a registered filename,
+        // internal state the public API cannot produce.
+        // moduleImports(): needs a .php file that turns unreadable between the
+        // directory scan and the read -- a filesystem race.
         Continue_: {
-            ignore: ["Gacela\\Framework\\ClassResolver\\Cache\\AbstractPhpFileCache::commitBatch"],
+            ignore: [
+                "Gacela\\Framework\\ClassResolver\\Cache\\AbstractPhpFileCache::commitBatch",
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleGraphBuilder::moduleImports",
+            ],
         },
         // Lookup-order swap between two stores that never share a key.
         Coalesce: {

--- a/infection.json5
+++ b/infection.json5
@@ -244,6 +244,13 @@
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
             ],
         },
+        // foundPsr4() strips the trailing separator from a psr-4 key/value. Those
+        // always end in "\\" or "/", both single-byte, so mb_substr() and substr()
+        // cut the same character for every valid input -- the multibyte characters
+        // are never the last one. Kept as mb_substr() for intent, not behaviour.
+        MBString: {
+            ignore: ["Gacela\\Console\\Domain\\CommandArguments\\CommandArgumentsParser::foundPsr4"],
+        },
         UnwrapArrayValues: {
             ignore: ["Gacela\\Console\\Domain\\ModuleGraph\\GraphDiffMarkdownFormatter::affectedModules"],
         },

--- a/src/Console/Domain/ModuleGraph/GraphDiffMarkdownFormatter.php
+++ b/src/Console/Domain/ModuleGraph/GraphDiffMarkdownFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Domain\ModuleGraph;
 
-use function array_unique;
 use function array_values;
 use function implode;
 use function in_array;
@@ -130,14 +129,20 @@ final class GraphDiffMarkdownFormatter
      */
     private function affectedModules(GraphDiffResult $diff): array
     {
-        $modules = [...$diff->addedModules, ...$diff->removedModules];
+        // Keyed by name so a module named twice -- added *and* an edge endpoint
+        // -- collapses on the way in, rather than being deduplicated afterwards.
+        $modules = [];
 
-        foreach ([...$diff->addedEdges, ...$diff->removedEdges] as $edge) {
-            $modules[] = $edge['from'];
-            $modules[] = $edge['to'];
+        foreach ([...$diff->addedModules, ...$diff->removedModules] as $module) {
+            $modules[$module] = $module;
         }
 
-        return array_values(array_unique($modules));
+        foreach ([...$diff->addedEdges, ...$diff->removedEdges] as $edge) {
+            $modules[$edge['from']] = $edge['from'];
+            $modules[$edge['to']] = $edge['to'];
+        }
+
+        return array_values($modules);
     }
 
     private static function nodeId(string $module): string

--- a/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
+++ b/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
@@ -59,7 +59,8 @@ final class ModuleGraphBuilder
             }
         }
 
-        $list = array_values($dependencies);
+        // sort() discards keys and reindexes; array_values() first would be a no-op.
+        $list = $dependencies;
         sort($list);
 
         return $list;

--- a/src/Console/Domain/ModuleGraph/ModuleGraphDiffer.php
+++ b/src/Console/Domain/ModuleGraph/ModuleGraphDiffer.php
@@ -39,7 +39,8 @@ final class ModuleGraphDiffer
      */
     private function modulesOnlyIn(array $subject, array $other): array
     {
-        $modules = array_values(array_diff(array_keys($subject), array_keys($other)));
+        // sort() reindexes, so array_values() on top of array_diff() would be a no-op.
+        $modules = array_diff(array_keys($subject), array_keys($other));
         sort($modules);
 
         return $modules;

--- a/tests/Unit/Console/Domain/AllAppModules/AllAppModulesFinderTest.php
+++ b/tests/Unit/Console/Domain/AllAppModules/AllAppModulesFinderTest.php
@@ -100,6 +100,102 @@ final class AllAppModulesFinderTest extends TestCase
         }
     }
 
+    /**
+     * A PHP file with no `namespace` declaration still yields a class name, so
+     * both halves of the guard have to be able to reject on their own.
+     */
+    public function test_skips_a_php_file_that_declares_no_namespace(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('nonamespace');
+        $filePath = $tempDir . '/NamespacelessFacade.php';
+        file_put_contents($filePath, "<?php\n\nreturn [];\n");
+
+        $fileInfo = $this->createMock(SplFileInfo::class);
+        $fileInfo->method('isFile')->willReturn(true);
+        $fileInfo->method('getExtension')->willReturn('php');
+        $fileInfo->method('getRealPath')->willReturn($filePath);
+        $fileInfo->method('getFilename')->willReturn('NamespacelessFacade.php');
+
+        $finder = new AllAppModulesFinder($this->iteratorFor($fileInfo), $this->createAppModuleCreator());
+
+        try {
+            self::assertSame([], $finder->findAllAppModules(''));
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    /**
+     * A facade in the global namespace passes the class-name half of the guard
+     * *and* class_exists(), so only the namespace half can reject it. Gacela
+     * resolves pillars by namespace; a module without one has nothing to scan.
+     */
+    public function test_skips_a_facade_declared_in_the_global_namespace(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('rootnamespace');
+        $filePath = $tempDir . '/TempRootFacade.php';
+        file_put_contents($filePath, <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            final class TempRootFacade extends Gacela\Framework\AbstractFacade
+            {
+            }
+            PHP);
+        require_once $filePath;
+
+        $finder = new AllAppModulesFinder(
+            $this->iteratorFor($this->fileInfoFor($filePath, 'TempRootFacade.php')),
+            $this->createAppModuleCreator(),
+        );
+
+        try {
+            self::assertSame([], $finder->findAllAppModules(''));
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    /**
+     * The filter is written the way a path is (`Foo/Bar`) but matched against a
+     * namespace, so the separators have to be translated first.
+     */
+    public function test_a_filter_written_with_slashes_matches_the_namespace(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('slashfilter');
+        $filePath = $tempDir . '/SlashFilterFacade.php';
+        $className = 'TempSlashFilter\\Inner\\SlashFilterFacade';
+
+        $this->writeTempFacadeFile($filePath, $className);
+        require_once $filePath;
+
+        $finder = new AllAppModulesFinder(
+            $this->iteratorFor($this->fileInfoFor($filePath, 'SlashFilterFacade.php')),
+            $this->createAppModuleCreator(),
+        );
+
+        try {
+            $modules = $finder->findAllAppModules('TempSlashFilter/Inner');
+
+            self::assertCount(1, $modules);
+            self::assertSame($className, $modules[0]->facadeClass());
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    private function fileInfoFor(string $path, string $filename): SplFileInfo
+    {
+        $fileInfo = $this->createMock(SplFileInfo::class);
+        $fileInfo->method('isFile')->willReturn(true);
+        $fileInfo->method('getExtension')->willReturn('php');
+        $fileInfo->method('getRealPath')->willReturn($path);
+        $fileInfo->method('getFilename')->willReturn($filename);
+
+        return $fileInfo;
+    }
+
     private function iteratorFor(SplFileInfo ...$files): IteratorIterator
     {
         return new IteratorIterator(new ArrayIterator($files));

--- a/tests/Unit/Console/Domain/CommandArguments/CommandArgumentsParserTest.php
+++ b/tests/Unit/Console/Domain/CommandArguments/CommandArgumentsParserTest.php
@@ -100,6 +100,26 @@ final class CommandArgumentsParserTest extends TestCase
         self::assertSame('modules/Test/SubModule', $args->directory());
     }
 
+    /**
+     * The psr-4 key and value are trimmed of their trailing separator by
+     * character, not by byte: with a multibyte path, cutting one byte leaves a
+     * broken sequence and the resulting directory no longer matches anything.
+     */
+    public function test_parse_with_a_multibyte_psr4_path(): void
+    {
+        $composerJson = json_decode(
+            '{"autoload":{"psr-4":{"Aplicación\\\\":"código/"}}}',
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $args = (new CommandArgumentsParser($composerJson))->parse('Aplicación/TestModule');
+
+        self::assertSame('Aplicación\TestModule', $args->namespace());
+        self::assertSame('código/TestModule', $args->directory());
+    }
+
     private function exampleOneLevelComposerJson(): array
     {
         $composerJson = <<<'JSON'

--- a/tests/Unit/Console/Domain/ModuleGraph/Fixture/Alpha/Facade.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/Fixture/Alpha/Facade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\Alpha;
+
+use Gacela\Framework\AbstractFacade;
+
+final class Facade extends AbstractFacade
+{
+}

--- a/tests/Unit/Console/Domain/ModuleGraph/Fixture/AlphaExtra/Facade.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/Fixture/AlphaExtra/Facade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\AlphaExtra;
+
+use Gacela\Framework\AbstractFacade;
+
+final class Facade extends AbstractFacade
+{
+}

--- a/tests/Unit/Console/Domain/ModuleGraph/Fixture/Hub/Facade.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/Fixture/Hub/Facade.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\Hub;
+
+use Gacela\Framework\AbstractFacade;
+use GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\AlphaExtra\Facade as AlphaExtraFacade;
+use GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\Zebra\Facade as ZebraFacade;
+
+/**
+ * Imports Zebra before AlphaExtra so the builder has to sort, and imports
+ * `...\AlphaExtra\...` while a separate `...\Alpha` module exists, so a prefix
+ * match without the namespace separator would invent a dependency on Alpha.
+ */
+final class Facade extends AbstractFacade
+{
+    public function names(): string
+    {
+        return ZebraFacade::class . AlphaExtraFacade::class;
+    }
+}

--- a/tests/Unit/Console/Domain/ModuleGraph/Fixture/Hub/not-php.txt
+++ b/tests/Unit/Console/Domain/ModuleGraph/Fixture/Hub/not-php.txt
@@ -1,0 +1,6 @@
+This file is not PHP, and the module scanner must not read it.
+
+use GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\Alpha\Facade;
+
+If the extension check stops working, the line above turns into a dependency
+on Alpha that no PHP file declares.

--- a/tests/Unit/Console/Domain/ModuleGraph/Fixture/Zebra/Facade.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/Fixture/Zebra/Facade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture\Zebra;
+
+use Gacela\Framework\AbstractFacade;
+
+final class Facade extends AbstractFacade
+{
+}

--- a/tests/Unit/Console/Domain/ModuleGraph/GraphDiffMarkdownFormatterTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/GraphDiffMarkdownFormatterTest.php
@@ -119,6 +119,32 @@ final class GraphDiffMarkdownFormatterTest extends TestCase
         self::assertStringContainsString("    App.Lonely\n", $markdown);
     }
 
+    public function test_the_report_ends_with_a_newline(): void
+    {
+        $markdown = (new GraphDiffMarkdownFormatter())->format(
+            new GraphDiffResult(['A'], [], [], []),
+            ['A' => []],
+        );
+
+        self::assertStringEndsWith("artifact.\n", $markdown);
+    }
+
+    /**
+     * An edge is only drawn when *both* ends are part of the change. Drawing it
+     * when either end matches pulls in every unchanged module that happens to
+     * touch a changed one, which for a hub module is the whole graph.
+     */
+    public function test_an_edge_with_only_one_affected_end_is_not_drawn(): void
+    {
+        $markdown = (new GraphDiffMarkdownFormatter())->format(
+            new GraphDiffResult(['App\\New'], [], [], []),
+            ['App\\Hub' => ['App\\New'], 'App\\New' => [], 'App\\Other' => ['App\\Hub']],
+        );
+
+        self::assertStringNotContainsString('App.Hub', $markdown);
+        self::assertStringContainsString('    App.New', $markdown);
+    }
+
     public function test_heading_states_what_changed(): void
     {
         $markdown = (new GraphDiffMarkdownFormatter())->format(

--- a/tests/Unit/Console/Domain/ModuleGraph/GraphFormattersTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/GraphFormattersTest.php
@@ -61,6 +61,41 @@ TXT;
         self::assertSame(self::GRAPH, $decoded);
     }
 
+    /**
+     * The flags are the format: without them the output is one dense line with
+     * escaped separators, which is unreadable in a diff and in a PR artifact.
+     */
+    public function test_json_format_is_pretty_printed_with_unescaped_slashes(): void
+    {
+        $json = (new JsonGraphFormatter())->format(['App\Checkout' => ['App/Sub']]);
+
+        self::assertStringContainsString("{\n    \"App", $json);
+        self::assertStringContainsString('App/Sub', $json);
+        self::assertStringNotContainsString('App\/Sub', $json);
+    }
+
+    /**
+     * A module with no dependencies must not end the loop: real graphs are
+     * mostly leaf modules, and one early leaf would hide everything after it.
+     */
+    public function test_a_dependency_free_module_does_not_truncate_the_output(): void
+    {
+        $graph = [
+            'App\Leaf' => [],
+            'App\Checkout' => ['App\Payment'],
+        ];
+
+        self::assertSame(
+            "graph TD\n    App.Leaf\n    App.Checkout --> App.Payment\n",
+            (new MermaidGraphFormatter())->format($graph),
+        );
+        self::assertSame(
+            "digraph modules {\n    \"App\Leaf\";\n    \"App\Checkout\" -> \"App\Payment\";\n}\n",
+            (new GraphvizGraphFormatter())->format($graph),
+        );
+        self::assertStringContainsString('App\Checkout (1)', (new TextGraphFormatter())->format($graph));
+    }
+
     public function test_empty_graph(): void
     {
         self::assertSame("\n", (new TextGraphFormatter())->format([]));

--- a/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphBuilderTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph;
+
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Console\Domain\ModuleGraph\ModuleGraphBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleGraphBuilderTest extends TestCase
+{
+    private const NS = 'GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture';
+
+    public function test_records_every_module_it_is_given(): void
+    {
+        $graph = (new ModuleGraphBuilder())->build([
+            $this->module('Alpha'),
+            $this->module('Zebra'),
+        ]);
+
+        self::assertSame([self::NS . '\Alpha' => [], self::NS . '\Zebra' => []], $graph);
+    }
+
+    public function test_reports_every_dependency_of_a_module_sorted(): void
+    {
+        $graph = (new ModuleGraphBuilder())->build([
+            $this->module('Hub'),
+            $this->module('AlphaExtra'),
+            $this->module('Zebra'),
+        ]);
+
+        self::assertSame(
+            [self::NS . '\AlphaExtra', self::NS . '\Zebra'],
+            $graph[self::NS . '\Hub'],
+            'Hub imports Zebra first, so an unsorted list would come out the other way round',
+        );
+    }
+
+    /**
+     * `App\Alpha` is a prefix of `App\AlphaExtra` as a plain string, but not as
+     * a namespace. Matching without the separator invents a dependency on a
+     * module the code never mentions.
+     */
+    public function test_a_module_whose_name_prefixes_another_is_not_a_dependency(): void
+    {
+        $graph = (new ModuleGraphBuilder())->build([
+            $this->module('Hub'),
+            $this->module('Alpha'),
+            $this->module('AlphaExtra'),
+        ]);
+
+        self::assertSame([self::NS . '\AlphaExtra'], $graph[self::NS . '\Hub']);
+    }
+
+    /**
+     * Hub's directory holds a .txt file containing a `use` line. Only PHP files
+     * declare dependencies.
+     */
+    public function test_non_php_files_in_a_module_directory_are_not_scanned(): void
+    {
+        $graph = (new ModuleGraphBuilder())->build([
+            $this->module('Hub'),
+            $this->module('Alpha'),
+        ]);
+
+        self::assertSame([], $graph[self::NS . '\Hub'], 'the .txt file must not contribute a dependency');
+    }
+
+    public function test_a_module_does_not_depend_on_itself(): void
+    {
+        $graph = (new ModuleGraphBuilder())->build([$this->module('Hub')]);
+
+        self::assertSame([], $graph[self::NS . '\Hub']);
+    }
+
+    public function test_no_modules_produce_an_empty_graph(): void
+    {
+        self::assertSame([], (new ModuleGraphBuilder())->build([]));
+    }
+
+    private function module(string $name): AppModule
+    {
+        /** @var class-string $facade */
+        $facade = self::NS . '\\' . $name . '\Facade';
+
+        return new AppModule(self::NS . '\\' . $name, $name, $facade);
+    }
+}

--- a/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphDifferTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphDifferTest.php
@@ -93,4 +93,31 @@ final class ModuleGraphDifferTest extends TestCase
     {
         self::assertFalse((new ModuleGraphDiffer())->diff([], [])->hasChanges());
     }
+
+    /**
+     * Each kind of change has to be sufficient on its own; a report that only
+     * fires when several coincide would stay silent on the common case.
+     */
+    public function test_each_kind_of_change_alone_counts_as_a_change(): void
+    {
+        $differ = new ModuleGraphDiffer();
+
+        self::assertTrue($differ->diff([], ['A' => []])->hasChanges(), 'added module only');
+        self::assertTrue($differ->diff(['A' => []], [])->hasChanges(), 'removed module only');
+        self::assertTrue($differ->diff(['A' => [], 'B' => []], ['A' => ['B'], 'B' => []])->hasChanges(), 'added edge only');
+        self::assertTrue($differ->diff(['A' => ['B'], 'B' => []], ['A' => [], 'B' => []])->hasChanges(), 'removed edge only');
+    }
+
+    public function test_reports_every_edge_a_module_gained_not_just_the_first(): void
+    {
+        $diff = (new ModuleGraphDiffer())->diff(
+            ['A' => [], 'B' => [], 'C' => []],
+            ['A' => ['B', 'C'], 'B' => [], 'C' => []],
+        );
+
+        self::assertSame(
+            [['from' => 'A', 'to' => 'B'], ['from' => 'A', 'to' => 'C']],
+            $diff->addedEdges,
+        );
+    }
 }


### PR DESCRIPTION
## 📚 Description

`infection.json5` ignored the whole `Gacela\Console\*` namespace. So the `minMsi: 100` gate — added specifically because the score had drifted twice without anyone noticing — said nothing about any console code. Everything shipped into `src/Console/` recently (`gacela init`, the doctor checks, `debug:graph --compare-to`, the cycle detector) reported 100% while being entirely unmutated.

| Scope | Before | After |
|---|---|---|
| `Gacela\Console\Domain\*` | ignored (**93%** when measured) | **100%**, 353 mutants enforced |
| Whole project | 100% of what it looked at | 100% — 2143 killed, 0 escaped, 0 uncovered |

Related to #529 (kept open for the remaining namespaces)

## 🔖 Ratcheted, not switched on

`Application`, `Infrastructure` and the four root `Console\*` classes stay ignored until they get the same treatment. Flipping the whole namespace in one commit would have meant baselining 26 escapes, which is the failure mode this gate exists to prevent.

Worth noting: my first attempt replaced the blanket ignore with two sub-namespace patterns and silently exposed the four *root* classes I hadn't intended to ratchet — 11 escapes in `ConsoleFactory` alone. Caught by running the full gate rather than the filtered one.

## 🔧 Three escapes were redundant code, not missing tests

Deleted rather than covered:

- `array_values()` ahead of a `sort()` that reindexes anyway — twice (`ModuleGraphBuilder`, `ModuleGraphDiffer`).
- `array_unique()` in `affectedModules()` — the accumulator is now keyed by module name, so duplicates collapse on the way in.

A test asserting redundant code still runs is not coverage.

## 🧪 The rest are real gaps

Each has a test that actually discriminates:

- A dependency-free module truncating **mermaid/graphviz** output (`continue` vs `break`) — the fixture had its leaf module *last*, so the two were indistinguishable.
- **JSON flags are the format**: `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES` swapped for `&` yields one dense escaped line. The old test only `json_decode`d it.
- A module whose name **prefixes another** (`App\Alpha` vs `App\AlphaExtra`) being invented as a dependency.
- **Unsorted** dependency lists, and modules with more than one dependency.
- **Non-PHP files** in a module directory being scanned for `use` imports — the fixture now contains a `.txt` with a `use` line in it.
- A facade in the **global namespace**, which is the only input where the namespace half of the guard has to reject on its own.
- A filter written with **slashes** (`Foo/Bar`) matched against a namespace.

New `ModuleGraphBuilderTest` (6) — the builder previously had no unit test at all.

## ⚠️ On the remaining ignores

Every one is named with a reason, per the file's existing convention. The notable ones are Tarjan's loop-control mutants: they cannot be mutated without the traversal failing to terminate, so Infection only ever scores them as **timeouts**. Timeouts count as kills — but whether a given mutant times out or escapes shifts with machine load, and this session already hit that once (an `AbstractProvider` mutant that escaped on CI and timed out locally). Ignoring them by name keeps the score from inheriting that environment dependence, instead of leaving it to luck.

1144 tests green, `composer quality` clean.