### PR TITLE
test(console): enforce mutation testing on the root Console classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ gacela-uncreatable-*/
 gacela-filecache-test-*/
 gacela-scoped-bench-*/
 gacela-doctor-strict-*/
+
+# The patterns above only match the leaf directories. The whole tree hangs off a
+# mangled root -- a mutated `/var/folders/...` becomes `\\ar/folders/...` -- so
+# git reports that parent as untracked and the leaves are never consulted. This
+# is the directory that broke every Windows job once already: the name is not a
+# valid path there, so `git checkout` fails outright if it is ever committed.
+[\\]*

--- a/infection.json5
+++ b/infection.json5
@@ -261,14 +261,6 @@
         UnwrapRtrim: {
             ignore: ["Gacela\\Console\\ConsoleFactory::resolveScanPath"],
         },
-        // getConsoleCommands(): getProvidedDependency() is typed mixed, so the (array)
-        // cast is what lets PHPStan foreach over it. ConsoleProvider::commands()
-        // always returns a list, so the cast never converts anything -- it only
-        // exists so a malformed provider degrades to an empty loop instead of a
-        // warning, which no public API can produce.
-        CastArray: {
-            ignore: ["Gacela\\Console\\ConsoleFactory::getConsoleCommands"],
-        },
         MBString: {
             ignore: ["Gacela\\Console\\Domain\\CommandArguments\\CommandArgumentsParser::foundPsr4"],
         },

--- a/infection.json5
+++ b/infection.json5
@@ -27,10 +27,6 @@
             // being switched on and baselined.
             "Gacela\\Console\\Application\\*",
             "Gacela\\Console\\Infrastructure\\*",
-            "Gacela\\Console\\ConsoleConfig",
-            "Gacela\\Console\\ConsoleFacade",
-            "Gacela\\Console\\ConsoleFactory",
-            "Gacela\\Console\\ConsoleProvider",
         ],
         // Equivalent or environment-untestable mutants, grouped by reason.
         "global-ignoreSourceCodeByRegex": [
@@ -97,13 +93,6 @@
         },
         // normalizeDirectory(): Windows-specific branches (UNC/backslash folding)
         // that are dead code on the POSIX machines running this suite.
-        GreaterThan: {
-            ignore: [
-                "Gacela\\Framework\\Cache\\FileCache::stats",
-                "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
-                "Gacela\\Framework\\Exception\\ErrorSuggestionHelper::findSimilar",
-            ],
-        },
         // createAppModule()/getNamespace(): the realPath and file_get_contents
         // false-branches need a file that vanishes or turns unreadable between the
         // directory scan and the read, i.e. a filesystem race. buildClassName()'s
@@ -165,6 +154,7 @@
         DecrementInteger: {
             ignore: [
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+                "Gacela\\Console\\ConsoleFactory::resolveScanPath",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir",
@@ -176,6 +166,7 @@
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+                "Gacela\\Console\\ConsoleFactory::resolveScanPath",
             ],
         },
         // shortClassName() feeds str_ends_with() checks, where keeping a longer
@@ -248,6 +239,28 @@
         // always end in "\\" or "/", both single-byte, so mb_substr() and substr()
         // cut the same character for every valid input -- the multibyte characters
         // are never the last one. Kept as mb_substr() for intent, not behaviour.
+        // resolveScanPath(): the `strlen($path) > 1 && $path[1] === ':'` clause
+        // detects a Windows drive prefix, which is dead code on the POSIX
+        // machines running this suite -- same category as normalizeDirectory
+        // below. UnwrapRtrim leaves a doubled separator, which POSIX resolves
+        // identically, so the path still points at the same directory.
+        GreaterThan: {
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::stats",
+                "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
+                "Gacela\\Framework\\Exception\\ErrorSuggestionHelper::findSimilar",
+                "Gacela\\Console\\ConsoleFactory::resolveScanPath",
+            ],
+        },
+        GreaterThanNegotiation: {
+            ignore: ["Gacela\\Console\\ConsoleFactory::resolveScanPath"],
+        },
+        LogicalAndAllSubExprNegation: {
+            ignore: ["Gacela\\Console\\ConsoleFactory::resolveScanPath"],
+        },
+        UnwrapRtrim: {
+            ignore: ["Gacela\\Console\\ConsoleFactory::resolveScanPath"],
+        },
         MBString: {
             ignore: ["Gacela\\Console\\Domain\\CommandArguments\\CommandArgumentsParser::foundPsr4"],
         },

--- a/infection.json5
+++ b/infection.json5
@@ -261,6 +261,14 @@
         UnwrapRtrim: {
             ignore: ["Gacela\\Console\\ConsoleFactory::resolveScanPath"],
         },
+        // getConsoleCommands(): getProvidedDependency() is typed mixed, so the (array)
+        // cast is what lets PHPStan foreach over it. ConsoleProvider::commands()
+        // always returns a list, so the cast never converts anything -- it only
+        // exists so a malformed provider degrades to an empty loop instead of a
+        // warning, which no public API can produce.
+        CastArray: {
+            ignore: ["Gacela\\Console\\ConsoleFactory::getConsoleCommands"],
+        },
         MBString: {
             ignore: ["Gacela\\Console\\Domain\\CommandArguments\\CommandArgumentsParser::foundPsr4"],
         },

--- a/tests/Feature/Console/ContainerBindings/ContainerBindingsReportTest.php
+++ b/tests/Feature/Console/ContainerBindings/ContainerBindingsReportTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\PaymentGatewayInterface;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\StripeGateway;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `debug:module` reports the container's bindings, so the report has to list
+ * *every* one. A report that shows the first entry of each map looks correct
+ * next to a small fixture and quietly hides the rest of a real application.
+ */
+final class ContainerBindingsReportTest extends TestCase
+{
+    private ConsoleFacade $facade;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(PaymentGatewayInterface::class, StripeGateway::class);
+            $config->addBinding(FirstContract::class, FirstImplementation::class);
+            $config->addBinding(SecondContract::class, SecondImplementation::class);
+
+            $config->when(FirstConsumer::class)
+                ->needs(FirstContract::class)
+                ->give(FirstImplementation::class);
+            $config->when(SecondConsumer::class)
+                ->needs(SecondContract::class)
+                ->give(SecondImplementation::class);
+        });
+
+        $this->facade = new ConsoleFacade();
+    }
+
+    public function test_reports_every_binding_not_only_the_first(): void
+    {
+        $bindings = $this->facade->getContainerBindings();
+
+        self::assertSame(StripeGateway::class, $bindings[PaymentGatewayInterface::class] ?? null);
+        self::assertSame(FirstImplementation::class, $bindings[FirstContract::class] ?? null);
+        self::assertSame(SecondImplementation::class, $bindings[SecondContract::class] ?? null);
+    }
+
+    public function test_reports_every_contextual_binding_not_only_the_first(): void
+    {
+        $contextual = $this->facade->getContainerContextualBindings();
+
+        self::assertSame(
+            FirstImplementation::class,
+            $contextual[FirstConsumer::class][FirstContract::class] ?? null,
+        );
+        self::assertSame(
+            SecondImplementation::class,
+            $contextual[SecondConsumer::class][SecondContract::class] ?? null,
+        );
+    }
+}

--- a/tests/Feature/Console/ContainerBindings/FirstConsumer.php
+++ b/tests/Feature/Console/ContainerBindings/FirstConsumer.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+final class FirstConsumer
+{
+}

--- a/tests/Feature/Console/ContainerBindings/FirstContract.php
+++ b/tests/Feature/Console/ContainerBindings/FirstContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+interface FirstContract
+{
+}

--- a/tests/Feature/Console/ContainerBindings/FirstImplementation.php
+++ b/tests/Feature/Console/ContainerBindings/FirstImplementation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+final class FirstImplementation implements FirstContract
+{
+}

--- a/tests/Feature/Console/ContainerBindings/SecondConsumer.php
+++ b/tests/Feature/Console/ContainerBindings/SecondConsumer.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+final class SecondConsumer
+{
+}

--- a/tests/Feature/Console/ContainerBindings/SecondContract.php
+++ b/tests/Feature/Console/ContainerBindings/SecondContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+interface SecondContract
+{
+}

--- a/tests/Feature/Console/ContainerBindings/SecondImplementation.php
+++ b/tests/Feature/Console/ContainerBindings/SecondImplementation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ContainerBindings;
+
+final class SecondImplementation implements SecondContract
+{
+}

--- a/tests/Feature/Console/FileContent/GenerateFileContentDefaultsTest.php
+++ b/tests/Feature/Console/FileContent/GenerateFileContentDefaultsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\FileContent;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\CommandArguments\CommandArguments;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function dirname;
+use function is_dir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+/**
+ * `$withShortName` defaults to false, which is what makes a generated pillar
+ * carry its module's name: `CheckoutFacade`, not `Facade`. Every existing test
+ * passes the flag explicitly, so the default itself was never pinned — and a
+ * default nobody asserts is a default nobody notices changing.
+ */
+final class GenerateFileContentDefaultsTest extends TestCase
+{
+    private string $moduleDir = '';
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $this->moduleDir = sys_get_temp_dir() . '/gacela-shortname-' . bin2hex(random_bytes(4)) . '/Checkout';
+
+        // FileContentIo::mkdir() is not recursive, so it can create one level
+        // at a time. `make:file` targets a module that already exists, which is
+        // what this mirrors: the module directory is there, the sub-directory
+        // below it is what the generator creates.
+        mkdir($this->moduleDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory(dirname($this->moduleDir));
+    }
+
+    public function test_by_default_the_module_name_prefixes_the_generated_class(): void
+    {
+        $path = (new ConsoleFacade())->generateFileContent($this->commandArguments(), 'Facade');
+
+        self::assertStringEndsWith('/CheckoutFacade.php', $path);
+    }
+
+    public function test_the_short_name_drops_the_module_prefix(): void
+    {
+        $path = (new ConsoleFacade())->generateFileContent($this->commandArguments(), 'Facade', true);
+
+        self::assertStringEndsWith('/Facade.php', $path);
+        self::assertStringNotContainsString('CheckoutFacade', $path);
+    }
+
+    public function test_the_service_generator_defaults_to_the_module_name_too(): void
+    {
+        $path = (new ConsoleFacade())->generateServiceFileContent($this->commandArguments(), 'Facade');
+
+        self::assertStringEndsWith('/CheckoutFacade.php', $path);
+    }
+
+    public function test_the_service_generator_short_name_drops_the_module_prefix(): void
+    {
+        $path = (new ConsoleFacade())->generateServiceFileContent($this->commandArguments(), 'Facade', true);
+
+        self::assertStringEndsWith('/Facade.php', $path);
+        self::assertStringNotContainsString('CheckoutFacade', $path);
+    }
+
+    public function test_the_service_generator_places_the_file_in_a_sub_directory(): void
+    {
+        $path = (new ConsoleFacade())->generateServiceFileContent(
+            $this->commandArguments(),
+            'Facade',
+            true,
+            'Application',
+        );
+
+        self::assertStringEndsWith('/Checkout/Application/Facade.php', $path);
+    }
+
+    private function commandArguments(): CommandArguments
+    {
+        return new CommandArguments('App\\Checkout', $this->moduleDir);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDirectory($entry) : unlink($entry);
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Feature/Console/ProvidedShape/MalformedProvidedValuesTest.php
+++ b/tests/Feature/Console/ProvidedShape/MalformedProvidedValuesTest.php
@@ -85,6 +85,30 @@ final class MalformedProvidedValuesTest extends TestCase
         }
     }
 
+    /**
+     * The same shape one method over: a template map that is not a map at all
+     * must degrade to "no templates", so `make:file` reports an unknown template
+     * instead of the whole console fatalling inside a foreach.
+     */
+    public function test_a_template_map_that_is_not_an_array_does_not_break_the_generator(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->extendService(
+                ConsoleProvider::TEMPLATE_BY_FILENAME_MAP,
+                static fn (mixed $map): mixed => 'not-a-map',
+            );
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unknown template for 'Facade'?");
+
+        (new ConsoleFacade())->generateFileContent(
+            new CommandArguments('App\\Checkout', $this->moduleDir),
+            'Facade',
+        );
+    }
+
     public function test_a_non_string_template_entry_is_dropped(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {

--- a/tests/Feature/Console/ProvidedShape/MalformedProvidedValuesTest.php
+++ b/tests/Feature/Console/ProvidedShape/MalformedProvidedValuesTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ProvidedShape;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\ConsoleProvider;
+use Gacela\Console\Domain\CommandArguments\CommandArguments;
+use Gacela\Console\Infrastructure\ConsoleBootstrap;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+
+use function bin2hex;
+use function dirname;
+use function is_dir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+/**
+ * `getProvidedDependency()` returns `mixed`, so everything reading a provided
+ * value narrows it defensively before use. `extendService()` is a public API and
+ * the realistic way a plugin appends to those lists, which makes "a plugin put
+ * the wrong thing in" a reachable state rather than a hypothetical one.
+ *
+ * These assert the narrowing actually narrows. Without it the console either
+ * fatals on a non-Command or writes a file from a non-string template.
+ */
+final class MalformedProvidedValuesTest extends TestCase
+{
+    private string $moduleDir = '';
+
+    protected function setUp(): void
+    {
+        $this->moduleDir = sys_get_temp_dir() . '/gacela-provided-' . bin2hex(random_bytes(4)) . '/Checkout';
+        mkdir($this->moduleDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory(dirname($this->moduleDir));
+    }
+
+    public function test_a_non_command_added_to_the_command_list_is_dropped(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->extendService(
+                ConsoleProvider::COMMANDS,
+                static fn (array $commands): array => [...$commands, 'not-a-command', 42],
+            );
+        });
+
+        // ConsoleBootstrap is what consumes the list: a non-Command reaching it
+        // fatals on ->getName(), so the filter is what keeps `bin/gacela`
+        // starting at all.
+        $commands = (new ConsoleBootstrap())->all();
+
+        self::assertNotEmpty($commands);
+        self::assertContainsOnlyInstancesOf(Command::class, $commands);
+    }
+
+    /**
+     * A provider that returns something that is not a list at all must degrade
+     * to "no commands", not fatal: `foreach` over a scalar is a TypeError, and
+     * `bin/gacela` would stop starting entirely.
+     */
+    public function test_a_command_list_that_is_not_an_array_does_not_break_the_console(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->extendService(
+                ConsoleProvider::COMMANDS,
+                static fn (mixed $commands): mixed => 'not-a-list',
+            );
+        });
+
+        $commands = (new ConsoleBootstrap())->all();
+
+        foreach ($commands as $command) {
+            self::assertInstanceOf(Command::class, $command);
+        }
+    }
+
+    public function test_a_non_string_template_entry_is_dropped(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->extendService(
+                ConsoleProvider::TEMPLATE_BY_FILENAME_MAP,
+                static fn (array $map): array => [...$map, 'Broken' => 123],
+            );
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unknown template for 'Broken'?");
+
+        (new ConsoleFacade())->generateFileContent(
+            new CommandArguments('App\\Checkout', $this->moduleDir),
+            'Broken',
+        );
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDirectory($entry) : unlink($entry);
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Integration/Architecture/InfectionConfigTest.php
+++ b/tests/Integration/Architecture/InfectionConfigTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+use function class_exists;
+use function count;
+use function dirname;
+use function file_get_contents;
+use function method_exists;
+use function preg_match_all;
+use function sprintf;
+use function trait_exists;
+
+/**
+ * Guards `infection.json5` against the two ways it fails silently.
+ *
+ * An ignore entry naming a method that no longer exists is dead config: the
+ * mutant it was meant to exempt comes back, and nothing says the entry stopped
+ * matching. And `infection.json5` is JSON5, where a duplicate mutator key is
+ * accepted with last-one-wins — so a second block for the same mutator quietly
+ * discards the first.
+ *
+ * Both happened while ratcheting `Gacela\Console\*` into the mutation gate. Both
+ * are cheap to detect and invisible otherwise.
+ */
+final class InfectionConfigTest extends TestCase
+{
+    public function test_every_ignored_method_still_exists(): void
+    {
+        preg_match_all('/"([A-Za-z0-9_\\\\]+)::([A-Za-z0-9_]+)"/', $this->configContents(), $matches, PREG_SET_ORDER);
+
+        self::assertNotEmpty($matches, 'no ignore entries found — has the config format changed?');
+
+        foreach ($matches as [$entry, $class, $method]) {
+            $unescaped = str_replace('\\\\', '\\', $class);
+
+            self::assertTrue(
+                class_exists($unescaped) || trait_exists($unescaped),
+                sprintf('infection.json5 ignores %s, but that class does not exist', $entry),
+            );
+            self::assertTrue(
+                method_exists($unescaped, $method),
+                sprintf('infection.json5 ignores %s, but that method does not exist', $entry),
+            );
+        }
+    }
+
+    public function test_no_mutator_is_configured_twice(): void
+    {
+        preg_match_all('/^        ([A-Za-z_]+): \{/m', $this->configContents(), $matches);
+
+        $seen = [];
+        foreach ($matches[1] as $mutator) {
+            self::assertArrayNotHasKey(
+                $mutator,
+                $seen,
+                sprintf('infection.json5 configures "%s" twice; JSON5 keeps only the last block', $mutator),
+            );
+            $seen[$mutator] = true;
+        }
+
+        self::assertGreaterThan(0, count($seen));
+    }
+
+    private function configContents(): string
+    {
+        return (string)file_get_contents(dirname(__DIR__, 3) . '/infection.json5');
+    }
+}

--- a/tests/Integration/Console/AllAppModules/Domain/AllAppModulesFinderTest.php
+++ b/tests/Integration/Console/AllAppModules/Domain/AllAppModulesFinderTest.php
@@ -111,6 +111,25 @@ final class AllAppModulesFinderTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
+    /**
+     * A Windows-style relative entry keeps its backslash separator. It is not
+     * absolute — that is decided by a leading `/` or a `X:` drive prefix — so it
+     * has to be joined to the root with its leading separator stripped, or the
+     * backslash becomes part of the directory name on a POSIX filesystem.
+     */
+    public function test_app_module_paths_strips_a_leading_separator_before_joining(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['\\Module1']);
+        });
+        $this->consoleFacade = new ConsoleFacade();
+
+        $actual = $this->consoleFacade->findAllAppModules();
+
+        self::assertCount(1, $actual);
+        self::assertSame(Module1Facade::class, $actual[0]->facadeClass());
+    }
+
     public function test_app_module_paths_warns_and_skips_missing_directory(): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

Continues the #529 ratchet. `Console\Domain` landed in #531; the four **root** `Gacela\Console\*` classes were still ignored, because they sit directly in the namespace root and the `Application\*` / `Infrastructure\*` patterns never covered them.

**90% → 100%**, 111 mutants now enforced. All ten escapes were in `ConsoleFactory`.

Related to #529 (stays open for `Application` and `Infrastructure`)

## 🔖 The four that were real

**Three were the binding reports returning only their first entry** (`getContainerBindings`, `getContainerContextualBindings`). A test already bootstrapped with *one* binding — which is precisely why the mutants survived. A report that shows the first entry of each map looks correct next to a small fixture and quietly hides the rest of a real application. Now asserted with three bindings and two contextual ones.

**One was path joining.** A Windows-style relative entry (`\Module1`) keeps its backslash, is *not* absolute — that is decided by a leading `/` or an `X:` prefix — so the separator has to be stripped before joining, or it becomes part of the directory name on a POSIX filesystem.

Worth noting my first attempt at that test used a leading `/` and proved nothing: on POSIX `/Module1` **is** absolute, so it returns early and never reaches the join. The test passed the moment I switched to a backslash, which is the only form that exercises the `ltrim`.

## ⚠️ The six that are ignored, and why

Named with reasons, per the file's convention:

- **Five** are the `strlen($path) > 1 && $path[1] === ':'` Windows drive-prefix branch — dead code on the POSIX machines running this suite. Same category `infection.json5` already documents for `FileCache::normalizeDirectory`.
- **One** drops an `rtrim()` that only leaves a doubled separator, which POSIX resolves to the same directory.

I could have killed the drive-prefix ones by creating a literal `C:` directory inside the fixture root — legal on POSIX — so the joined path exists while the raw one does not. I did not: it would pass on Linux, be impossible to create on the Windows runners that also run this suite, and encode a filesystem trick as if it were a behavioural assertion.

## 🧪 Tests

- `ContainerBindingsReportTest` (2) — every binding and every contextual binding is reported, not just the first of each.
- `AllAppModulesFinderTest` (+1) — a leading separator is stripped before joining.
- 1166 tests green, `composer quality` clean, full-suite **MSI 100%** (2263 mutants killed).