### PR TITLE
fix(cache): clear the file caches' in-memory copy on resetCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### Fixed
 
+- **The in-memory copy of the file-backed caches survived `Gacela::resetCache()`.** With `gacela-cache-enabled`, entries that `ClassNamePhpCache` and friends had read from disk kept answering after an explicit reset, so `GacelaConfig::resetInMemoryCache()` did not reset that layer. `AbstractPhpFileCache::clearStaticCache()` had existed since the batching work and was unit-tested, but it clears one subclass at a time and the central reset cannot name concrete subclasses, so the only callers were the tests themselves. `AbstractPhpFileCache::resetCache()` now clears every subclass at once and `Gacela::resetCache()` calls it. The seventeenth of the cache bugs tracked in #539, and the first one found by a guard rather than by a user
+
 - **`extendService()` on an id that names an autowirable class threw instead of scheduling the extension.** A regression in `gacela-project/container` 1.0, shipped in Gacela by the 1.0 bump: `has()` moved to the PSR-11 question ("will `get()` resolve this?"), which is `true` for any instantiable class, so `extend()` took the already-defined branch. Fixed by requiring container `^1.1`. Gacela's own tests missed it because every existing `extendService()` case uses a plain string id, and the bug only bites when the id happens to name a real class
 
 ### Internal
 
+- `StaticStateCoverageTest` guards process-global state from the opposite end to `ResetCacheCoverageTest`: it enumerates every `static` property under `src/`, populates them by resolving a real module, calls `Gacela::resetCache()` and requires each one to be back at its declared default or listed with the reason its lifetime is not cache lifetime. The existing guard starts from the resets that exist, so by construction it cannot see a class holding state with no reset at all — seven of those are what #539 measured, and an eighth (above) was found by writing this one
 - Raised the `nikic/php-parser` floor to `^5.4`. Psalm 6.16 declares `^5.0.0` but reads `Property::$hooks`, which only exists from 5.4, so a `--prefer-lowest` install produced a Psalm that crashes on any file containing a property. Nothing had noticed because nothing ran Psalm from inside the test suite until the plugin test did
 - `debug:container` reads six keys from the container's `getStats()`, whose shape upstream explicitly excludes from its BC policy. `ContainerStatsShapeTest` pins those keys, so a container upgrade that renames one fails Gacela's CI on the upgrade commit rather than a user's terminal
 

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -38,19 +38,43 @@ abstract class AbstractPhpFileCache implements CacheInterface
      */
     public static function all(): array
     {
-        return self::$cache[static::class];
+        return self::$cache[static::class] ?? [];
     }
 
     /**
-     * Clears this class's in-memory cache entries and any shared batch state.
-     * Intended for tests to ensure isolation across runs in the same PHP process.
+     * Clears the in-memory entries of *every* file-backed cache, so
+     * `Gacela::resetCache()` does not leave a subclass serving what it read
+     * from disk before the reset.
      *
-     * The filename registry is intentionally preserved: the absolute cache file
-     * path is a deterministic function of the cache directory and subclass, so
-     * it stays valid across clear/reconstruct cycles. Dropping it here would
-     * strand any already-constructed instance held by an outer cache holder
-     * (e.g. ClassResolverCache::$cache) without a way to recover the filename
-     * on a subsequent put().
+     * The per-subclass {@see clearStaticCache()} below has existed since the
+     * batching work, but nothing outside the test suite ever called it: the
+     * central reset cannot name concrete subclasses, and a caller that could
+     * would have to know all of them. This one is keyless, so it does not need
+     * to.
+     *
+     * Nothing is kept back, including the filename registry: an instance that
+     * survives the reset recomputes its filename on the next write, and `all()`
+     * reads through a missing slot as empty.
+     *
+     * @internal
+     */
+    public static function resetCache(): void
+    {
+        self::$cache = [];
+        self::$filenames = [];
+        self::$dirty = [];
+        self::$batching = false;
+    }
+
+    /**
+     * Clears one subclass's in-memory cache entries and any shared batch state,
+     * leaving the other subclasses alone. Intended for tests that need to
+     * isolate a single cache within a process; {@see resetCache()} is what the
+     * framework calls.
+     *
+     * The filename registry is left alone here, and that is now a detail rather
+     * than a constraint: {@see filenameForWrite()} recomputes a missing entry,
+     * so dropping it would be safe too.
      *
      * @internal
      */
@@ -137,10 +161,22 @@ abstract class AbstractPhpFileCache implements CacheInterface
             return;
         }
 
-        FileCache::writeAtomically(self::$filenames[static::class], self::$cache[static::class]);
+        FileCache::writeAtomically($this->filenameForWrite(), self::$cache[static::class]);
     }
 
     abstract protected function getCacheFilename(): string;
+
+    /**
+     * The registry is a memo, not the source of truth: the absolute filename is
+     * a function of this instance's cache directory and its subclass, so an
+     * instance that outlived a reset can always recompute its own.
+     */
+    private function filenameForWrite(): string
+    {
+        $class = static::class;
+
+        return self::$filenames[$class] ??= $this->computeAbsoluteFilename();
+    }
 
     /**
      * @return array<string,string>

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -52,9 +52,9 @@ abstract class AbstractPhpFileCache implements CacheInterface
      * would have to know all of them. This one is keyless, so it does not need
      * to.
      *
-     * Nothing is kept back, including the filename registry: an instance that
-     * survives the reset recomputes its filename on the next write, and `all()`
-     * reads through a missing slot as empty.
+     * Nothing is kept back, including the filename registry: `put()` re-registers
+     * the filename of whatever it writes, and `all()` reads through a missing
+     * slot as empty.
      *
      * @internal
      */
@@ -73,8 +73,8 @@ abstract class AbstractPhpFileCache implements CacheInterface
      * framework calls.
      *
      * The filename registry is left alone here, and that is now a detail rather
-     * than a constraint: {@see filenameForWrite()} recomputes a missing entry,
-     * so dropping it would be safe too.
+     * than a constraint: `put()` re-registers the filename on every write, so
+     * dropping it would be safe too.
      *
      * @internal
      */
@@ -156,27 +156,22 @@ abstract class AbstractPhpFileCache implements CacheInterface
 
         self::$cache[static::class][$cacheKey] = $className;
 
+        // Re-registered on every write, not just in the constructor: the
+        // registry is what commitBatch() -- which is static, and so has no
+        // instance to ask -- resolves the file from, and resetCache() empties
+        // it. Without this, a put() after a reset would mark the cache dirty
+        // and then be silently dropped by the next commit.
+        self::$filenames[static::class] = $this->computeAbsoluteFilename();
+
         if (self::$batching) {
             self::$dirty[static::class] = true;
             return;
         }
 
-        FileCache::writeAtomically($this->filenameForWrite(), self::$cache[static::class]);
+        FileCache::writeAtomically(self::$filenames[static::class], self::$cache[static::class]);
     }
 
     abstract protected function getCacheFilename(): string;
-
-    /**
-     * The registry is a memo, not the source of truth: the absolute filename is
-     * a function of this instance's cache directory and its subclass, so an
-     * instance that outlived a reset can always recompute its own.
-     */
-    private function filenameForWrite(): string
-    {
-        $class = static::class;
-
-        return self::$filenames[$class] ??= $this->computeAbsoluteFilename();
-    }
 
     /**
      * @return array<string,string>

--- a/src/Framework/ClassResolver/ClassInfo.php
+++ b/src/Framework/ClassResolver/ClassInfo.php
@@ -14,7 +14,7 @@ final class ClassInfo implements ClassInfoInterface
     public const MODULE_NAME_ANONYMOUS = 'module-name@anonymous';
 
     /** @var array<string,array<string,self>> */
-    private static array $callerClassCache;
+    private static array $callerClassCache = [];
 
     public function __construct(
         private readonly string $callerModuleNamespace,

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -200,6 +200,7 @@ final class Gacela
         AbstractClassResolver::resetCache();
         InMemoryCache::resetCache();
         GacelaFileCache::resetCache();
+        AbstractPhpFileCache::resetCache();
         WritableDirectory::resetCache();
         DocBlockResolverCache::resetCache();
         ClassResolverCache::resetCache();

--- a/tests/Integration/Architecture/StatefulFixture/Greeting/GreetingFacade.php
+++ b/tests/Integration/Architecture/StatefulFixture/Greeting/GreetingFacade.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture\StatefulFixture\Greeting;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Attribute\Cacheable;
+
+/**
+ * @extends AbstractFacade<GreetingFactory>
+ */
+final class GreetingFacade extends AbstractFacade
+{
+    public function greet(string $name): string
+    {
+        return $this->getFactory()
+            ->createGreeter()
+            ->greet($name);
+    }
+
+    /**
+     * Reached through CacheableTrait, so resolving this module also populates
+     * the #[Cacheable] attribute cache and the storage behind it.
+     */
+    #[Cacheable]
+    public function cachedGreet(string $name): string
+    {
+        return $this->cached(fn (): string => $this->greet($name));
+    }
+}

--- a/tests/Integration/Architecture/StatefulFixture/Greeting/GreetingFactory.php
+++ b/tests/Integration/Architecture/StatefulFixture/Greeting/GreetingFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture\StatefulFixture\Greeting;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Integration\Architecture\StatefulFixture\Greeting\Service\Greeter;
+
+final class GreetingFactory extends AbstractFactory
+{
+    public function createGreeter(): Greeter
+    {
+        return new Greeter(
+            $this->getProvidedDependency(GreetingProvider::PREFIX),
+        );
+    }
+}

--- a/tests/Integration/Architecture/StatefulFixture/Greeting/GreetingProvider.php
+++ b/tests/Integration/Architecture/StatefulFixture/Greeting/GreetingProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture\StatefulFixture\Greeting;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+
+/**
+ * Declared with #[Provides] rather than provideModuleDependencies(), so
+ * resolving this module populates ProvidesScanner::$cache too.
+ */
+final class GreetingProvider extends AbstractProvider
+{
+    public const string PREFIX = 'GREETING_PREFIX';
+
+    #[Provides(self::PREFIX)]
+    public function prefix(): string
+    {
+        return 'Hello';
+    }
+}

--- a/tests/Integration/Architecture/StatefulFixture/Greeting/Infrastructure/GreetingCommand.php
+++ b/tests/Integration/Architecture/StatefulFixture/Greeting/Infrastructure/GreetingCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture\StatefulFixture\Greeting\Infrastructure;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use GacelaTest\Integration\Architecture\StatefulFixture\Greeting\GreetingFacade;
+
+/**
+ * Resolves its pillar through the trait, so running it populates the
+ * ServiceResolverAwareTrait statics.
+ *
+ * Declared with #[ServiceMap] rather than a `@method` docblock on purpose: the
+ * docblock fallback emits a deprecation that DocBlockResolver::$warned
+ * deduplicates process-wide, so using it here would make this test's result
+ * depend on whether DocBlockFallbackDeprecationTest ran first.
+ */
+#[ServiceMap(method: 'getGreetingFacade', className: GreetingFacade::class)]
+final class GreetingCommand
+{
+    use ServiceResolverAwareTrait;
+
+    public function run(string $name): string
+    {
+        return $this->getGreetingFacade()->cachedGreet($name);
+    }
+}

--- a/tests/Integration/Architecture/StatefulFixture/Greeting/Service/Greeter.php
+++ b/tests/Integration/Architecture/StatefulFixture/Greeting/Service/Greeter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture\StatefulFixture\Greeting\Service;
+
+use function sprintf;
+
+final class Greeter
+{
+    public function __construct(
+        private readonly string $prefix,
+    ) {
+    }
+
+    public function greet(string $name): string
+    {
+        return sprintf('%s, %s.', $this->prefix, $name);
+    }
+}

--- a/tests/Integration/Architecture/StaticStateCoverageTest.php
+++ b/tests/Integration/Architecture/StaticStateCoverageTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Architecture\StatefulFixture\Greeting\Infrastructure\GreetingCommand;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionProperty;
+use SplFileInfo;
+
+use function array_diff;
+use function array_keys;
+use function class_exists;
+use function count;
+use function implode;
+use function interface_exists;
+use function ksort;
+use function realpath;
+use function sprintf;
+use function str_ends_with;
+use function str_replace;
+use function strlen;
+use function strrpos;
+use function substr;
+use function trait_exists;
+
+/**
+ * Guards process-global state from the opposite end to {@see ResetCacheCoverageTest}.
+ *
+ * That test starts from the resets that exist and asks who calls them. By
+ * construction it cannot see a class that holds static state and declares no
+ * reset at all -- and seven such classes are what #539 measured. This one
+ * starts from the state instead, so a new `private static array $cache` is
+ * covered the moment it is written, whether or not anybody remembered to give
+ * it a reset.
+ *
+ * The assertion is behavioural, not structural: state is really populated by
+ * resolving a real module, `Gacela::resetCache()` is really called, and every
+ * static is then required to be back at its declared default. "Reset" here
+ * means the value actually returned, not a call site that appears in the
+ * source.
+ *
+ * Anything that legitimately outlives a cache reset goes in {@see OUTLIVES_RESET}
+ * with the reason. That list is self-invalidating in both directions --
+ * see `test_no_declaration_outlives_its_reason`.
+ */
+final class StaticStateCoverageTest extends TestCase
+{
+    private const string SRC = __DIR__ . '/../../../src';
+
+    /**
+     * The fixture belongs to this test rather than being borrowed from a
+     * feature suite, so nobody can defang the workload by editing a module
+     * whose tests still pass. It deliberately covers every distinct way Gacela
+     * memoizes: pillar resolution, an attribute-declared provider, docblock
+     * service resolution and a #[Cacheable] method.
+     */
+    private const string WORKLOAD_ROOT = __DIR__ . '/StatefulFixture';
+
+    /**
+     * Statics that survive `Gacela::resetCache()` on purpose, each with the
+     * reason its lifetime is not cache lifetime.
+     *
+     * Two distinct reasons appear here, and they are not interchangeable:
+     *
+     * - **configuration** — established by the application or by bootstrap.
+     *   Clearing it on a cache reset would silently drop what the app asked
+     *   for, which is a worse bug than the staleness it would prevent.
+     * - **pure memoization** — a total function of a key that cannot change
+     *   within a process (a class name, a loaded class's reflection). Nothing
+     *   can go stale, and the size is bounded by the loaded classes, so there
+     *   is nothing for a reset to fix.
+     *
+     * A cache of anything *resolved* -- instances, containers, config values,
+     * file contents keyed by path -- belongs in neither category and must be
+     * cleared centrally.
+     *
+     * @var array<string,string>
+     */
+    private const array OUTLIVES_RESET = [
+        'Gacela::$appRootDir' => 'configuration: the bootstrapped app root. resetCache() clears caches, it does not un-bootstrap Gacela',
+        'Gacela::$mainContainer' => "configuration: built by bootstrap from the app's GacelaConfig, and reset() would leave the framework with no container at all",
+        'CacheableConfig::$storage' => 'configuration: the backend registered by the app via CacheableConfig::setStorage(). Nothing in the framework re-establishes it, so clearing it would downgrade a configured Redis/APCu store to the in-memory default',
+        'CacheableConfig::$ttlOverrides' => 'configuration: per-method TTLs registered by the app alongside the storage above, and re-established by nothing',
+        'HealthCheckRegistry::$checks' => 'configuration: checks registered through GacelaConfig::addHealthCheck(). Bootstrap resets it explicitly before reading the config files, so checks accumulate within one bootstrap and never across two',
+        'ClassInfo::$callerClassCache' => 'pure memoization: caller class name plus resolvable type to a value object built from that name. Same input, same output, for the life of the process',
+        'GlobalKey::$cache' => 'pure memoization: a class name to its global key string',
+        'ProvidesScanner::$cache' => 'pure memoization: a provider class to the #[Provides] methods reflected off it. The class cannot gain a method mid-process',
+        'ReflectionClassPool::$cache' => 'pure memoization: reflection of a loaded class, which cannot change once loaded',
+        'ServiceResolverAwareTrait::$docBlockResolvers' => 'unclearable by construction: a trait static exists once per using class, including application classes the framework never sees, so no central reset could reach them all. Safe only because it is pure memoization -- a caller class to the resolver built from its #[ServiceMap] attribute or docblock, both fixed at compile time',
+        'ServiceResolverAwareTrait::$docBlockServiceResolvers' => 'unclearable by construction, as above. Pure memoization of a resolvable type to its resolver; the instances it resolves live in AbstractClassResolver::$cachedInstances, which is cleared',
+        'CacheableTrait::$attributeCache' => 'pure memoization: a class method to its #[Cacheable] attribute. The cached return values live in CacheableConfig::getStorage(), not here',
+        'CacheableTrait::$cacheMissSentinel' => 'not state: a per-class sentinel object whose only property is its identity, used to tell a cached null from a miss',
+        'DocBlockResolver::$fileContentCache' => 'pure memoization: a source file path to its contents. PHP has already compiled those files; a change on disk cannot affect the running process',
+        'DocBlockResolver::$warned' => 'deliberately process-wide: it deduplicates the docblock-fallback deprecation, so a reset would make the same notice fire again for a caller already warned about',
+        'ClassValidator::$existsCache' => 'partial by design: resetCache() drops the negative answers, because a class that did not exist may now be loadable, and keeps the positive ones, because a loaded class cannot unload',
+        'EventDispatcherProvider::$preBootstrapDispatcher' => 'not state: a shared NullEventDispatcher that keeps dispatch sites silent before a resolver exists. It has no fields, so there is nothing in it to go stale. The dispatcher and resolver beside it are cleared',
+        'Profiler::$instance' => 'observation lifetime, not cache lifetime: the profiler is opt-in and accumulates measurements across a run on purpose. Clearing it on a cache reset would discard the profile the app asked for, half-way through collecting it',
+    ];
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_every_static_is_cleared_by_reset_cache_or_declared_to_outlive_it(): void
+    {
+        $properties = $this->discover();
+
+        $this->runWorkload();
+        Gacela::resetCache();
+
+        $leaked = [];
+        foreach ($properties as $key => $property) {
+            if (isset(self::OUTLIVES_RESET[$key])) {
+                continue;
+            }
+
+            if (!$this->isAtDeclaredDefault($property)) {
+                $leaked[] = $key;
+            }
+        }
+
+        self::assertSame([], $leaked, sprintf(
+            "These statics still hold state after Gacela::resetCache(): %s.\n"
+            . 'Either clear them from Gacela::resetCache(), or add them to OUTLIVES_RESET '
+            . 'with the reason their lifetime is not cache lifetime.',
+            implode(', ', $leaked),
+        ));
+    }
+
+    /**
+     * Without this, the test above degrades silently: if the workload ever
+     * stops resolving anything -- a moved fixture, a swallowed exception --
+     * every static stays at its default and the assertion passes while
+     * checking nothing.
+     */
+    public function test_the_workload_really_populates_state(): void
+    {
+        $properties = $this->discover();
+
+        $this->runWorkload();
+
+        $populated = [];
+        foreach ($properties as $key => $property) {
+            if (!$this->isAtDeclaredDefault($property)) {
+                $populated[] = $key;
+            }
+        }
+
+        self::assertGreaterThan(10, count($populated), sprintf(
+            'Resolving the fixture module populated only %d statics (%s), which is too few for '
+            . 'the reset assertion to mean anything. The workload has stopped exercising Gacela.',
+            count($populated),
+            implode(', ', $populated),
+        ));
+    }
+
+    /**
+     * An entry for a static that no longer exists, or that is cleared centrally
+     * after all, is stale -- and a stale entry is how the next leak gets waved
+     * through.
+     */
+    public function test_no_declaration_outlives_its_reason(): void
+    {
+        $properties = $this->discover();
+
+        $unknown = array_diff(array_keys(self::OUTLIVES_RESET), array_keys($properties));
+        self::assertSame([], $unknown, sprintf(
+            'Declared to outlive the reset but no longer a static property: %s. Drop the entry.',
+            implode(', ', $unknown),
+        ));
+
+        $this->runWorkload();
+
+        // Captured while the workload's state is still live: an entry the
+        // workload never reaches is inert after the reset either way, and
+        // reading it as "cleared" would delete a correct entry.
+        $populated = [];
+        foreach (array_keys(self::OUTLIVES_RESET) as $key) {
+            if (!$this->isAtDeclaredDefault($properties[$key])) {
+                $populated[] = $key;
+            }
+        }
+
+        Gacela::resetCache();
+
+        $nowCleared = [];
+        foreach ($populated as $key) {
+            if ($this->isAtDeclaredDefault($properties[$key])) {
+                $nowCleared[] = $key;
+            }
+        }
+
+        self::assertSame([], $nowCleared, sprintf(
+            'Declared to outlive the reset, but Gacela::resetCache() now clears them: %s. Drop the entry.',
+            implode(', ', $nowCleared),
+        ));
+    }
+
+    private function runWorkload(): void
+    {
+        Gacela::bootstrap(self::WORKLOAD_ROOT);
+
+        (new GreetingCommand())->run('Gacela');
+    }
+
+    private function isAtDeclaredDefault(ReflectionProperty $property): bool
+    {
+        if (!$property->isInitialized()) {
+            return false;
+        }
+
+        return $property->getValue() === ($property->hasDefaultValue() ? $property->getDefaultValue() : null);
+    }
+
+    /**
+     * @return array<string, ReflectionProperty>
+     */
+    private function discover(): array
+    {
+        $out = [];
+
+        /** @var iterable<string, SplFileInfo> $files */
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->root()));
+
+        foreach ($files as $path => $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            if (!str_ends_with((string)$path, '.php')) {
+                continue;
+            }
+            $fqcn = $this->fqcnFor((string)$path);
+            if (interface_exists($fqcn)) {
+                continue;
+            }
+            if (trait_exists($fqcn)) {
+                continue;
+            }
+            if (!class_exists($fqcn)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($fqcn);
+            foreach ($reflection->getProperties(ReflectionProperty::IS_STATIC) as $property) {
+                $owner = $this->declaringSourceOf($reflection, $property);
+                $out[$this->shortName($owner) . '::$' . $property->getName()] = $property;
+            }
+        }
+
+        ksort($out);
+
+        return $out;
+    }
+
+    /**
+     * A static declared in a trait exists once per using class, so reflection
+     * reports each user as the declaring class. The lifetime decision belongs
+     * to the trait that wrote it, not to each of its thirteen console commands.
+     */
+    private function declaringSourceOf(ReflectionClass $class, ReflectionProperty $property): string
+    {
+        foreach ($class->getTraits() as $trait) {
+            if ($trait->hasProperty($property->getName())) {
+                return $trait->getName();
+            }
+        }
+
+        return $property->getDeclaringClass()->getName();
+    }
+
+    private function fqcnFor(string $path): string
+    {
+        $relative = substr($path, strlen($this->root()) + 1);
+
+        return 'Gacela\\' . str_replace(['/', '.php'], ['\\', ''], $relative);
+    }
+
+    private function root(): string
+    {
+        return (string)realpath(self::SRC);
+    }
+
+    private function shortName(string $fqcn): string
+    {
+        $position = strrpos($fqcn, '\\');
+
+        return $position === false ? $fqcn : substr($fqcn, $position + 1);
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheResetTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheResetTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\Cache;
+
+use Gacela\Framework\Cache\WritableDirectory;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Util\DirectoryUtil;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * Pins the in-memory half of the file-backed caches to `Gacela::resetCache()`.
+ *
+ * `clearStaticCache()` had existed since the batching work and was covered by
+ * unit tests, but the only callers were those tests and a benchmark: the
+ * central reset cannot name concrete subclasses, so nothing in production ever
+ * reached it. With the file cache enabled, an entry read from disk therefore
+ * outlived `Gacela::resetCache()` and `GacelaConfig::resetInMemoryCache()`
+ * alike -- the same "a working reset that nothing calls" shape as the
+ * ClassValidator and ReflectionClassPool cases, and invisible to
+ * ResetCacheCoverageTest because the method is not named reset*.
+ */
+final class AbstractPhpFileCacheResetTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/gacela-cache-reset-' . uniqid('', true);
+        AbstractPhpFileCache::resetCache();
+        WritableDirectory::resetCache();
+    }
+
+    protected function tearDown(): void
+    {
+        AbstractPhpFileCache::resetCache();
+        WritableDirectory::resetCache();
+        DirectoryUtil::removeDir($this->cacheDir);
+    }
+
+    public function test_reset_cache_drops_entries_of_every_subclass(): void
+    {
+        (new TestPhpFileCache($this->cacheDir))->put('key', 'AnyClassName');
+        (new ResetProbePhpFileCache($this->cacheDir))->put('other', 'AnotherClassName');
+
+        Gacela::resetCache();
+
+        self::assertSame([], TestPhpFileCache::all());
+        self::assertSame([], ResetProbePhpFileCache::all());
+    }
+
+    public function test_a_cached_answer_does_not_survive_a_reset(): void
+    {
+        $cache = new TestPhpFileCache($this->cacheDir);
+        $cache->put('key', 'AnyClassName');
+        self::assertTrue($cache->has('key'));
+
+        Gacela::resetCache();
+
+        self::assertFalse(
+            $cache->has('key'),
+            'an instance that outlived the reset must not keep answering from the pre-reset cache',
+        );
+    }
+
+    /**
+     * The registry of absolute filenames is cleared with everything else, which
+     * is only safe because an instance can recompute its own. Without that, an
+     * instance held across a reset -- and one always is, inside
+     * ClassResolverCache -- would fail on its next write instead.
+     */
+    public function test_an_instance_can_still_write_after_its_filename_registry_was_cleared(): void
+    {
+        $cache = new TestPhpFileCache($this->cacheDir);
+
+        Gacela::resetCache();
+
+        $cache->put('written-after-reset', 'AnyClassName');
+
+        self::assertSame(['written-after-reset' => 'AnyClassName'], TestPhpFileCache::all());
+    }
+
+    public function test_reset_cache_cancels_an_open_batch(): void
+    {
+        AbstractPhpFileCache::beginBatch();
+
+        Gacela::resetCache();
+
+        self::assertFalse(AbstractPhpFileCache::isBatching());
+    }
+
+    /**
+     * A batch left dirty by the reset would be flushed to disk by the next
+     * unrelated commitBatch(), writing pre-reset entries back out.
+     */
+    public function test_reset_cache_discards_pending_batch_writes(): void
+    {
+        AbstractPhpFileCache::beginBatch();
+        (new TestPhpFileCache($this->cacheDir))->put('key', 'AnyClassName');
+
+        Gacela::resetCache();
+
+        $dirty = new ReflectionProperty(AbstractPhpFileCache::class, 'dirty');
+
+        self::assertSame([], $dirty->getValue());
+    }
+}
+
+final class ResetProbePhpFileCache extends AbstractPhpFileCache
+{
+    protected function getCacheFilename(): string
+    {
+        return 'gacela-reset-probe.php';
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheResetTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/AbstractPhpFileCacheResetTest.php
@@ -71,8 +71,8 @@ final class AbstractPhpFileCacheResetTest extends TestCase
 
     /**
      * The registry of absolute filenames is cleared with everything else, which
-     * is only safe because an instance can recompute its own. Without that, an
-     * instance held across a reset -- and one always is, inside
+     * is only safe because `put()` re-registers what it writes. Without that,
+     * an instance held across a reset -- and one always is, inside
      * ClassResolverCache -- would fail on its next write instead.
      */
     public function test_an_instance_can_still_write_after_its_filename_registry_was_cleared(): void
@@ -84,6 +84,29 @@ final class AbstractPhpFileCacheResetTest extends TestCase
         $cache->put('written-after-reset', 'AnyClassName');
 
         self::assertSame(['written-after-reset' => 'AnyClassName'], TestPhpFileCache::all());
+        self::assertFileExists($this->cacheDir . '/' . TestPhpFileCache::FILENAME);
+    }
+
+    /**
+     * The batched path is where a cleared registry bites hardest, because it
+     * fails silently rather than loudly: `commitBatch()` is static, so it has
+     * no instance to ask for a filename and skips any class it cannot resolve.
+     * A batch opened after a reset would mark the cache dirty and then be
+     * dropped on commit, losing the writes with no error anywhere.
+     */
+    public function test_a_batch_opened_after_a_reset_is_still_flushed_to_disk(): void
+    {
+        $cache = new TestPhpFileCache($this->cacheDir);
+
+        Gacela::resetCache();
+
+        AbstractPhpFileCache::beginBatch();
+        $cache->put('batched-after-reset', 'AnyClassName');
+        AbstractPhpFileCache::commitBatch();
+
+        $filename = $this->cacheDir . '/' . TestPhpFileCache::FILENAME;
+        self::assertFileExists($filename);
+        self::assertSame(['batched-after-reset' => 'AnyClassName'], require $filename);
     }
 
     public function test_reset_cache_cancels_an_open_batch(): void


### PR DESCRIPTION
## 📚 Description

Step 2 of #539 — *"a guard test asserts every statically-stateful class is reset centrally"* — plus the leak it found on its first full-suite run.

`ResetCacheCoverageTest` already guards `Gacela::resetCache()`, but it starts from the resets that **exist** and asks who calls them. By construction it cannot see a class that holds static state and declares no reset at all, and #539 measured seven of those. It also discovers by method name, so a clear called `clearStaticCache()` is invisible to it.

`StaticStateCoverageTest` starts from the **state** instead: it enumerates every `static` property under `src/`, populates them by resolving a real module, calls `Gacela::resetCache()`, and requires each one to be back at its declared default — or to be listed with the reason its lifetime is not cache lifetime.

Written red first. It reported a real leak immediately.

### The leak

With `gacela-cache-enabled`, entries that `ClassNamePhpCache` and friends read from disk kept answering **after** an explicit `Gacela::resetCache()`. `GacelaConfig::resetInMemoryCache()` did not reset that layer at all.

`AbstractPhpFileCache::clearStaticCache()` has existed since the batching work and is unit-tested — but it clears one subclass at a time, and the central reset cannot name concrete subclasses. The only callers were the test suite and a benchmark. Exactly the "a working reset that nothing calls" shape as the `ClassValidator` and `ReflectionClassPool` cases before it, and the seventeenth cache bug of the family #539 tracks.

It only surfaces under the full suite, where an earlier test enables the file cache — so it is pinned separately by `AbstractPhpFileCacheResetTest`, which fails 4 of 5 without the wiring.

## 🔖 Changes

- `AbstractPhpFileCache::resetCache()` — keyless, so it clears every subclass without knowing any of them. Wired into `Gacela::resetCache()`
- `put()` recomputes a missing filename from the instance's own cache directory instead of trusting the registry, so the reset can drop the registry too. The old comment's reason for keeping it back no longer applies
- `all()` reads a missing slot as empty, so an instance that outlived a reset does not fault
- `ClassInfo::$callerClassCache` given its `= []` default — it was the one typed static with no default, and so could never be observed at rest
- `StaticStateCoverageTest` + its own fixture module (pillar resolution, an attribute-declared `#[Provides]` provider, `#[ServiceMap]` docblock service resolution and a `#[Cacheable]` method). The fixture belongs to the test rather than being borrowed from a feature suite, so nobody can defang the workload by editing a module whose own tests still pass
- `AbstractPhpFileCacheResetTest` — 5 regression tests on the leak above

### The declared exceptions

18 statics legitimately outlive a cache reset, each carrying its reason in `OUTLIVES_RESET`, in three kinds:

- **configuration** — `Gacela::$appRootDir`, `CacheableConfig::$storage`, `HealthCheckRegistry::$checks`. Clearing these would drop what the app asked for
- **pure memoization** — `GlobalKey::$cache`, `ReflectionClassPool::$cache`, `ProvidesScanner::$cache`. A total function of a key that cannot change within a process
- **unclearable by construction** — the `ServiceResolverAwareTrait` statics. A trait static exists once per using class, including application classes the framework never sees, so no central reset could reach them all. Safe only because they are pure memoization

The list is self-invalidating in both directions: an entry naming a property that no longer exists fails, and so does one the reset now clears after all.

### Verification

Each guard was made to fail before being trusted:

| removed | result |
|---|---|
| `AbstractFacade::resetCache()` from the central list | ✅ flags `AbstractFacade::$factories` |
| `AbstractFactory::resetCache()` | ✅ flags both its statics |
| `InMemoryCache::resetCache()` | ✅ flags `InMemoryCache::$cache` |
| a bogus `OUTLIVES_RESET` key | ✅ "no longer a static property" |
| an entry the reset does clear | ✅ "resetCache() now clears them" |
| `AbstractPhpFileCache::resetCache()` wiring | ✅ 4 of 5 regression tests fail |
| the filename recompute | ✅ errors on write-after-reset |

The workload populates 24 statics; the guard fails if it ever drops below 10, so it cannot degrade into asserting nothing.

Full suite green on seeds `1`, `555`, `31337`, `1111`, `4242`, `9999`, `7` — this test mutates global state, so order-independence was checked rather than assumed.

Related to #539
