### PR TITLE
test(config): pin that the config read cache is keyed by reader

### DIFF
--- a/tests/Unit/Framework/Config/ConfigLoaderReaderKeyedCacheTest.php
+++ b/tests/Unit/Framework/Config/ConfigLoaderReaderKeyedCacheTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Config\ConfigLoader;
+use Gacela\Framework\Config\ConfigReaderInterface;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFile;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use Gacela\Framework\Config\PathFinderInterface;
+use Gacela\Framework\Config\PathNormalizerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The read cache is keyed by reader as well as by path.
+ *
+ * `ConfigLoader` memoizes reads so a file matched by both a glob and the local
+ * override is parsed once. That cache was keyed by path alone, so two config
+ * items pointing at the same path with *different* readers shared one entry:
+ * the second reader was never called and silently received whatever the first
+ * had parsed. A project reading one file through two formats — or through a
+ * custom reader alongside the default — got the wrong reader's interpretation
+ * with no error.
+ *
+ * `ConfigLoaderReadCountTest` pins the memoization itself; nothing pinned the
+ * keying, which is the part that was wrong. Written while inventorying the
+ * cache bugs for #539.
+ */
+final class ConfigLoaderReaderKeyedCacheTest extends TestCase
+{
+    private const string SHARED_PATH = '/app/config/shared.php';
+
+    /** @var array<string,int> */
+    private array $readsPerReader = [];
+
+    public function test_two_readers_on_the_same_path_do_not_share_a_cache_entry(): void
+    {
+        $loader = $this->loaderForBothReaders();
+
+        $all = $loader->loadAll();
+
+        self::assertSame(
+            1,
+            $this->readsPerReader['b'] ?? 0,
+            'the second reader must be asked to read, not handed the first reader\'s parse',
+        );
+        self::assertArrayHasKey(
+            'only-known-to-b',
+            $all,
+            'the second reader\'s interpretation of the file must reach the merged config',
+        );
+        self::assertSame('from-reader-b', $all['shared-key']);
+    }
+
+    /**
+     * Both items resolve to the same absolute path -- the collision the cache
+     * key has to survive. Reader B is registered second, so with the merge
+     * order its values win; under the pre-fix keying it was never consulted.
+     */
+    private function loaderForBothReaders(): ConfigLoader
+    {
+        $readerA = $this->createRecordingReader('a', ['shared-key' => 'from-reader-a']);
+        $readerB = $this->createRecordingReader('b', [
+            'shared-key' => 'from-reader-b',
+            'only-known-to-b' => true,
+        ]);
+
+        $pathFinder = $this->createStub(PathFinderInterface::class);
+        $pathFinder->method('matchingPattern')->willReturn([self::SHARED_PATH]);
+
+        $normalizer = $this->createStub(PathNormalizerInterface::class);
+        $normalizer->method('normalizePathPattern')->willReturn(self::SHARED_PATH);
+        $normalizer->method('normalizePathPatternWithEnvironment')->willReturn(self::SHARED_PATH);
+        $normalizer->method('normalizePathLocal')->willReturn(self::SHARED_PATH);
+
+        return new ConfigLoader(
+            (new GacelaConfigFile())->setConfigItems([
+                new GacelaConfigItem('config/*.php', 'config/local.php', $readerA),
+                new GacelaConfigItem('config/*.php', 'config/local.php', $readerB),
+            ]),
+            $pathFinder,
+            $normalizer,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $content
+     */
+    private function createRecordingReader(string $name, array $content): ConfigReaderInterface
+    {
+        return new class($name, $content, $this->readsPerReader) implements ConfigReaderInterface {
+            /**
+             * @param array<string,mixed> $content
+             * @param array<string,int> $readsPerReader
+             */
+            public function __construct(
+                private readonly string $name,
+                private readonly array $content,
+                private array &$readsPerReader,
+            ) {
+            }
+
+            public function read(string $absolutePath): array
+            {
+                $this->readsPerReader[$this->name] = ($this->readsPerReader[$this->name] ?? 0) + 1;
+
+                return $this->content;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 📚 Description

Second and last gap found while completing #539's regression inventory.

`ConfigLoader` memoizes reads so a file matched by both a glob and the local override is parsed once. That cache was keyed by **path alone**, so two config items pointing at the same path with *different* readers shared one entry — the second reader was never called and silently received the first reader's parse. A project reading one file through two formats got the wrong reader's interpretation, with no error.

`ConfigLoaderReadCountTest` pins the memoization itself. Nothing pinned the **keying**, which is the part that was actually wrong.

## 🔖 Changes

- `ConfigLoaderReaderKeyedCacheTest`: two config items on the same absolute path with different readers must each be consulted, and the second reader's interpretation must reach the merged config
- Verified red against the pre-fix key (`$absolutePath` alone): *"the second reader must be asked to read, not handed the first reader's parse"*

## 📋 #539 regression inventory — complete

| Cache bug (1.14–1.20) | Status |
|---|---|
| 1.20 `provideModuleDependencies()` ran twice | ✅ `ProviderRegistrationTest` |
| 1.18 merged-config filename lacked app-root hash | ⚠️ **was a gap** → #543 |
| 1.18 read cache not keyed by reader | ⚠️ **was a gap** → this PR |
| 1.18 `resetCache()` missed the glob cache | ✅ `PathFinderResetTest` |
| 1.18 `APP_ENV` read from a single source | ✅ `AppEnvTest`, `test_env_keys_produce_separate_cache_files` |
| 1.17 `cache:clear` not registered in console | ✅ `test_cache_clear_command_is_registered_in_the_console_application` |
| 1.17 `cache:clear` missed custom-services file | ✅ `test_cache_clear_removes_the_custom_services_cache_file` |
| 1.16 file caches in read-only environments | ✅ `ReadOnlyAppRootTest`, `MergedConfigCacheTest` |
| 1.14.4 Windows cache-dir resolution | ✅ `test_normalize_preserves_windows_unc_prefix` and neighbours |
| — `resetCache()` missed the class-exists memo | ⚠️ **was a live bug** → #540 |

Ten behaviours, three unheld: two pinned, one an actual bug. Step 1 of #539 is done, so the container work can proceed against a suite that would notice a reintroduction.

## ✅ Verification

1314 tests green, quality clean. No CHANGELOG entry — pins existing behaviour.

Related to #539