### PR TITLE
docs: name one primary path per intent for obtaining a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Gacela::resetCache()` now drops the memoized "this class does not exist" answers. `ClassValidator` caches the *negative* result of `class_exists()`, so a class that was not loadable when first resolved stayed "missing" for the life of the process — `Gacela::resetCache()` did not clear it, because `ClassValidator::resetCache()` was reachable only from its own unit test. Affects any process where the set of loadable classes changes after the first resolution: long-running workers (RoadRunner, Swoole, queue consumers) that re-bootstrap, code generation, and `cache:warm` emitting classes. Positive answers are kept — a class that exists cannot stop existing, so they never go stale, and clearing them cost ~20% on the no-file-cache bootstrap path for no correctness gain
 
+### Documentation
+
+- New `docs/getting-a-dependency.md`: names **one primary path per intent** — `#[ServiceMap]` + `getFacade()` to reach another module, `create*()`/`make()` for an own collaborator, `#[Provides]`/`addBinding()` for an external service, and the typed getters for config. The other paths are listed with the situation where each is genuinely the right answer. Nothing was removed: the 25-path inventory in `docs/rfc/0002` showed the problem was never the count — reading config has six methods for one intent and nobody complains, because they are the same path with typed variants
+
 ### Changed (BREAKING — 2.0)
 
 - **The PHPStan suppression for undeclared pillar accessors is gone.** 1.x shipped an `ignoreErrors` entry in `phpstan-gacela.neon` silencing `Call to an undefined method ...::getFacade()`. A class resolving a pillar through `ServiceResolverAwareTrait` must now declare it with `#[ServiceMap]` (or a `@method` docblock, which PHPStan reads natively) or the call is reported. A suppressed call was never a typed one — it evaluated to `mixed`, which switched off checking of everything reached *through* the accessor. 1.21 shipped the `#[ServiceMap]` typing precisely so this migration can be done first

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # Gacela Documentation
 
 - [Getting started](getting-started.md) — install and build your first module
+- [Getting a dependency](getting-a-dependency.md) — one primary path per intent, and when the other paths are right
 - [Container configuration](container-configuration.md) — factories, aliases, contextual bindings
 - [Static analysis](static-analysis.md) — PHPStan and Psalm setup
 - [Module health checks](module-health-checks.md) — report module operational status

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -1,0 +1,157 @@
+# Getting a dependency
+
+Gacela supports many ways to obtain a dependency. This page names **one primary
+path per intent** — the one the docs teach, the one that is type-safe, and the
+one to reach for when you have no specific reason to do otherwise.
+
+The rest still work. They are listed at the bottom with the situations where
+they are genuinely the right answer, because "supported" is not "deprecated".
+
+| I want to… | Use |
+|---|---|
+| reach another module | `#[ServiceMap]` + `$this->getFacade()` |
+| get a collaborator inside my own module | a `create*()` method on the Factory, or `make()` when autowiring pays |
+| get an external / infrastructure service | `#[Provides]` in the Provider, or `addBinding()` for an interface |
+| read a config value | the typed getters on your `Config` |
+
+## Reach another module
+
+Declare the pillar with `#[ServiceMap]` and call the accessor:
+
+```php
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+
+#[ServiceMap(method: 'getFacade', className: BillingFacade::class)]
+final class Factory extends AbstractFactory
+{
+    public function createInvoiceSender(): InvoiceSender
+    {
+        return new InvoiceSender($this->getFacade());
+    }
+}
+```
+
+**Why declare it.** The accessor works without the attribute — the runtime falls
+back to reading a `@method` docblock, and then to scanning your file's `use`
+statements. But an undeclared accessor is untyped: PHPStan reports it in 2.0,
+and before that it evaluated to `mixed`, which switched off checking of
+everything reached *through* it. A `@method` docblock is equally fine; PHPStan
+reads it natively.
+
+Cross-module access goes through the other module's **Facade**, never its
+Factory or internals. `CrossModuleViaFacadeRule` enforces this if you enable it.
+
+## Get a collaborator inside my own module
+
+Write a `create*()` method on your Factory:
+
+```php
+final class Factory extends AbstractFactory
+{
+    public function createInvoiceSender(): InvoiceSender
+    {
+        return new InvoiceSender($this->createPdfRenderer());
+    }
+}
+```
+
+When the wiring is pure type-based plumbing, `make()` autowires it through the
+module container instead — honouring `#[Inject]`, `#[Singleton]` and
+`#[Factory]`, and needing no Provider at all:
+
+```php
+public function createInvoiceSender(): InvoiceSender
+{
+    return $this->make(InvoiceSender::class);
+}
+```
+
+Use `create*()` when construction has decisions in it, `make()` when it does
+not. A Facade reaches its own Factory with `$this->getFactory()`, which is a
+real typed method — no attribute required.
+
+## Get an external / infrastructure service
+
+Declare it in the module's Provider with `#[Provides]`:
+
+```php
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+
+final class Provider extends AbstractProvider
+{
+    #[Provides(PaymentGateway::class)]
+    public function paymentGateway(): PaymentGateway
+    {
+        return new StripeGateway();
+    }
+}
+```
+
+Read it back in the Factory with the class-string form, which is typed:
+
+```php
+$gateway = $this->getProvidedDependency(PaymentGateway::class);
+```
+
+For "this interface means that implementation" across the whole app, use
+`addBinding()` in `gacela.php` instead — the container then autowires it
+everywhere, including through `make()`:
+
+```php
+$config->addBinding(PaymentGateway::class, StripeGateway::class);
+```
+
+## Read a config value
+
+The typed getters are `protected`, so they are used *inside* your `Config`
+class, which exposes intention-revealing methods to the rest of the module:
+
+```php
+final class Config extends AbstractConfig
+{
+    public function retryAttempts(): int
+    {
+        return $this->getInt('billing.retry-attempts', 3);
+    }
+}
+```
+
+`getString()`, `getInt()`, `getFloat()`, `getBool()`, `getArray()` and the
+untyped `get()` are all available. This is the shape the other three intents are
+aiming for: one path, typed variants, impossible to use wrongly.
+
+## The other paths, and when they are right
+
+These are supported and are **not** deprecated. They are simply not the answer
+to "how do I get a dependency?" — reach for them when the situation below is
+actually yours.
+
+| Path | Reach for it when |
+|---|---|
+| `addBindingIf()` | shipping a plugin default an application may override |
+| `addFactory('id', fn)` | you need a **new instance per resolution**, not a shared one |
+| `addProtected('id', fn)` | the value *is* a closure and must not be invoked |
+| `addAlias('short', Full::class)` | a long id needs a short name |
+| `addLazy()` | construction is expensive and often unused |
+| `extendService('id', fn)` | decorating a service registered elsewhere |
+| `when(X)->needs(Y)->give(Z)` | one consumer needs a different implementation than everyone else |
+| `addExternalService()` | handing a framework object (Symfony kernel, PSR container) to Gacela at bootstrap |
+| `$container->get('id')` inside a Provider | wiring one provided service from another |
+| `#[Singleton]` / `#[Factory]` on a class | declaring **lifetime**, which is a different question from lookup |
+
+### Why none of them were removed
+
+The 2.0 inventory ([RFC-0002](rfc/0002-dependency-paths-inventory.md)) counted 25
+paths and the obvious conclusion was "delete most of them". That would have been
+the wrong lesson.
+
+Reading a config value has **six** methods for one intent and nobody has ever
+complained, because they are the same path with typed variants — discovered
+together, impossible to confuse. The problem in the other intents was never the
+count. It was that unrelated mechanisms competed for the same job with no
+indication which one you were supposed to use.
+
+Naming a primary path fixes that. Deleting working escape hatches would only
+have broken applications that had a good reason to use one.


### PR DESCRIPTION
## 📚 Description

Implements **D3** for #525.

RFC-0002 counted **25 paths** to obtain a dependency, and the obvious conclusion was "delete most of them". That would have been the wrong lesson, and the RFC's own data says why:

> Reading a config value has **six** methods for one intent and nobody has ever complained — because they are the same path with typed variants, discovered together, impossible to confuse.

The problem was never the count. It was that **unrelated mechanisms competed for the same job with no indication which one you were meant to use**. Naming a primary path fixes that; deleting working escape hatches would only break applications that had a good reason to use one.

## 🔖 Changes

New `docs/getting-a-dependency.md`, indexed from `docs/README.md`:

| Intent | Primary path |
|---|---|
| reach another module | `#[ServiceMap]` + `$this->getFacade()` |
| own collaborator | `create*()`, or `make()` when autowiring pays |
| external service | `#[Provides]`, or `addBinding()` for an interface |
| config value | the typed getters on your `Config` |

Plus a table of the remaining paths with **the situation where each is genuinely right** — `addFactory` when you need a new instance per resolution, `addProtected` when the value *is* a closure, `when()->needs()->give()` when one consumer differs from everyone else. Explicitly marked as supported, **not** deprecated.

## ✅ Verification

Every API referenced was checked against source rather than written from memory:

- `GacelaConfig::when()` exists — it is `when()`, not `addContextualBinding()`
- all seven `add*`/`extend*` methods exist on `GacelaConfig`
- `ServiceMap(method:, className:)` named arguments verified by constructing one
- the config getters are `protected`, so the example shows them used *inside* the `Config` class exposing intention-revealing methods — which is how they are actually meant to be used

1325 tests green, quality clean.

Closes #525
