### PR TITLE
test(console): enforce mutation testing on Console\Application

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -25,7 +25,6 @@
             // namespace (#529). Domain is done and is now enforced at 100%; the
             // rest stays ignored until it gets the same treatment, rather than
             // being switched on and baselined.
-            "Gacela\\Console\\Application\\*",
             "Gacela\\Console\\Infrastructure\\*",
             "Gacela\\Console\\ConsoleConfig",
             "Gacela\\Console\\ConsoleFacade",
@@ -89,8 +88,16 @@
         },
         // stats() aggregates over existing files, where the int-casts and the
         // equal-timestamp comparisons cannot change the outcome.
+        // Same for the cache-manager and doctor casts: filesize()/filemtime()
+        // only return false for a file that vanished between the existence
+        // check right above and the call itself, i.e. a filesystem race.
         CastInt: {
-            ignore: ["Gacela\\Framework\\Cache\\FileCache::stats"],
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::stats",
+                "Gacela\\Console\\Application\\CacheWarm\\CacheManager::getCacheFileSize",
+                "Gacela\\Console\\Application\\CacheWarm\\CacheManager::getExistingCacheFilesWithSize",
+                "Gacela\\Console\\Application\\Doctor\\Check\\CacheStalenessCheck::run",
+            ],
         },
         LessThan: {
             ignore: ["Gacela\\Framework\\Cache\\FileCache::stats"],
@@ -330,6 +337,19 @@
                 "Gacela\\PHPStan\\Rules\\FacadeOnlyDelegatesRule::isCachedDelegation",
                 "Gacela\\Framework\\Container\\ContextualBindingRegistrar::register",
             ],
+        },
+        // warmAttributeCache() breaks out of the prefix scan after the first
+        // match. The four prefixes (get/create/find/build) are mutually
+        // exclusive -- none is a prefix of another -- so continuing the scan
+        // after a match can never match a second time.
+        Break_: {
+            ignore: ["Gacela\\Console\\Application\\CacheWarm\\CacheWarmService::warmAttributeCache"],
+        },
+        // Memoization guard: the four resolvers are stateless and constructed
+        // the same way every time, so rebuilding them per call is
+        // observationally identical, only slower.
+        AssignCoalesce: {
+            ignore: ["Gacela\\Console\\Application\\CacheWarm\\CacheWarmService::classResolvers"],
         },
         LogicalOrSingleSubExprNegation: {
             ignoreSourceCodeByRegex: [

--- a/src/Console/Application/CacheWarm/CacheManager.php
+++ b/src/Console/Application/CacheWarm/CacheManager.php
@@ -11,7 +11,6 @@ use Gacela\Framework\Config\Config;
 
 use function array_filter;
 use function array_map;
-use function array_values;
 use function file_exists;
 use function filesize;
 
@@ -75,14 +74,14 @@ final class CacheManager
     }
 
     /**
-     * @return list<string>
+     * @return array<string>
      */
     private function existingCacheFiles(): array
     {
-        return array_values(array_filter(
+        return array_filter(
             $this->allCacheFilePaths(),
             static fn (string $cacheFile): bool => file_exists($cacheFile),
-        ));
+        );
     }
 
     /**

--- a/src/Console/Application/CacheWarm/CacheWarmService.php
+++ b/src/Console/Application/CacheWarm/CacheWarmService.php
@@ -91,13 +91,15 @@ final class CacheWarmService
         return $classes;
     }
 
+    /**
+     * class_exists() autoloads by default, so the guard below is what actually
+     * loads the class; a second autoloading call would be a no-op.
+     */
     public function resolveClass(string $className): void
     {
         if (!class_exists($className)) {
             throw new ClassNotFoundException($className);
         }
-
-        class_exists($className, true);
     }
 
     /**

--- a/src/Console/Application/Debug/ConstructorInspector.php
+++ b/src/Console/Application/Debug/ConstructorInspector.php
@@ -100,17 +100,16 @@ final class ConstructorInspector
         return new ParameterInspection($name, $renderedType, ParameterStatus::MissingType, 'type does not exist');
     }
 
+    /**
+     * ReflectionType::__toString() already renders every shape the way this
+     * command wants it: `?Foo` for a nullable named type, `mixed` (never
+     * `?mixed`) for mixed, and `A|B` / `A&B` for union and intersection types.
+     */
     private function renderType(?ReflectionType $type): string
     {
-        if (!$type instanceof ReflectionType) {
-            return 'mixed';
-        }
-
-        if ($type instanceof ReflectionNamedType) {
-            return ($type->allowsNull() && $type->getName() !== 'mixed' ? '?' : '') . $type->getName();
-        }
-
-        return (string) $type;
+        return $type instanceof ReflectionType
+            ? (string) $type
+            : 'mixed';
     }
 
     private function defaultDetail(ReflectionParameter $parameter): string

--- a/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
@@ -77,11 +77,11 @@ final class FilenameMismatchCheck implements HealthCheck
     }
 
     /**
-     * @return list<class-string>
+     * @return array<class-string>
      */
     private static function pillarsOf(AppModule $module): array
     {
-        return array_values(array_filter(
+        return array_filter(
             [
                 $module->facadeClass(),
                 $module->factoryClass(),
@@ -89,7 +89,7 @@ final class FilenameMismatchCheck implements HealthCheck
                 $module->providerClass(),
             ],
             static fn (?string $pillar): bool => $pillar !== null,
-        ));
+        );
     }
 
     /**

--- a/tests/Integration/Console/CacheWarm/AttributeWarm/AttributeWarmRepository.php
+++ b/tests/Integration/Console/CacheWarm/AttributeWarm/AttributeWarmRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm\AttributeWarm;
+
+final class AttributeWarmRepository
+{
+}

--- a/tests/Integration/Console/CacheWarm/AttributeWarm/AttributeWarmService.php
+++ b/tests/Integration/Console/CacheWarm/AttributeWarm/AttributeWarmService.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm\AttributeWarm;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+
+/**
+ * The declaration order is the fixture: warmAttributeCache() walks the public
+ * methods in order, and the two methods before `getRepository()` are the ones
+ * it has to leave alone. A magic method must be skipped without ending the
+ * scan, and a plain method that matches none of the resolvable prefixes must
+ * not be resolved at all -- resolving it would throw and abort the warm.
+ */
+#[ServiceMap(method: 'getRepository', className: AttributeWarmRepository::class)]
+final class AttributeWarmService
+{
+    public function __invoke(): void
+    {
+    }
+
+    public function doSomething(): void
+    {
+    }
+
+    public function getRepository(): void
+    {
+    }
+}

--- a/tests/Integration/Console/CacheWarm/CacheManagerTest.php
+++ b/tests/Integration/Console/CacheWarm/CacheManagerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm;
+
+use Gacela\Console\Application\CacheWarm\CacheManager;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function str_repeat;
+use function uniqid;
+
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+
+final class CacheManagerTest extends TestCase
+{
+    private string $cacheDir;
+
+    private CacheManager $cacheManager;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = __DIR__ . DIRECTORY_SEPARATOR . '.gacela-cache-' . uniqid('', true);
+        mkdir($this->cacheDir, 0o777, true);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(true, $cacheDir);
+        });
+
+        $this->cacheManager = new CacheManager();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ((array) glob($this->cacheDir . DIRECTORY_SEPARATOR . '*') as $file) {
+            @unlink((string) $file);
+        }
+
+        @rmdir($this->cacheDir);
+    }
+
+    public function test_cache_file_path_points_at_the_class_name_cache(): void
+    {
+        self::assertSame(
+            Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME,
+            $this->cacheManager->getCacheFilePath(),
+        );
+    }
+
+    public function test_missing_cache_file_has_no_size(): void
+    {
+        self::assertFalse($this->cacheManager->cacheFileExists());
+        self::assertSame(0, $this->cacheManager->getCacheFileSize());
+        self::assertSame('0 B', $this->cacheManager->getFormattedCacheFileSize());
+    }
+
+    public function test_existing_cache_file_reports_the_bytes_on_disk(): void
+    {
+        $this->writeCacheFile(ClassNamePhpCache::FILENAME, 2048);
+
+        self::assertTrue($this->cacheManager->cacheFileExists());
+        self::assertSame(2048, $this->cacheManager->getCacheFileSize());
+        self::assertSame('2.00 KB', $this->cacheManager->getFormattedCacheFileSize());
+    }
+
+    public function test_every_managed_cache_file_is_listed_with_its_size(): void
+    {
+        $classNameCache = $this->writeCacheFile(ClassNamePhpCache::FILENAME, 1024);
+        $customServicesCache = $this->writeCacheFile(CustomServicesPhpCache::FILENAME, 512);
+
+        self::assertSame([
+            $classNameCache => '1.00 KB',
+            $customServicesCache => '512 B',
+        ], $this->cacheManager->getExistingCacheFilesWithSize());
+    }
+
+    public function test_only_the_cache_files_that_exist_are_listed(): void
+    {
+        $customServicesCache = $this->writeCacheFile(CustomServicesPhpCache::FILENAME, 256);
+
+        self::assertSame(
+            [$customServicesCache => '256 B'],
+            $this->cacheManager->getExistingCacheFilesWithSize(),
+        );
+    }
+
+    public function test_no_cache_file_at_all_lists_nothing(): void
+    {
+        self::assertSame([], $this->cacheManager->getExistingCacheFilesWithSize());
+    }
+
+    public function test_clear_cache_removes_every_managed_cache_file(): void
+    {
+        $classNameCache = $this->writeCacheFile(ClassNamePhpCache::FILENAME, 16);
+        $customServicesCache = $this->writeCacheFile(CustomServicesPhpCache::FILENAME, 16);
+
+        $this->cacheManager->clearCache();
+
+        self::assertFileDoesNotExist($classNameCache);
+        self::assertFileDoesNotExist($customServicesCache);
+        self::assertSame([], $this->cacheManager->getExistingCacheFilesWithSize());
+    }
+
+    private function writeCacheFile(string $filename, int $bytes): string
+    {
+        $path = Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . $filename;
+
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0o777, true);
+        }
+
+        file_put_contents($path, str_repeat('x', $bytes));
+
+        return $path;
+    }
+}

--- a/tests/Integration/Console/CacheWarm/CacheWarmServiceTest.php
+++ b/tests/Integration/Console/CacheWarm/CacheWarmServiceTest.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Console\CacheWarm;
 
 use Gacela\Console\Application\CacheWarm\CacheWarmService;
+use Gacela\Console\Application\CacheWarm\ClassNotFoundException;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Gacela;
 use GacelaTest\Integration\Console\AllAppModules\Domain\Module1\Module1Facade;
+use GacelaTest\Integration\Console\CacheWarm\AttributeWarm\AttributeWarmRepository;
+use GacelaTest\Integration\Console\CacheWarm\AttributeWarm\AttributeWarmService;
 use PHPUnit\Framework\TestCase;
 
 use function array_values;
+use function class_exists;
 use function implode;
 use function rmdir;
 use function uniqid;
@@ -84,29 +89,107 @@ final class CacheWarmServiceTest extends TestCase
     {
         $service = new CacheWarmService();
 
+        // The dropped modules come first on purpose: the result is declared as a
+        // list, so the surviving modules have to be reindexed from 0, not keep
+        // the holes left behind by the filter.
         $modules = array_map(
             static fn (string $facade): AppModule => new AppModule($facade, 'name', $facade),
             [
-                'App\\Testimonial\\TestimonialFacade',
-                'App\\Testament\\TestamentFacade',
                 'App\\Test\\SomeFacade',
                 'App\\Tests\\SomeFacade',
                 'App\\Fixtures\\SomeFacade',
                 'App\\Benchmark\\SomeFacade',
+                'App\\Testimonial\\TestimonialFacade',
+                'App\\Testament\\TestamentFacade',
             ],
         );
 
         $kept = array_map(
             static fn (AppModule $module): string => $module->facadeClass(),
-            array_values($service->filterProductionModules($modules)),
+            $service->filterProductionModules($modules),
         );
 
         // 'Test' as a substring of a real word (Testimonial, Testament) must survive;
         // only the \Test\, \Tests\, \Fixtures\, \Benchmark\ namespace segments are dropped.
         self::assertSame([
-            'App\\Testimonial\\TestimonialFacade',
-            'App\\Testament\\TestamentFacade',
+            0 => 'App\\Testimonial\\TestimonialFacade',
+            1 => 'App\\Testament\\TestamentFacade',
         ], $kept);
+    }
+
+    public function test_module_classes_list_every_pillar_the_module_declares(): void
+    {
+        $service = new CacheWarmService();
+
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            'App\\Foo\\FooFactory',
+            'App\\Foo\\FooConfig',
+            'App\\Foo\\FooProvider',
+        );
+
+        self::assertSame([
+            ['type' => 'Facade', 'className' => 'App\\Foo\\FooFacade'],
+            ['type' => 'Factory', 'className' => 'App\\Foo\\FooFactory'],
+            ['type' => 'Config', 'className' => 'App\\Foo\\FooConfig'],
+            ['type' => 'Provider', 'className' => 'App\\Foo\\FooProvider'],
+        ], $service->getModuleClasses($module));
+    }
+
+    public function test_module_classes_skip_the_pillars_the_module_does_not_declare(): void
+    {
+        $service = new CacheWarmService();
+
+        $module = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooFacade');
+
+        self::assertSame(
+            [['type' => 'Facade', 'className' => 'App\\Foo\\FooFacade']],
+            $service->getModuleClasses($module),
+        );
+    }
+
+    public function test_resolve_class_autoloads_a_class_that_exists(): void
+    {
+        $service = new CacheWarmService();
+
+        $service->resolveClass(Module1Facade::class);
+
+        self::assertTrue(class_exists(Module1Facade::class, false), 'resolveClass must autoload the class');
+    }
+
+    public function test_resolve_class_rejects_a_class_that_does_not_exist(): void
+    {
+        $service = new CacheWarmService();
+
+        $this->expectException(ClassNotFoundException::class);
+        $this->expectExceptionMessage('Class not found: Non\\Existing\\MissingClass');
+
+        $service->resolveClass('Non\\Existing\\MissingClass');
+    }
+
+    public function test_warm_attribute_cache_resolves_the_service_map_methods(): void
+    {
+        CustomServicesPhpCache::clearStaticCache();
+
+        (new CacheWarmService())->warmAttributeCache(AttributeWarmService::class);
+
+        self::assertSame(
+            [AttributeWarmService::class . '::getRepository' => AttributeWarmRepository::class],
+            CustomServicesPhpCache::all(),
+        );
+    }
+
+    public function test_warm_attribute_cache_skips_a_class_that_does_not_exist(): void
+    {
+        CustomServicesPhpCache::clearStaticCache();
+
+        /** @var class-string $fake */
+        $fake = 'Non\\Existing\\MissingService';
+        (new CacheWarmService())->warmAttributeCache($fake);
+
+        self::assertSame([], CustomServicesPhpCache::all());
     }
 
     private function removeCacheDir(): void

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
@@ -65,7 +65,11 @@ final class ModuleWarmerFacadeWarmTest extends TestCase
 
         self::assertStringContainsString('HealthyFactory', $resolved, 'warming must continue past the broken module');
         self::assertGreaterThanOrEqual(1, $skippedCount, 'the broken module must be counted as skipped');
-        self::assertStringContainsString('Broken', $output->fetch(), 'the failed module must be reported');
+        self::assertStringContainsString(
+            '✗ Failed Facade: ' . BrokenFacade::class,
+            $output->fetch(),
+            'the facade that could not be warmed must be named in the output',
+        );
     }
 
     private function removeCacheDir(): void

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\CacheWarm;
+
+use Error;
+use Gacela\Console\Application\CacheWarm\CacheWarmOutputFormatter;
+use Gacela\Console\Application\CacheWarm\CacheWarmService;
+use Gacela\Console\Application\CacheWarm\ModuleWarmer;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Console\CacheWarm\AttributeWarm\AttributeWarmRepository;
+use GacelaTest\Integration\Console\CacheWarm\AttributeWarm\AttributeWarmService;
+use GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Healthy\HealthyFacade;
+use GacelaTest\Integration\Console\CacheWarm\FacadeWarm\Domain\Healthy\HealthyFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function implode;
+use function is_dir;
+use function rmdir;
+use function spl_autoload_register;
+use function spl_autoload_unregister;
+use function uniqid;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+use const PHP_EOL;
+
+/**
+ * Pins what `cache:warm` reports and counts per module: every pillar that
+ * resolves, every one that is missing, and every one whose autoloading blows
+ * up have to be told apart in both the counters and the output.
+ */
+final class ModuleWarmerTest extends TestCase
+{
+    /** @var class-string */
+    private const EXPLODING_CLASS = 'GacelaTest\\Integration\\Console\\CacheWarm\\Exploding\\ExplodingFactory';
+
+    private string $cacheDir;
+
+    private BufferedOutput $output;
+
+    private ModuleWarmer $warmer;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = __DIR__ . DIRECTORY_SEPARATOR . '.gacela-cache-' . uniqid('', true);
+
+        $cacheDir = $this->cacheDir;
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(true, $cacheDir);
+            $config->setProjectNamespaces(['GacelaTest\\Integration\\Console\\CacheWarm\\FacadeWarm\\Domain']);
+        });
+
+        ClassNamePhpCache::clearStaticCache();
+
+        $this->output = new BufferedOutput();
+        $this->warmer = new ModuleWarmer(new CacheWarmService(), new CacheWarmOutputFormatter($this->output));
+    }
+
+    protected function tearDown(): void
+    {
+        ClassNamePhpCache::clearStaticCache();
+        $this->removeCacheDir();
+    }
+
+    public function test_every_resolved_pillar_is_counted_and_reported(): void
+    {
+        $module = new AppModule('Healthy', 'Healthy', HealthyFacade::class, HealthyFactory::class);
+
+        [$resolved, $skipped] = $this->warmer->warmModule($module, warmAttributes: false);
+
+        self::assertSame(2, $resolved);
+        self::assertSame(0, $skipped);
+        self::assertSame(self::lines(
+            'Processing: Healthy',
+            '  ✓ Resolved Facade: ' . HealthyFacade::class,
+            '  ✓ Resolved Factory: ' . HealthyFactory::class,
+            '',
+        ), $this->output->fetch());
+    }
+
+    public function test_a_missing_pillar_class_is_skipped_not_failed(): void
+    {
+        /** @var class-string $missingFactory */
+        $missingFactory = 'Missing\\Factory';
+        $module = new AppModule('Healthy', 'Healthy', HealthyFacade::class, $missingFactory);
+
+        [$resolved, $skipped] = $this->warmer->warmModule($module, warmAttributes: false);
+
+        self::assertSame(1, $resolved);
+        self::assertSame(1, $skipped);
+        self::assertSame(self::lines(
+            'Processing: Healthy',
+            '  ✓ Resolved Facade: ' . HealthyFacade::class,
+            '  ⚠ Skipped Factory: Missing\\Factory (class not found)',
+            '',
+        ), $this->output->fetch());
+    }
+
+    public function test_a_pillar_whose_autoloading_throws_is_reported_as_failed(): void
+    {
+        $autoloader = static function (string $class): void {
+            if ($class === self::EXPLODING_CLASS) {
+                throw new Error('autoloading blew up');
+            }
+        };
+        spl_autoload_register($autoloader);
+
+        try {
+            $module = new AppModule('Healthy', 'Healthy', HealthyFacade::class, self::EXPLODING_CLASS);
+
+            [$resolved, $skipped] = $this->warmer->warmModule($module, warmAttributes: false);
+        } finally {
+            spl_autoload_unregister($autoloader);
+        }
+
+        self::assertSame(1, $resolved);
+        self::assertSame(1, $skipped);
+        self::assertSame(self::lines(
+            'Processing: Healthy',
+            '  ✓ Resolved Facade: ' . HealthyFacade::class,
+            '  ✗ Failed Factory: ' . self::EXPLODING_CLASS . ' (autoloading blew up)',
+            '',
+        ), $this->output->fetch());
+    }
+
+    public function test_attribute_warming_only_happens_when_it_is_asked_for(): void
+    {
+        CustomServicesPhpCache::clearStaticCache();
+
+        $module = new AppModule('AttributeWarm', 'AttributeWarm', AttributeWarmService::class);
+
+        $this->warmer->warmModule($module, warmAttributes: false);
+        self::assertSame([], CustomServicesPhpCache::all());
+
+        $this->warmer->warmModule($module, warmAttributes: true);
+        self::assertSame(
+            [AttributeWarmService::class . '::getRepository' => AttributeWarmRepository::class],
+            CustomServicesPhpCache::all(),
+        );
+    }
+
+    public function test_counts_are_accumulated_across_modules(): void
+    {
+        /** @var class-string $missingFactory */
+        $missingFactory = 'Missing\\Factory';
+
+        $first = new AppModule('Healthy', 'Healthy', HealthyFacade::class, HealthyFactory::class);
+        $second = new AppModule('Healthy', 'Healthy', HealthyFacade::class, $missingFactory);
+
+        self::assertSame([3, 1], $this->warmer->warmModules([$first, $second], warmAttributes: false));
+    }
+
+    private static function lines(string ...$lines): string
+    {
+        return implode(PHP_EOL, $lines) . PHP_EOL;
+    }
+
+    private function removeCacheDir(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            return;
+        }
+
+        foreach (glob($this->cacheDir . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->cacheDir);
+    }
+}

--- a/tests/Unit/Console/Application/CacheWarm/BytesFormatterTest.php
+++ b/tests/Unit/Console/Application/CacheWarm/BytesFormatterTest.php
@@ -27,5 +27,9 @@ final class BytesFormatterTest extends TestCase
         yield 'largest kb rounds up to 1024.00' => [1048575, '1024.00 KB'];
         yield 'mb boundary' => [1048576, '1.00 MB'];
         yield 'large non-round mb' => [1572864, '1.50 MB'];
+        // 5243 MiB exactly. Big enough that dividing by 1048575 or 1048577
+        // instead of 1048576 already shifts the second decimal, so the divisor
+        // itself is pinned and not just the KB/MB threshold.
+        yield 'multi-gigabyte value pins the mb divisor' => [5497683968, '5243.00 MB'];
     }
 }

--- a/tests/Unit/Console/Application/CacheWarm/CacheWarmOutputFormatterTest.php
+++ b/tests/Unit/Console/Application/CacheWarm/CacheWarmOutputFormatterTest.php
@@ -8,17 +8,173 @@ use Gacela\Console\Application\CacheWarm\CacheWarmOutputFormatter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+use function implode;
+use function str_repeat;
+
+use const PHP_EOL;
+
+/**
+ * Every method here is a pure "what does cache:warm print" contract, so each
+ * one is asserted against its full, exact output: a dropped line or a blank
+ * line that stops being written is a visible regression in the command.
+ */
 final class CacheWarmOutputFormatterTest extends TestCase
 {
+    private const SEPARATOR_WIDTH = 60;
+
+    private BufferedOutput $output;
+
+    private CacheWarmOutputFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput();
+        $this->formatter = new CacheWarmOutputFormatter($this->output);
+    }
+
+    public function test_header_frames_the_banner_with_blank_lines(): void
+    {
+        $this->formatter->writeHeader();
+
+        self::assertSame(
+            self::lines('', 'Warming Gacela cache...', str_repeat('=', self::SEPARATOR_WIDTH), ''),
+            $this->output->fetch(),
+        );
+    }
+
+    public function test_cache_cleared_is_followed_by_a_blank_line(): void
+    {
+        $this->formatter->writeCacheCleared();
+
+        self::assertSame(self::lines('Cleared existing cache', ''), $this->output->fetch());
+    }
+
     public function test_module_discovery_warning_surfaces_the_underlying_error(): void
     {
-        $output = new BufferedOutput();
-        $formatter = new CacheWarmOutputFormatter($output);
+        $this->formatter->writeModuleDiscoveryWarning('composer.json is not readable');
 
-        $formatter->writeModuleDiscoveryWarning('composer.json is not readable');
+        self::assertSame(
+            self::lines(
+                'Warning: Some modules could not be discovered due to errors',
+                '  Error: composer.json is not readable',
+            ),
+            $this->output->fetch(),
+        );
+    }
 
-        $text = $output->fetch();
-        self::assertStringContainsString('Some modules could not be discovered', $text);
-        self::assertStringContainsString('composer.json is not readable', $text);
+    public function test_modules_found_reports_the_count(): void
+    {
+        $this->formatter->writeModulesFound(['a', 'b', 'c']);
+
+        self::assertSame(self::lines('Found 3 modules', ''), $this->output->fetch());
+    }
+
+    public function test_module_name_is_prefixed_with_processing(): void
+    {
+        $this->formatter->writeModuleName('Foo');
+
+        self::assertSame(self::lines('Processing: Foo'), $this->output->fetch());
+    }
+
+    public function test_resolved_class_is_reported_with_its_type(): void
+    {
+        $this->formatter->writeClassResolved('Factory', 'App\\Foo\\FooFactory');
+
+        self::assertSame(self::lines('  ✓ Resolved Factory: App\\Foo\\FooFactory'), $this->output->fetch());
+    }
+
+    public function test_skipped_class_explains_why_it_was_skipped(): void
+    {
+        $this->formatter->writeClassSkipped('Config', 'App\\Foo\\FooConfig');
+
+        self::assertSame(
+            self::lines('  ⚠ Skipped Config: App\\Foo\\FooConfig (class not found)'),
+            $this->output->fetch(),
+        );
+    }
+
+    public function test_failed_class_includes_the_error_message(): void
+    {
+        $this->formatter->writeClassFailed('Provider', 'App\\Foo\\FooProvider', 'cannot construct');
+
+        self::assertSame(
+            self::lines('  ✗ Failed Provider: App\\Foo\\FooProvider (cannot construct)'),
+            $this->output->fetch(),
+        );
+    }
+
+    public function test_empty_line_writes_exactly_one_newline(): void
+    {
+        $this->formatter->writeEmptyLine();
+
+        self::assertSame(PHP_EOL, $this->output->fetch());
+    }
+
+    public function test_summary_lists_every_counter(): void
+    {
+        $this->formatter->writeSummary(3, 7, 2, '0.123 seconds', '1.00 KB');
+
+        self::assertSame(
+            self::lines(
+                str_repeat('=', self::SEPARATOR_WIDTH),
+                'Cache warming complete!',
+                '',
+                'Modules processed: 3',
+                'Classes resolved: 7',
+                'Classes skipped: 2',
+                'Time taken: 0.123 seconds',
+                'Memory used: 1.00 KB',
+                '',
+            ),
+            $this->output->fetch(),
+        );
+    }
+
+    public function test_cache_info_shows_the_file_and_its_size(): void
+    {
+        $this->formatter->writeCacheInfo('/tmp/gacela/class-name-cache.php', '1.00 KB');
+
+        self::assertSame(
+            self::lines(
+                'Cache file: /tmp/gacela/class-name-cache.php',
+                'Cache size: 1.00 KB',
+                '',
+            ),
+            $this->output->fetch(),
+        );
+    }
+
+    public function test_merged_config_cache_info_shows_the_file_and_its_size(): void
+    {
+        $this->formatter->writeMergedConfigCacheInfo('/tmp/gacela/merged-config.php', '2.00 KB');
+
+        self::assertSame(
+            self::lines(
+                'Merged config cache: /tmp/gacela/merged-config.php',
+                'Merged config size: 2.00 KB',
+                '',
+            ),
+            $this->output->fetch(),
+        );
+    }
+
+    public function test_cache_warning_explains_how_to_enable_file_caching(): void
+    {
+        $this->formatter->writeCacheWarning();
+
+        self::assertSame(
+            self::lines(
+                'Warning: Cache file was not created. File caching might be disabled.',
+                'Enable file caching in your gacela.php configuration:',
+                '  $config->enableFileCache();',
+                '',
+            ),
+            $this->output->fetch(),
+        );
+    }
+
+    private static function lines(string ...$lines): string
+    {
+        return implode(PHP_EOL, $lines) . PHP_EOL;
     }
 }

--- a/tests/Unit/Console/Application/CacheWarm/PerformanceMetricsTest.php
+++ b/tests/Unit/Console/Application/CacheWarm/PerformanceMetricsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\CacheWarm;
+
+use Gacela\Console\Application\CacheWarm\PerformanceMetrics;
+use PHPUnit\Framework\TestCase;
+
+use function memory_get_usage;
+
+final class PerformanceMetricsTest extends TestCase
+{
+    public function test_elapsed_time_is_measured_from_construction_not_from_the_epoch(): void
+    {
+        $metrics = new PerformanceMetrics();
+
+        $elapsed = $metrics->getElapsedTime();
+
+        self::assertGreaterThanOrEqual(0.0, $elapsed);
+        self::assertLessThan(60.0, $elapsed, 'the elapsed time must be a delta, not a unix timestamp');
+    }
+
+    public function test_memory_used_is_a_delta_not_the_total_process_usage(): void
+    {
+        $metrics = new PerformanceMetrics();
+
+        self::assertLessThan(memory_get_usage(true), $metrics->getMemoryUsed());
+    }
+
+    public function test_elapsed_time_is_formatted_with_three_decimals(): void
+    {
+        $metrics = new PerformanceMetrics();
+
+        self::assertMatchesRegularExpression('/^\d+\.\d{3} seconds$/', $metrics->formatElapsedTime());
+    }
+
+    public function test_memory_used_is_formatted_as_human_readable_bytes(): void
+    {
+        $metrics = new PerformanceMetrics();
+
+        self::assertMatchesRegularExpression('/^\d+(\.\d{2})? (B|KB|MB)$/', $metrics->formatMemoryUsed());
+    }
+}

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
@@ -52,6 +52,22 @@ final class ConstructorInspectorTest extends TestCase
         self::assertSame(ParameterStatus::MissingType, $inspection->parameters[2]->status);
     }
 
+    public function test_every_type_shape_is_rendered_the_way_php_writes_it(): void
+    {
+        $inspection = $this->inspector->inspect(UntypedAndUnionService::class);
+
+        self::assertSame('mixed', $inspection->parameters[0]->renderedType, 'an untyped parameter reads as mixed');
+        self::assertSame('string|int', $inspection->parameters[1]->renderedType);
+        self::assertSame('Totally\\Missing\\Type', $inspection->parameters[2]->renderedType);
+    }
+
+    public function test_a_nullable_type_keeps_its_question_mark(): void
+    {
+        $inspection = $this->inspector->inspect(MixedDependenciesService::class);
+
+        self::assertSame('?' . AutowirableCollaborator::class, $inspection->parameters[5]->renderedType);
+    }
+
     public function test_mixed_dependencies_are_categorized(): void
     {
         $inspection = $this->inspector->inspect(MixedDependenciesService::class);
@@ -112,5 +128,20 @@ final class ConstructorInspectorTest extends TestCase
         $override = $inspection->parameters[1];
         self::assertSame(ParameterStatus::Inject, $override->status);
         self::assertSame('inject -> ' . BoundImplementation::class, $override->detail);
+    }
+
+    public function test_a_binding_to_an_already_built_object_names_its_class(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(BoundContract::class, new BoundImplementation());
+        });
+
+        $inspection = (new ConstructorInspector())->inspect(MixedDependenciesService::class);
+
+        self::assertSame(
+            'bound -> ' . BoundImplementation::class . ' instance',
+            $inspection->parameters[0]->detail,
+        );
     }
 }

--- a/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
@@ -7,9 +7,18 @@ namespace GacelaTest\Unit\Console\Application\Doctor\Check;
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
+use function file_put_contents;
 use function is_string;
+use function mkdir;
+use function sys_get_temp_dir;
+use function time;
+use function touch;
+use function uniqid;
+use function var_export;
 
 final class CacheStalenessCheckTest extends TestCase
 {
@@ -34,77 +43,176 @@ final class CacheStalenessCheckTest extends TestCase
 
     public function test_missing_cache_dir_returns_ok(): void
     {
-        $check = new CacheStalenessCheck('/nonexistent/path/xyz');
+        $result = (new CacheStalenessCheck('/nonexistent/path/xyz'))->run();
 
-        self::assertSame(CheckStatus::Ok, $check->run()->status);
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no cache directory — nothing to check'], $result->details);
+    }
+
+    public function test_unconfigured_cache_dir_returns_ok(): void
+    {
+        $result = (new CacheStalenessCheck(''))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no cache directory — nothing to check'], $result->details);
     }
 
     public function test_empty_cache_dir_returns_ok(): void
     {
-        $check = new CacheStalenessCheck($this->tempDir);
+        $result = (new CacheStalenessCheck($this->tempDir))->run();
 
-        self::assertSame(CheckStatus::Ok, $check->run()->status);
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['all cache entries are fresh'], $result->details);
     }
 
     public function test_fresh_cache_returns_ok(): void
     {
-        $sourceFile = $this->tempDir . '/Source.php';
-        file_put_contents($sourceFile, '<?php');
-        touch($sourceFile, time() - 120);
+        $sourceFile = $this->writeSource(time() - 120);
+        $this->writeCache(ClassNamePhpCache::FILENAME, ['SomeKey' => 'Some\\Class'], time());
 
-        $cacheFile = $this->tempDir . '/' . ClassNamePhpCache::FILENAME;
-        file_put_contents(
-            $cacheFile,
-            '<?php return ' . var_export(['SomeKey' => 'Some\\Class'], true) . ';',
-        );
-        touch($cacheFile, time());
-
-        $check = new CacheStalenessCheck(
-            $this->tempDir,
-            static fn (string $className): string => $sourceFile,
-        );
+        $check = new CacheStalenessCheck($this->tempDir, static fn (string $className): string => $sourceFile);
 
         self::assertSame(CheckStatus::Ok, $check->run()->status);
     }
 
     public function test_source_newer_than_cache_returns_warn(): void
     {
-        $sourceFile = $this->tempDir . '/Source.php';
-        file_put_contents($sourceFile, '<?php');
-        touch($sourceFile, time());
+        $sourceFile = $this->writeSource(time());
+        $this->writeCache(ClassNamePhpCache::FILENAME, ['SomeKey' => 'Some\\Class'], time() - 120);
 
-        $cacheFile = $this->tempDir . '/' . ClassNamePhpCache::FILENAME;
-        file_put_contents(
-            $cacheFile,
-            '<?php return ' . var_export(['SomeKey' => 'Some\\Class'], true) . ';',
-        );
-        touch($cacheFile, time() - 120);
-
-        $check = new CacheStalenessCheck(
-            $this->tempDir,
-            static fn (string $className): string => $sourceFile,
-        );
+        $check = new CacheStalenessCheck($this->tempDir, static fn (string $className): string => $sourceFile);
 
         $result = $check->run();
+
         self::assertSame(CheckStatus::Warn, $result->status);
-        self::assertNotEmpty($result->details);
+        self::assertSame(['stale: SomeKey → Some\\Class'], $result->details);
+        self::assertSame('run `bin/gacela cache:clear && bin/gacela cache:warm` to rebuild', $result->remediation);
+    }
+
+    /**
+     * A source touched at the very same second as the cache was written is the
+     * normal outcome of `cache:warm`, so it must not be reported as stale.
+     */
+    public function test_source_with_the_same_mtime_as_the_cache_is_not_stale(): void
+    {
+        $when = time() - 60;
+        $sourceFile = $this->writeSource($when);
+        $this->writeCache(ClassNamePhpCache::FILENAME, ['SomeKey' => 'Some\\Class'], $when);
+
+        $check = new CacheStalenessCheck($this->tempDir, static fn (string $className): string => $sourceFile);
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
     }
 
     public function test_unresolvable_source_is_reported(): void
     {
-        $cacheFile = $this->tempDir . '/' . ClassNamePhpCache::FILENAME;
-        file_put_contents(
-            $cacheFile,
-            '<?php return ' . var_export(['SomeKey' => 'Ghost\\Class'], true) . ';',
+        $this->writeCache(ClassNamePhpCache::FILENAME, ['SomeKey' => 'Ghost\\Class'], time());
+
+        $check = new CacheStalenessCheck($this->tempDir, static fn (string $className): ?string => null);
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['missing source: SomeKey → Ghost\\Class (source file not found)'], $result->details);
+    }
+
+    public function test_an_unresolvable_entry_does_not_hide_the_entries_after_it(): void
+    {
+        $sourceFile = $this->writeSource(time());
+        $this->writeCache(
+            ClassNamePhpCache::FILENAME,
+            ['GhostKey' => 'Ghost\\Class', 'RealKey' => 'Real\\Class'],
+            time() - 120,
         );
 
         $check = new CacheStalenessCheck(
             $this->tempDir,
-            static fn (string $className): ?string => null,
+            static fn (string $className): ?string => $className === 'Ghost\\Class' ? null : $sourceFile,
         );
 
-        $result = $check->run();
+        self::assertSame([
+            'stale: RealKey → Real\\Class',
+            'missing source: GhostKey → Ghost\\Class (source file not found)',
+        ], $check->run()->details);
+    }
+
+    public function test_an_entry_pointing_at_a_deleted_file_does_not_hide_the_entries_after_it(): void
+    {
+        $sourceFile = $this->writeSource(time());
+        $deletedFile = $this->tempDir . '/Deleted.php';
+        $this->writeCache(
+            ClassNamePhpCache::FILENAME,
+            ['GoneKey' => 'Gone\\Class', 'RealKey' => 'Real\\Class'],
+            time() - 120,
+        );
+
+        $check = new CacheStalenessCheck(
+            $this->tempDir,
+            static fn (string $className): string => $className === 'Gone\\Class' ? $deletedFile : $sourceFile,
+        );
+
+        self::assertSame([
+            'stale: RealKey → Real\\Class',
+            'missing source: GoneKey → Gone\\Class (' . $deletedFile . ')',
+        ], $check->run()->details);
+    }
+
+    /**
+     * The class-name cache is optional: warming only the custom-services cache
+     * still has to be checked, so a missing first file cannot end the scan.
+     */
+    public function test_the_custom_services_cache_is_checked_when_the_class_name_cache_is_missing(): void
+    {
+        $sourceFile = $this->writeSource(time());
+        $this->writeCache(CustomServicesPhpCache::FILENAME, ['SomeKey' => 'Some\\Class'], time() - 120);
+
+        $check = new CacheStalenessCheck($this->tempDir, static fn (string $className): string => $sourceFile);
+
+        self::assertSame(['stale: SomeKey → Some\\Class'], $check->run()->details);
+    }
+
+    public function test_the_default_resolver_finds_the_source_of_a_real_class(): void
+    {
+        $this->writeCache(
+            ClassNamePhpCache::FILENAME,
+            ['SomeKey' => CacheStalenessCheck::class],
+            time() + 3600,
+        );
+
+        $result = (new CacheStalenessCheck($this->tempDir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['all cache entries are fresh'], $result->details);
+    }
+
+    public function test_the_default_resolver_reports_a_class_php_has_no_source_file_for(): void
+    {
+        $this->writeCache(ClassNamePhpCache::FILENAME, ['SomeKey' => stdClass::class], time());
+
+        $result = (new CacheStalenessCheck($this->tempDir))->run();
+
         self::assertSame(CheckStatus::Warn, $result->status);
-        self::assertStringContainsString('missing source', $result->details[0] ?? '');
+        self::assertSame(['missing source: SomeKey → stdClass (source file not found)'], $result->details);
+    }
+
+    private function writeSource(int $mtime): string
+    {
+        $sourceFile = $this->tempDir . '/Source.php';
+        file_put_contents($sourceFile, '<?php');
+        touch($sourceFile, $mtime);
+
+        return $sourceFile;
+    }
+
+    /**
+     * @param array<string, string> $entries
+     */
+    private function writeCache(string $filename, array $entries, int $mtime): string
+    {
+        $cacheFile = $this->tempDir . '/' . $filename;
+        file_put_contents($cacheFile, '<?php return ' . var_export($entries, true) . ';');
+        touch($cacheFile, $mtime);
+
+        return $cacheFile;
     }
 }

--- a/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Unit\Console\Application\Doctor\Check;
 
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use PHPUnit\Framework\TestCase;
@@ -193,6 +194,43 @@ final class CacheStalenessCheckTest extends TestCase
 
         self::assertSame(CheckStatus::Warn, $result->status);
         self::assertSame(['missing source: SomeKey → stdClass (source file not found)'], $result->details);
+    }
+
+    /**
+     * The entry a stale cache most often holds: a class that was renamed or
+     * deleted, so the name resolves to neither a class nor an interface. It
+     * must be reported rather than handed to ReflectionClass, which would
+     * throw on a name that does not exist.
+     */
+    public function test_the_default_resolver_reports_a_class_that_no_longer_exists(): void
+    {
+        $this->writeCache(ClassNamePhpCache::FILENAME, ['SomeKey' => 'Some\\Deleted\\Class'], time());
+
+        $result = (new CacheStalenessCheck($this->tempDir))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['missing source: SomeKey → Some\\Deleted\\Class (source file not found)'],
+            $result->details,
+        );
+    }
+
+    /**
+     * Interfaces are cached like any other resolvable type, so the default
+     * resolver has to find their source file too, not just classes'.
+     */
+    public function test_the_default_resolver_finds_the_source_of_an_interface(): void
+    {
+        $this->writeCache(
+            ClassNamePhpCache::FILENAME,
+            ['SomeKey' => HealthCheck::class],
+            time() + 3600,
+        );
+
+        $result = (new CacheStalenessCheck($this->tempDir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['all cache entries are fresh'], $result->details);
     }
 
     private function writeSource(int $mtime): string

--- a/tests/Unit/Console/Application/Doctor/Check/FilenameMismatchCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/FilenameMismatchCheckTest.php
@@ -8,6 +8,10 @@ use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function end;
+use function explode;
 
 final class FilenameMismatchCheckTest extends TestCase
 {
@@ -60,9 +64,68 @@ final class FilenameMismatchCheckTest extends TestCase
         $result = $check->run();
 
         self::assertSame(CheckStatus::Error, $result->status);
-        self::assertStringContainsString('App\\Foo\\Provider', $result->details[0]);
-        self::assertStringContainsString('DependencyProvider.php', $result->details[0]);
-        self::assertStringContainsString('Provider.php', $result->remediation);
+        self::assertSame(
+            ['App\\Foo\\Provider is declared in DependencyProvider.php, expected Provider.php'],
+            $result->details,
+        );
+        self::assertSame(
+            'rename the file to match the class — pillars resolve by filename, '
+            . 'so `Provider` declared in `DependencyProvider.php` is never found',
+            $result->remediation,
+        );
+    }
+
+    /**
+     * The same trap, but resolved through the production file resolver instead
+     * of an injected one, so the reflection path is exercised too.
+     */
+    public function test_the_default_file_resolver_catches_a_class_renamed_without_its_file(): void
+    {
+        require_once __DIR__ . '/Fixtures/DependencyProvider.php';
+
+        $module = new AppModule(
+            'GacelaTest\\Fixtures',
+            'Fixtures',
+            'GacelaTest\\Unit\\Console\\Application\\Doctor\\Check\\Fixtures\\Provider',
+        );
+
+        $result = (new FilenameMismatchCheck([$module]))->run();
+
+        self::assertSame(CheckStatus::Error, $result->status);
+        self::assertStringContainsString(
+            'is declared in DependencyProvider.php, expected Provider.php',
+            $result->details[0],
+        );
+    }
+
+    public function test_the_default_file_resolver_accepts_a_class_that_matches_its_file(): void
+    {
+        $module = new AppModule('Gacela\\Doctor', 'Doctor', FilenameMismatchCheck::class);
+
+        self::assertSame(CheckStatus::Ok, (new FilenameMismatchCheck([$module]))->run()->status);
+    }
+
+    /**
+     * Internal classes have no source file at all; they are skipped, not
+     * reported as a mismatch.
+     */
+    public function test_the_default_file_resolver_skips_a_class_without_a_source_file(): void
+    {
+        $module = new AppModule('Php\\Internal', 'Internal', stdClass::class);
+
+        self::assertSame(CheckStatus::Ok, (new FilenameMismatchCheck([$module]))->run()->status);
+    }
+
+    public function test_windows_style_paths_are_split_on_backslashes_too(): void
+    {
+        $module = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooFacade');
+
+        $check = new FilenameMismatchCheck(
+            [$module],
+            static fn (string $class): string => 'C:\\app\\Foo\\FooFacade.php',
+        );
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
     }
 
     public function test_unlocatable_class_is_skipped_not_reported(): void

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/DependencyProvider.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/DependencyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures;
+
+/**
+ * Deliberately declared in `DependencyProvider.php`: the migration from
+ * `AbstractDependencyProvider` to `AbstractProvider` renames the class but
+ * leaves the file behind, and Gacela resolves pillars by filename. The file
+ * cannot be autoloaded under PSR-4 for exactly that reason, so the test that
+ * uses it requires it by hand.
+ */
+final class Provider
+{
+}

--- a/tests/Unit/Console/Application/Doctor/Check/SuffixMismatchCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/SuffixMismatchCheckTest.php
@@ -65,6 +65,78 @@ final class SuffixMismatchCheckTest extends TestCase
         self::assertSame(CheckStatus::Warn, $result->status);
     }
 
+    public function test_optional_config_with_wrong_suffix_is_warning(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            null,
+            'App\\Foo\\FooSettings', // bad
+        );
+
+        $result = (new SuffixMismatchCheck([$module], $this->defaultSuffixes()))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['Config "App\\Foo\\FooSettings" does not end with any configured Config suffix [Config]'],
+            $result->details,
+        );
+    }
+
+    public function test_optional_provider_with_wrong_suffix_is_warning(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            null,
+            null,
+            'App\\Foo\\FooRegistrar', // bad
+        );
+
+        $result = (new SuffixMismatchCheck([$module], $this->defaultSuffixes()))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['Provider "App\\Foo\\FooRegistrar" does not end with any configured Provider suffix [Provider]'],
+            $result->details,
+        );
+    }
+
+    public function test_errors_and_warnings_are_merged_into_one_flat_detail_list(): void
+    {
+        $first = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooFaced');
+        $second = new AppModule('App\\Bar', 'Bar', 'App\\Bar\\BarFaced', 'App\\Bar\\BarFactorio');
+
+        $result = (new SuffixMismatchCheck([$first, $second], $this->defaultSuffixes()))->run();
+
+        self::assertSame(CheckStatus::Error, $result->status);
+        self::assertSame([
+            'Facade "App\\Foo\\FooFaced" does not end with any configured Facade suffix [Facade]',
+            'Facade "App\\Bar\\BarFaced" does not end with any configured Facade suffix [Facade]',
+            'Factory "App\\Bar\\BarFactorio" does not end with any configured Factory suffix [Factory]',
+        ], $result->details);
+    }
+
+    /**
+     * An unconfigured suffix map falls back to the framework defaults, so a
+     * module using them all must still pass.
+     */
+    public function test_the_framework_defaults_apply_when_no_suffix_is_configured(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            'App\\Foo\\FooFactory',
+            'App\\Foo\\FooConfig',
+            'App\\Foo\\FooProvider',
+        );
+
+        self::assertSame(CheckStatus::Ok, (new SuffixMismatchCheck([$module], []))->run()->status);
+    }
+
     public function test_custom_suffix_is_respected(): void
     {
         $module = new AppModule(
@@ -75,6 +147,36 @@ final class SuffixMismatchCheckTest extends TestCase
 
         $suffixes = $this->defaultSuffixes();
         $suffixes['Facade'][] = 'PublicApi';
+
+        self::assertSame(CheckStatus::Ok, (new SuffixMismatchCheck([$module], $suffixes))->run()->status);
+    }
+
+    public function test_custom_factory_suffix_is_respected(): void
+    {
+        $module = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooFacade', 'App\\Foo\\FooCreator');
+
+        $suffixes = $this->defaultSuffixes();
+        $suffixes['Factory'][] = 'Creator';
+
+        self::assertSame(CheckStatus::Ok, (new SuffixMismatchCheck([$module], $suffixes))->run()->status);
+    }
+
+    public function test_custom_config_suffix_is_respected(): void
+    {
+        $module = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooFacade', null, 'App\\Foo\\FooSettings');
+
+        $suffixes = $this->defaultSuffixes();
+        $suffixes['Config'][] = 'Settings';
+
+        self::assertSame(CheckStatus::Ok, (new SuffixMismatchCheck([$module], $suffixes))->run()->status);
+    }
+
+    public function test_custom_provider_suffix_is_respected(): void
+    {
+        $module = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooFacade', null, null, 'App\\Foo\\FooRegistrar');
+
+        $suffixes = $this->defaultSuffixes();
+        $suffixes['Provider'][] = 'Registrar';
 
         self::assertSame(CheckStatus::Ok, (new SuffixMismatchCheck([$module], $suffixes))->run()->status);
     }


### PR DESCRIPTION
## 📚 Description

Removes `Gacela\Console\Application\*` from infection's `global-ignore` and brings the namespace up to the gate.

**Before:** MSI 70%, Covered MSI 76% — 76 escaped mutants, 28 not covered.
**After:** MSI 100%, Covered MSI 100% — 0 escaped, 0 not covered.

```
XDEBUG_MODE=coverage ./vendor/bin/infection --threads=max --min-msi=100 \
  --min-covered-msi=100 --no-progress --filter=src/Console/Application
```

Most of what escaped was a real gap rather than a scoring artefact. `CacheManager` and `PerformanceMetrics` had no tests at all; the `cache:warm` output formatter had one test out of thirteen methods, so any line it prints could be dropped unnoticed; `ModuleWarmer` never distinguished "skipped, class not found" from "failed, autoloading threw"; and both doctor checks only ever ran through their injected resolvers, so the production reflection paths — the ones that actually run in `bin/gacela doctor` — were untested.

Related to #529. Sibling namespaces (`Infrastructure`, and the four root classes) stay ignored until they get the same treatment.

## 🔖 Changes

**Real gaps closed by tests**

- `CacheWarmOutputFormatterTest`: every one of the 13 methods is now asserted against its full, exact output, including the blank lines and the 60-char banner width
- `CacheManagerTest` (new): cache file path, size on disk vs. 0 when missing, the per-file size listing, and `clearCache()`
- `PerformanceMetricsTest` (new): elapsed time is a delta and not a unix timestamp, memory used is a delta and not total process usage, plus both formatted shapes
- `ModuleWarmerTest` (new): exact counters and exact output for a fully resolved module, a module with a missing pillar class, and a pillar whose autoloading throws — the three paths that were indistinguishable before. Also pins that `--attributes` is what triggers attribute warming
- `CacheWarmServiceTest`: `getModuleClasses()` per pillar, `resolveClass()` both ways including the exception message, and `warmAttributeCache()` asserted through the cache it populates
- `CacheStalenessCheckTest`: the default (reflection) source resolver, equal mtimes not counting as stale, the exact detail strings, and that one unresolvable entry does not hide the entries after it
- `FilenameMismatchCheckTest`: the default file resolver against a class renamed without its file, a class with no source file at all, and Windows-style paths
- `SuffixMismatchCheckTest`: the framework defaults when nothing is configured, a custom suffix per pillar, and the flat error+warning detail list
- `ModuleWarmerFacadeWarmTest`: the assertion matched the module name printed by an earlier line, so removing the failure report still passed — it now names the failed facade line
- `CacheWarmServiceTest::test_filter_production_modules...`: the test wrapped the result in `array_values()` itself, which masked whether `filterProductionModules()` returns the list it declares. The dropped modules now come first so the reindexing is observable

**Escapes removed by deleting the code, not testing it**

- `CacheWarmService::resolveClass()`: dropped the trailing `class_exists($className, true)`. `class_exists()` autoloads by default, so the guard on the line above had already loaded the class
- `ConstructorInspector::renderType()`: dropped the hand-rolled `ReflectionNamedType` rendering. `ReflectionType::__toString()` produces the identical string for every type shape PHP has — including `mixed`, which is exactly what the `!== 'mixed'` special case existed to reproduce
- `CacheManager::existingCacheFiles()` and `FilenameMismatchCheck::pillarsOf()`: dropped `array_values()` around private `array_filter()` helpers whose only consumers are `foreach` loops, and relaxed the annotation to match

**Ignored by name, with a reason (6 mutants)**

- `CastInt` on `CacheManager::getCacheFileSize`, `CacheManager::getExistingCacheFilesWithSize` and `CacheStalenessCheck::run`: `filesize()`/`filemtime()` only return `false` for a file that vanished between the existence check right above and the call itself — a filesystem race
- `Break_` on `CacheWarmService::warmAttributeCache`: the four prefixes (`get`/`create`/`find`/`build`) are mutually exclusive, so continuing the scan after a match can never match a second time
- `AssignCoalesce` on `CacheWarmService::classResolvers`: memoization guard over four stateless resolvers, so rebuilding them per call is observationally identical

Each of the six was confirmed to still escape with the tests in place before the ignore was added.
