### PR TITLE
test(bench): restore FileCacheBench to the default ±10% gate tolerance

### DIFF
--- a/tests/Benchmark/FileCache/FileCacheBench.php
+++ b/tests/Benchmark/FileCache/FileCacheBench.php
@@ -9,7 +9,6 @@ use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
 use PhpBench\Attributes\AfterClassMethods;
-use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\BeforeClassMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
@@ -25,24 +24,16 @@ use function unlink;
  * merged-config cache files written by unrelated test runs on the same
  * machine, which poisoned the enabled-cache path with foreign config values.
  *
- * TEMPORARY tolerance, to be restored to the default +/-10% once `2.0` carries
- * the new baseline. See #541.
+ * `bench_without_cache` costs what it does because this bench asks for
+ * `resetInMemoryCache()` on every rev and registers 15 custom suffix types, so
+ * each of the seven modules probes many candidate class names that do not
+ * exist. Until #540 it read ~21% faster, because `ClassValidator` ignored the
+ * reset and revs 2..50 reused rev 1's misses -- the cross-rev state bleed this
+ * suite's README forbids. Do not treat that older, lower number as the target;
+ * it was measuring a cache that should not have survived.
  *
- * `bench_without_cache` moved +21.79% when `Gacela::resetCache()` started
- * dropping the memoized "this class does not exist" answers. That is not a
- * regression: this bench asks for `resetInMemoryCache()` on every rev and
- * registers 15 custom suffix types, so each of the seven modules probes many
- * candidate class names that do not exist. `ClassValidator` was ignoring the
- * reset, so revs 2..50 reused rev 1's misses -- the cross-rev state bleed this
- * suite's README explicitly forbids. The bench is now paying honestly for the
- * work it always claimed to do, and the old number was the wrong one.
- *
- * The gate cannot express "intentional, reviewed change", and the base branch
- * still measures the leaky behaviour, so every run of this PR would fail
- * against it. Widened only until the merge makes the two sides comparable
- * again.
+ * Gated at the default +/-10% (#541).
  */
-#[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 35%')]
 #[BeforeClassMethods('removeCacheFiles')]
 #[AfterClassMethods('removeCacheFiles')]
 #[Groups(['gate', 'bootstrap'])]


### PR DESCRIPTION
## 📚 Description

Removes the temporary ±35% `#[Assert]` added in #540.

It existed for one reason: that PR's base still measured the pre-fix behaviour, so the guard was comparing two different behaviours and would have failed no matter how correct the code was. `2.0` now carries the new baseline, so both sides are comparable again and the default ±10% applies.

A widened tolerance that outlives its reason stops being a decision and becomes a mute button — `ScopedCacheBench` reached ±30% that way before it had to leave the gate entirely. This one lasted exactly one merge.

## 🔖 Changes

- Removed the class-level `#[Assert]` and the now-unused `PhpBench\Attributes\Assert` import
- Kept the explanation of *why* `bench_without_cache` costs what it does, rewritten as permanent context rather than a temporary note. The point worth preserving: the older, ~21% lower number is **not** a target to get back to — it was inflated by `ClassValidator` ignoring `resetInMemoryCache()`, which let revs 2..50 reuse rev 1's failed lookups. Someone optimising toward it would be chasing a restored state leak

## ✅ Verification

Self-comparison on identical code, default tolerance:

```
bench_without_cache   421.155μs  -0.93%   ±0.36%
bench_with_cache      218.634μs  -2.63%   ±1.43%
```

Closes #541