### PR TITLE
✨ Answer debug:dependencies from the container's resolution view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md) — and run 
 
 ### Added
 
+- **`debug:dependencies --tree` answers from the container instead of from reflection.** Without it the command reports one level of constructor parameters, re-derived from type hints. With it, the transitive tree is taken from `Container::getDependencyTree()` — the same walk the resolver performs — so bindings, contextual bindings and attributes are already applied, and a bound interface is listed as the concrete that will actually be built. Every node is marked with how the container will supply it: `binding`, `instance`, `autowired`, or `unresolvable`. That last distinction is new information: it comes from `Container::provides()`, which asks whether the container *owns* something for an id, where `has()` is also true of anything merely autowirable — so an interface with a binding used to read exactly like one without. An unresolvable node is printed, never thrown; the command stays a diagnostic. See [container configuration](docs/container-configuration.md#visibility-in-tooling)
+- **`Gacela\Framework\Container\Container::provides()`** forwards container 1.3's `provides()`. Like `stats()`, it is declared on the concrete class rather than `ContainerInterface`, so the decorator needs an explicit forwarder
 - **A Psalm plugin that types the pillar accessors from `#[ServiceMap]`** (`Gacela\Psalm\Plugin`), the counterpart of the PHPStan extension. Register it in `psalm.xml`:
   ```xml
   <plugins>

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -219,6 +219,45 @@ with the override concrete rendered inline when present:
 ✓ $cache CacheInterface (inject -> App\Cache\RedisCache)
 ```
 
+That view stops at the constructor, and it is derived from type hints. Add
+`--tree` to append the **transitive** dependencies, taken from the container's
+own resolution view rather than re-derived — so bindings and contextual
+bindings are already applied, and a bound interface is listed as the concrete
+that will actually be built:
+
+```
+bin/gacela debug:dependencies "App\Catalog\CatalogService" --tree
+```
+
+```
+Dependency tree for App\Catalog\CatalogService
+============================================================
+
+  ✓ App\Catalog\ProductRepository (autowired)
+  ✓ App\Cache\RedisCache (binding)
+  ✓ Psr\Log\LoggerInterface (instance)
+  ✗ App\Search\IndexerInterface (unresolvable)
+
+Dependencies: 4
+```
+
+Each node reports how the container will supply it:
+
+| Marker | Meaning |
+|---|---|
+| `binding` | an explicit binding is registered for the id |
+| `instance` | the container already holds an instance, or a singleton it resolved |
+| `autowired` | nothing registered, but the class will be constructed on demand |
+| `unresolvable` | the container owns nothing and the class cannot be built |
+
+The distinction comes from `Container::provides()`, which asks whether the
+container *owns* something for an id. That is narrower than `has()`, which is
+also true of anything merely autowirable — and it is the difference the
+one-level view could not express, because an interface with a binding read the
+same as one without.
+
+An unresolvable node is printed, not thrown: the command stays a diagnostic.
+
 ### Migration from `ServiceResolverAwareTrait`
 
 Before:

--- a/src/Console/Application/Debug/DependencyNode.php
+++ b/src/Console/Application/Debug/DependencyNode.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+final class DependencyNode
+{
+    public function __construct(
+        public readonly string $className,
+        public readonly ProvisionStatus $status,
+    ) {
+    }
+
+    public function isProvided(): bool
+    {
+        return $this->status->isProvided();
+    }
+}

--- a/src/Console/Application/Debug/DependencyTreeInspection.php
+++ b/src/Console/Application/Debug/DependencyTreeInspection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+final class DependencyTreeInspection
+{
+    /**
+     * @param class-string $className
+     * @param list<DependencyNode> $nodes
+     * @param bool $containerAvailable false when Gacela was never bootstrapped,
+     *        which is a different answer from "this class has no dependencies"
+     */
+    public function __construct(
+        public readonly string $className,
+        public readonly array $nodes,
+        public readonly bool $containerAvailable = true,
+    ) {
+    }
+
+    /**
+     * @return list<DependencyNode>
+     */
+    public function unresolvableNodes(): array
+    {
+        $result = [];
+        foreach ($this->nodes as $node) {
+            if (!$node->isProvided()) {
+                $result[] = $node;
+            }
+        }
+
+        return $result;
+    }
+
+    public function isFullyProvided(): bool
+    {
+        return $this->unresolvableNodes() === [];
+    }
+}

--- a/src/Console/Application/Debug/DependencyTreeInspector.php
+++ b/src/Console/Application/Debug/DependencyTreeInspector.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Exception\GacelaNotBootstrappedException;
+use Gacela\Framework\Gacela;
+
+use function class_exists;
+
+/**
+ * Reports the transitive dependencies of a class as the container sees them.
+ *
+ * {@see ConstructorInspector} re-derives one level of the answer from type
+ * hints; this asks the container for the tree it will actually walk, so
+ * bindings, contextual bindings and attributes are already accounted for.
+ */
+final class DependencyTreeInspector
+{
+    /**
+     * @param class-string $className
+     */
+    public function inspect(string $className): DependencyTreeInspection
+    {
+        $container = $this->container();
+        if (!$container instanceof Container) {
+            return new DependencyTreeInspection($className, [], containerAvailable: false);
+        }
+
+        $bindings = $container->getBindings();
+        $nodes = [];
+
+        foreach ($container->getDependencyTree($className) as $dependency) {
+            $nodes[] = new DependencyNode($dependency, $this->classify($container, $bindings, $dependency));
+        }
+
+        return new DependencyTreeInspection($className, $nodes);
+    }
+
+    /**
+     * The merged bindings map is read once by the caller and passed down: it
+     * merges every parent container's map on each call, so building it per node
+     * would make inspecting a scope scale with the size of its parent.
+     *
+     * @param array<string, mixed> $bindings
+     */
+    private function classify(Container $container, array $bindings, string $id): ProvisionStatus
+    {
+        if (isset($bindings[$id])) {
+            return ProvisionStatus::Binding;
+        }
+
+        // Deliberately not has(), which is true of anything instantiable and so
+        // cannot tell a stored instance from a class nobody registered.
+        if ($container->provides($id)) {
+            return ProvisionStatus::Instance;
+        }
+
+        return class_exists($id)
+            ? ProvisionStatus::Autowired
+            : ProvisionStatus::Unresolvable;
+    }
+
+    private function container(): ?Container
+    {
+        try {
+            return Gacela::container();
+        } catch (GacelaNotBootstrappedException) {
+            return null;
+        }
+    }
+}

--- a/src/Console/Application/Debug/ProvisionStatus.php
+++ b/src/Console/Application/Debug/ProvisionStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+/**
+ * How the container will supply a node of a dependency tree.
+ *
+ * Distinct from {@see ParameterStatus}, which categorises a single constructor
+ * parameter from its type hint. This one is answered by the container itself:
+ * `provides()` reports whether it owns something for the id, and `getBindings()`
+ * separates a declared binding from an instance that merely ended up stored.
+ */
+enum ProvisionStatus: string
+{
+    case Binding = 'binding';
+    case Instance = 'instance';
+    case Autowired = 'autowired';
+    case Unresolvable = 'unresolvable';
+
+    public function isProvided(): bool
+    {
+        return $this !== self::Unresolvable;
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -6,6 +6,9 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Debug\ConstructorInspection;
 use Gacela\Console\Application\Debug\ConstructorInspector;
+use Gacela\Console\Application\Debug\DependencyNode;
+use Gacela\Console\Application\Debug\DependencyTreeInspection;
+use Gacela\Console\Application\Debug\DependencyTreeInspector;
 use Gacela\Console\Application\Debug\ParameterInspection;
 use Gacela\Console\Application\Debug\ParameterStatus;
 use PhpToken;
@@ -13,6 +16,7 @@ use ReflectionClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function class_exists;
@@ -28,7 +32,8 @@ final class DebugDependenciesCommand extends Command
         $this->setName('debug:dependencies')
             ->setDescription('Show the constructor parameters of a class and their resolvability through the container')
             ->setHelp($this->getHelpText())
-            ->addArgument('class', InputArgument::REQUIRED, 'Fully qualified class name or a path to a PHP file declaring the class');
+            ->addArgument('class', InputArgument::REQUIRED, 'Fully qualified class name or a path to a PHP file declaring the class')
+            ->addOption('tree', null, InputOption::VALUE_NONE, 'Also show the transitive dependency tree as the container resolves it');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -58,11 +63,45 @@ final class DebugDependenciesCommand extends Command
             return Command::FAILURE;
         }
 
-        $inspection = (new ConstructorInspector())->inspect($className);
+        $this->renderInspection($output, (new ConstructorInspector())->inspect($className));
 
-        $this->renderInspection($output, $inspection);
+        if ($input->getOption('tree') === true) {
+            $this->renderTree($output, (new DependencyTreeInspector())->inspect($className));
+        }
 
         return Command::SUCCESS;
+    }
+
+    private function renderTree(OutputInterface $output, DependencyTreeInspection $inspection): void
+    {
+        ConsoleSection::title($output, sprintf('Dependency tree for %s', $inspection->className));
+
+        if (!$inspection->containerAvailable) {
+            $output->writeln('  <comment>No container available — bootstrap Gacela to resolve the tree.</comment>');
+            $output->writeln('');
+            return;
+        }
+
+        if ($inspection->nodes === []) {
+            $output->writeln('  <fg=cyan>No transitive dependencies</>');
+            $output->writeln('');
+            return;
+        }
+
+        foreach ($inspection->nodes as $node) {
+            $output->writeln('  ' . $this->formatNode($node));
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf('<fg=cyan>Dependencies:</> %d', count($inspection->nodes)));
+        $output->writeln('');
+    }
+
+    private function formatNode(DependencyNode $node): string
+    {
+        $marker = $node->isProvided() ? '<fg=green>✓</>' : '<fg=red>✗</>';
+
+        return sprintf('%s %s (%s)', $marker, $node->className, $node->status->value);
     }
 
     private function renderInspection(OutputInterface $output, ConstructorInspection $inspection): void
@@ -219,9 +258,19 @@ declares the target class.
   <fg=red>✗ interface</fg=red>    interface type with no binding
   <fg=red>✗ missing</fg=red>      type does not exist
 
+<info>--tree</info> appends the transitive dependency tree, taken from the container
+rather than re-derived from type hints, so bindings and contextual bindings are
+already applied. Each node reports how the container will supply it:
+
+  <fg=green>✓ binding</fg=green>      an explicit binding is registered for the id
+  <fg=green>✓ instance</fg=green>     the container already holds an instance or resolved singleton
+  <fg=green>✓ autowired</fg=green>    nothing registered, but the class will be constructed on demand
+  <fg=red>✗ unresolvable</fg=red> the container owns nothing and the class cannot be built
+
 <info>Examples:</info>
   bin/gacela debug:dependencies "App\MyModule\MyFactory"
   bin/gacela debug:dependencies src/MyModule/MyFactory.php
+  bin/gacela debug:dependencies "App\MyModule\MyFactory" --tree
 HELP;
     }
 }

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -127,6 +127,20 @@ final class Container implements ContainerInterface
         return $this->inner->has($id);
     }
 
+    /**
+     * Whether the container actually owns something for this id -- a binding, a
+     * stored instance, or a singleton it has already resolved.
+     *
+     * Narrower than {@see has()}, which is also true of anything merely
+     * autowirable. New in container 1.3 and, like {@see stats()}, declared on
+     * the concrete class rather than ContainerInterface, so it is forwarded
+     * explicitly here.
+     */
+    public function provides(string $id): bool
+    {
+        return $this->inner->provides($id);
+    }
+
     public function afterResolving(string $id, Closure $callback): void
     {
         $this->inner->afterResolving($id, $callback);

--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -266,10 +266,74 @@ final class DebugDependenciesCommandTest extends TestCase
         );
     }
 
-    private function inspect(string $argument): CommandTester
+    public function test_the_transitive_tree_is_off_by_default(): void
+    {
+        $tester = $this->inspect(Fixtures\NestedRootService::class);
+
+        $display = $tester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        // Only the constructor parameter, none of what it drags in.
+        self::assertStringContainsString('$mid ' . Fixtures\NestedMidService::class, $display);
+        self::assertStringNotContainsString('Dependency tree', $display);
+        self::assertStringNotContainsString(AutowirableCollaborator::class, $display);
+    }
+
+    public function test_tree_option_adds_the_transitive_view_below_the_constructor_view(): void
+    {
+        $tester = $this->inspect(Fixtures\NestedRootService::class, ['--tree' => true]);
+
+        $display = $tester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        // The one-level view is kept, and the tree is appended to it.
+        self::assertStringContainsString('Constructor dependencies for', $display);
+        self::assertStringContainsString('Dependency tree for ' . Fixtures\NestedRootService::class, $display);
+
+        // Each node carries how the container will actually supply it.
+        self::assertStringContainsString(Fixtures\NestedMidService::class . ' (autowired)', $display);
+        self::assertStringContainsString(BoundImplementation::class . ' (autowired)', $display);
+        self::assertStringContainsString(UnboundContract::class . ' (unresolvable)', $display);
+        self::assertMatchesRegularExpression('/Dependencies:\s+4/', $display);
+    }
+
+    public function test_tree_option_marks_a_node_the_container_already_owns(): void
+    {
+        Gacela::container()->set(AutowirableCollaborator::class, new AutowirableCollaborator());
+
+        $tester = $this->inspect(Fixtures\NestedRootService::class, ['--tree' => true]);
+
+        self::assertStringContainsString(
+            AutowirableCollaborator::class . ' (instance)',
+            $tester->getDisplay(),
+        );
+    }
+
+    public function test_tree_option_on_a_class_with_no_dependencies_says_so(): void
+    {
+        $tester = $this->inspect(NoConstructorService::class, ['--tree' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('No transitive dependencies', $tester->getDisplay());
+    }
+
+    public function test_tree_option_reports_an_unresolvable_node_without_failing(): void
+    {
+        $tester = $this->inspect(MixedDependenciesService::class, ['--tree' => true]);
+
+        // The command stays a diagnostic: an unresolvable dependency is
+        // something to print, never something to throw or fail on.
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString(UnboundContract::class . ' (unresolvable)', $tester->getDisplay());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function inspect(string $argument, array $options = []): CommandTester
     {
         $tester = new CommandTester(new DebugDependenciesCommand());
-        $tester->execute(['class' => $argument]);
+        $tester->execute(['class' => $argument] + $options);
 
         return $tester;
     }

--- a/tests/Feature/Console/DebugDependencies/Fixtures/NestedMidService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/NestedMidService.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+final class NestedMidService
+{
+    public function __construct(
+        public readonly BoundContract $bound,
+        public readonly AutowirableCollaborator $collaborator,
+        public readonly UnboundContract $unbound,
+    ) {
+    }
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/NestedRootService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/NestedRootService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+/**
+ * Its own constructor names a single collaborator, so the one-level view says
+ * nothing about the three dependencies one step further down.
+ */
+final class NestedRootService
+{
+    public function __construct(
+        public readonly NestedMidService $mid,
+    ) {
+    }
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/SecondUnboundContract.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/SecondUnboundContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+interface SecondUnboundContract
+{
+}

--- a/tests/Feature/Console/DebugDependencies/Fixtures/TwoUnresolvableService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/TwoUnresolvableService.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+final class TwoUnresolvableService
+{
+    public function __construct(
+        public readonly UnboundContract $first,
+        public readonly SecondUnboundContract $second,
+    ) {
+    }
+}

--- a/tests/Integration/Framework/Container/ContainerDelegationTest.php
+++ b/tests/Integration/Framework/Container/ContainerDelegationTest.php
@@ -123,6 +123,39 @@ final class ContainerDelegationTest extends TestCase
         self::assertSame(['A', 'B'], [...$container->tagged('letters')]);
     }
 
+    /**
+     * `has()` answers "would get() resolve this", which is true of anything
+     * instantiable. `provides()` answers the narrower question the debug
+     * commands actually need: does the container own something for this id.
+     * Forwarding one to the other would go unnoticed everywhere but here.
+     */
+    public function test_provides_is_narrower_than_has(): void
+    {
+        $container = new Container();
+
+        self::assertTrue($container->has(stdClass::class), 'an instantiable class satisfies has()');
+        self::assertFalse($container->provides(stdClass::class), '...but the container owns nothing for it');
+
+        $container->set(stdClass::class, static fn (): stdClass => new stdClass());
+
+        self::assertTrue($container->provides(stdClass::class));
+    }
+
+    public function test_provides_reports_a_registered_binding(): void
+    {
+        $container = new Container();
+        $container->bind(StringValueInterface::class, static fn (): StringValue => new StringValue('x'));
+
+        self::assertTrue($container->provides(StringValueInterface::class));
+    }
+
+    public function test_provides_is_false_for_an_interface_with_no_binding(): void
+    {
+        $container = new Container();
+
+        self::assertFalse($container->provides(StringValueInterface::class));
+    }
+
     public function test_warm_up_leaves_the_class_resolvable(): void
     {
         $container = new Container();

--- a/tests/Unit/Console/Application/Debug/DependencyTreeInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/DependencyTreeInspectorTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Debug;
+
+use Gacela\Console\Application\Debug\DependencyTreeInspection;
+use Gacela\Console\Application\Debug\DependencyTreeInspector;
+use Gacela\Console\Application\Debug\ProvisionStatus;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\AutowirableCollaborator;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundContract;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NestedMidService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NestedRootService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\SecondUnboundContract;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\TwoUnresolvableService;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\UnboundContract;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function array_map;
+
+final class DependencyTreeInspectorTest extends TestCase
+{
+    private DependencyTreeInspector $inspector;
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(BoundContract::class, BoundImplementation::class);
+        });
+
+        $this->inspector = new DependencyTreeInspector();
+    }
+
+    public function test_a_class_without_dependencies_has_an_empty_tree(): void
+    {
+        $inspection = $this->inspector->inspect(NoConstructorService::class);
+
+        self::assertTrue($inspection->containerAvailable);
+        self::assertSame([], $inspection->nodes);
+        self::assertTrue($inspection->isFullyProvided());
+    }
+
+    public function test_the_tree_reaches_past_the_first_level(): void
+    {
+        $inspection = $this->inspector->inspect(NestedRootService::class);
+
+        // The constructor names only NestedMidService; the other three are its
+        // dependencies, which the one-level view cannot report.
+        self::assertSame(
+            [
+                NestedMidService::class,
+                BoundImplementation::class,
+                AutowirableCollaborator::class,
+                UnboundContract::class,
+            ],
+            self::classNames($inspection),
+        );
+    }
+
+    public function test_a_bound_interface_is_reported_as_its_concrete_target(): void
+    {
+        $inspection = $this->inspector->inspect(NestedRootService::class);
+
+        // The container resolves the binding before walking further, so the tree
+        // names what will actually be built -- BoundContract never appears.
+        self::assertContains(BoundImplementation::class, self::classNames($inspection));
+        self::assertNotContains(BoundContract::class, self::classNames($inspection));
+    }
+
+    public function test_an_unbound_interface_is_the_only_unresolvable_node(): void
+    {
+        $inspection = $this->inspector->inspect(NestedRootService::class);
+
+        self::assertSame([UnboundContract::class], array_map(
+            static fn (object $node): string => $node->className,
+            $inspection->unresolvableNodes(),
+        ));
+        self::assertFalse($inspection->isFullyProvided());
+    }
+
+    public function test_every_unresolvable_node_is_reported_not_only_the_first(): void
+    {
+        $inspection = $this->inspector->inspect(TwoUnresolvableService::class);
+
+        self::assertSame(
+            [UnboundContract::class, SecondUnboundContract::class],
+            array_map(
+                static fn (object $node): string => $node->className,
+                $inspection->unresolvableNodes(),
+            ),
+        );
+    }
+
+    public function test_an_autowired_node_is_distinguished_from_a_stored_instance(): void
+    {
+        $before = self::statusIn($this->inspector->inspect(NestedRootService::class), AutowirableCollaborator::class);
+        self::assertSame(ProvisionStatus::Autowired, $before);
+
+        Gacela::container()->set(AutowirableCollaborator::class, new AutowirableCollaborator());
+
+        // provides() is what tells the two apart: has() was already true of both.
+        self::assertSame(ProvisionStatus::Instance, self::statusIn(
+            $this->inspector->inspect(NestedRootService::class),
+            AutowirableCollaborator::class,
+        ));
+    }
+
+    public function test_a_registered_binding_keeps_its_own_status(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            // A closure binding is not a class-string, so the tree keeps the
+            // interface name and the binding stays visible on the node itself.
+            $config->addBinding(UnboundContract::class, static fn (): object => new BoundImplementation());
+            $config->addBinding(BoundContract::class, BoundImplementation::class);
+        });
+
+        $inspection = (new DependencyTreeInspector())->inspect(NestedMidService::class);
+
+        self::assertSame(ProvisionStatus::Binding, self::statusIn($inspection, UnboundContract::class));
+        self::assertTrue($inspection->isFullyProvided());
+    }
+
+    public function test_an_unknown_class_yields_an_empty_tree_instead_of_throwing(): void
+    {
+        /** @var class-string $missing */
+        $missing = 'Totally\\Missing\\Service';
+
+        $inspection = $this->inspector->inspect($missing);
+
+        self::assertSame($missing, $inspection->className);
+        self::assertTrue($inspection->containerAvailable);
+        self::assertSame([], $inspection->nodes);
+    }
+
+    public function test_without_a_bootstrapped_container_the_tree_is_reported_as_unavailable(): void
+    {
+        $gacelaProxy = new ReflectionClass(Gacela::class);
+        $gacelaProxy->getProperty('mainContainer')->setValue($gacelaProxy, value: null);
+
+        $inspection = $this->inspector->inspect(NestedRootService::class);
+
+        // Unavailable is not the same answer as "no dependencies", and the
+        // command renders the two differently.
+        self::assertFalse($inspection->containerAvailable);
+        self::assertSame([], $inspection->nodes);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function classNames(DependencyTreeInspection $inspection): array
+    {
+        return array_map(
+            static fn (object $node): string => $node->className,
+            $inspection->nodes,
+        );
+    }
+
+    private static function statusIn(DependencyTreeInspection $inspection, string $className): ProvisionStatus
+    {
+        foreach ($inspection->nodes as $node) {
+            if ($node->className === $className) {
+                return $node->status;
+            }
+        }
+
+        self::fail($className . ' is not part of the tree');
+    }
+}


### PR DESCRIPTION
## 📚 Description

`debug:dependencies` built its answer from a hand-rolled `ConstructorInspector` over `new ReflectionClass($className)`. That gives **one level** of constructor parameters and a resolvable/unresolvable count guessed from type hints — so the command reported what reflection can see, while the container knew what would actually happen. Those diverge precisely where a user is debugging.

This routes the answer through the container's own resolution view.

`--tree` appends the **transitive** tree from `Container::getDependencyTree()` — the same walk the resolver performs, so bindings, contextual bindings and attributes are already applied and a bound interface is listed as the concrete that will actually be built. The existing one-level view stays the default depth.

Each node is marked with how the container will supply it. The distinction comes from `Container::provides()` (container 1.3), which asks whether the container **owns** something for an id — narrower than `has()`, which is also true of anything merely autowirable. That is exactly what the command's "Unresolvable parameters need an explicit binding" hint was trying to say and could not: an interface with a binding used to read like one without.

```
Dependency tree for App\Catalog\CatalogService
============================================================

  ✓ App\Catalog\ProductRepository (autowired)
  ✓ App\Cache\RedisCache (binding)
  ✓ Psr\Log\LoggerInterface (instance)
  ✗ App\Search\IndexerInterface (unresolvable)

Dependencies: 4
```

An unresolvable node is printed, never thrown — the command stays a diagnostic. `getStats()` is untouched, as the issue asks: its shape is outside upstream's BC promise.

Closes #566

## 🔖 Changes

- **`debug:dependencies --tree`** renders the transitive dependency tree below the existing constructor view. Without the flag the output is unchanged
- **`ProvisionStatus`** — `binding` / `instance` / `autowired` / `unresolvable`, distinct from `ParameterStatus`, which categorises a constructor parameter from its type hint. This one is answered by the container
- **`DependencyTreeInspector`** + `DependencyTreeInspection` / `DependencyNode` in `Console/Application/Debug/`, mirroring the existing `ConstructorInspector` trio
- **`Gacela\Framework\Container\Container::provides()`** — a forwarder. Like `stats()`, it lives on the concrete container rather than `ContainerInterface`, so the decorator needs one explicitly
- **Never-throw path**: a container that was never bootstrapped is reported as unavailable, which the command renders differently from "this class has no dependencies" — the two are different answers. An unknown class yields an empty tree
- Merged bindings map read once and passed down, not rebuilt per node: `getBindings()` merges every parent's map on each call, so per-node lookup would make inspecting a scope scale with the size of its parent
- Docs: `docs/container-configuration.md#visibility-in-tooling` gains the `--tree` output, the marker table, and why `provides()` is the right question
- Tests: `DependencyTreeInspectorTest` (unit), `--tree` cases in `DebugDependenciesCommandTest` (feature), and three `provides()` delegation cases in `ContainerDelegationTest` pinning it as narrower than `has()` — the forwarding bug class that test file exists for
- 100% MSI on every changed file

## 🧹 Refactor pass

Folded into the implementation commit rather than a follow-up, since both were caught before the first push: the two branches of `formatNode()` differed only in the marker and were collapsed to one `sprintf`, and the reason the bindings map is hoisted out of the per-node loop is now stated in a docblock rather than left as an unexplained parameter.

Nothing else needed changing. `ConstructorInspector` and `DependencyTreeInspector` each catch `GacelaNotBootstrappedException` once, with different return shapes — two call sites is not enough to justify a shared helper, so they stay separate.
