### PR TITLE
test(psalm): drive the plugin in-process so it is under the mutation gate

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -29,6 +29,10 @@ on:
   schedule:
     # 03:17 UTC, off the hour to avoid the scheduling stampede.
     - cron: '17 3 * * *'
+  # The full run is otherwise reachable only by merging to main or waiting for
+  # the nightly, so a fix for a full-run failure could not be verified before
+  # it landed. Dispatch runs the `full` job against any branch.
+  workflow_dispatch:
 
 name: Infection
 

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -20,3 +20,13 @@ parameters:
         - '#Class GacelaTest\\Unit\\Framework\\Container\\NonExisting not found.#'
         - '#has invalid type Totally\\Missing\\Type#'
         - '#Access to constant on internal class Gacela\\Framework\\Container\\Locator.#'
+        # Psalm exposes no public way to observe that a plugin registered a hook;
+        # the registration lands in its internal event dispatcher. Driving the
+        # entry point in-process is what puts it under the mutation gate at all,
+        # so the coupling is deliberate and confined to this one test.
+        -
+            identifier: new.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php
+        -
+            identifier: parameter.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php

--- a/tests/Unit/Psalm/PluginTest.php
+++ b/tests/Unit/Psalm/PluginTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Psalm\Plugin;
+use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\Internal\EventDispatcher;
+use Psalm\PluginRegistrationSocket;
+use ReflectionClass;
+use SimpleXMLElement;
+
+/**
+ * `ServiceMapPluginTest` proves the plugin works by running a real
+ * `vendor/bin/psalm`, but that is a subprocess and invisible to coverage. These
+ * tests drive the entry point in-process so its behaviour is under the mutation
+ * gate too.
+ */
+final class PluginTest extends TestCase
+{
+    public function test_it_registers_the_pseudo_method_handler(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        self::assertFalse(
+            $dispatcher->hasAfterClassLikeVisitHandlers(),
+            'precondition: nothing is registered before the plugin runs',
+        );
+
+        (new Plugin())($this->socket($dispatcher));
+
+        self::assertTrue($dispatcher->hasAfterClassLikeVisitHandlers());
+    }
+
+    public function test_it_ignores_the_optional_plugin_config(): void
+    {
+        // Psalm passes the <pluginClass> element when one carries child config.
+        $dispatcher = new EventDispatcher();
+
+        (new Plugin())($this->socket($dispatcher), new SimpleXMLElement('<pluginClass/>'));
+
+        self::assertTrue($dispatcher->hasAfterClassLikeVisitHandlers());
+    }
+
+    /**
+     * Psalm registers handlers by class-string with autoloading disabled, so the
+     * plugin has to `require_once` the handler itself. Registration succeeding is
+     * what proves that happened — Psalm would reject an unloaded class.
+     */
+    private function socket(EventDispatcher $dispatcher): PluginRegistrationSocket
+    {
+        $configReflection = new ReflectionClass(Config::class);
+        $config = $configReflection->newInstanceWithoutConstructor();
+        $configReflection->getProperty('eventDispatcher')->setValue($config, $dispatcher);
+
+        // Both Config and the socket are final with non-public constructors that
+        // want a whole analysis context; the entry point touches neither.
+        $socketReflection = new ReflectionClass(PluginRegistrationSocket::class);
+        $socket = $socketReflection->newInstanceWithoutConstructor();
+        $socketReflection->getProperty('config')->setValue($socket, $config);
+
+        return $socket;
+    }
+}

--- a/tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php
+++ b/tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php
@@ -71,6 +71,49 @@ final class ServiceMapPseudoMethodsTest extends TestCase
         self::assertSame(['getfacade', 'getconfig'], array_keys($storage->pseudo_methods));
     }
 
+    public function test_it_keeps_scanning_after_an_unrelated_attribute_in_the_same_group(): void
+    {
+        // `#[SomethingElse, ServiceMap(...)]` — one group, two attributes. The
+        // scan has to skip the first and carry on, not stop at it.
+        $unrelated = new Name('SomethingElse');
+        $unrelated->setAttribute('resolvedName', 'App\SomethingElse');
+
+        $storage = $this->visitGroup(
+            new Attribute($unrelated, []),
+            $this->serviceMapAttribute('getFacade', self::FACADE),
+        );
+
+        self::assertArrayHasKey('getfacade', $storage->pseudo_methods);
+    }
+
+    public function test_it_keeps_scanning_after_an_incomplete_service_map_in_the_same_group(): void
+    {
+        // The first attribute is a ServiceMap but unusable, so it is skipped for
+        // a different reason than the one above — and the scan must still reach
+        // the second.
+        $storage = $this->visitGroup(
+            $this->attributeWithArgs([new Arg(new String_('getFacade'), name: new Identifier('method'))]),
+            $this->serviceMapAttribute('getConfig', 'App\Billing\BillingConfig'),
+        );
+
+        self::assertArrayHasKey('getconfig', $storage->pseudo_methods);
+    }
+
+    public function test_it_honours_named_arguments_given_out_of_order(): void
+    {
+        // `#[ServiceMap(className: X::class, method: 'getFacade')]`. Reading the
+        // names is what makes this work; inferring from position would read the
+        // class constant as `method` and the string as `className`, and register
+        // nothing.
+        $storage = $this->visit($this->attributeWithArgs([
+            new Arg($this->classConstFetch(self::FACADE), name: new Identifier('className')),
+            new Arg(new String_('getFacade'), name: new Identifier('method')),
+        ]));
+
+        self::assertArrayHasKey('getfacade', $storage->pseudo_methods);
+        self::assertSame(self::FACADE, (string)$storage->pseudo_methods['getfacade']->return_type);
+    }
+
     public function test_it_ignores_an_unrelated_attribute(): void
     {
         $other = new Name('SomethingElse');
@@ -173,15 +216,34 @@ final class ServiceMapPseudoMethodsTest extends TestCase
         self::assertSame([], $storage->pseudo_methods);
     }
 
+    /**
+     * One group per attribute, as stacked `#[A]` `#[B]` lines produce.
+     */
     private function visit(Attribute ...$attributes): ClassLikeStorage
     {
         $groups = [];
         foreach ($attributes as $attribute) {
-            // One group per attribute: repeated attributes may be written either
-            // stacked or comma-separated, and both reach here as groups.
             $groups[] = new AttributeGroup([$attribute]);
         }
 
+        return $this->visitGroups($groups);
+    }
+
+    /**
+     * All attributes in a single group, as comma-separated `#[A, B]` produces.
+     * Distinct from visit() because only this shape exercises the inner loop
+     * more than once.
+     */
+    private function visitGroup(Attribute ...$attributes): ClassLikeStorage
+    {
+        return $this->visitGroups([new AttributeGroup($attributes)]);
+    }
+
+    /**
+     * @param list<AttributeGroup> $groups
+     */
+    private function visitGroups(array $groups): ClassLikeStorage
+    {
         $storage = new ClassLikeStorage('App\Billing\Consumer');
         ServiceMapPseudoMethods::afterClassLikeVisit(
             $this->event(new Class_('Consumer', ['attrGroups' => $groups]), $storage),

--- a/tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php
+++ b/tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Psalm\ServiceMapPseudoMethods;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PHPUnit\Framework\TestCase;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+use Psalm\Storage\ClassLikeStorage;
+use ReflectionClass;
+
+/**
+ * Drives the Psalm hook directly, in-process.
+ *
+ * `ServiceMapPluginTest` already runs the plugin end-to-end through a real
+ * `vendor/bin/psalm`, which is the stronger proof that it works — but that runs
+ * in a subprocess, so coverage cannot see it and every mutant in this namespace
+ * counted as untested. These tests exist to put the logic back under the
+ * mutation gate; the subprocess test stays as the integration check.
+ */
+final class ServiceMapPseudoMethodsTest extends TestCase
+{
+    private const FACADE = 'App\Billing\BillingFacade';
+
+    public function test_it_registers_a_pseudo_method_from_the_attribute(): void
+    {
+        $storage = $this->visit($this->serviceMapAttribute('getFacade', self::FACADE));
+
+        // Psalm looks pseudo-methods up by lowercase name, but reports the cased
+        // one, so both halves matter.
+        self::assertArrayHasKey('getfacade', $storage->pseudo_methods);
+        self::assertSame('getFacade', $storage->pseudo_methods['getfacade']->cased_name);
+        self::assertSame(self::FACADE, (string)$storage->pseudo_methods['getfacade']->return_type);
+    }
+
+    public function test_the_pseudo_method_is_not_static(): void
+    {
+        $storage = $this->visit($this->serviceMapAttribute('getFacade', self::FACADE));
+
+        self::assertFalse($storage->pseudo_methods['getfacade']->is_static);
+    }
+
+    public function test_it_reads_positional_arguments(): void
+    {
+        // #[ServiceMap('getFactory', SomeFactory::class)] — no argument names.
+        $storage = $this->visit($this->serviceMapAttribute('getFactory', self::FACADE, named: false));
+
+        self::assertSame('getFactory', $storage->pseudo_methods['getfactory']->cased_name);
+    }
+
+    public function test_it_registers_every_repeated_attribute(): void
+    {
+        $storage = $this->visit(
+            $this->serviceMapAttribute('getFacade', self::FACADE),
+            $this->serviceMapAttribute('getConfig', 'App\Billing\BillingConfig'),
+        );
+
+        self::assertSame(['getfacade', 'getconfig'], array_keys($storage->pseudo_methods));
+    }
+
+    public function test_it_ignores_an_unrelated_attribute(): void
+    {
+        $other = new Name('SomethingElse');
+        $other->setAttribute('resolvedName', 'App\SomethingElse');
+
+        $storage = $this->visit(new Attribute($other, [
+            new Arg(new String_('getFacade'), name: new Identifier('method')),
+        ]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_matches_an_unresolved_fully_qualified_name(): void
+    {
+        // Written out in full in the source, so the resolver left no
+        // `resolvedName` and toString() is the only name available.
+        $storage = $this->visit($this->serviceMapAttribute(
+            'getFacade',
+            self::FACADE,
+            attributeName: new Name(ServiceMap::class),
+        ));
+
+        self::assertArrayHasKey('getfacade', $storage->pseudo_methods);
+    }
+
+    public function test_it_matches_a_leading_backslash(): void
+    {
+        $storage = $this->visit($this->serviceMapAttribute(
+            'getFacade',
+            self::FACADE,
+            attributeName: new Name('\\' . ServiceMap::class),
+        ));
+
+        self::assertArrayHasKey('getfacade', $storage->pseudo_methods);
+    }
+
+    public function test_it_ignores_a_method_argument_that_is_not_a_literal_string(): void
+    {
+        $storage = $this->visit($this->attributeWithArgs([
+            new Arg(new Variable('method'), name: new Identifier('method')),
+            new Arg($this->classConstFetch(self::FACADE), name: new Identifier('className')),
+        ]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_ignores_a_class_name_argument_that_is_not_a_class_constant(): void
+    {
+        $storage = $this->visit($this->attributeWithArgs([
+            new Arg(new String_('getFacade'), name: new Identifier('method')),
+            new Arg(new String_(self::FACADE), name: new Identifier('className')),
+        ]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_ignores_a_class_constant_whose_class_is_an_expression(): void
+    {
+        // `$var::class` — the left side is not a Name, so no class name resolves.
+        $storage = $this->visit($this->attributeWithArgs([
+            new Arg(new String_('getFacade'), name: new Identifier('method')),
+            new Arg(
+                new ClassConstFetch(new Variable('var'), new Identifier('class')),
+                name: new Identifier('className'),
+            ),
+        ]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_ignores_an_attribute_missing_the_method_argument(): void
+    {
+        $storage = $this->visit($this->attributeWithArgs([
+            new Arg($this->classConstFetch(self::FACADE), name: new Identifier('className')),
+        ]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_ignores_an_attribute_missing_the_class_name_argument(): void
+    {
+        $storage = $this->visit($this->attributeWithArgs([
+            new Arg(new String_('getFacade'), name: new Identifier('method')),
+        ]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_ignores_an_attribute_with_no_arguments(): void
+    {
+        $storage = $this->visit($this->attributeWithArgs([]));
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    public function test_it_registers_nothing_for_a_class_without_attributes(): void
+    {
+        $storage = $this->visit();
+
+        self::assertSame([], $storage->pseudo_methods);
+    }
+
+    private function visit(Attribute ...$attributes): ClassLikeStorage
+    {
+        $groups = [];
+        foreach ($attributes as $attribute) {
+            // One group per attribute: repeated attributes may be written either
+            // stacked or comma-separated, and both reach here as groups.
+            $groups[] = new AttributeGroup([$attribute]);
+        }
+
+        $storage = new ClassLikeStorage('App\Billing\Consumer');
+        ServiceMapPseudoMethods::afterClassLikeVisit(
+            $this->event(new Class_('Consumer', ['attrGroups' => $groups]), $storage),
+        );
+
+        return $storage;
+    }
+
+    /**
+     * The event is a value object and the hook reads only two of its five fields,
+     * but its constructor also demands a `Codebase`, which is `final` and so
+     * neither mockable nor cheap to build. Bypassing the constructor keeps the
+     * test about the hook.
+     */
+    private function event(ClassLike $stmt, ClassLikeStorage $storage): AfterClassLikeVisitEvent
+    {
+        $reflection = new ReflectionClass(AfterClassLikeVisitEvent::class);
+        $event = $reflection->newInstanceWithoutConstructor();
+
+        $reflection->getProperty('stmt')->setValue($event, $stmt);
+        $reflection->getProperty('storage')->setValue($event, $storage);
+
+        return $event;
+    }
+
+    private function serviceMapAttribute(
+        string $method,
+        string $className,
+        bool $named = true,
+        ?Name $attributeName = null,
+    ): Attribute {
+        $args = $named
+            ? [
+                new Arg(new String_($method), name: new Identifier('method')),
+                new Arg($this->classConstFetch($className), name: new Identifier('className')),
+            ]
+            : [
+                new Arg(new String_($method)),
+                new Arg($this->classConstFetch($className)),
+            ];
+
+        return $this->attributeWithArgs($args, $attributeName);
+    }
+
+    /**
+     * @param list<Arg> $args
+     */
+    private function attributeWithArgs(array $args, ?Name $attributeName = null): Attribute
+    {
+        if ($attributeName === null) {
+            // How an imported `#[ServiceMap]` reaches the hook: the short name in
+            // the source, the resolved one left on the node by the resolver.
+            $attributeName = new Name('ServiceMap');
+            $attributeName->setAttribute('resolvedName', ServiceMap::class);
+        }
+
+        return new Attribute($attributeName, $args);
+    }
+
+    private function classConstFetch(string $className): Expr
+    {
+        $fetch = new ClassConstFetch(new Name('BillingFacade'), new Identifier('class'));
+        $fetch->class->setAttribute('resolvedName', $className);
+
+        return $fetch;
+    }
+}


### PR DESCRIPTION
## 📚 Description

The full mutation gate has been **red on `main` since #556** (`519d95d8`), and every commit since inherited it. Nothing escaped — the numbers were:

```
2624 mutants were killed
   0 covered mutants were not detected
  43 mutants were not covered by tests
     MSI: 98%   Covered Code MSI: 100%
```

So the code is not untested; it is **unmeasurable**. #556 added `src/Psalm/Plugin.php` and `src/Psalm/ServiceMapPseudoMethods.php` (143 lines), verified by `ServiceMapPluginTest` — which runs a real `vendor/bin/psalm` through `shell_exec`. Coverage cannot see a subprocess, so those 143 lines report zero coverage and all their mutants count as uncovered. `infection.json5` sets `minMsi: 100`, so the gate fails.

`src/PHPStan` does not have this problem: PHPStan's `RuleTestCase` runs in-process, which is why that namespace has a long list of carefully-justified per-mutator ignores rather than being invisible.

## 🔖 Changes

- `tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php` — 14 tests driving `afterClassLikeVisit()` directly: named and positional attribute arguments, repeated attributes, an unresolved fully-qualified name, a leading backslash, a class expression (`$var::class`) instead of a `Name`, a non-literal `method` argument, a `className` that is not a class constant, each argument missing individually, and a class with no attributes at all
- `tests/Unit/Psalm/PluginTest.php` — 5 tests asserting the hook actually **lands in Psalm's dispatcher**, not merely that `__invoke()` did not throw. The weaker assertion would survive a `MethodCallRemoval` mutant, which is the mutant that matters here
- `.github/workflows/infection.yml` — `workflow_dispatch`
- `phpstan-tests.neon` — two scoped ignores, see below

The existing subprocess test is untouched. It remains the end-to-end proof; these are what put the logic under the gate.

## 🔖 Two deliberate compromises

**The event object's constructor is bypassed.** `AfterClassLikeVisitEvent` requires a `Psalm\Codebase`, which is `final` — so neither mockable nor cheap to construct — while the hook reads only two of the event's five fields. `newInstanceWithoutConstructor()` plus setting those two keeps the test about the hook rather than about building an analysis context.

**`Psalm\Internal\EventDispatcher` is `@internal`,** and PHPStan flagged instantiating it. Psalm exposes no public way to observe that a plugin registered a hook. The two ignores added to `phpstan-tests.neon` are scoped by both `identifier` and `path`, and follow the internal-class ignore already in that file. The alternative was leaving the entry point unmeasured — the thing this PR exists to fix.

## 🔖 On `workflow_dispatch`

The `full` job previously ran only on push-to-`main`, the nightly, or a schedule. A fix for a full-run failure therefore could not be verified before landing on `main` — you had to merge and hope. `workflow_dispatch` makes the `full` job runnable against any branch, and it was used to verify this branch before requesting the merge.

Worth having independently of this PR: a gate you cannot run on demand is a gate that gets diagnosed by bisecting merge commits.

Verified: 1367 tests pass; cs-fixer, Psalm and both PHPStan configs clean.
