### PR TITLE
feat!: deprecate resolving a pillar from a docblock or use statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - New `docs/getting-a-dependency.md`: names **one primary path per intent** — `#[ServiceMap]` + `getFacade()` to reach another module, `create*()`/`make()` for an own collaborator, `#[Provides]`/`addBinding()` for an external service, and the typed getters for config. The other paths are listed with the situation where each is genuinely the right answer. Nothing was removed: the 25-path inventory in `docs/rfc/0002` showed the problem was never the count — reading config has six methods for one intent and nobody complains, because they are the same path with typed variants
 
+### Deprecated
+
+- Resolving a pillar from a `@method` docblock, or by scanning the caller's `use` statements, now raises `E_USER_DEPRECATED` and is removed in 3.0. Declare the pillar with `#[ServiceMap(method: ..., className: ...)]` instead — the attribute is checked first, so adding it silences the notice. The notice fires on a **cold resolve only**, because the answer is memoized per caller-and-method; run `gacela cache:clear`, or develop with the file cache off, to surface every occurrence. **Keeping the `@method` docblock alongside the attribute is fine and recommended if you use Psalm or rely on IDE completion** — Gacela ships a PHPStan extension for `#[ServiceMap]` but no Psalm equivalent yet
+
 ### Changed (BREAKING — 2.0)
 
 - **The PHPStan suppression for undeclared pillar accessors is gone.** 1.x shipped an `ignoreErrors` entry in `phpstan-gacela.neon` silencing `Call to an undefined method ...::getFacade()`. A class resolving a pillar through `ServiceResolverAwareTrait` must now declare it with `#[ServiceMap]` (or a `@method` docblock, which PHPStan reads natively) or the call is reported. A suppressed call was never a typed one — it evaluated to `mixed`, which switched off checking of everything reached *through* the accessor. 1.21 shipped the `#[ServiceMap]` typing precisely so this migration can be done first

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,11 @@ includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - phpstan-baseline.neon
+    # Gacela analyses itself with the extension it ships. Without this the
+    # pillar accessors are only typed by `@method` docblocks, which is the
+    # duplication 2.0 removes -- and it meant the shipped extension was never
+    # exercised against Gacela's own source.
+    - phpstan-gacela.neon
 
 parameters:
     level: max
@@ -17,6 +22,16 @@ parameters:
         # (e.g. strrpos() returning a falsy 0) still shows up as an opt-out.
         disallowedShortTernary: false
     ignoreErrors:
+        # SuffixExtendsRule asks that a class named *Facade/*Factory/*Config/*Provider
+        # extends the matching pillar base class. That is the contract for a consumer's
+        # *modules*; Gacela's own framework internals reuse those words for things that
+        # are not pillars -- GacelaConfig is the bootstrap builder, ConfigFactory builds
+        # config objects, EventDispatcherProvider is a static holder. Scoped to
+        # src/Framework so the rule still applies to Gacela\Console, which is a real
+        # Gacela module and does satisfy it.
+        -
+            identifier: gacela.suffixExtends
+            path: src/Framework/*
         # Building a MethodReflection is unavoidable for a methodsClassReflectionExtension,
         # and PHPStan covers no way of doing it under its BC promise -- neither implementing
         # ExtendedMethodReflection nor constructing its own implementation of it. The class

--- a/src/Console/Infrastructure/Command/CacheClearCommand.php
+++ b/src/Console/Infrastructure/Command/CacheClearCommand.php
@@ -7,9 +7,11 @@ namespace Gacela\Console\Infrastructure\Command;
 use Gacela\Console\Application\CacheWarm\CacheManager;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function file_exists;
@@ -18,6 +20,7 @@ use function sprintf;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class CacheClearCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -16,10 +16,12 @@ use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Event\Cache\CacheWarmedEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Throwable;
@@ -31,6 +33,7 @@ use function filesize;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class CacheWarmCommand extends Command
 {
     use EventDispatchingCapabilities;

--- a/src/Console/Infrastructure/Command/DebugConfigCommand.php
+++ b/src/Console/Infrastructure/Command/DebugConfigCommand.php
@@ -6,17 +6,20 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function count;
 use function is_bool;
 use function is_scalar;
 use function ksort;
+
 use function sprintf;
 
 use function str_contains;
@@ -27,6 +30,7 @@ use const JSON_UNESCAPED_SLASHES;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DebugConfigCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function class_exists;
@@ -19,6 +21,7 @@ use function sprintf;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DebugContainerCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -7,12 +7,14 @@ namespace Gacela\Console\Infrastructure\Command;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\ModuleGraph\CycleAllowList;
 use Gacela\Console\Domain\ModuleGraph\MalformedCycleAllowListException;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use JsonException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function implode;
@@ -20,6 +22,7 @@ use function in_array;
 use function is_array;
 use function is_file;
 use function json_decode;
+
 use function sprintf;
 
 use const JSON_THROW_ON_ERROR;
@@ -27,6 +30,7 @@ use const JSON_THROW_ON_ERROR;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DebugGraphCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/DebugModuleCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModuleCommand.php
@@ -6,14 +6,17 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function json_encode;
+
 use function sprintf;
 
 use const JSON_PRETTY_PRINT;
@@ -23,6 +26,7 @@ use const JSON_UNESCAPED_SLASHES;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DebugModuleCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -9,6 +9,7 @@ use Gacela\Console\Application\Debug\ConstructorInspector;
 use Gacela\Console\Application\Debug\ParameterInspection;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use ReflectionClass;
 use ReflectionException;
@@ -17,6 +18,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
 use Throwable;
 
 use function class_exists;
@@ -26,6 +28,7 @@ use function strlen;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DebugModulesCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -15,11 +15,13 @@ use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Health\HealthCheckRegistry;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
@@ -27,6 +29,7 @@ use function sprintf;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DoctorCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -6,6 +6,7 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
@@ -20,6 +22,7 @@ use function sprintf;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class ListModulesCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/MakeFileCommand.php
+++ b/src/Console/Infrastructure/Command/MakeFileCommand.php
@@ -6,11 +6,13 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
@@ -18,6 +20,7 @@ use function sprintf;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class MakeFileCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -7,11 +7,13 @@ namespace Gacela\Console\Infrastructure\Command;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function in_array;
@@ -20,6 +22,7 @@ use function sprintf;
 /**
  * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class MakeModuleCommand extends Command
 {
     use ServiceResolverAwareTrait;

--- a/src/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/Console/Infrastructure/ConsoleBootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure;
 
 use Gacela\Console\ConsoleFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 /**
  * @method ConsoleFactory getFactory()
  */
+#[ServiceMap(method: 'getFactory', className: ConsoleFactory::class)]
 final class ConsoleBootstrap extends Application
 {
     use ServiceResolverAwareTrait;

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -20,6 +20,14 @@ final class DocBlockResolver
 {
     private const SPECIAL_RESOLVABLE_TYPES = ['Facade', 'Factory', 'Config'];
 
+    /**
+     * One string, deliberately not a concatenation: splitting it for line length
+     * generates Concat mutants that no reasonable assertion kills, and pinning
+     * the exact rendered characters would turn a behavioural test into a
+     * golden master over a message nobody reads character by character.
+     */
+    private const string FALLBACK_DEPRECATION = 'Gacela: %s::%s() was resolved from %s. This fallback is deprecated and will be removed in 3.0. Declare it with #[ServiceMap(method: \'%s\', className: ...)] instead.';
+
     /** @var array<string,string> [fileName => fileContent] */
     private static array $fileContentCache = [];
 
@@ -119,14 +127,7 @@ final class DocBlockResolver
     private function triggerFallbackDeprecation(string $method, string $strategy): void
     {
         trigger_error(
-            sprintf(
-                'Gacela: %s::%s() was resolved from %s. This fallback is deprecated and will be removed'
-                . ' in 3.0. Declare it with #[ServiceMap(method: \'%s\', className: ...)] instead.',
-                $this->callerClass,
-                $method,
-                $strategy,
-                $method,
-            ),
+            sprintf(self::FALLBACK_DEPRECATION, $this->callerClass, $method, $strategy, $method),
             E_USER_DEPRECATED,
         );
     }

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -31,7 +31,7 @@ final class DocBlockResolver
     /** @var array<string,string> [fileName => fileContent] */
     private static array $fileContentCache = [];
 
-    /** @var array<string,true> caller-and-method pairs already reported as deprecated */
+    /** @var array<string,array<string,string>> [callerClass][method] => strategy already reported */
     private static array $warned = [];
 
     /**
@@ -134,12 +134,15 @@ final class DocBlockResolver
         // every cache reset -- repeating an identical message, and charging
         // sprintf() to a cold-resolution path that measured +28.59% on
         // FileCacheBench::bench_without_cache when it did.
-        $key = $this->callerClass . '::' . $method;
-        if (isset(self::$warned[$key])) {
+        // Nested rather than a concatenated "class::method" key: building one
+        // string generates Concat mutants that no assertion can kill, because
+        // the separator and operand order cannot change which pairs are
+        // distinct. Two dimensions make the uniqueness structural instead.
+        if (isset(self::$warned[$this->callerClass][$method])) {
             return;
         }
 
-        self::$warned[$key] = true;
+        self::$warned[$this->callerClass][$method] = $strategy;
 
         trigger_error(
             sprintf(self::FALLBACK_DEPRECATION, $this->callerClass, $method, $strategy, $method),

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -12,6 +12,9 @@ use ReflectionAttribute;
 use ReflectionClass;
 
 use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 final class DocBlockResolver
 {
@@ -83,11 +86,15 @@ final class DocBlockResolver
 
         $className = $this->searchClassOverDocBlock($reflectionClass, $method);
         if (class_exists($className)) {
+            $this->triggerFallbackDeprecation($method, '@method docblock');
+
             return $className;
         }
 
         $className = $this->searchClassOverUseStatements($reflectionClass, $className);
         if (class_exists($className)) {
+            $this->triggerFallbackDeprecation($method, "the file's use statements");
+
             return $className;
         }
 
@@ -96,6 +103,32 @@ final class DocBlockResolver
         }
 
         throw MissingClassDefinitionException::missingDefinition($this->callerClass, $method, $className);
+    }
+
+    /**
+     * Resolving a pillar from a `@method` docblock, or by scanning the caller's
+     * `use` statements, is deprecated. Declare the pillar with `#[ServiceMap]`
+     * instead: the attribute states the same fact where a reader and an
+     * analyser can both see it, rather than leaving it to be re-derived from
+     * source at runtime.
+     *
+     * Fires on a cold resolve only -- the answer is memoized per
+     * caller-and-method, so a warm cache stays silent. Run `gacela cache:clear`
+     * (or develop with the file cache off) to surface every occurrence.
+     */
+    private function triggerFallbackDeprecation(string $method, string $strategy): void
+    {
+        trigger_error(
+            sprintf(
+                'Gacela: %s::%s() was resolved from %s. This fallback is deprecated and will be removed'
+                . ' in 3.0. Declare it with #[ServiceMap(method: \'%s\', className: ...)] instead.',
+                $this->callerClass,
+                $method,
+                $strategy,
+                $method,
+            ),
+            E_USER_DEPRECATED,
+        );
     }
 
     /**

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -31,6 +31,9 @@ final class DocBlockResolver
     /** @var array<string,string> [fileName => fileContent] */
     private static array $fileContentCache = [];
 
+    /** @var array<string,true> caller-and-method pairs already reported as deprecated */
+    private static array $warned = [];
+
     /**
      * @param class-string $callerClass
      */
@@ -126,6 +129,18 @@ final class DocBlockResolver
      */
     private function triggerFallbackDeprecation(string $method, string $strategy): void
     {
+        // Once per caller-and-method for the life of the process. The resolved
+        // class is memoized, so without this the notice would fire again on
+        // every cache reset -- repeating an identical message, and charging
+        // sprintf() to a cold-resolution path that measured +28.59% on
+        // FileCacheBench::bench_without_cache when it did.
+        $key = $this->callerClass . '::' . $method;
+        if (isset(self::$warned[$key])) {
+            return;
+        }
+
+        self::$warned[$key] = true;
+
         trigger_error(
             sprintf(self::FALLBACK_DEPRECATION, $this->callerClass, $method, $strategy, $method),
             E_USER_DEPRECATED,

--- a/tests/Benchmark/FileCache/ModuleA/Facade.php
+++ b/tests/Benchmark/FileCache/ModuleA/Facade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleA;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleA\Infrastructure\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleA\Infrastructure\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleA\Infrastructure\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Facade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleA/FactoryA.php
+++ b/tests/Benchmark/FileCache/ModuleA/FactoryA.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleA;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleA\Infrastructure\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleA\Infrastructure\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: ConfigA::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class FactoryA extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleB/Facade.php
+++ b/tests/Benchmark/FileCache/ModuleB/Facade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleB;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleB\Infrastructure\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleB\Infrastructure\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleB\Infrastructure\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Facade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleB/FactoryB.php
+++ b/tests/Benchmark/FileCache/ModuleB/FactoryB.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleB;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleA\Infrastructure\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleB\Infrastructure\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: ConfigB::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class FactoryB extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleC/Facade.php
+++ b/tests/Benchmark/FileCache/ModuleC/Facade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleC;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleC\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleC\Infra\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleC\Infra\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Facade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleC/FactoryC.php
+++ b/tests/Benchmark/FileCache/ModuleC/FactoryC.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleC;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleC\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleC\Infra\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: ConfigC::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class FactoryC extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleD/Facade.php
+++ b/tests/Benchmark/FileCache/ModuleD/Facade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleD;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleD\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleD\Infra\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleD\Infra\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Facade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleD/FactoryD.php
+++ b/tests/Benchmark/FileCache/ModuleD/FactoryD.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleD;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleD\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleD\Infra\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: ConfigD::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class FactoryD extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleE/Facade.php
+++ b/tests/Benchmark/FileCache/ModuleE/Facade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleE;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleE\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleE\Infra\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleE\Infra\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Facade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleE/FactoryE.php
+++ b/tests/Benchmark/FileCache/ModuleE/FactoryE.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleE;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleE\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleE\Infra\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: ConfigE::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class FactoryE extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleF/Facade.php
+++ b/tests/Benchmark/FileCache/ModuleF/Facade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleF;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleF\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleF\Infra\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleF\Infra\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Facade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleF/Factory.php
+++ b/tests/Benchmark/FileCache/ModuleF/Factory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleF;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleF\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleF\Infra\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: Config::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class Factory extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleG/ModuleGFacade.php
+++ b/tests/Benchmark/FileCache/ModuleG/ModuleGFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleG;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleG\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleG\Infra\Repository;
@@ -15,6 +16,8 @@ use GacelaTest\Benchmark\FileCache\ModuleG\Infra\Repository;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class ModuleGFacade extends AbstractFacade
 {
     use ServiceResolverAwareTrait;

--- a/tests/Benchmark/FileCache/ModuleG/ModuleGFactory.php
+++ b/tests/Benchmark/FileCache/ModuleG/ModuleGFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\FileCache\ModuleG;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Benchmark\FileCache\ModuleG\Infra\EntityManager;
 use GacelaTest\Benchmark\FileCache\ModuleG\Infra\Repository;
@@ -15,6 +16,9 @@ use GacelaTest\Fixtures\StringValueInterface;
  * @method Repository getRepository()
  * @method EntityManager getEntityManager()
  */
+#[ServiceMap(method: 'getConfig', className: ModuleGConfig::class)]
+#[ServiceMap(method: 'getRepository', className: Repository::class)]
+#[ServiceMap(method: 'getEntityManager', className: EntityManager::class)]
 final class ModuleGFactory extends AbstractFactory
 {
     use ServiceResolverAwareTrait;

--- a/tests/Integration/Architecture/NoCircularDependenciesTest.php
+++ b/tests/Integration/Architecture/NoCircularDependenciesTest.php
@@ -137,6 +137,20 @@ final class NoCircularDependenciesTest extends TestCase
             . ' | Gacela\Framework\Event\ClassResolver\ClassNameFinder'
             . ' | Gacela\Framework\Health'
             . ' | Gacela\Framework\ServiceResolver',
+
+        // The console module's own shape: ConsoleProvider registers the commands,
+        // and each command calls back into ConsoleFacade. Cohesive by design --
+        // it is one module, and this is the pattern Gacela teaches.
+        //
+        // It appeared the moment the commands moved from `@method ConsoleFacade
+        // getFacade()` to `#[ServiceMap(className: ConsoleFacade::class)]`, but it
+        // is not new: this graph builds edges from real AST nodes, and a docblock
+        // is not one. The dependency always existed; declaring it made it visible.
+        // That is the argument for the attribute, not against it -- an analyser
+        // that cannot see a dependency cannot check it either.
+        'Gacela\Console'
+            . ' | Gacela\Console\Infrastructure'
+            . ' | Gacela\Console\Infrastructure\Command',
     ];
 
     public function test_source_tree_has_no_unexpected_class_cycles(): void

--- a/tests/Integration/Framework/ServiceResolver/DocBlockFallbackDeprecationTest.php
+++ b/tests/Integration/Framework/ServiceResolver/DocBlockFallbackDeprecationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ServiceResolver;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeAttributeCommand;
+use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeCommand;
+use PHPUnit\Framework\TestCase;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Resolving a pillar from a `@method` docblock, or by scanning the caller's
+ * `use` statements, is deprecated in 2.0 and removed in 3.0. `#[ServiceMap]`
+ * is the replacement.
+ *
+ * Without this test the deprecation is invisible: it fires on a **cold resolve
+ * only**, because the answer is memoized per caller-and-method. A warm cache
+ * stays silent, which is right for production and useless as a guard — so the
+ * cache is reset here deliberately.
+ */
+final class DocBlockFallbackDeprecationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetGacela();
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetGacela();
+    }
+
+    public function test_resolving_from_a_docblock_raises_a_deprecation(): void
+    {
+        $notices = $this->capturingDeprecations(static function (): void {
+            (new FakeCommand())->getFacade();
+        });
+
+        self::assertCount(1, $notices);
+        self::assertStringContainsString('FakeCommand::getFacade()', $notices[0]);
+        self::assertStringContainsString('#[ServiceMap(', $notices[0]);
+    }
+
+    public function test_declaring_the_pillar_with_the_attribute_raises_nothing(): void
+    {
+        $notices = $this->capturingDeprecations(static function (): void {
+            (new FakeAttributeCommand())->getFacade();
+        });
+
+        self::assertSame([], $notices, 'the attribute is the primary path and must stay silent');
+    }
+
+    /**
+     * @param callable():void $body
+     *
+     * @return list<string>
+     */
+    private function capturingDeprecations(callable $body): array
+    {
+        $notices = [];
+
+        set_error_handler(
+            static function (int $severity, string $message) use (&$notices): bool {
+                $notices[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $body();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $notices;
+    }
+
+    private function resetGacela(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        InMemoryCache::resetCache();
+    }
+}

--- a/tests/Integration/Framework/ServiceResolver/DocBlockFallbackDeprecationTest.php
+++ b/tests/Integration/Framework/ServiceResolver/DocBlockFallbackDeprecationTest.php
@@ -9,8 +9,9 @@ use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeAttributeCommand;
-use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeCommand;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeFqcnDocBlockCommand;
+use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeRepeatedCommand;
+use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeUseStatementCommand;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -32,10 +33,7 @@ final class DocBlockFallbackDeprecationTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->resetGacela();
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
-            $config->setFileCache(false);
-        });
+        $this->bootstrapFresh();
     }
 
     protected function tearDown(): void
@@ -43,14 +41,21 @@ final class DocBlockFallbackDeprecationTest extends TestCase
         $this->resetGacela();
     }
 
-    public function test_resolving_from_a_docblock_raises_a_deprecation(): void
+    /**
+     * Each test below uses its **own** fixture class. The notice is emitted once
+     * per caller-and-method for the life of the process, so two tests sharing a
+     * fixture would make the second one depend on running first -- and this
+     * suite runs in random order.
+     */
+    public function test_the_use_statement_scan_reports_its_own_strategy(): void
     {
         $notices = $this->capturingDeprecations(static function (): void {
-            (new FakeCommand())->getFacade();
+            (new FakeUseStatementCommand())->getFacade();
         });
 
         self::assertCount(1, $notices);
-        self::assertStringContainsString('FakeCommand::getFacade()', $notices[0]);
+        self::assertStringContainsString('FakeUseStatementCommand::getFacade()', $notices[0]);
+        self::assertStringContainsString("the file's use statements", $notices[0]);
         self::assertStringContainsString('#[ServiceMap(', $notices[0]);
     }
 
@@ -70,14 +75,23 @@ final class DocBlockFallbackDeprecationTest extends TestCase
         self::assertStringContainsString('@method docblock', $notices[0]);
     }
 
-    public function test_the_use_statement_scan_reports_its_own_strategy(): void
+    /**
+     * The resolved class is memoized, so a cache reset would otherwise re-emit
+     * an identical message and re-charge sprintf() to cold resolution --
+     * measured at +28.59% on `FileCacheBench::bench_without_cache` before this
+     * was deduped.
+     */
+    public function test_the_notice_is_emitted_once_per_caller_and_method(): void
     {
-        $notices = $this->capturingDeprecations(static function (): void {
-            (new FakeCommand())->getFacade();
+        $notices = $this->capturingDeprecations(function (): void {
+            $command = new FakeRepeatedCommand();
+            $command->getFacade();
+
+            $this->bootstrapFresh();
+            (new FakeRepeatedCommand())->getFacade();
         });
 
-        self::assertCount(1, $notices);
-        self::assertStringContainsString("the file's use statements", $notices[0]);
+        self::assertCount(1, $notices, 'the same caller and method must report once per process');
     }
 
     public function test_declaring_the_pillar_with_the_attribute_raises_nothing(): void
@@ -87,6 +101,14 @@ final class DocBlockFallbackDeprecationTest extends TestCase
         });
 
         self::assertSame([], $notices, 'the attribute is the primary path and must stay silent');
+    }
+
+    private function bootstrapFresh(): void
+    {
+        $this->resetGacela();
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
     }
 
     /**

--- a/tests/Integration/Framework/ServiceResolver/DocBlockFallbackDeprecationTest.php
+++ b/tests/Integration/Framework/ServiceResolver/DocBlockFallbackDeprecationTest.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeAttributeCommand;
 use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeCommand;
+use GacelaTest\Integration\Framework\ServiceResolver\Module\FakeFqcnDocBlockCommand;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -51,6 +52,32 @@ final class DocBlockFallbackDeprecationTest extends TestCase
         self::assertCount(1, $notices);
         self::assertStringContainsString('FakeCommand::getFacade()', $notices[0]);
         self::assertStringContainsString('#[ServiceMap(', $notices[0]);
+    }
+
+    /**
+     * The two fallbacks are separate call sites reporting different strategies.
+     * `FakeCommand` names its pillar unqualified, so it resolves through the
+     * use-statement scan; this one names it fully-qualified and stops at the
+     * docblock. Without both, one call site is never executed.
+     */
+    public function test_resolving_from_a_fully_qualified_docblock_names_the_docblock_strategy(): void
+    {
+        $notices = $this->capturingDeprecations(static function (): void {
+            (new FakeFqcnDocBlockCommand())->getFacade();
+        });
+
+        self::assertCount(1, $notices);
+        self::assertStringContainsString('@method docblock', $notices[0]);
+    }
+
+    public function test_the_use_statement_scan_reports_its_own_strategy(): void
+    {
+        $notices = $this->capturingDeprecations(static function (): void {
+            (new FakeCommand())->getFacade();
+        });
+
+        self::assertCount(1, $notices);
+        self::assertStringContainsString("the file's use statements", $notices[0]);
     }
 
     public function test_declaring_the_pillar_with_the_attribute_raises_nothing(): void

--- a/tests/Integration/Framework/ServiceResolver/Module/FakeAttributeCommand.php
+++ b/tests/Integration/Framework/ServiceResolver/Module/FakeAttributeCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ServiceResolver\Module;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Declares its pillar with the attribute rather than a `@method` docblock, so
+ * it resolves through the primary path and must **not** raise a deprecation.
+ */
+#[ServiceMap(method: 'getFacade', className: FakeFacade::class)]
+final class FakeAttributeCommand
+{
+    use ServiceResolverAwareTrait;
+}

--- a/tests/Integration/Framework/ServiceResolver/Module/FakeFqcnDocBlockCommand.php
+++ b/tests/Integration/Framework/ServiceResolver/Module/FakeFqcnDocBlockCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ServiceResolver\Module;
+
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Names the pillar with a **fully-qualified** class name, so it resolves at the
+ * docblock step and never reaches the use-statement scan.
+ *
+ * The two fallbacks are separate call sites reporting different strategies, and
+ * `FakeCommand` only covers the use-statement one.
+ *
+ * @method \GacelaTest\Integration\Framework\ServiceResolver\Module\FakeFacade getFacade()
+ */
+final class FakeFqcnDocBlockCommand
+{
+    use ServiceResolverAwareTrait;
+}

--- a/tests/Integration/Framework/ServiceResolver/Module/FakeRepeatedCommand.php
+++ b/tests/Integration/Framework/ServiceResolver/Module/FakeRepeatedCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ServiceResolver\Module;
+
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Owned by the "emitted once per caller-and-method" test, which resolves twice
+ * across a cache reset. It needs a fixture no other test has already reported.
+ *
+ * @method FakeFacade getFacade()
+ */
+final class FakeRepeatedCommand
+{
+    use ServiceResolverAwareTrait;
+}

--- a/tests/Integration/Framework/ServiceResolver/Module/FakeUseStatementCommand.php
+++ b/tests/Integration/Framework/ServiceResolver/Module/FakeUseStatementCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ServiceResolver\Module;
+
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Names its pillar **unqualified**, so resolution falls through the docblock
+ * step to the use-statement scan.
+ *
+ * Owned solely by the deprecation test. The notice is emitted once per
+ * caller-and-method per process, so a fixture shared with any other test class
+ * would make this assertion depend on suite order -- which is randomised.
+ *
+ * @method FakeFacade getFacade()
+ */
+final class FakeUseStatementCommand
+{
+    use ServiceResolverAwareTrait;
+}


### PR DESCRIPTION
## 📚 Description

Implements **D5**. Resolving a pillar from a `@method` docblock, or by scanning the caller's `use` statements, now raises `E_USER_DEPRECATED` and is removed in 3.0.

RFC-0002 called this the sharpest problem in the whole inventory: paths 1–3 are not choices a developer makes, they are **fallbacks the runtime tries in order**. Someone who writes no docblock and no attribute still gets a working `getFacade()` — resolved by parsing their own source at runtime. *"It is not a 'too many options' problem, it is a 'the option is invisible' problem."*

## 🔖 Scoped deliberately

`#[ServiceMap]` resolves through `__call` too, so deprecating `__call` wholesale would have punished everyone who already migrated. Only the docblock and use-statement strategies raise; the attribute path is silent.

The notice fires on a **cold resolve only** — the answer is memoized per caller-and-method, so a warm cache stays quiet. That is right for production and useless as a guard, so `DocBlockFallbackDeprecationTest` resets the cache and pins both directions: docblock resolution raises exactly one notice, the attribute raises none.

## 🔍 Two things this surfaced that matter more than the deprecation

**Gacela's own console commands all used the deprecated path.** Gacela would have emitted its own deprecations on every `gacela` command. Twelve classes now declare `#[ServiceMap]`.

**`phpstan.neon` never included `phpstan-gacela.neon`.** The shipped `ServiceMap` extension was never exercised against Gacela's own source — the `@method` docblocks were quietly doing that work. Including it took 26 accessor errors to zero. `SuffixExtendsRule` is scoped away from `src/Framework`, whose internals reuse the pillar suffixes (`GacelaConfig` is the bootstrap builder, `EventDispatcherProvider` a static holder) for classes that are not pillars.

## ⚠️ The `@method` docblocks are kept on purpose

I removed them first, and Psalm's inference fell from **99.83% → 98.55%**.

Gacela ships a PHPStan extension for `#[ServiceMap]` and **no Psalm equivalent**, so the docblock is still the only signal Psalm and IDEs get. Keeping both is therefore not the "declare the same fact twice" duplication the 2.0 brief targets — the two declarations serve different consumers. The changelog says so explicitly, so nobody deletes their docblocks and silently loses Psalm coverage.

A Psalm plugin would make the docblock genuinely redundant. Not in this PR.

## 🔁 Allow-list addition

`Gacela\Console | ...\Infrastructure | ...\Infrastructure\Command` is now allow-listed. **The cycle is not new.** The dependency graph builds edges from real AST nodes, and a docblock is not one — so `ConsoleFacade::class` inside the attribute made a dependency visible that was always there. An analyser that cannot see a dependency cannot check it either, which is the argument *for* the attribute.

## ✅ Verification

1327 tests, psalm and phpstan clean, 99.83% inference restored, zero deprecations from `src/`.

The 12 remaining deprecations are all test fixtures that exercise the fallback **on purpose** (`DocBlockServiceAware`, `DocBlockResolverTest`, `ServiceResolverAware`). They should emit — that is the path under test.

Related to #503
