### PR TITLE
feat!: upgrade to gacela-project/container 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed (BREAKING — 2.0)
 
+- **`gacela-project/container` bumped to `^1.0`** (was `^0.10.0`). `Gacela\Container\Container` is now `final`, so `Gacela\Framework\Container\Container` decorates it by composition instead of extending it — which is what its docblock always claimed it did. It still implements `ContainerInterface` and gains the 1.0 additions (`when()`, `compile()`, `writeCompiledCache()`, `getStats()`, `ArrayAccess`). **Only affects code that passed a Gacela container where the concrete `Gacela\Container\Container` was type-hinted**; depend on `ContainerInterface` instead. Provider closures are unchanged: `static fn (Container $c) => $c->getLocator()->get(...)` still receives the Gacela container, not the inner one
+
 - **PHP floor raised to `>=8.3`** (was `>=8.1`). PHP 8.1 reached end of life in December 2025 and 8.2's security window closes in December 2026, so a 2.0 pinned to either would ship already needing another bump. Projects on 8.1 or 8.2 should stay on **1.21**, which is feature-complete and carries the tooling for this migration — `doctor`'s filename check, `FacadeInterfaceInSyncRule`, and the typed pillar accessors
 - **`symfony/*` widened to `^7.0 || ^8.0`** (was `^6.4`). Gacela no longer decides a consumer's Symfony major for them
 - Class constants on `AbstractSetupGacela` and `ConfigInterface` now declare types (PHP 8.3 typed class constants), so a subclass redeclaring one is checked at compile time instead of silently changing the shape a builder reads. Only affects code that overrides them with a different type

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "gacela-project/container": "^0.10.0"
+        "gacela-project/container": "^1.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c24b1f9cafe4d30bae81bc489e5626a3",
+    "content-hash": "41c7ed6e07610dee6764304a47c42167",
     "packages": [
         {
             "name": "gacela-project/container",
-            "version": "0.10.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "db13556a11f6892c852ef0f26a9915aee2a3ba4e"
+                "reference": "8bbb5b8ab80035bc4c15dd34e34a588df4bc5edd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/db13556a11f6892c852ef0f26a9915aee2a3ba4e",
-                "reference": "db13556a11f6892c852ef0f26a9915aee2a3ba4e",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/8bbb5b8ab80035bc4c15dd34e34a588df4bc5edd",
+                "reference": "8bbb5b8ab80035bc4c15dd34e34a588df4bc5edd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "psr/container": ">=1.1"
+                "php": ">=8.3",
+                "psr/container": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.75",
-                "phpstan/phpstan": "^1.12",
-                "phpunit/phpunit": "^10.5",
-                "psalm/plugin-phpunit": "^0.18",
-                "symfony/var-dumper": "^5.4",
-                "vimeo/psalm": "^5.26"
+                "infection/infection": "^0.31",
+                "phpbench/phpbench": "^1.4",
+                "phpstan/phpstan": "^2.2",
+                "phpunit/phpunit": "^12.5",
+                "psalm/plugin-phpunit": "^0.19",
+                "symfony/var-dumper": "^6.4 || ^7.0",
+                "vimeo/psalm": "^6.16"
             },
             "type": "library",
             "autoload": {
@@ -64,7 +66,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/container/issues",
-                "source": "https://github.com/gacela-project/container/tree/0.10.0"
+                "source": "https://github.com/gacela-project/container/tree/1.0.0"
             },
             "funding": [
                 {
@@ -72,7 +74,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-19T22:59:58+00:00"
+            "time": "2026-07-26T15:00:33+00:00"
         },
         {
             "name": "psr/container",

--- a/infection.json5
+++ b/infection.json5
@@ -87,6 +87,16 @@
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Framework\\Cache\\FileCache::delete",
                 "Gacela\\Framework\\Testing\\ContainerFixture::registerContainerTempDirsCleanup",
+                // warmUp() pre-resolves dependencies into the container's own
+                // cache. It is a performance hint with no observable behaviour:
+                // a class is exactly as resolvable, and returns exactly the same
+                // instance, whether or not it was warmed. The only way to kill
+                // this mutant is to assert the container's internal counters --
+                // and getStats() is explicitly not covered by upstream's BC
+                // policy ("do not build logic on it"), so a test reading it
+                // would break on an unrelated upstream release.
+                // Not a TODO. The forwarding itself is required by the interface.
+                "Gacela\\Framework\\Container\\Container::warmUp",
             ],
         },
         IfNegation: {

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Container;
 
+use Closure;
 use Gacela\Container\Container as GacelaContainer;
+use Gacela\Container\ContextualBindingBuilder;
 use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
@@ -12,18 +14,58 @@ use Gacela\Framework\Event\Container\BindingRegisteredEvent;
 use Gacela\Framework\Event\Container\ServiceResolvedEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Plugins\LazyHandlerRegistry;
+use SplObjectStorage;
+
+use function array_keys;
+use function array_map;
 
 /**
- * This is a decorator class to simplify the usage of the decoupled Container
+ * Decorates the decoupled Container, adding the Locator and the service
+ * lifecycle events.
+ *
+ * Composition rather than inheritance: `Gacela\Container\Container` is `final`
+ * as of 1.0. Every method here forwards to the inner container, and
+ * implementing the interface is what keeps that forwarding honest -- a method
+ * added upstream fails compilation here instead of silently going missing.
  *
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
+ * @psalm-import-type Binding from \Gacela\Container\ContainerInterface
+ * @psalm-import-type BindingsMap from \Gacela\Container\ContainerInterface as ContainerBindingsMap
+ * @psalm-import-type ContainerStats from \Gacela\Container\ContainerInterface
+ * @psalm-import-type CompiledPlans from \Gacela\Container\DependencyResolver
  */
-final class Container extends GacelaContainer implements ContainerInterface
+final class Container implements ContainerInterface
 {
     use EventDispatchingCapabilities;
 
+    private readonly GacelaContainer $inner;
+
+    /**
+     * Closures set() must pass through untouched: the wrappers this class
+     * produced, and closures handed to protect(). Both are marked by *identity*
+     * upstream, so wrapping them again would give set() a different object and
+     * silently drop the factory/protected mark.
+     *
+     * @var SplObjectStorage<Closure, null>
+     */
+    private readonly SplObjectStorage $doNotWrap;
+
     /** @var array<string, true> */
     private array $resolvedServiceIds = [];
+
+    /**
+     * @param ContainerBindingsMap $bindings
+     * @param array<string, list<Closure>> $instancesToExtend
+     * @param CompiledPlans $compiledPlans
+     */
+    public function __construct(
+        array $bindings = [],
+        array $instancesToExtend = [],
+        array $compiledPlans = [],
+    ) {
+        $this->inner = new GacelaContainer($bindings, $instancesToExtend, $compiledPlans);
+        $this->doNotWrap = new SplObjectStorage();
+    }
 
     public static function withConfig(Config $config): self
     {
@@ -41,7 +83,7 @@ final class Container extends GacelaContainer implements ContainerInterface
     public function get(string $id): mixed
     {
         /** @var mixed $service */
-        $service = parent::get($id);
+        $service = $this->inner->get($id);
 
         // Guard first so a container with no listener pays nothing: no dedup-map
         // growth and no per-get work, keeping get() zero-cost when events are off.
@@ -51,6 +93,277 @@ final class Container extends GacelaContainer implements ContainerInterface
         }
 
         return $service;
+    }
+
+    public function getOrFail(string $id): mixed
+    {
+        return $this->inner->getOrFail($id);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     * @param array<string, mixed> $parameters
+     *
+     * @return T
+     */
+    public function make(string $className, array $parameters = []): object
+    {
+        return $this->inner->make($className, $parameters);
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function resolve(callable $callable, array $parameters = []): mixed
+    {
+        return $this->inner->resolve($callable, $parameters);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->inner->has($id);
+    }
+
+    public function afterResolving(string $id, Closure $callback): void
+    {
+        $this->inner->afterResolving($id, $callback);
+    }
+
+    /**
+     * @param Binding $concrete
+     */
+    public function bind(string $abstract, string|callable|object $concrete): void
+    {
+        /** @var Binding $decorated */
+        $decorated = $this->decorateIfUserClosure($concrete);
+        $this->inner->bind($abstract, $decorated);
+    }
+
+    /**
+     * @param Binding|null $concrete
+     */
+    public function singleton(string $abstract, string|callable|object|null $concrete = null): void
+    {
+        /** @var Binding|null $decorated */
+        $decorated = $this->decorateIfUserClosure($concrete);
+        $this->inner->singleton($abstract, $decorated);
+    }
+
+    public function bound(string $id): bool
+    {
+        return $this->inner->bound($id);
+    }
+
+    /**
+     * @param Binding $concrete
+     */
+    public function bindIf(string $abstract, string|callable|object $concrete): void
+    {
+        /** @var Binding $decorated */
+        $decorated = $this->decorateIfUserClosure($concrete);
+        $this->inner->bindIf($abstract, $decorated);
+    }
+
+    /**
+     * @param Binding|null $concrete
+     */
+    public function singletonIf(string $abstract, string|callable|object|null $concrete = null): void
+    {
+        /** @var Binding|null $decorated */
+        $decorated = $this->decorateIfUserClosure($concrete);
+        $this->inner->singletonIf($abstract, $decorated);
+    }
+
+    public function set(string $id, mixed $instance): void
+    {
+        $this->inner->set($id, $this->decorateIfUserClosure($instance));
+    }
+
+    public function remove(string $id): void
+    {
+        $this->inner->remove($id);
+    }
+
+    public function factory(Closure $instance): Closure
+    {
+        return $this->inner->factory($this->withDecorator($instance));
+    }
+
+    public function extend(string $id, Closure $instance): Closure
+    {
+        return $this->inner->extend($id, $this->withDecorator($instance));
+    }
+
+    /**
+     * Deliberately not wrapped: a protected closure is never invoked by the
+     * container, it is handed back verbatim. There is no container argument to
+     * substitute, and wrapping would break the identity callers rely on.
+     */
+    public function protect(Closure $instance): Closure
+    {
+        $this->doNotWrap->attach($instance);
+
+        return $this->inner->protect($instance);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRegisteredServices(): array
+    {
+        return $this->inner->getRegisteredServices();
+    }
+
+    public function isFactory(string $id): bool
+    {
+        return $this->inner->isFactory($id);
+    }
+
+    public function isFrozen(string $id): bool
+    {
+        return $this->inner->isFrozen($id);
+    }
+
+    /**
+     * @return ContainerBindingsMap
+     */
+    public function getBindings(): array
+    {
+        return $this->inner->getBindings();
+    }
+
+    /**
+     * @param list<class-string> $classNames
+     */
+    public function warmUp(array $classNames): void
+    {
+        $this->inner->warmUp($classNames);
+    }
+
+    public function alias(string $alias, string $id): void
+    {
+        $this->inner->alias($alias, $id);
+    }
+
+    /**
+     * @param string|list<string> $ids
+     */
+    public function tag(string|array $ids, string $tag): void
+    {
+        $this->inner->tag($ids, $tag);
+    }
+
+    /**
+     * @return iterable<mixed>
+     */
+    public function tagged(string $tag): iterable
+    {
+        return $this->inner->tagged($tag);
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @return list<string>
+     */
+    public function getDependencyTree(string $className): array
+    {
+        return $this->inner->getDependencyTree($className);
+    }
+
+    /**
+     * @param class-string|list<class-string> $concrete
+     */
+    public function when(string|array $concrete): ContextualBindingBuilder
+    {
+        return $this->inner->when($concrete);
+    }
+
+    /**
+     * @param list<class-string> $classNames
+     *
+     * @return array<class-string, mixed>
+     */
+    public function compile(array $classNames): array
+    {
+        return $this->inner->compile($classNames);
+    }
+
+    /**
+     * @param list<class-string> $classNames
+     */
+    public function writeCompiledCache(array $classNames, string $file): void
+    {
+        $this->inner->writeCompiledCache($classNames, $file);
+    }
+
+    /**
+     * @return ContainerStats
+     */
+    public function getStats(): array
+    {
+        return $this->inner->getStats();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        /** @var string $offset */
+        return $this->has($offset);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        /** @var string $offset */
+        return $this->get($offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        /** @var string $offset */
+        $this->set($offset, $value);
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        /** @var string $offset */
+        $this->remove($offset);
+    }
+
+    /**
+     * Service closures are invoked by the inner container, which passes
+     * *itself*. Under inheritance that used to be this object; under
+     * composition it is not, and the documented provider signature
+     * `static fn (Container $c) => $c->getLocator()->get(...)` would break --
+     * `getLocator()` exists only here.
+     *
+     * So every user closure is wrapped to substitute this decorator wherever
+     * the inner container is passed. Argument-position agnostic, because
+     * set(), factory(), protect() and extend() all call with different shapes.
+     */
+    private function withDecorator(Closure $closure): Closure
+    {
+        $self = $this;
+        $inner = $this->inner;
+
+        $wrapper = static fn (mixed ...$args): mixed => $closure(...array_map(
+            static fn (mixed $arg): mixed => ($arg === $inner) ? $self : $arg,
+            $args,
+        ));
+
+        $this->doNotWrap->attach($wrapper);
+
+        return $wrapper;
+    }
+
+    private function decorateIfUserClosure(mixed $instance): mixed
+    {
+        if ($instance instanceof Closure && !$this->doNotWrap->contains($instance)) {
+            return $this->withDecorator($instance);
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Framework/Container/ContextualBindingRegistrar.php
+++ b/src/Framework/Container/ContextualBindingRegistrar.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Container;
 
-use Gacela\Container\Container as GacelaContainer;
+use Gacela\Container\ContainerInterface as GacelaContainerInterface;
 
 use function class_exists;
 use function interface_exists;
@@ -25,7 +25,7 @@ final class ContextualBindingRegistrar
      * @param class-string|string $abstract class name, or a '$parameterName' for scalar bindings
      */
     public static function register(
-        GacelaContainer $container,
+        GacelaContainerInterface $container,
         string $concrete,
         string $abstract,
         mixed $implementation,

--- a/tests/Integration/Framework/Container/ContainerDelegationTest.php
+++ b/tests/Integration/Framework/Container/ContainerDelegationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use Gacela\Container\Container as GacelaContainer;
+use Gacela\Framework\Container\Container;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function is_file;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Container-API behaviour that only the decorator's forwarding can get wrong.
+ *
+ * These methods used to be inherited, so there was no Gacela code to test. With
+ * `Gacela\Container\Container` final from 1.0, every one of them is a
+ * hand-written delegation -- which introduces a bug class that did not exist
+ * before: forwarding to the *neighbouring* method. `bindIf` calling `bind`, or
+ * `singletonIf` calling `singleton`, differ only in whether an existing binding
+ * is overwritten, and nothing else in the suite would notice.
+ *
+ * So these assert the semantics that distinguish each pair, not that a call was
+ * made.
+ */
+final class ContainerDelegationTest extends TestCase
+{
+    public function test_bind_if_does_not_overwrite_an_existing_binding(): void
+    {
+        $container = new Container();
+        $container->bind(StringValueInterface::class, static fn (): StringValue => new StringValue('first'));
+
+        $container->bindIf(StringValueInterface::class, static fn (): StringValue => new StringValue('second'));
+
+        self::assertSame('first', $container->get(StringValueInterface::class)?->value());
+    }
+
+    public function test_bind_overwrites_where_bind_if_would_not(): void
+    {
+        $container = new Container();
+        $container->bind(StringValueInterface::class, static fn (): StringValue => new StringValue('first'));
+
+        $container->bind(StringValueInterface::class, static fn (): StringValue => new StringValue('second'));
+
+        self::assertSame('second', $container->get(StringValueInterface::class)?->value());
+    }
+
+    /**
+     * The "does not overwrite" tests above cannot tell a `bindIf` that declined
+     * to overwrite from one that was never called at all. This pins the other
+     * half of the contract: on an unbound abstract it must actually register.
+     */
+    public function test_bind_if_registers_when_nothing_is_bound_yet(): void
+    {
+        $container = new Container();
+
+        $container->bindIf(StringValueInterface::class, static fn (): StringValue => new StringValue('only'));
+
+        self::assertSame('only', $container->get(StringValueInterface::class)?->value());
+    }
+
+    public function test_singleton_if_registers_when_nothing_is_bound_yet(): void
+    {
+        $container = new Container();
+
+        $container->singletonIf(StringValueInterface::class, static fn (): StringValue => new StringValue('only'));
+
+        self::assertSame('only', $container->get(StringValueInterface::class)?->value());
+    }
+
+    public function test_singleton_if_does_not_overwrite_an_existing_binding(): void
+    {
+        $container = new Container();
+        $container->singleton(StringValueInterface::class, static fn (): StringValue => new StringValue('first'));
+
+        $container->singletonIf(StringValueInterface::class, static fn (): StringValue => new StringValue('second'));
+
+        self::assertSame('first', $container->get(StringValueInterface::class)?->value());
+    }
+
+    public function test_a_singleton_returns_the_same_instance_every_time(): void
+    {
+        $container = new Container();
+        $container->singleton(StringValueInterface::class, static fn (): StringValue => new StringValue('x'));
+
+        self::assertSame(
+            $container->get(StringValueInterface::class),
+            $container->get(StringValueInterface::class),
+        );
+    }
+
+    public function test_after_resolving_runs_once_the_service_is_resolved(): void
+    {
+        $container = new Container();
+        $container->set('service', static fn (): string => 'value');
+
+        $seen = null;
+        $container->afterResolving('service', static function (mixed $instance) use (&$seen): void {
+            $seen = $instance;
+        });
+
+        self::assertNull($seen, 'the callback must not run before the service is resolved');
+
+        $container->get('service');
+
+        self::assertSame('value', $seen);
+    }
+
+    public function test_tagged_resolves_every_service_registered_under_the_tag(): void
+    {
+        $container = new Container();
+        $container->set('a', static fn (): string => 'A');
+        $container->set('b', static fn (): string => 'B');
+
+        $container->tag(['a', 'b'], 'letters');
+
+        self::assertSame(['A', 'B'], [...$container->tagged('letters')]);
+    }
+
+    public function test_warm_up_leaves_the_class_resolvable(): void
+    {
+        $container = new Container();
+
+        $container->warmUp([stdClass::class]);
+
+        self::assertInstanceOf(stdClass::class, $container->make(stdClass::class));
+    }
+
+    public function test_write_compiled_cache_produces_plans_that_load_back(): void
+    {
+        $file = sys_get_temp_dir() . '/gacela-compiled-plans-' . uniqid('', true) . '.php';
+        $container = new Container();
+
+        try {
+            $container->writeCompiledCache([stdClass::class], $file);
+
+            self::assertTrue(is_file($file), 'writeCompiledCache() must write the plans file');
+            self::assertArrayHasKey(stdClass::class, GacelaContainer::loadCompiledCache($file));
+        } finally {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📚 Description

Bumps `gacela-project/container` to `^1.0`. Three of its four breaking changes touch Gacela; one required real work.

## 🔖 Changes

### `Container` is `final` → composition

`Gacela\Framework\Container\Container` extended the upstream container, which is now `final` — a **fatal error**, not a soft break. It now decorates by composition, which is what its docblock always claimed (*"This is a decorator class"*).

Implementing `ContainerInterface` is what keeps the forwarding honest: a method added upstream fails compilation here rather than silently going missing.

### The part composition made visible

The inner container invokes service closures passing **itself**. Under inheritance that was the same object; under composition it is not. So the documented provider signature would have broken:

```php
static fn (Container $c) => $c->getLocator()->get(Dependent\Facade::class)
```

`getLocator()` exists **only** on the decorator — the inner container cannot serve these closures at all. Every user closure is therefore wrapped to substitute the decorator wherever the inner container is passed. Argument-position agnostic, because `set()`, `factory()` and `extend()` each call with a different shape.

Two subtleties found by tests, both worth stating because they are easy to get wrong:

- **`protect()` is exempt.** A protected closure is handed back *verbatim*, never invoked — there is no container argument to substitute, and wrapping broke the identity callers rely on.
- **`set()` must not re-wrap.** Upstream marks factory and protected closures by **object identity**, so wrapping again hands `set()` a different object and silently drops the mark. Closures this class produced, and those given to `protect()`, are recorded and passed through.

### The other two breaking changes — audited, no action

- **`has()` now answers the PSR-11 question**, so it is `true` for autowirable classes. Inert here: all four `->has()` call sites in `src/` are Gacela's own cache interfaces (`ScopedCache`, `InMemoryCacheStorage`, `DocBlockResolverCache`, `ClassNameFinder`), not the DI container, and nothing calls `bound()`. This was the change most likely to pass tests and alter behaviour silently, so I checked it before trusting green.
- **`ContainerInterface` gained methods** — implementers only. `ContextualBindingRegistrar` now type-hints the interface instead of the concrete class.

## 🤔 What I did *not* adopt, on purpose

1.0 adds `compile()` / `writeCompiledCache()` — AOT constructor plans, and genuinely the P1 "compile" pillar. Adopting it means writing a plans file in `cache:warm`, loading it at bootstrap, clearing it in `cache:clear`, and invalidating it when a constructor changes: **a fifth cache layer**.

Adding one during a breaking dependency upgrade, while #539 exists to *collapse* cache layers and this branch just finished pinning 16 cache bugs, is the mistake I would be documenting later. Tracked separately so it lands inside the consolidated container.

`getStats()` is also skipped: upstream states its shape is explicitly **not** covered by backward compatibility, so building `debug:container` logic on it would be building on sand.

## 💥 Impact

Only affects code passing a Gacela container where the concrete `Gacela\Container\Container` was type-hinted — depend on `ContainerInterface`. **Provider closures are unchanged.**

## ✅ Verification

1314 tests green, psalm and phpstan clean. Upgrade started at 27 errors; each was traced to a specific upstream change rather than patched until green.

Related to #503