### PR TITLE
chore: remove Scrutinizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Removed Scrutinizer. Its `checks: php` and `php_cs_fixer` duplicated PHPStan (level max), Psalm (level 1) and php-cs-fixer, all of which already gate every pull request, and its analysis had become a permanently-exempt check rather than one anyone acted on. `gacela-project/container` dropped it at 1.0 for the same reason. Type coverage (Shepherd) and mutation score (Stryker) badges remain — a 100% MSI gate is a stronger claim than a line-coverage percentage, since a mutant cannot be killed by a line that is merely executed
+
 ### Fixed
 
 - `Gacela::resetCache()` now drops the memoized "this class does not exist" answers. `ClassValidator` caches the *negative* result of `class_exists()`, so a class that was not loadable when first resolved stayed "missing" for the life of the process — `Gacela::resetCache()` did not clear it, because `ClassValidator::resetCache()` was reachable only from its own unit test. Affects any process where the set of loadable classes changes after the first resolution: long-running workers (RoadRunner, Swoole, queue consumers) that re-bootstrap, code generation, and `cache:warm` emitting classes. Positive answers are kept — a class that exists cannot stop existing, so they never go stale, and clearing them cost ~20% on the no-file-cache bootstrap path for no correctness gain

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@
   <a href="https://github.com/gacela-project/gacela/actions/workflows/tests.yml">
     <img src="https://github.com/gacela-project/gacela/actions/workflows/tests.yml/badge.svg" alt="GitHub Build Status">
   </a>
-  <a href="https://scrutinizer-ci.com/g/gacela-project/gacela/?branch=main">
-    <img src="https://scrutinizer-ci.com/g/gacela-project/gacela/badges/quality-score.png?b=main" alt="Scrutinizer Code Quality">
-  </a>
-  <a href="https://scrutinizer-ci.com/g/gacela-project/gacela/?branch=main">
-    <img src="https://scrutinizer-ci.com/g/gacela-project/gacela/badges/coverage.png?b=main" alt="Scrutinizer Code Coverage">
-  </a>
   <a href="https://shepherd.dev/github/gacela-project/gacela">
     <img src="https://shepherd.dev/github/gacela-project/gacela/coverage.svg" alt="Psalm Type-coverage Status">
   </a>


### PR DESCRIPTION
## 📚 Description

Removes Scrutinizer. The repository has already been deleted from Scrutinizer, so the badges pointed at nothing.

## 🔖 Changes

- Dropped both Scrutinizer badges from `README.md` (quality score, code coverage)
- Changelog entry under Internal

That is the entire footprint in this repo — no `.scrutinizer.yml` existed (the config lived only in the web UI), and no workflow or composer entry referenced it. The one remaining `grep` hit is `scrutinizer/ocular` inside `composer.lock`, which is a **third-party package's `suggest` block**, not ours.

## 🤔 Why removing rather than fixing

**It duplicated what already gates every PR** — `checks: php` and `php_cs_fixer` overlap PHPStan at level max, Psalm at level 1, and php-cs-fixer.

**It had stopped being a gate.** The standing rule was *"every check green before merge — Scrutinizer is the only exception."* A check that is permanently exempt is not a check; it is noise that trains people to ignore a red mark.

**The floor raise finished it off.** Its build pinned `php: 8.1`, where `composer install` now refuses the `>=8.3` platform requirement and typed class constants do not parse. It was structurally broken, not flaky.

**Precedent:** `gacela-project/container` removed it at 1.0 — *"Remove Scrutinizer; PHPStan, Psalm and the coverage gate cover it."*

## 📉 What is lost, honestly

The **line-coverage badge**. Type coverage (Shepherd) and mutation score (Stryker) badges remain, and I would argue the mutation badge is the stronger signal: a mutant cannot be killed by a line that is merely *executed*, so 100% MSI implies meaningful coverage in a way that a line percentage does not.

If you want line coverage back as a *gate* rather than a badge, that is a separate PR — a coverage step in `tests.yml` with a minimum threshold, which is what the container package did. Not included here to keep this to removal.

Related to #503
