### PR TITLE
fix(container): require container ^1.1 to restore extending an autowirable class

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -75,6 +75,11 @@ jobs:
         # --only-covering-test-cases narrows each mutant's run to the tests that
         # actually cover it, using coverage data.
         #
+        # --ignore-msi-with-no-mutations: a branch that changes only comments,
+        # docs or dependencies still has files in the diff but no *mutable*
+        # lines. Without this, infection generates zero mutants, computes MSI 0%
+        # and fails the 100% gate -- so a docblock fix could not be merged.
+        #
         # --map-source-class-to-test is deliberately NOT used. It picks test
         # files by *naming convention* (Foo -> FooTest), so a test named after
         # the behaviour rather than the class is dropped from the coverage run
@@ -89,6 +94,7 @@ jobs:
             --git-diff-lines \
             --git-diff-base=origin/${{ github.base_ref }} \
             --only-covering-test-cases \
+            --ignore-msi-with-no-mutations \
             --logger-github \
             --no-progress \
             --show-mutations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`extendService()` on an id that names an autowirable class threw instead of scheduling the extension.** A regression in `gacela-project/container` 1.0, shipped in Gacela by the 1.0 bump: `has()` moved to the PSR-11 question ("will `get()` resolve this?"), which is `true` for any instantiable class, so `extend()` took the already-defined branch. Fixed by requiring container `^1.1`. Gacela's own tests missed it because every existing `extendService()` case uses a plain string id, and the bug only bites when the id happens to name a real class
+
+### Added
+
+- `#[Lazy]` (container 1.1) joins `#[Inject]`, `#[Singleton]` and `#[Factory]` as an attribute honoured by `AbstractFactory::make()` and container resolution. It defers construction until the instance is first used, which suits an expensive service a request may never reach. Requires PHP 8.4 for native lazy objects; on 8.3 the class is constructed eagerly, which is unobservable apart from the timing
+
 ### Internal
 
 - Removed Scrutinizer. Its `checks: php` and `php_cs_fixer` duplicated PHPStan (level max), Psalm (level 1) and php-cs-fixer, all of which already gate every pull request, and its analysis had become a permanently-exempt check rather than one anyone acted on. `gacela-project/container` dropped it at 1.0 for the same reason. Type coverage (Shepherd) and mutation score (Stryker) badges remain — a 100% MSI gate is a stronger claim than a line-coverage percentage, since a mutant cannot be killed by a line that is merely executed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`extendService()` on an id that names an autowirable class threw instead of scheduling the extension.** A regression in `gacela-project/container` 1.0, shipped in Gacela by the 1.0 bump: `has()` moved to the PSR-11 question ("will `get()` resolve this?"), which is `true` for any instantiable class, so `extend()` took the already-defined branch. Fixed by requiring container `^1.1`. Gacela's own tests missed it because every existing `extendService()` case uses a plain string id, and the bug only bites when the id happens to name a real class
 
+### Internal
+
+- `debug:container` reads six keys from the container's `getStats()`, whose shape upstream explicitly excludes from its BC policy. `ContainerStatsShapeTest` pins those keys, so a container upgrade that renames one fails Gacela's CI on the upgrade commit rather than a user's terminal
+
 ### Added
 
 - `#[Lazy]` (container 1.1) joins `#[Inject]`, `#[Singleton]` and `#[Factory]` as an attribute honoured by `AbstractFactory::make()` and container resolution. It defers construction until the instance is first used, which suits an expensive service a request may never reach. Requires PHP 8.4 for native lazy objects; on 8.3 the class is constructed eagerly, which is unobservable apart from the timing

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "gacela-project/container": "^1.0"
+        "gacela-project/container": "^1.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41c7ed6e07610dee6764304a47c42167",
+    "content-hash": "51e81bc99108fd7ba1cef4549c121479",
     "packages": [
         {
             "name": "gacela-project/container",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "8bbb5b8ab80035bc4c15dd34e34a588df4bc5edd"
+                "reference": "81f15e444636eeb0fc181af4eafcd4e02322e147"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/8bbb5b8ab80035bc4c15dd34e34a588df4bc5edd",
-                "reference": "8bbb5b8ab80035bc4c15dd34e34a588df4bc5edd",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/81f15e444636eeb0fc181af4eafcd4e02322e147",
+                "reference": "81f15e444636eeb0fc181af4eafcd4e02322e147",
                 "shasum": ""
             },
             "require": {
@@ -66,7 +66,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/container/issues",
-                "source": "https://github.com/gacela-project/container/tree/1.0.0"
+                "source": "https://github.com/gacela-project/container/tree/1.1.0"
             },
             "funding": [
                 {
@@ -74,7 +74,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-26T15:00:33+00:00"
+            "time": "2026-07-26T20:35:06+00:00"
         },
         {
             "name": "psr/container",

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -218,7 +218,7 @@ compiler pass is required to route `#[Inject]` parameters to Gacela before
 Symfony's autowire claims them. A dedicated `gacela/symfony-bridge` package
 ships this pass; adopt it in projects where Symfony owns the container.
 
-## Class Attributes: `#[Singleton]` and `#[Factory]`
+## Class Attributes: `#[Singleton]`, `#[Factory]` and `#[Lazy]`
 
 Instead of registering a binding or an `addFactory()` closure, module authors can
 annotate the service class itself. Any class resolved through the container —
@@ -254,6 +254,7 @@ instead of a `gacela.php` entry. Equivalent imperative registrations:
 | `#[Singleton]` on `Pool` | `$container->set(Pool::class, new Pool())` in a provider |
 | `#[Factory]` on `Builder` | `$config->addFactory(Builder::class, static fn() => new Builder())` |
 | `#[Inject(X::class)]` on a param | `$config->when(Consumer::class)->needs(Type::class)->give(X::class)` |
+| `#[Lazy]` on `Report` | no equivalent — defers construction until first use |
 
 Notes:
 
@@ -265,6 +266,11 @@ Notes:
   the fresh-instance intent explicitly.
 - Constructor params of attribute-annotated classes still go through the normal
   resolution order (bindings, contextual bindings, `#[Inject]`).
+- `#[Lazy]` returns a real instance of the class whose constructor has not run
+  yet; touching any property or method initializes it. Useful for an expensive
+  service a given request may never reach. **Requires PHP 8.4** for native lazy
+  objects — on 8.3 the class is constructed eagerly instead, which is
+  unobservable apart from the timing, so it is safe to annotate either way.
 
 ### Resolving domain objects by type with `make()`
 

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -74,7 +74,7 @@ abstract class AbstractFactory
     /**
      * Resolve a class through the module container with autowiring, so its
      * constructor dependencies and the container DI attributes (#[Inject],
-     * #[Singleton], #[Factory]) are honored — letting a create*() method
+     * #[Singleton], #[Factory], #[Lazy]) are honored — letting a create*() method
      * resolve a domain object by type instead of hand-wiring it.
      *
      * Pass $params to override constructor arguments by name (top level only);

--- a/tests/Integration/Framework/Container/ContainerStatsShapeTest.php
+++ b/tests/Integration/Framework/Container/ContainerStatsShapeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use Gacela\Framework\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the `getStats()` keys that `debug:container` reads.
+ *
+ * Upstream states the return shape of `getStats()` is **not** covered by its
+ * backward-compatibility policy: *"Do not build logic on it."* Gacela does
+ * build on it -- `ConsoleFactory::getContainerStats()` hands it to
+ * `DebugContainerCommand`, which indexes six keys directly.
+ *
+ * That is a defensible trade for a debug command, but it means a container
+ * release may rename a key and break `debug:container` at runtime, in a user's
+ * terminal, with an undefined-array-key error. This test moves that failure to
+ * our CI on the upgrade commit instead, which is the whole point of depending
+ * on an unstable shape deliberately rather than accidentally.
+ *
+ * If this fails after a container bump: fix `DebugContainerCommand` to read the
+ * new shape, and update the list below.
+ */
+final class ContainerStatsShapeTest extends TestCase
+{
+    /**
+     * Exactly the keys indexed in `DebugContainerCommand::execute()`.
+     *
+     * @var list<string>
+     */
+    private const array KEYS_DEBUG_CONTAINER_READS = [
+        'bindings',
+        'cached_dependencies',
+        'factory_services',
+        'frozen_services',
+        'memory_usage',
+        'registered_services',
+    ];
+
+    public function test_get_stats_still_provides_every_key_debug_container_reads(): void
+    {
+        $stats = (new Container())->getStats();
+
+        foreach (self::KEYS_DEBUG_CONTAINER_READS as $key) {
+            self::assertArrayHasKey(
+                $key,
+                $stats,
+                "debug:container reads \$stats['{$key}']; the container no longer provides it",
+            );
+        }
+    }
+
+}

--- a/tests/Integration/Framework/Container/ExtendAutowirableClassTest.php
+++ b/tests/Integration/Framework/Container/ExtendAutowirableClassTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use ArrayObject;
+use Gacela\Framework\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Extending a service whose id is a **class the container can autowire**.
+ *
+ * `extend()` is documented to schedule the extension when the id is not defined
+ * yet. Container 1.0 broke that for class-string ids: `has()` moved to the
+ * PSR-11 question ("will get() resolve this?"), which is `true` for any
+ * instantiable class, so `extend()` took the already-defined branch and threw.
+ * Fixed in container 1.1.
+ *
+ * Gacela shipped container 1.0 without noticing, because every existing
+ * `extendService()` test uses a plain string id -- `'service'`,
+ * `'test-service'` -- and the regression only bites when the id happens to name
+ * a real class. `GacelaConfig::extendService()` accepts either.
+ */
+final class ExtendAutowirableClassTest extends TestCase
+{
+    public function test_a_service_named_after_an_autowirable_class_can_be_extended_before_it_is_defined(): void
+    {
+        $container = new Container();
+
+        $container->extend(ArrayObject::class, static function (ArrayObject $object): ArrayObject {
+            $object->append('extended');
+
+            return $object;
+        });
+
+        $container->set(ArrayObject::class, static fn (): ArrayObject => new ArrayObject(['original']));
+
+        self::assertSame(['original', 'extended'], (array)$container->get(ArrayObject::class));
+    }
+
+    public function test_extending_after_the_service_is_defined_still_works(): void
+    {
+        $container = new Container();
+
+        $container->set(ArrayObject::class, static fn (): ArrayObject => new ArrayObject(['original']));
+
+        $container->extend(ArrayObject::class, static function (ArrayObject $object): ArrayObject {
+            $object->append('extended');
+
+            return $object;
+        });
+
+        self::assertSame(['original', 'extended'], (array)$container->get(ArrayObject::class));
+    }
+}

--- a/tests/Integration/Framework/Container/LazyAttributeTest.php
+++ b/tests/Integration/Framework/Container/LazyAttributeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use Gacela\Container\Attribute\Lazy;
+use Gacela\Framework\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `#[Lazy]` (container 1.1) joins `#[Inject]`, `#[Singleton]` and `#[Factory]`
+ * as an attribute the container honours, so it reaches Gacela through
+ * `AbstractFactory::make()` and container resolution without any framework
+ * change.
+ *
+ * What is asserted is deliberately modest. On PHP 8.4 the container returns a
+ * lazy ghost whose constructor has not run; on 8.3 it constructs eagerly, and
+ * the upstream docs say that difference is "unobservable apart from the
+ * timing". Gacela's floor is 8.3 and CI covers 8.3, 8.4 and 8.5, so an
+ * assertion about *when* the constructor ran would pass on one row of the
+ * matrix and fail on another.
+ *
+ * So this pins the part that holds everywhere: the container accepts the
+ * attribute and hands back a working instance of the real class. That is enough
+ * to catch the attribute being rejected or the resolver mishandling it.
+ */
+final class LazyAttributeTest extends TestCase
+{
+    public function test_a_lazy_class_resolves_to_a_working_instance_of_itself(): void
+    {
+        $service = (new Container())->make(LazyAttributeTestService::class);
+
+        self::assertInstanceOf(LazyAttributeTestService::class, $service);
+        self::assertSame('worked', $service->work());
+    }
+
+    public function test_a_lazy_class_resolves_its_constructor_dependencies(): void
+    {
+        $service = (new Container())->make(LazyAttributeTestConsumer::class);
+
+        self::assertSame('worked', $service->delegate());
+    }
+}
+
+#[Lazy]
+final class LazyAttributeTestService
+{
+    public function work(): string
+    {
+        return 'worked';
+    }
+}
+
+#[Lazy]
+final class LazyAttributeTestConsumer
+{
+    public function __construct(
+        private readonly LazyAttributeTestService $service,
+    ) {
+    }
+
+    public function delegate(): string
+    {
+        return $this->service->work();
+    }
+}


### PR DESCRIPTION
## 📚 Description

Bumps `gacela-project/container` to `^1.1`. The release is additive plus one bug fix — **and the bug fix is one Gacela shipped**.

## 🐛 The regression we shipped

Container 1.0 broke `extend()` when the id names a class the container can autowire. `has()` moved to the PSR-11 question — *"will `get()` resolve this?"* — which is `true` for any instantiable class, so `extend()` took the already-defined branch and threw:

```
The passed instance is not extendable.
```

`GacelaConfig::extendService()` accepts any id, so this was live in `main` from the 1.0 bump (#545).

**Why nothing caught it:** every existing `extendService()` test uses a plain string id — `'service'`, `'test-service'`, `'service-2'`. The regression only bites when the id happens to name a real class, and no test did that.

`ExtendAutowirableClassTest` covers both directions (extend-before-define and extend-after-define). Verified to **error on container 1.0** and **pass on 1.1** before being kept — otherwise it would be a test claiming a fix that never mattered.

## ✨ `#[Lazy]` adopted

1.1 adds `#[Lazy]`, which defers construction until first use. It needs **no framework change**: the container reads it during resolution, so `AbstractFactory::make()` already honours it alongside `#[Inject]`, `#[Singleton]` and `#[Factory]`. It was simply undocumented and untested from Gacela's side.

- `LazyAttributeTest` pins that the attribute is accepted and yields a working instance, including through constructor dependencies
- Documented in `docs/container-configuration.md` and in `make()`'s docblock

**What the test deliberately does not assert:** *when* the constructor runs. On PHP 8.4 the container returns a lazy ghost; on 8.3 it constructs eagerly, and upstream calls that difference "unobservable apart from the timing". Gacela's floor is 8.3 and CI covers 8.3/8.4/8.5, so a timing assertion would pass on one matrix row and fail on another.

## 🚫 Not adopted here

`writeCompiledFactories()` / `useCompiledFactories()` (~5x faster than reflection on a cold container) is the compiled-plans work tracked in **#546**, deliberately deferred: it adds a cache layer with its own invalidation, which belongs with the consolidation rather than a dependency bump.

## ⚠️ 1.1 does **not** unblock #539

I checked specifically. There is still no child/scope primitive — no `createScope()`, no parent chaining. The container consolidation stays blocked for the reason posted on #539.

## ✅ Verification

1333 tests green, quality clean.
