### PR TITLE
test(bench): restore FileCacheBench to the default ±10% gate tolerance

### DIFF
--- a/tests/Benchmark/FileCache/FileCacheBench.php
+++ b/tests/Benchmark/FileCache/FileCacheBench.php
@@ -9,7 +9,6 @@ use Gacela\Framework\Gacela;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
 use PhpBench\Attributes\AfterClassMethods;
-use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\BeforeClassMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
@@ -25,21 +24,14 @@ use function unlink;
  * merged-config cache files written by unrelated test runs on the same
  * machine, which poisoned the enabled-cache path with foreign config values.
  *
- * TEMPORARY tolerance, restored to the default +/-10% in the follow-up once
- * `1.x` carries the new baseline.
- *
- * `bench_without_cache` moved +23.33% when `Gacela::resetCache()` started
- * dropping the memoized "this class does not exist" answers. That is not a
- * regression: this bench asks for `resetInMemoryCache()` on every rev and
- * registers 15 custom suffix types, so each of the seven modules probes many
- * candidate class names that do not exist. `ClassValidator` was ignoring the
- * reset, so revs 2..50 reused rev 1's misses -- cross-rev state bleed. The
- * bench now pays honestly for the work it always claimed to do.
- *
- * The gate compares head against base and cannot express "intentional change",
- * so every run of this PR fails against a base that still measures the leak.
+ * `bench_without_cache` costs what it does because this bench asks for
+ * `resetInMemoryCache()` on every rev and registers 15 custom suffix types, so
+ * each of the seven modules probes many candidate class names that do not
+ * exist. Until #548 it read ~23% faster, because `ClassValidator` ignored the
+ * reset and revs 2..50 reused rev 1's misses -- cross-rev state bleed. Do not
+ * treat that older, lower number as the target; it measured a cache that
+ * should not have survived.
  */
-#[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 35%')]
 #[BeforeClassMethods('removeCacheFiles')]
 #[AfterClassMethods('removeCacheFiles')]
 #[Groups(['gate', 'bootstrap'])]


### PR DESCRIPTION
## 📚 Description

Removes the temporary ±35% `#[Assert]` added in #548.

It existed for one reason: that PR's base still measured the pre-fix behaviour, so the guard was comparing two different behaviours and would have failed no matter how correct the code was. `1.x` now carries the new baseline, so both sides are comparable again and the default ±10% applies.

A widened tolerance that outlives its reason stops being a decision and becomes a mute button. This one lasted exactly one merge.

## 🔖 Changes

- Removed the class-level `#[Assert]` and the now-unused `PhpBench\Attributes\Assert` import
- Kept the explanation of *why* `bench_without_cache` costs what it does, rewritten as permanent context rather than a temporary note

The point worth preserving: the older, ~23% lower number is **not** a target to optimise back toward. It was inflated by `ClassValidator` ignoring `resetInMemoryCache()`, which let revs 2..50 reuse rev 1's failed lookups. Someone tuning toward it would be restoring a state leak.

Follow-up to #548.
