### PR TITLE
✨ Expose container tags and give collections one intent each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md) — and run 
 
 ### Added
 
+- **`GacelaConfig::tag()` makes container tagging reachable.** The container has shipped `tag()`/`tagged()` for a while and Gacela's decorator forwarded both, but nothing could reach them: `GacelaConfig` had `addBinding`, `addFactory`, `addAlias`, `addLazy`, `extendService` and `when` — no `tag`. So the only collection primitive a user could actually reach was `addHandlerRegistry()`, which is **keyed**, and had to be bent into jobs it does not fit.
+  ```php
+  // gacela.php — reaches every module's container
+  $config->tag([NotEmptyValidator::class, EmailValidator::class], 'validators');
+
+  // a module adds its own, in its Provider
+  $container->tag(CardValidator::class, 'validators');
+  $container->set('validators', static fn (): array => [...$container->tagged('validators')]);
+  ```
+  A module-local contribution stays in that module's container: two modules tagging under the same label each see the app-wide set plus their own, and never each other's. That is the behaviour, not a limitation — module containers are separate, and a tag is not a back channel between modules. Tags from two config sources are merged, not overwritten. The two collection primitives now each have one intent: `tag()` for an unkeyed set you iterate (validators, listeners), `addHandlerRegistry()` for a keyed lookup that throws on a miss (a command bus). `docs/getting-a-dependency.md` gains a "collect several implementations" section, which had no primary path before
 - **`debug:dependencies --tree` answers from the container instead of from reflection.** Without it the command reports one level of constructor parameters, re-derived from type hints. With it, the transitive tree is taken from `Container::getDependencyTree()` — the same walk the resolver performs — so bindings, contextual bindings and attributes are already applied, and a bound interface is listed as the concrete that will actually be built. Every node is marked with how the container will supply it: `binding`, `instance`, `autowired`, or `unresolvable`. That last distinction is new information: it comes from `Container::provides()`, which asks whether the container *owns* something for an id, where `has()` is also true of anything merely autowirable — so an interface with a binding used to read exactly like one without. An unresolvable node is printed, never thrown; the command stays a diagnostic. See [container configuration](docs/container-configuration.md#visibility-in-tooling)
 - **`Gacela\Framework\Container\Container::provides()`** forwards container 1.3's `provides()`. Like `stats()`, it is declared on the concrete class rather than `ContainerInterface`, so the decorator needs an explicit forwarder
 - **A Psalm plugin that types the pillar accessors from `#[ServiceMap]`** (`Gacela\Psalm\Plugin`), the counterpart of the PHPStan extension. Register it in `psalm.xml`:

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -12,6 +12,7 @@ they are genuinely the right answer, because "supported" is not "deprecated".
 | reach another module | from an entry point: `ServiceResolverAwareTrait` + `#[ServiceMap]` + `$this->getFacade()`. From a Factory: `#[Provides]` + `getProvidedDependency()` |
 | get a collaborator inside my own module | a `create*()` method on the Factory, or `make()` when autowiring pays |
 | get an external / infrastructure service | `#[Provides]` in the Provider, or `addBinding()` for an interface |
+| collect several implementations | `tag()` when the set is unkeyed, `addHandlerRegistry()` when you look one up by key |
 | read a config value | the typed getters on your `Config` |
 
 ## Reach another module
@@ -133,6 +134,80 @@ everywhere, including through `make()`:
 ```php
 $config->addBinding(PaymentGateway::class, StripeGateway::class);
 ```
+
+## Collect several implementations
+
+Two shapes, and which one you want is decided by a single question: **do you
+look a member up, or do you use all of them?**
+
+### Unkeyed — every implementation of something
+
+A set of validators, listeners or rules, where the consumer iterates the whole
+collection. Group them with `tag()` in `gacela.php`:
+
+```php
+$config->tag([NotEmptyValidator::class, EmailValidator::class], 'validators');
+```
+
+Resolve the group with `tagged()`, which instantiates each id lazily, in the
+order it was tagged. A Provider is where you turn it into a provided dependency:
+
+```php
+final class Provider extends AbstractProvider
+{
+    public const VALIDATORS = 'CHECKOUT_VALIDATORS';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(
+            self::VALIDATORS,
+            static fn (): array => [...$container->tagged('validators')],
+        );
+    }
+}
+```
+
+A tag declared in `gacela.php` reaches **every** module's container, so a module
+can consume a tag it did not declare — which is what makes a tag an extension
+point rather than just a list.
+
+A module that wants to *add* to a tag calls `Container::tag()` in its own
+Provider:
+
+```php
+public function provideModuleDependencies(Container $container): void
+{
+    $container->tag(CardValidator::class, 'validators');
+    // tagged('validators') here now yields the app-wide ids plus CardValidator
+}
+```
+
+That contribution stays in **that module's** container. Two modules tagging
+under the same label do not collide and do not see each other's additions; each
+sees the app-wide set plus its own. That is deliberate — module containers are
+separate, and a tag is not a back channel between modules.
+
+### Keyed — the one implementation for this key
+
+A command bus, a message dispatcher, anything that picks a handler by a business
+key. Use `addHandlerRegistry()`:
+
+```php
+$config->addHandlerRegistry(HandlerRegistry::class, [
+    'email' => EmailHandler::class,
+    'sms' => SmsHandler::class,
+]);
+```
+
+```php
+$registry = $this->getProvidedDependency(HandlerRegistry::class);
+$handler = $registry->get('email');
+```
+
+Both resolve their members through the container and both instantiate lazily.
+They are not two ways to do one thing: a registry answers *"the handler for this
+key"* and throws on an unknown one, while a tag answers *"all of these"* and has
+no notion of a key to miss.
 
 ## Read a config value
 

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -40,6 +40,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string handlerRegistries = 'handlerRegistries';
 
+    public const string tags = 'tags';
+
     public const string lazyServices = 'lazyServices';
 
     public const string plugins = 'plugins';
@@ -75,6 +77,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_CONTEXTUAL_BINDINGS = [];
 
     protected const array DEFAULT_HANDLER_REGISTRIES = [];
+
+    protected const array DEFAULT_TAGS = [];
 
     protected const array DEFAULT_LAZY_SERVICES = [];
 

--- a/src/Framework/Bootstrap/ContainerConfigurationInterface.php
+++ b/src/Framework/Bootstrap/ContainerConfigurationInterface.php
@@ -14,6 +14,7 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
  * @psalm-type ServiceAliasMap = array<string, string>
  * @psalm-type ServicesToExtendMap = array<string, list<Closure>>
  * @psalm-type HandlerRegistriesMap = array<string, array<string|int, class-string>>
+ * @psalm-type TagsMap = array<string, list<string>>
  * @psalm-type ContextualBindingsMap = array<string, array<string, mixed>>
  */
 interface ContainerConfigurationInterface
@@ -54,6 +55,15 @@ interface ContainerConfigurationInterface
      * @return HandlerRegistriesMap
      */
     public function getHandlerRegistries(): array;
+
+    /**
+     * Service identifiers grouped under a label, resolvable together through
+     * `Container::tagged()`. Unkeyed, where a handler registry is keyed: a tag
+     * answers "every implementation of this", not "the one for this key".
+     *
+     * @return TagsMap
+     */
+    public function getTags(): array;
 
     /**
      * Services instantiated on first access rather than at container build.

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -18,6 +18,7 @@ use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use InvalidArgumentException;
 
 use function array_key_exists;
+use function is_array;
 use function sprintf;
 
 /**
@@ -28,6 +29,7 @@ use function sprintf;
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type SpecificListenersMap from \Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher
  */
@@ -85,6 +87,9 @@ final class GacelaConfig
 
     /** @var HandlerRegistriesMap */
     private array $handlerRegistries = [];
+
+    /** @var TagsMap */
+    private array $tags = [];
 
     /** @var ServiceFactoryMap */
     private array $lazyServices = [];
@@ -458,6 +463,46 @@ final class GacelaConfig
     }
 
     /**
+     * Group service identifiers under a label so a module can ask for "every
+     * service tagged X" without knowing who registered them. Resolve the group
+     * with `Container::tagged($tag)`, which instantiates each id lazily, in the
+     * order it was tagged.
+     *
+     * Example:
+     * ```php
+     * $config->tag([EmailValidator::class, SmsValidator::class], 'validators');
+     *
+     * // in a Provider
+     * $container->set('validators', static fn (Container $c) => $c->tagged('validators'));
+     * ```
+     *
+     * Declared here, a tag reaches every module's container, so any module can
+     * consume it. A module that wants to *add* to a tag calls `Container::tag()`
+     * in its own Provider: that stays local to that module's container, which is
+     * what keeps one module's contribution from leaking into a sibling's.
+     *
+     * Complementary to {@see addHandlerRegistry()}, not a replacement for it: a
+     * registry is keyed and answers "the handler for this key" (a command bus);
+     * a tag is unkeyed and answers "every implementation of this" (validators,
+     * listeners). See docs/getting-a-dependency.md.
+     *
+     * Repeated calls add to the tag rather than replacing it. An id tagged twice
+     * is only yielded once -- deduplication is left to the container's tag
+     * registry, which does it anyway, rather than done again here.
+     *
+     * @param string|list<string> $ids one identifier, or several, to put under the tag
+     * @param string $tag the label the group is resolved by
+     */
+    public function tag(string|array $ids, string $tag): self
+    {
+        foreach (is_array($ids) ? $ids : [$ids] as $id) {
+            $this->tags[$tag][] = $id;
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a new invokable class that can extend the GacelaConfig object.
      *
      * This configClass will receive the GacelaConfig object as argument to the __invoke() method.
@@ -546,6 +591,7 @@ final class GacelaConfig
             $this->contextualBindings,
             $this->handlerRegistries,
             $this->lazyServices,
+            $this->tags,
         );
     }
 

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -20,6 +20,7 @@ use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type SpecificListenersMap from ConfigurableEventDispatcher
@@ -42,6 +43,7 @@ final class GacelaConfigTransfer
      * @param ContextualBindingsMap $contextualBindings
      * @param HandlerRegistriesMap $handlerRegistries
      * @param ServiceFactoryMap $lazyServices
+     * @param TagsMap $tags
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,
@@ -66,6 +68,7 @@ final class GacelaConfigTransfer
         public readonly array $contextualBindings,
         public readonly array $handlerRegistries = [],
         public readonly array $lazyServices = [],
+        public readonly array $tags = [],
     ) {
     }
 }

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -23,6 +23,7 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type SpecificListenersMap from ConfigurableEventDispatcher
@@ -98,6 +99,9 @@ final class Properties
 
     /** @var ?HandlerRegistriesMap */
     public ?array $handlerRegistries = null;
+
+    /** @var ?TagsMap */
+    public ?array $tags = null;
 
     public function __construct()
     {

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -21,6 +21,7 @@ use function array_unique;
  * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  */
@@ -123,6 +124,24 @@ final class PropertyMerger
         $this->setup->setHandlerRegistries(
             $this->mergeNested($this->setup->getHandlerRegistries(), $list),
         );
+    }
+
+    /**
+     * A tag is a collection, so the later setup adds to it rather than replacing
+     * it -- and an id both setups declared appears once, matching what the
+     * container's own tag registry does.
+     *
+     * @param TagsMap $list
+     */
+    public function mergeTags(array $list): void
+    {
+        $merged = $this->setup->getTags();
+
+        foreach ($list as $tag => $ids) {
+            $merged[$tag] = array_values(array_unique(array_merge($merged[$tag] ?? [], $ids)));
+        }
+
+        $this->setup->setTags($merged);
     }
 
     /**

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -40,6 +40,7 @@ final class SetupInitializer
             ->setAliases($dto->aliases)
             ->setContextualBindings($dto->contextualBindings)
             ->setHandlerRegistries($dto->handlerRegistries)
+            ->setTags($dto->tags)
             ->setLazyServices($dto->lazyServices);
     }
 }

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -36,6 +36,7 @@ final class SetupMerger
         $this->whenChanged($other, SetupGacela::aliases, fn () => $this->original->mergeAliases($other->getAliases()));
         $this->whenChanged($other, SetupGacela::contextualBindings, fn () => $this->original->mergeContextualBindings($other->getContextualBindings()));
         $this->whenChanged($other, SetupGacela::handlerRegistries, fn () => $this->original->mergeHandlerRegistries($other->getHandlerRegistries()));
+        $this->whenChanged($other, SetupGacela::tags, fn () => $this->original->mergeTags($other->getTags()));
         $this->whenChanged($other, SetupGacela::lazyServices, fn () => $this->original->mergeLazyServices($other->getLazyServices()));
         $this->whenChanged($other, SetupGacela::plugins, fn () => $this->original->mergePlugins($other->getPlugins()));
         $this->whenChanged($other, SetupGacela::gacelaConfigsToExtend, fn () => $this->original->mergeGacelaConfigsToExtend($other->getGacelaConfigsToExtend()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -32,6 +32,7 @@ use function sprintf;
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type SpecificListenersMap from \Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher
  */
@@ -330,6 +331,14 @@ final class SetupGacela extends AbstractSetupGacela
     public function getHandlerRegistries(): array
     {
         return $this->properties->handlerRegistries ?? self::DEFAULT_HANDLER_REGISTRIES;
+    }
+
+    /**
+     * @return TagsMap
+     */
+    public function getTags(): array
+    {
+        return $this->properties->tags ?? self::DEFAULT_TAGS;
     }
 
     /**
@@ -659,6 +668,30 @@ final class SetupGacela extends AbstractSetupGacela
         );
 
         return $this;
+    }
+
+    /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
+     * @param ?TagsMap $list
+     */
+    public function setTags(?array $list): self
+    {
+        $this->properties->tags = $this->setPropertyWithTracking(
+            self::tags,
+            $list,
+            self::DEFAULT_TAGS,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param TagsMap $list
+     */
+    public function mergeTags(array $list): void
+    {
+        $this->propertyMerger->mergeTags($list);
     }
 
     /**

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -442,6 +442,12 @@ final class Container implements ContainerInterface
             );
         }
 
+        // After the ids they name are registered, so a tagged binding is already
+        // resolvable; before lazy services only because tagging never resolves.
+        foreach ($containerConfig->getTags() as $tag => $ids) {
+            $container->tag($ids, $tag);
+        }
+
         foreach ($containerConfig->getLazyServices() as $id => $lazyFactory) {
             $container->set($id, $container->factory(static fn (): mixed => $lazyFactory($container)));
             self::notifyBindingRegistered($id);

--- a/src/Framework/Plugins/LazyHandlerRegistry.php
+++ b/src/Framework/Plugins/LazyHandlerRegistry.php
@@ -23,7 +23,15 @@ use function sprintf;
  */
 final class LazyHandlerRegistry implements HandlerRegistry
 {
-    /** @var array<string|int, object> */
+    /**
+     * Deliberately a second cache, not an oversight: the container caches by
+     * binding style, so a handler bound as a factory would be rebuilt on every
+     * `get()`. The registry's own contract is that a key resolves to one handler
+     * for the registry's lifetime, and that has to hold regardless of how the
+     * handler happens to be bound.
+     *
+     * @var array<string|int, object>
+     */
     private array $resolved = [];
 
     /**

--- a/tests/Feature/Framework/ContainerTags/Checkout/CardValidator.php
+++ b/tests/Feature/Framework/ContainerTags/Checkout/CardValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Checkout;
+
+use GacelaTest\Feature\Framework\ContainerTags\Validation\ValidatorInterface;
+
+final class CardValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'card';
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Checkout/Facade.php
+++ b/tests/Feature/Framework/ContainerTags/Checkout/Facade.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Checkout;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    /**
+     * @return list<string>
+     */
+    public function validatorNames(): array
+    {
+        return $this->getFactory()->createValidatorNames();
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Checkout/Factory.php
+++ b/tests/Feature/Framework/ContainerTags/Checkout/Factory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Checkout;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Feature\Framework\ContainerTags\Validation\ValidatorInterface;
+
+use function array_map;
+
+/**
+ * @method Provider getProvider()
+ */
+final class Factory extends AbstractFactory
+{
+    /**
+     * @return list<string>
+     */
+    public function createValidatorNames(): array
+    {
+        /** @var list<ValidatorInterface> $validators */
+        $validators = $this->getProvidedDependency(Provider::VALIDATORS);
+
+        return array_map(
+            static fn (ValidatorInterface $validator): string => $validator->name(),
+            $validators,
+        );
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Checkout/Provider.php
+++ b/tests/Feature/Framework/ContainerTags/Checkout/Provider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Checkout;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class Provider extends AbstractProvider
+{
+    public const VALIDATORS = 'CHECKOUT_VALIDATORS';
+
+    public const TAG = 'validators';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        // Adds to the app-wide tag, for this module's container only.
+        $container->tag(CardValidator::class, self::TAG);
+
+        $container->set(
+            self::VALIDATORS,
+            static fn (): array => [...$container->tagged(self::TAG)],
+        );
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/FeatureTest.php
+++ b/tests/Feature/Framework/ContainerTags/FeatureTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\ContainerTags\Validation\EmailValidator;
+use GacelaTest\Feature\Framework\ContainerTags\Validation\NotEmptyValidator;
+use PHPUnit\Framework\TestCase;
+
+use function array_slice;
+
+final class FeatureTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->tag([NotEmptyValidator::class, EmailValidator::class], 'validators');
+        });
+    }
+
+    public function test_a_module_consumes_an_app_wide_tag_it_did_not_declare(): void
+    {
+        $names = (new Checkout\Facade())->validatorNames();
+
+        // The two app-wide validators come first, in the order they were tagged.
+        self::assertSame(['not-empty', 'email'], array_slice($names, 0, 2));
+    }
+
+    public function test_a_module_adds_its_own_service_to_the_app_wide_tag(): void
+    {
+        self::assertSame(
+            ['not-empty', 'email', 'card'],
+            (new Checkout\Facade())->validatorNames(),
+        );
+    }
+
+    public function test_one_module_local_contribution_does_not_leak_into_a_sibling(): void
+    {
+        // Both modules tag under 'validators', but each tags into its own
+        // container -- so Shipping sees the app-wide pair plus its own, and
+        // never Checkout's.
+        self::assertSame(
+            ['not-empty', 'email', 'address'],
+            (new Shipping\Facade())->validatorNames(),
+        );
+
+        self::assertSame(
+            ['not-empty', 'email', 'card'],
+            (new Checkout\Facade())->validatorNames(),
+        );
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Shipping/AddressValidator.php
+++ b/tests/Feature/Framework/ContainerTags/Shipping/AddressValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Shipping;
+
+use GacelaTest\Feature\Framework\ContainerTags\Validation\ValidatorInterface;
+
+final class AddressValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'address';
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Shipping/Facade.php
+++ b/tests/Feature/Framework/ContainerTags/Shipping/Facade.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Shipping;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    /**
+     * @return list<string>
+     */
+    public function validatorNames(): array
+    {
+        return $this->getFactory()->createValidatorNames();
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Shipping/Factory.php
+++ b/tests/Feature/Framework/ContainerTags/Shipping/Factory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Shipping;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Feature\Framework\ContainerTags\Validation\ValidatorInterface;
+
+use function array_map;
+
+/**
+ * @method Provider getProvider()
+ */
+final class Factory extends AbstractFactory
+{
+    /**
+     * @return list<string>
+     */
+    public function createValidatorNames(): array
+    {
+        /** @var list<ValidatorInterface> $validators */
+        $validators = $this->getProvidedDependency(Provider::VALIDATORS);
+
+        return array_map(
+            static fn (ValidatorInterface $validator): string => $validator->name(),
+            $validators,
+        );
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Shipping/Provider.php
+++ b/tests/Feature/Framework/ContainerTags/Shipping/Provider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Shipping;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class Provider extends AbstractProvider
+{
+    public const VALIDATORS = 'SHIPPING_VALIDATORS';
+
+    public const TAG = 'validators';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->tag(AddressValidator::class, self::TAG);
+
+        $container->set(
+            self::VALIDATORS,
+            static fn (): array => [...$container->tagged(self::TAG)],
+        );
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Validation/EmailValidator.php
+++ b/tests/Feature/Framework/ContainerTags/Validation/EmailValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Validation;
+
+final class EmailValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'email';
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Validation/NotEmptyValidator.php
+++ b/tests/Feature/Framework/ContainerTags/Validation/NotEmptyValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Validation;
+
+final class NotEmptyValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'not-empty';
+    }
+}

--- a/tests/Feature/Framework/ContainerTags/Validation/ValidatorInterface.php
+++ b/tests/Feature/Framework/ContainerTags/Validation/ValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerTags\Validation;
+
+interface ValidatorInterface
+{
+    public function name(): string;
+}

--- a/tests/Integration/Framework/Container/ContainerTagsTest.php
+++ b/tests/Integration/Framework/Container/ContainerTagsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\Container\Tagged\EmailValidator;
+use GacelaTest\Integration\Framework\Container\Tagged\PushValidator;
+use GacelaTest\Integration\Framework\Container\Tagged\SmsValidator;
+use GacelaTest\Integration\Framework\Container\Tagged\ValidatorInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function array_map;
+use function iterator_to_array;
+
+final class ContainerTagsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        (new ReflectionClass(Gacela::class))->getMethod('resetCache')->invoke(null);
+    }
+
+    public function test_an_app_wide_tag_is_resolvable_from_the_container(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag([EmailValidator::class, SmsValidator::class], 'validators');
+        });
+
+        self::assertSame(['email', 'sms'], $this->namesTaggedIn(Gacela::container(), 'validators'));
+    }
+
+    public function test_a_single_id_does_not_have_to_be_wrapped_in_an_array(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag(EmailValidator::class, 'validators');
+        });
+
+        self::assertSame(['email'], $this->namesTaggedIn(Gacela::container(), 'validators'));
+    }
+
+    public function test_repeated_calls_add_to_the_same_tag_rather_than_replacing_it(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag(EmailValidator::class, 'validators');
+            $config->tag(SmsValidator::class, 'validators');
+        });
+
+        // A tag is a collection: the second call must not win over the first.
+        self::assertSame(['email', 'sms'], $this->namesTaggedIn(Gacela::container(), 'validators'));
+    }
+
+    public function test_the_same_id_tagged_twice_is_only_yielded_once(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag([EmailValidator::class, EmailValidator::class], 'validators');
+            $config->tag(EmailValidator::class, 'validators');
+        });
+
+        self::assertSame(['email'], $this->namesTaggedIn(Gacela::container(), 'validators'));
+    }
+
+    public function test_two_tags_stay_separate(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag(EmailValidator::class, 'validators');
+            $config->tag(SmsValidator::class, 'notifiers');
+        });
+
+        self::assertSame(['email'], $this->namesTaggedIn(Gacela::container(), 'validators'));
+        self::assertSame(['sms'], $this->namesTaggedIn(Gacela::container(), 'notifiers'));
+    }
+
+    public function test_an_unknown_tag_yields_nothing(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag(EmailValidator::class, 'validators');
+        });
+
+        self::assertSame([], $this->namesTaggedIn(Gacela::container(), 'nobody-registered-this'));
+    }
+
+    public function test_a_tagged_id_is_resolved_through_the_container_so_a_binding_is_honoured(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->addBinding(ValidatorInterface::class, PushValidator::class);
+            $config->tag(ValidatorInterface::class, 'validators');
+        });
+
+        // The tag names the interface; what comes out is what the binding says.
+        self::assertSame(['push'], $this->namesTaggedIn(Gacela::container(), 'validators'));
+    }
+
+    public function test_app_wide_tags_reach_a_module_container(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag([EmailValidator::class, SmsValidator::class], 'validators');
+        });
+
+        // A module's container is seeded from the same app config, which is what
+        // lets a Provider consume a tag it did not declare.
+        $moduleContainer = Container::withConfig(Config::getInstance());
+
+        self::assertSame(['email', 'sms'], $this->namesTaggedIn($moduleContainer, 'validators'));
+    }
+
+    public function test_a_module_local_tag_extends_the_app_wide_one_for_that_module_only(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->tag(EmailValidator::class, 'validators');
+        });
+
+        $moduleContainer = Container::withConfig(Config::getInstance());
+        $moduleContainer->tag(PushValidator::class, 'validators');
+
+        self::assertSame(['email', 'push'], $this->namesTaggedIn($moduleContainer, 'validators'));
+
+        // ...and a sibling module, built from the same config, is unaffected:
+        // module containers are separate, so a module-local tag cannot leak.
+        $sibling = Container::withConfig(Config::getInstance());
+        self::assertSame(['email'], $this->namesTaggedIn($sibling, 'validators'));
+    }
+
+    /**
+     * @param callable(GacelaConfig):void $configFn
+     */
+    private function bootstrapWith(callable $configFn): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
+            $config->resetInMemoryCache();
+            $configFn($config);
+        });
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function namesTaggedIn(Container $container, string $tag): array
+    {
+        /** @var list<ValidatorInterface> $validators */
+        $validators = iterator_to_array($container->tagged($tag), false);
+
+        return array_map(
+            static fn (ValidatorInterface $validator): string => $validator->name(),
+            $validators,
+        );
+    }
+}

--- a/tests/Integration/Framework/Container/Tagged/EmailValidator.php
+++ b/tests/Integration/Framework/Container/Tagged/EmailValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container\Tagged;
+
+final class EmailValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'email';
+    }
+}

--- a/tests/Integration/Framework/Container/Tagged/PushValidator.php
+++ b/tests/Integration/Framework/Container/Tagged/PushValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container\Tagged;
+
+final class PushValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'push';
+    }
+}

--- a/tests/Integration/Framework/Container/Tagged/SmsValidator.php
+++ b/tests/Integration/Framework/Container/Tagged/SmsValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container\Tagged;
+
+final class SmsValidator implements ValidatorInterface
+{
+    public function name(): string
+    {
+        return 'sms';
+    }
+}

--- a/tests/Integration/Framework/Container/Tagged/ValidatorInterface.php
+++ b/tests/Integration/Framework/Container/Tagged/ValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container\Tagged;
+
+interface ValidatorInterface
+{
+    public function name(): string;
+}

--- a/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
+++ b/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
@@ -206,6 +206,43 @@ final class SetupMergerTest extends TestCase
         self::assertSame('RedisCache', $contextualBindings[stdClass::class]['CacheInterface']);
     }
 
+    public function test_merge_tags_from_two_setups(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->tag('service-a', 'tag-a');
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->tag('service-b', 'tag-b');
+        });
+
+        $merged = $setup1->merge($setup2);
+
+        $tags = $merged->getTags();
+        self::assertSame(['service-a'], $tags['tag-a'] ?? null);
+        self::assertSame(['service-b'], $tags['tag-b'] ?? null);
+    }
+
+    public function test_merge_the_same_tag_from_two_setups_unions_its_ids(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->tag(['service-a', 'shared'], 'validators');
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->tag(['shared', 'service-b'], 'validators');
+        });
+
+        $merged = $setup1->merge($setup2);
+
+        // A tag is a collection, so the later setup adds to it rather than
+        // replacing it -- and an id both setups declared appears once.
+        self::assertSame(
+            ['service-a', 'shared', 'service-b'],
+            $merged->getTags()['validators'] ?? null,
+        );
+    }
+
     public function test_merge_handler_registries_from_two_setups(): void
     {
         $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

The container has shipped `tag(string|array $ids, string $tag)` and `tagged(string $tag): iterable` for a while, and Gacela's decorator forwards both. Nothing in Gacela ever called them, and `GacelaConfig` offered no way to reach them — the public surface had `addBinding`, `addBindingIf`, `addFactory`, `addProtected`, `addAlias`, `addLazy`, `extendService` and `when`, but no `tag`.

Meanwhile Gacela shipped its own collection primitive for an adjacent job: `addHandlerRegistry()`, backed by `LazyHandlerRegistry`. So the only collection a user could actually reach was the **keyed** one, and it had to be bent into jobs it does not fit.

This makes tagging reachable and gives the two primitives one intent each.

```php
// gacela.php — reaches every module's container
$config->tag([NotEmptyValidator::class, EmailValidator::class], 'validators');

// a module adds its own, in its Provider
$container->tag(CardValidator::class, 'validators');
$container->set('validators', static fn (): array => [...$container->tagged('validators')]);
```

**On the open question in the issue** — whether tags belong in `GacelaConfig` (app-wide) or in a module's `Provider` (module-local) — the answer is both, and it needed no new machinery on the Provider side: `Container::tag()` was already forwarded, and every module container is seeded from the same app config by `Container::withConfig()`. So an app-wide tag reaches every module, and a Provider adds to it locally.

The module-local key collision that #539 describes does not bite here, and it is worth being precise about why: module containers are **separate**, so two modules tagging under the same label do not overwrite each other — each sees the app-wide set plus its own, and never the sibling's. That is the behaviour, not a limitation. A tag is not a back channel between modules.

Closes #567

## 🔖 Changes

- **`GacelaConfig::tag(string|array $ids, string $tag)`**, threaded through `GacelaConfigTransfer` → `Properties` → `SetupInitializer` → `SetupGacela` → `ContainerConfigurationInterface::getTags()`, and applied in `Container::withContainerConfiguration()` after the ids it names are registered
- **`PropertyMerger::mergeTags()`** — a tag is a collection, so a second config source adds to it rather than replacing it, and an id both sources declared appears once. `mergeNested` was not reusable here: it merges *maps*, and a tag's payload is a list
- **Consumption** needed nothing new. `tagged()` was already forwarded; the documented path is a Provider turning it into a provided dependency, which is what the issue proposed
- **`LazyHandlerRegistry` keeps its own `$resolved` cache**, and the reason is now in the code rather than implied: the container caches by binding style, so a handler bound as a factory would be rebuilt on every `get()`, while the registry's contract is that a key resolves to one handler for the registry's lifetime. Not the duplicate-cache pattern #539 exists to stop — the two answer different questions
- **`docs/getting-a-dependency.md`** gains a "collect several implementations" section. That doc names one primary path per intent, and this intent had none. Unkeyed set you iterate → `tag()`; keyed lookup that throws on a miss → `addHandlerRegistry()`
- Tests: `ContainerTagsTest` (integration) covers the app-wide path, single-id vs list, additive repeat calls, tag isolation, binding resolution through a tagged interface, and module-local containment; `ContainerTags/FeatureTest` drives it end-to-end through two real modules with Providers, Factories and Facades, pinning that one module's contribution does not leak into a sibling; `SetupMergerTest` covers merging and the union of a shared tag
- 100% MSI on every changed file

## 🧹 Refactor pass

One change came out of it, and mutation testing is what surfaced it: `GacelaConfig::tag()` originally deduplicated ids as it collected them, but the container's own `TagRegistry` already deduplicates, so that branch could not be observed from any test — it was redundant code with an untestable branch. Removed, with a comment saying where deduplication actually happens.
