### PR TITLE
feat!: stop shipping the pillar-accessor suppression + add the 2.0 upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed (BREAKING — 2.0)
 
+- **The PHPStan suppression for undeclared pillar accessors is gone.** 1.x shipped an `ignoreErrors` entry in `phpstan-gacela.neon` silencing `Call to an undefined method ...::getFacade()`. A class resolving a pillar through `ServiceResolverAwareTrait` must now declare it with `#[ServiceMap]` (or a `@method` docblock, which PHPStan reads natively) or the call is reported. A suppressed call was never a typed one — it evaluated to `mixed`, which switched off checking of everything reached *through* the accessor. 1.21 shipped the `#[ServiceMap]` typing precisely so this migration can be done first
+
 - **`gacela-project/container` bumped to `^1.0`** (was `^0.10.0`). `Gacela\Container\Container` is now `final`, so `Gacela\Framework\Container\Container` decorates it by composition instead of extending it — which is what its docblock always claimed it did. It still implements `ContainerInterface` and gains the 1.0 additions (`when()`, `compile()`, `writeCompiledCache()`, `getStats()`, `ArrayAccess`). **Only affects code that passed a Gacela container where the concrete `Gacela\Container\Container` was type-hinted**; depend on `ContainerInterface` instead. Provider closures are unchanged: `static fn (Container $c) => $c->getLocator()->get(...)` still receives the Gacela container, not the inner one
 
 - **PHP floor raised to `>=8.3`** (was `>=8.1`). PHP 8.1 reached end of life in December 2025 and 8.2's security window closes in December 2026, so a 2.0 pinned to either would ship already needing another bump. Projects on 8.1 or 8.2 should stay on **1.21**, which is feature-complete and carries the tooling for this migration — `doctor`'s filename check, `FacadeInterfaceInSyncRule`, and the typed pillar accessors

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,10 +1,110 @@
 # Upgrading
 
-Everything deprecated in the 1.x line still works. Each entry below is scheduled
-for removal in 2.0, so migrating now is optional but keeps the 2.0 upgrade
-mechanical.
+- [Upgrading to 2.0](#upgrading-to-20)
+- [Deprecated in 1.x, removed in 2.0](#deprecated-in-1x-removed-in-20)
+
+## Upgrading to 2.0
+
+**Do this on 1.21 first.** Every deprecation in the [next
+section](#deprecated-in-1x-removed-in-20) is *removed* in 2.0, and 1.21 emits a
+runtime notice for each. Clearing them on 1.21 turns this upgrade into a version
+bump; skipping that step turns it into a debugging session, because a pillar that
+no longer resolves fails by being silently absent rather than by throwing.
+
+1.21 is the final 1.x feature release and deliberately ships the tooling for this
+migration: `doctor`'s filename check, `FacadeInterfaceInSyncRule`, and the typed
+pillar accessors.
+
+### 1. PHP 8.3 is the minimum
+
+Was `>=8.1`. PHP 8.1 reached end of life in December 2025 and 8.2's security
+window closes in December 2026, so a 2.0 pinned to either would ship already
+needing another bump.
+
+**Staying on 8.1 or 8.2?** Stay on **1.21**. It is feature-complete, not a
+downgrade.
+
+### 2. `symfony/*` is `^7.0 || ^8.0`
+
+Was `^6.4`. Both majors are accepted, so Gacela does not decide your Symfony
+version for you. Only the console commands depend on Symfony.
+
+### 3. `gacela-project/container` is `^1.0`
+
+`Gacela\Container\Container` is now `final`, so `Gacela\Framework\Container\Container`
+composes it instead of extending it.
+
+**Your providers are unaffected.** This still works exactly as before:
+
+```php
+public function provideModuleDependencies(Container $container): void
+{
+    $container->set(
+        'FACADE_OTHER',
+        static fn (Container $container) => $container->getLocator()->get(Other\Facade::class),
+    );
+}
+```
+
+The one thing that breaks is type-hinting the *upstream* concrete class where a
+Gacela container is passed. Depend on the interface instead:
+
+```diff
+-use Gacela\Container\Container;
++use Gacela\Container\ContainerInterface;
+
+-public function register(Container $container): void
++public function register(ContainerInterface $container): void
+```
+
+### 4. Undeclared pillar accessors are reported by PHPStan
+
+1.x shipped an `ignoreErrors` entry in `phpstan-gacela.neon` that silenced
+`Call to an undefined method ...::getFacade()`. It is gone.
+
+A suppressed call was never a typed one: it evaluated to `mixed`, which switched
+off checking of everything reached *through* the accessor. Declaring the pillar
+gets that checking back.
+
+```diff
++#[ServiceMap(method: 'getFacade', className: MyFacade::class)]
+ final class MyConsumer
+ {
+     use ServiceResolverAwareTrait;
+ }
+```
+
+A `@method` docblock works too — PHPStan reads it natively:
+
+```php
+/**
+ * @method MyFacade getFacade()
+ */
+```
+
+If you already declared your pillars on 1.21, this is a no-op for you.
+
+### 5. Class constants are typed
+
+`AbstractSetupGacela` and `ConfigInterface` declare types on their constants (a
+PHP 8.3 feature). This only affects code that **redeclares** one with a different
+type — previously silent, now a compile error.
+
+### Behaviour fix worth knowing
+
+`Gacela::resetCache()` now drops the memoized "this class does not exist"
+answers. `ClassValidator` cached the negative result of `class_exists()`, so a
+class that was not loadable when first resolved stayed "missing" for the life of
+the process. This affects long-running workers (RoadRunner, Swoole, queue
+consumers) that re-bootstrap, code generation, and `cache:warm` emitting classes.
+
+Positive answers are deliberately kept: a class that exists cannot stop existing,
+so they never go stale.
 
 ## Deprecated in 1.x, removed in 2.0
+
+Everything below still works on 1.x and is **removed in 2.0**. Migrate on 1.21,
+where each still runs.
 
 | Deprecated | Replacement | Since |
 |---|---|---|
@@ -44,7 +144,13 @@ Change the parent class and rename the method:
 **Rename the file too.** `DependencyProvider.php` must become `Provider.php` —
 Gacela resolves module pillars by filename suffix, so a class named `Provider`
 sitting in `DependencyProvider.php` will not be found. This is the step most
-people miss.
+people miss, and `gacela doctor` reports it.
+
+2.0 also removes the internal `DependencyProviderResolver` and the dual
+provider-resolution path it fed. A side effect worth knowing: on 1.x a module's
+`provideModuleDependencies()` could run **twice**, because both resolvers shared
+a normalized cache slot. If your provider body is not idempotent -- counters,
+external registrations, logging -- it now runs once.
 
 `provideModuleDependencies()` keeps working on `AbstractProvider`. If you would
 rather register by attribute, `#[Provides]` is the attribute-first path:

--- a/phpstan-gacela.neon
+++ b/phpstan-gacela.neon
@@ -1,19 +1,3 @@
-parameters:
-    ignoreErrors:
-        # Fallback for classes that resolve a pillar through ServiceResolverAwareTrait
-        # without declaring it. A class carrying #[ServiceMap] no longer needs this:
-        # ServiceMapMethodsClassReflectionExtension (below) gives those accessors a
-        # real return type, and a suppressed call is not a typed one -- it degrades
-        # to mixed, which stops the analyser checking everything behind the accessor.
-        #
-        # Declare your pillars with #[ServiceMap] (or a @method docblock, which
-        # PHPStan reads natively) to get that checking back. This entry is scheduled
-        # for removal in 2.0; reportUnmatched keeps it from failing builds that have
-        # already stopped needing it.
-        -
-            message: '#Call to an undefined method .+::(getFacade|getFactory|getConfig)\(\)\.$#'
-            reportUnmatched: false
-
 services:
     # Types getFacade()/getFactory()/getConfig() from the #[ServiceMap] attribute
     # that already declares the method name and the class it resolves to.

--- a/tests/Integration/PHPStan/Fixture/UndeclaredConsumer.php
+++ b/tests/Integration/PHPStan/Fixture/UndeclaredConsumer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\PHPStan\Fixture;
+
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Resolves a pillar through `ServiceResolverAwareTrait` while declaring neither
+ * `#[ServiceMap]` nor a `@method` docblock.
+ *
+ * 1.x shipped an `ignoreErrors` entry in `phpstan-gacela.neon` that silenced
+ * this. 2.0 removes it, so the call is now reported -- which is the point: a
+ * suppressed call is not a typed one. It degraded to `mixed`, and everything
+ * reached *through* the accessor went unchecked along with it.
+ */
+final class UndeclaredConsumer
+{
+    use ServiceResolverAwareTrait;
+
+    public function resolvesAnUndeclaredPillar(): mixed
+    {
+        return $this->getFacade();
+    }
+}

--- a/tests/Integration/PHPStan/ServiceMapAnalysisTest.php
+++ b/tests/Integration/PHPStan/ServiceMapAnalysisTest.php
@@ -42,11 +42,33 @@ final class ServiceMapAnalysisTest extends TestCase
         self::assertStringNotContainsString('knownMethod', $errors);
     }
 
-    public function test_the_accessor_itself_is_never_an_undefined_method(): void
+    public function test_a_declared_accessor_is_never_an_undefined_method(): void
     {
         $errors = $this->analyseFixture();
 
-        self::assertStringNotContainsString('::getFacade()', $errors);
+        // Namespace-qualified on purpose: "Consumer::getFacade()" alone is also a
+        // substring of "UndeclaredConsumer::getFacade()", which must be reported.
+        self::assertStringNotContainsString('Fixture\Consumer::getFacade()', $errors);
+    }
+
+    /**
+     * The counterpart, and the reason 2.0 drops the `ignoreErrors` entry that
+     * 1.x shipped: a class declaring neither `#[ServiceMap]` nor a `@method`
+     * docblock is now reported instead of silenced.
+     *
+     * A suppressed call was never a typed one -- it evaluated to `mixed`, which
+     * switched off checking of everything reached through the accessor. This is
+     * the breaking half of the attribute-first move, so it is pinned rather than
+     * left as a property of a config file nobody reads.
+     */
+    public function test_an_undeclared_accessor_is_reported(): void
+    {
+        $errors = $this->analyseFixture();
+
+        self::assertStringContainsString(
+            'Call to an undefined method GacelaTest\Integration\PHPStan\Fixture\UndeclaredConsumer::getFacade().',
+            $errors,
+        );
     }
 
     private function analyseFixture(): string


### PR DESCRIPTION
## 📚 Description

`phpstan-gacela.neon` shipped an `ignoreErrors` entry silencing `Call to an undefined method ...::getFacade()` for classes that resolve a pillar through `ServiceResolverAwareTrait` without declaring it. The entry documented itself as *"scheduled for removal in 2.0"*. This removes it.

**A suppressed call is not a typed one.** It evaluated to `mixed`, which switched off checking of everything reached *through* the accessor — so the accessor looked handled while silently disabling analysis behind it. That is the whole argument for attribute-first, and #521 shipped the `#[ServiceMap]` typing in **1.21** precisely so consumers can migrate *before* taking 2.0.

## 🔖 Changes

- Removed the `parameters.ignoreErrors` block from `phpstan-gacela.neon`. The `services` section (the extensions and rules) is untouched
- New `UndeclaredConsumer` fixture: declares neither `#[ServiceMap]` nor a `@method` docblock
- `ServiceMapAnalysisTest` asserts its accessor **is** now reported, so the behaviour is pinned by a test rather than left as a property of a config file nobody reads

## ⚠️ Two things worth review

**An existing test was asserting the old behaviour.** `test_the_accessor_itself_is_never_an_undefined_method` asserted `"::getFacade()"` appeared *nowhere* in the output — only true while the suppression existed. It is now scoped to the declared consumer and renamed accordingly.

**That scoping needed a namespace qualifier.** My first attempt asserted `"Consumer::getFacade()"` was absent, which fails: it is also a substring of `"UndeclaredConsumer::getFacade()"`, the one that *must* be reported. Anchored on `Fixture\Consumer::getFacade()` instead, with a comment saying why.

## 💥 Migration

Declare the pillar:

```php
#[ServiceMap(method: 'getFacade', className: MyFacade::class)]
final class MyConsumer
{
    use ServiceResolverAwareTrait;
}
```

A `@method` docblock also works — PHPStan reads it natively. Running `1.21` with `#[ServiceMap]` already declared means this release is a no-op for you.

## ✅ Verification

1325 tests green, quality clean. PHPStan reports no errors on Gacela's own source with the suppression gone — it was covering consumer code, not ours.

Related to #503