### PR TITLE
feat(bootstrap): reach the container's load()/loadFile() for declarative bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md) — and run 
 
 ### Added
 
+- **`GacelaConfig::loadDefinitions()` — wiring as data.** The container has shipped `load(array)` and `loadFile(string)` since 1.0 and nothing in Gacela could reach either, so every binding had to be a method call inside a PHP closure. That is fine when a human writes it and wrong when the wiring is generated, shared between environments, or reviewed as a diff.
+  ```php
+  // gacela.php
+  $config->loadDefinitions([
+      LoggerInterface::class => FileLogger::class,
+      Database::class => ['singleton' => DatabasePool::class],
+      'db.dsn' => ['value' => 'pgsql://localhost/app'],
+  ]);
+  $config->loadDefinitions(__DIR__ . '/config/services.json');
+  ```
+  Each entry ends up calling the registration method it stands for, so a definition behaves exactly like the imperative call it replaces. Applies **app-wide**, reaching every module container, the way `addBinding()` already does; `Container::load()`/`loadFile()` are now forwarded on the decorator too, so a Provider can scope definitions to its own module. Sources apply in declaration order and **after** the imperative registrations — a later source overrides an earlier one, and a definitions file overrides `addBinding()`, which is the whole job of an environment override file; `tags` accumulate instead. Paths are used **as given**, not rebased under the app root the way `enableFileCache()` rebases its directory, so write them with `__DIR__`. YAML stays out: neither the container nor Gacela takes a parser dependency for it — pass `Yaml::parseFile(...)` as the array
 - **`GacelaConfig::afterResolving()` — a post-construction hook.** There was no supported way to say "after anything implementing `LoggerAwareInterface` is built, hand it the logger". The two adjacent tools solve adjacent but different problems: `extendService()` *replaces* what comes out, which is right for decoration and wrong for calling a setter on an instance you would have to know and rebuild to touch; and the event listeners *observe*, with `BindingRegisteredEvent` firing at registration rather than at resolution and handing you an event object rather than the instance.
   ```php
   $config->afterResolving(

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -393,6 +393,60 @@ final class CheckoutFactory extends AbstractFactory
 - Additive and opt-in: existing `getProvidedDependency()` and hand-wired
   `create*()` methods keep working unchanged.
 
+## Definitions as Data
+
+Every binding above is a method call in a closure. When the wiring is generated,
+shared between environments, or reviewed as a diff, you want it as *data* instead
+— `loadDefinitions()` takes a definitions array, or the path of a `.php` file
+returning one or a `.json` file holding one:
+
+```php
+return static function (GacelaConfig $config): void {
+    $config->loadDefinitions([
+        LoggerInterface::class => FileLogger::class,              // interface => concrete
+        Database::class => ['singleton' => DatabasePool::class],  // explicit lifetime
+        'db.dsn' => ['value' => 'pgsql://localhost/app'],         // a config value
+        'logger' => ['alias' => LoggerInterface::class],
+        Metrics::class => ['singleton' => Metrics::class, 'tags' => ['reporters']],
+    ]);
+
+    $config->loadDefinitions(__DIR__ . '/config/services.json');
+};
+```
+
+Each entry ends up calling the registration method it stands for, so a definition
+behaves exactly like the imperative call it replaces.
+
+**Ordering.** Sources apply in the order declared, and *after* the imperative
+registrations — so a later source overrides an earlier one, and a definitions file
+overrides `addBinding()`. That is the point: an environment override file that lost
+to the code it is meant to override could not do its job. `tags` accumulate instead
+of overriding, the way `tag()` does.
+
+**Scope.** App-wide, reaching every module container, like `addBinding()`. For
+definitions local to one module, call `Container::load()` in that module's Provider:
+
+```php
+final class Provider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->load([Clock::class => SystemClock::class]);
+    }
+}
+```
+
+**Paths are used as given.** Unlike `enableFileCache()`, a definitions path is not
+rebased under the application root — write it with `__DIR__`. A missing, unreadable
+or unparsable file throws rather than leaving the wiring half-applied.
+
+**No YAML.** Neither the container nor gacela takes a parser dependency for it. Pass
+the parsed array instead:
+
+```php
+$config->loadDefinitions(Yaml::parseFile(__DIR__ . '/services.yaml'));
+```
+
 ## Quick Reference
 
 | Type | Behavior | Use Case |
@@ -406,6 +460,7 @@ final class CheckoutFactory extends AbstractFactory
 | `#[Inject]` | Constructor-param opt-in | Explicit concrete override, tool visibility |
 | `#[Singleton]` | One cached instance per container | Shared stateful services, no registration needed |
 | `#[Factory]` | New instance each resolution | Explicit fresh-instance intent on the class |
+| `loadDefinitions()` | Bindings described as data | Generated, shared or per-environment wiring |
 
 ## Example
 
@@ -432,12 +487,9 @@ return static function (GacelaConfig $config): void {
 The `gacela-project/container` package offers a few capabilities that gacela
 deliberately keeps internal, to avoid two ways of doing the same thing:
 
-- **Service tagging** (`tag()` / `tagged()`): use [`addHandlerRegistry()`](events.md)
-  instead. Handler registries are a superset — lazily resolved, keyed dispatch
-  tables, frozen after boot — so a flat tag group would only duplicate a weaker
-  version of the same idea.
-- **`afterResolving()` hooks**: use the [`ServiceResolvedEvent`](events.md) instead.
-  It is the gacela-native, zero-cost-when-unused way to react to resolution.
+- **`createScope()`**: request-lifetime containers need a parent/child primitive
+  the container does not have yet, and a scope seam gacela has not drawn. Tracked
+  in the 2.1 consolidation.
 - **`make()` with runtime parameters**: kept internal. One-off construction with
   ad-hoc overrides encourages service location; resolve through your module's
   Factory instead.

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -440,6 +440,11 @@ final class Provider extends AbstractProvider
 rebased under the application root — write it with `__DIR__`. A missing, unreadable
 or unparsable file throws rather than leaving the wiring half-applied.
 
+**No `BindingRegisteredEvent`.** Definitions register bindings but do not announce
+them: the loader is an upstream internal, so naming what a source registered would
+mean reconstructing it from the container's registries — which misses aliases. A
+listener counting registrations sees the imperative ones only.
+
 **No YAML.** Neither the container nor gacela takes a parser dependency for it. Pass
 the parsed array instead:
 

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -244,6 +244,7 @@ actually yours.
 | `extendService('id', fn)` | decorating a service registered elsewhere — *replacing* what comes out |
 | `afterResolving('id', fn)` | touching an instance after it is built without rebuilding it, e.g. a setter on every implementation of an interface |
 | `when(X)->needs(Y)->give(Z)` | one consumer needs a different implementation than everyone else |
+| `loadDefinitions([...])` / `loadDefinitions('file.json')` | the wiring is generated, shared between environments, or reviewed as a diff — see [container-configuration](container-configuration.md#definitions-as-data) |
 | `addExternalService()` | handing a framework object (Symfony kernel, PSR container) to Gacela at bootstrap |
 | `$container->get('id')` inside a Provider | wiring one provided service from another |
 | `#[Singleton]` / `#[Factory]` on a class | declaring **lifetime**, which is a different question from lookup |

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -46,6 +46,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string lazyServices = 'lazyServices';
 
+    public const string definitions = 'definitions';
+
     public const string plugins = 'plugins';
 
     public const string gacelaConfigsToExtend = 'gacelaConfigsToExtend';
@@ -85,6 +87,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_AFTER_RESOLVING_CALLBACKS = [];
 
     protected const array DEFAULT_LAZY_SERVICES = [];
+
+    protected const array DEFAULT_DEFINITIONS = [];
 
     protected const array DEFAULT_GACELA_CONFIGS_TO_EXTEND = [];
 

--- a/src/Framework/Bootstrap/ContainerConfigurationInterface.php
+++ b/src/Framework/Bootstrap/ContainerConfigurationInterface.php
@@ -16,6 +16,7 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
  * @psalm-type HandlerRegistriesMap = array<string, array<string|int, class-string>>
  * @psalm-type TagsMap = array<string, list<string>>
  * @psalm-type AfterResolvingMap = array<string, list<Closure>>
+ * @psalm-type DefinitionSources = list<string|array<array-key, mixed>>
  * @psalm-type ContextualBindingsMap = array<string, array<string, mixed>>
  */
 interface ContainerConfigurationInterface
@@ -81,4 +82,13 @@ interface ContainerConfigurationInterface
      * @return ServiceFactoryMap
      */
     public function getLazyServices(): array;
+
+    /**
+     * Wiring described as data instead of as a closure: each source is either a
+     * definitions array or the path of a '.php'/'.json' file holding one, in the
+     * order they were declared.
+     *
+     * @return DefinitionSources
+     */
+    public function getDefinitions(): array;
 }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -31,6 +31,7 @@ use function sprintf;
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
+ * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type SpecificListenersMap from \Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher
  */
@@ -97,6 +98,9 @@ final class GacelaConfig
 
     /** @var ServiceFactoryMap */
     private array $lazyServices = [];
+
+    /** @var DefinitionSources */
+    private array $definitions = [];
 
     /**
      * @param ExternalServicesMap $externalServices
@@ -469,6 +473,51 @@ final class GacelaConfig
     }
 
     /**
+     * Register a whole set of bindings from *data* rather than from a closure,
+     * so wiring that is generated, shared between environments, or diffed in
+     * review does not have to be written as a sequence of method calls.
+     *
+     * Pass the definitions inline, or the path of a '.php' file returning an
+     * array or a '.json' file holding an object:
+     * ```php
+     * $config->loadDefinitions([
+     *     LoggerInterface::class => FileLogger::class,
+     *     Database::class => ['singleton' => DatabasePool::class],
+     *     'db.dsn' => ['value' => 'pgsql://localhost/app'],
+     * ]);
+     * $config->loadDefinitions(__DIR__ . '/services.json');
+     * ```
+     *
+     * Applies app-wide, reaching every module's container, which is how
+     * {@see addBinding()} already behaves. A module that wants definitions of
+     * its own calls `Container::load()` in its Provider, keeping them local to
+     * that module's container.
+     *
+     * Every entry ends up calling the registration method it stands for, so a
+     * definition behaves exactly like the imperative call it replaces. Sources
+     * are applied in the order declared, and *after* the imperative
+     * registrations: a later source overrides an earlier one, and a definitions
+     * file overrides `addBinding()`, which is what a per-environment override
+     * file is loaded to do. Tags accumulate instead of overriding.
+     *
+     * The path is used as given -- unlike {@see enableFileCache()} it is not
+     * rebased under the application root, so write it with `__DIR__`. A missing
+     * or unparsable file throws rather than leaving the wiring half-applied.
+     *
+     * YAML is deliberately not supported: there is no parser in the container,
+     * and neither it nor Gacela takes a second runtime dependency for one. Pass
+     * `Yaml::parseFile('services.yaml')` as the array instead.
+     *
+     * @param string|array<array-key, mixed> $definitions a definitions array, or the path of a '.php'/'.json' file holding one
+     */
+    public function loadDefinitions(string|array $definitions): self
+    {
+        $this->definitions[] = $definitions;
+
+        return $this;
+    }
+
+    /**
      * Define contextual bindings - different implementations based on the requesting class.
      * This allows you to provide different implementations of an interface depending on
      * which class is requesting it.
@@ -638,6 +687,7 @@ final class GacelaConfig
             $this->lazyServices,
             $this->tags,
             $this->afterResolvingCallbacks,
+            $this->definitions,
         );
     }
 

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -22,6 +22,7 @@ use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
+ * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type SpecificListenersMap from ConfigurableEventDispatcher
@@ -46,6 +47,7 @@ final class GacelaConfigTransfer
      * @param ServiceFactoryMap $lazyServices
      * @param TagsMap $tags
      * @param AfterResolvingMap $afterResolvingCallbacks
+     * @param DefinitionSources $definitions
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,
@@ -72,6 +74,7 @@ final class GacelaConfigTransfer
         public readonly array $lazyServices = [],
         public readonly array $tags = [],
         public readonly array $afterResolvingCallbacks = [],
+        public readonly array $definitions = [],
     ) {
     }
 }

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -25,6 +25,7 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
+ * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type SpecificListenersMap from ConfigurableEventDispatcher
@@ -106,6 +107,9 @@ final class Properties
 
     /** @var ?AfterResolvingMap */
     public ?array $afterResolvingCallbacks = null;
+
+    /** @var ?DefinitionSources */
+    public ?array $definitions = null;
 
     public function __construct()
     {

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -23,6 +23,7 @@ use function array_unique;
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
+ * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  */
@@ -160,6 +161,18 @@ final class PropertyMerger
         }
 
         $this->setup->setAfterResolvingCallbacks($merged);
+    }
+
+    /**
+     * Sources are an ordered layer stack, not a keyed map, so the later setup's
+     * sources go on top: they are the overrides, and the container applies the
+     * last one to register.
+     *
+     * @param DefinitionSources $list
+     */
+    public function mergeDefinitions(array $list): void
+    {
+        $this->setup->setDefinitions([...$this->setup->getDefinitions(), ...$list]);
     }
 
     /**

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -42,6 +42,7 @@ final class SetupInitializer
             ->setHandlerRegistries($dto->handlerRegistries)
             ->setTags($dto->tags)
             ->setAfterResolvingCallbacks($dto->afterResolvingCallbacks)
-            ->setLazyServices($dto->lazyServices);
+            ->setLazyServices($dto->lazyServices)
+            ->setDefinitions($dto->definitions);
     }
 }

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -39,6 +39,7 @@ final class SetupMerger
         $this->whenChanged($other, SetupGacela::tags, fn () => $this->original->mergeTags($other->getTags()));
         $this->whenChanged($other, SetupGacela::afterResolvingCallbacks, fn () => $this->original->mergeAfterResolvingCallbacks($other->getAfterResolvingCallbacks()));
         $this->whenChanged($other, SetupGacela::lazyServices, fn () => $this->original->mergeLazyServices($other->getLazyServices()));
+        $this->whenChanged($other, SetupGacela::definitions, fn () => $this->original->mergeDefinitions($other->getDefinitions()));
         $this->whenChanged($other, SetupGacela::plugins, fn () => $this->original->mergePlugins($other->getPlugins()));
         $this->whenChanged($other, SetupGacela::gacelaConfigsToExtend, fn () => $this->original->mergeGacelaConfigsToExtend($other->getGacelaConfigsToExtend()));
 

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -34,6 +34,7 @@ use function sprintf;
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
+ * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  * @psalm-import-type ContextualBindingsMap from ContainerConfigurationInterface
  * @psalm-import-type SpecificListenersMap from \Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher
  */
@@ -356,6 +357,14 @@ final class SetupGacela extends AbstractSetupGacela
     public function getLazyServices(): array
     {
         return $this->properties->lazyServices ?? self::DEFAULT_LAZY_SERVICES;
+    }
+
+    /**
+     * @return DefinitionSources
+     */
+    public function getDefinitions(): array
+    {
+        return $this->properties->definitions ?? self::DEFAULT_DEFINITIONS;
     }
 
     public function setFileCacheEnabled(?bool $flag): self
@@ -741,6 +750,30 @@ final class SetupGacela extends AbstractSetupGacela
         );
 
         return $this;
+    }
+
+    /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
+     * @param ?DefinitionSources $list
+     */
+    public function setDefinitions(?array $list): self
+    {
+        $this->properties->definitions = $this->setPropertyWithTracking(
+            self::definitions,
+            $list,
+            self::DEFAULT_DEFINITIONS,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param DefinitionSources $list
+     */
+    public function mergeDefinitions(array $list): void
+    {
+        $this->propertyMerger->mergeDefinitions($list);
     }
 
     /**

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -21,6 +21,7 @@ use Throwable;
 use function array_keys;
 use function array_map;
 use function is_object;
+use function is_string;
 
 /**
  * Decorates the decoupled Container, adding the Locator and the service
@@ -344,6 +345,54 @@ final class Container implements ContainerInterface
     }
 
     /**
+     * Register a whole definition set from data rather than from a closure --
+     * the counterpart of `addBinding`/`addAlias`/`tag` for wiring that is
+     * generated, shared between environments, or diffed in review.
+     *
+     * ```php
+     * $container->load([
+     *     LoggerInterface::class => FileLogger::class,
+     *     'db.dsn' => ['value' => 'pgsql://localhost/app'],
+     * ]);
+     * ```
+     *
+     * Every entry ends up calling the registration method it stands for, so a
+     * definition behaves exactly like its imperative equivalent. Later keys
+     * override earlier ones, which is what makes layering base + overrides
+     * work; 'tags' accumulate instead, the way `tag()` does.
+     *
+     * Like {@see provides()} and {@see stats()}, declared on the concrete
+     * container upstream rather than on ContainerInterface -- 1.x promises
+     * nothing is added there -- so it is forwarded explicitly here.
+     *
+     * @param array<array-key, mixed> $definitions
+     */
+    public function load(array $definitions): void
+    {
+        $this->inner->load($definitions);
+    }
+
+    /**
+     * Load definitions from a '.php' file returning an array, or a '.json' file.
+     *
+     * The path is used as given. Unlike `GacelaConfig::enableFileCache()`, it is
+     * not rebased under the application root: a definitions file is referenced
+     * from the config that names it, so `__DIR__` is the honest way to write it
+     * and a silent rebase would only move where the failure appears.
+     *
+     * YAML stays out on purpose -- there is no parser in the container, and
+     * adding one means a second runtime dependency. Once here, the documented
+     * path is `$container->load(Yaml::parseFile('services.yaml'))`.
+     *
+     * @throws \Gacela\Container\Exception\ContainerException when the file is
+     *         missing, unreadable, of an unsupported type, or does not hold an array
+     */
+    public function loadFile(string $file): void
+    {
+        $this->inner->loadFile($file);
+    }
+
+    /**
      * @param class-string|list<class-string> $concrete
      */
     public function when(string|array $concrete): ContextualBindingBuilder
@@ -508,6 +557,16 @@ final class Container implements ContainerInterface
         foreach ($containerConfig->getLazyServices() as $id => $lazyFactory) {
             $container->set($id, $container->factory(static fn (): mixed => $lazyFactory($container)));
             self::notifyBindingRegistered($id);
+        }
+
+        // Last, so the data layer wins: a definitions file is loaded to override
+        // what the config declares imperatively, and could not do that from any
+        // earlier position. Sources apply in declaration order, so the last one
+        // wins among themselves too.
+        foreach ($containerConfig->getDefinitions() as $definitions) {
+            is_string($definitions)
+                ? $container->loadFile($definitions)
+                : $container->load($definitions);
         }
 
         return $container;

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -38,6 +38,7 @@ use function is_string;
  * @psalm-import-type StatsArray from \Gacela\Container\ContainerInterface
  * @psalm-import-type CompiledPlans from \Gacela\Container\DependencyResolver
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
+ * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  */
 final class Container implements ContainerInterface
 {
@@ -563,13 +564,34 @@ final class Container implements ContainerInterface
         // what the config declares imperatively, and could not do that from any
         // earlier position. Sources apply in declaration order, so the last one
         // wins among themselves too.
-        foreach ($containerConfig->getDefinitions() as $definitions) {
-            is_string($definitions)
-                ? $container->loadFile($definitions)
-                : $container->load($definitions);
-        }
+        $container->loadDefinitions($containerConfig->getDefinitions());
 
         return $container;
+    }
+
+    /**
+     * Apply the declared definition sources, in the order they were declared.
+     *
+     * No `BindingRegisteredEvent` is dispatched, deliberately. The loader is an
+     * upstream internal, so the only way to name what a source registered is to
+     * reconstruct it: a file's contents are not in hand here, and reading the
+     * ids back off the container catches `bind()` and `set()` definitions but
+     * not the aliases, which live in a third registry. A listener that counts
+     * registrations is better served by nothing than by an undercount it cannot
+     * see the shape of. Tracked against the upstream loader growing a way to
+     * report what it registered.
+     *
+     * @param DefinitionSources $sources
+     */
+    private function loadDefinitions(array $sources): void
+    {
+        foreach ($sources as $definitions) {
+            if (is_string($definitions)) {
+                $this->loadFile($definitions);
+            } else {
+                $this->load($definitions);
+            }
+        }
     }
 
     /**

--- a/tests/Feature/Framework/ContainerDefinitions/Billing/Facade.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Billing/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Billing;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function notifierName(): string
+    {
+        return $this->getFactory()->createInvoice()->notifierName();
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Billing/Factory.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Billing/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Billing;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createInvoice(): Invoice
+    {
+        return $this->make(Invoice::class);
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Billing/Invoice.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Billing/Invoice.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Billing;
+
+use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\NotifierInterface;
+
+final class Invoice
+{
+    public function __construct(
+        private readonly NotifierInterface $notifier,
+    ) {
+    }
+
+    public function notifierName(): string
+    {
+        return $this->notifier->name();
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/FeatureTest.php
+++ b/tests/Feature/Framework/ContainerDefinitions/FeatureTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\EmailNotifier;
+use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\NotifierInterface;
+use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\SmsNotifier;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * `loadDefinitions()` is the data-shaped counterpart of `addBinding()`: it hands
+ * Gacela a description of the wiring rather than a closure that performs it,
+ * which is what generated, shared or reviewed wiring needs.
+ *
+ * Each test bootstraps its own application, because the point being pinned is
+ * what a *different* set of definitions produces.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        (new ReflectionClass(Gacela::class))->getMethod('resetCache')->invoke(null);
+    }
+
+    public function test_a_definitions_array_wires_a_module(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->loadDefinitions([
+                NotifierInterface::class => EmailNotifier::class,
+            ]);
+        });
+
+        self::assertSame('email', (new Greeting\Facade())->notifierName());
+    }
+
+    public function test_a_definitions_file_wires_a_module(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->loadDefinitions(__DIR__ . '/services.json');
+        });
+
+        self::assertSame('sms', (new Greeting\Facade())->notifierName());
+    }
+
+    /**
+     * App-wide, matching how `addBinding()` already behaves: a module that never
+     * mentions the definition still resolves it.
+     */
+    public function test_the_definitions_reach_every_module_container(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->loadDefinitions([
+                NotifierInterface::class => EmailNotifier::class,
+            ]);
+        });
+
+        self::assertSame('email', (new Greeting\Facade())->notifierName());
+        self::assertSame('email', (new Billing\Facade())->notifierName());
+    }
+
+    /**
+     * The layering the feature exists for: load the base set, then an
+     * environment-specific one that overrides part of it.
+     */
+    public function test_a_later_source_overrides_an_earlier_one(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->loadDefinitions([NotifierInterface::class => EmailNotifier::class]);
+            $config->loadDefinitions([NotifierInterface::class => SmsNotifier::class]);
+        });
+
+        self::assertSame('sms', (new Greeting\Facade())->notifierName());
+    }
+
+    /**
+     * Data is applied after code, so an override file wins over a binding
+     * declared in `gacela.php` -- otherwise the override file could not do the
+     * one job it is loaded for.
+     */
+    public function test_definitions_override_an_imperative_binding(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->addBinding(NotifierInterface::class, EmailNotifier::class);
+            $config->loadDefinitions([NotifierInterface::class => SmsNotifier::class]);
+        });
+
+        self::assertSame('sms', (new Greeting\Facade())->notifierName());
+    }
+
+    private function bootstrapWith(callable $configure): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configure): void {
+            $config->resetInMemoryCache();
+            $configure($config);
+        });
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/FeatureTest.php
+++ b/tests/Feature/Framework/ContainerDefinitions/FeatureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\ContainerDefinitions;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\Container\BindingRegisteredEvent;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\EmailNotifier;
 use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\NotifierInterface;
@@ -90,6 +91,31 @@ final class FeatureTest extends TestCase
         });
 
         self::assertSame('sms', (new Greeting\Facade())->notifierName());
+    }
+
+    /**
+     * Pins the documented gap rather than hiding it: a definition registers a
+     * binding but does not announce one, because naming what a source
+     * registered means reconstructing it from the container's registries and
+     * the aliases are not in them. Fails loudly if that ever becomes reportable.
+     */
+    public function test_a_definition_does_not_announce_a_binding_registration(): void
+    {
+        $registered = [];
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use (&$registered): void {
+            $config->registerSpecificListener(
+                BindingRegisteredEvent::class,
+                static function (BindingRegisteredEvent $event) use (&$registered): void {
+                    $registered[] = $event->id();
+                },
+            );
+            $config->loadDefinitions([NotifierInterface::class => EmailNotifier::class]);
+        });
+
+        (new Greeting\Facade())->notifierName();
+
+        self::assertNotContains(NotifierInterface::class, $registered);
     }
 
     private function bootstrapWith(callable $configure): void

--- a/tests/Feature/Framework/ContainerDefinitions/Greeting/Facade.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Greeting/Facade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Greeting;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function notifierName(): string
+    {
+        return $this->getFactory()->createGreeter()->notifierName();
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Greeting/Factory.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Greeting/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Greeting;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createGreeter(): Greeter
+    {
+        return $this->make(Greeter::class);
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Greeting/Greeter.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Greeting/Greeter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Greeting;
+
+use GacelaTest\Feature\Framework\ContainerDefinitions\Notifying\NotifierInterface;
+
+final class Greeter
+{
+    public function __construct(
+        private readonly NotifierInterface $notifier,
+    ) {
+    }
+
+    public function notifierName(): string
+    {
+        return $this->notifier->name();
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Notifying/EmailNotifier.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Notifying/EmailNotifier.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Notifying;
+
+final class EmailNotifier implements NotifierInterface
+{
+    public function name(): string
+    {
+        return 'email';
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Notifying/NotifierInterface.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Notifying/NotifierInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Notifying;
+
+interface NotifierInterface
+{
+    public function name(): string;
+}

--- a/tests/Feature/Framework/ContainerDefinitions/Notifying/SmsNotifier.php
+++ b/tests/Feature/Framework/ContainerDefinitions/Notifying/SmsNotifier.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ContainerDefinitions\Notifying;
+
+final class SmsNotifier implements NotifierInterface
+{
+    public function name(): string
+    {
+        return 'sms';
+    }
+}

--- a/tests/Feature/Framework/ContainerDefinitions/services.json
+++ b/tests/Feature/Framework/ContainerDefinitions/services.json
@@ -1,0 +1,3 @@
+{
+    "GacelaTest\\Feature\\Framework\\ContainerDefinitions\\Notifying\\NotifierInterface": "GacelaTest\\Feature\\Framework\\ContainerDefinitions\\Notifying\\SmsNotifier"
+}

--- a/tests/Integration/Framework/Container/ContainerDefinitionsTest.php
+++ b/tests/Integration/Framework/Container/ContainerDefinitionsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use Gacela\Container\Exception\ContainerException;
+use Gacela\Framework\Container\Container;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function is_file;
+use function json_encode;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * `load()` and `loadFile()` describe wiring as data rather than as a closure.
+ *
+ * The loader upstream is an implementation detail, so these do not re-test what
+ * it does with each definition key. They pin the two things the decorator owns:
+ * that both methods are reachable at all, and that a definition ends up in the
+ * *decorated* container -- the one a Provider is handed -- rather than in an
+ * inner container nobody can read from.
+ */
+final class ContainerDefinitionsTest extends TestCase
+{
+    /** @var list<string> */
+    private array $writtenFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->writtenFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->writtenFiles = [];
+    }
+
+    public function test_load_registers_a_definition_on_the_decorator(): void
+    {
+        $container = new Container();
+
+        $container->load([
+            StringValueInterface::class => StringValue::class,
+        ]);
+
+        self::assertInstanceOf(StringValueInterface::class, $container->get(StringValueInterface::class));
+    }
+
+    public function test_load_registers_a_plain_value(): void
+    {
+        $container = new Container();
+
+        $container->load([
+            'db.dsn' => ['value' => 'pgsql://localhost/app'],
+        ]);
+
+        self::assertSame('pgsql://localhost/app', $container->get('db.dsn'));
+    }
+
+    /**
+     * The point of the data layer: a later load overrides an earlier key, which
+     * is what makes a per-environment override file work.
+     */
+    public function test_a_later_definition_overrides_an_earlier_one(): void
+    {
+        $container = new Container();
+
+        $container->load(['db.dsn' => ['value' => 'first']]);
+        $container->load(['db.dsn' => ['value' => 'second']]);
+
+        self::assertSame('second', $container->get('db.dsn'));
+    }
+
+    public function test_load_file_reads_a_json_file(): void
+    {
+        $file = $this->writeFile('json', (string)json_encode([
+            'db.dsn' => ['value' => 'pgsql://from-json/app'],
+        ]));
+
+        $container = new Container();
+        $container->loadFile($file);
+
+        self::assertSame('pgsql://from-json/app', $container->get('db.dsn'));
+    }
+
+    public function test_load_file_reads_a_php_file(): void
+    {
+        $file = $this->writeFile('php', "<?php return ['db.dsn' => ['value' => 'pgsql://from-php/app']];");
+
+        $container = new Container();
+        $container->loadFile($file);
+
+        self::assertSame('pgsql://from-php/app', $container->get('db.dsn'));
+    }
+
+    /**
+     * A missing file is the failure mode a relative path produces, and it must
+     * be loud: the whole risk of describing wiring as data is a file that
+     * silently does not arrive.
+     */
+    public function test_load_file_throws_when_the_file_is_missing(): void
+    {
+        $container = new Container();
+
+        $this->expectException(ContainerException::class);
+
+        $container->loadFile(sys_get_temp_dir() . '/gacela-definitions-does-not-exist.json');
+    }
+
+    private function writeFile(string $extension, string $contents): string
+    {
+        $file = sys_get_temp_dir() . '/' . uniqid('gacela-definitions-', true) . '.' . $extension;
+        file_put_contents($file, $contents);
+        $this->writtenFiles[] = $file;
+
+        return $file;
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
+++ b/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
@@ -282,6 +282,43 @@ final class SetupMergerTest extends TestCase
         self::assertSame([$onOther], $callbacks['OtherClass'] ?? null);
     }
 
+    public function test_merge_definitions_from_two_setups(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->loadDefinitions(['id' => ['value' => 'base']]);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->loadDefinitions(['id' => ['value' => 'override']]);
+        });
+
+        $merged = $setup1->merge($setup2);
+
+        // Sources are an ordered layer stack, not a keyed map: the later setup's
+        // source goes on top rather than replacing the stack, so the container
+        // still applies the base before the override.
+        self::assertSame(
+            [['id' => ['value' => 'base']], ['id' => ['value' => 'override']]],
+            $merged->getDefinitions(),
+        );
+    }
+
+    public function test_a_setup_that_declares_no_definitions_does_not_drop_the_originals(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->loadDefinitions(['id' => ['value' => 'base']]);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('unrelated', true);
+        });
+
+        self::assertSame(
+            [['id' => ['value' => 'base']]],
+            $setup1->merge($setup2)->getDefinitions(),
+        );
+    }
+
     public function test_merge_handler_registries_from_two_setups(): void
     {
         $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

`GacelaConfig` was entirely imperative — `addBinding`, `addFactory`, `addAlias`, `addLazy`, `extendService`, `tag`, `when`. Every binding had to be a method call inside a PHP closure, so there was no way to hand Gacela a *data* description of a module's wiring: the thing you want when the wiring is generated, shared between environments, or diffed in review.

The container has shipped `load(array)` and `loadFile(string)` since 1.0 and nothing in Gacela could reach either. This exposes both.

```php
// gacela.php
$config->loadDefinitions([
    LoggerInterface::class => FileLogger::class,
    Database::class => ['singleton' => DatabasePool::class],
    'db.dsn' => ['value' => 'pgsql://localhost/app'],
]);
$config->loadDefinitions(__DIR__ . '/config/services.json');
```

```php
// a Provider, for definitions local to one module
$container->load([Clock::class => SystemClock::class]);
```

## 🔖 Changes

- **`GacelaConfig::loadDefinitions(string|array)`** — takes a definitions array, or the path of a `.php` file returning one or a `.json` file holding one. Applies **app-wide**, reaching every module container, which is how `addBinding()` already behaves. Plumbed through the usual chain: `GacelaConfigTransfer` → `SetupInitializer` → `SetupGacela` → `ContainerConfigurationInterface::getDefinitions()`
- **`Container::load()` / `loadFile()` forwarded on the decorator**, so a Provider can scope definitions to its own module. Declared on the concrete class rather than on `ContainerInterface`, matching `provides()` and `stats()` — upstream promises nothing is added to the interface in 1.x
- **Ordering: sources apply in declaration order, and *after* the imperative registrations.** A later source overrides an earlier one, and a definitions file overrides `addBinding()`. That is the point rather than an accident: an environment override file that lost to the code it is meant to override could not do the one job it is loaded for. `tags` accumulate instead, the way `tag()` does
- **Merging** across setups treats sources as an ordered layer stack, not a keyed map: the later setup's sources go on top, so the base still applies before the override
- **Paths are used as given** — not rebased under the app root the way `enableFileCache()` rebases its directory. `__DIR__` is the honest way to write one, and a silent rebase would only move where the failure appears. Flagged in the issue as worth not repeating blindly
- **YAML stays out**, as upstream decided: no parser in the container, and Gacela does not take that dependency either. `loadDefinitions(Yaml::parseFile('services.yaml'))` already works
- Docs: a "Definitions as Data" section in `container-configuration.md`, a row in the `getting-a-dependency.md` intent table, and a quick-reference row

### Known gap: no `BindingRegisteredEvent`

Definitions register bindings but do not announce them. The first attempt diffed the container's registered ids around the load; that catches `bind()` and `set()` entries but **not aliases**, which live in a third registry — an undercount a listener cannot see the shape of, and reconstruction against an `@internal` upstream loader besides. Second commit backs that out and pins the gap instead: recorded in the docblock, in the docs, and in a test that fails loudly if it ever becomes reportable.

### Drive-by

`docs/container-configuration.md` still listed **service tagging** and **`afterResolving()`** under "features gacela does not expose" — both shipped in #571 and #572. Corrected while editing the neighbouring section, and replaced with `createScope()`, which genuinely is not exposed (it needs #539).

### Note for #574

`ContainerForwardingCoverageTest` on `feat/shared-plan-cache` declares `NOT_FORWARDED = ['createScope', 'load', 'loadFile']`. Once this lands, that list is `['createScope']`.

## ✅ Tests

- `tests/Integration/Framework/Container/ContainerDefinitionsTest.php` — the decorator owns two things: that both methods are reachable, and that a definition lands in the *decorated* container rather than an inner one nobody can read from. Covers array, `.json` and `.php` sources, later-wins, and the loud failure on a missing file
- `tests/Feature/Framework/ContainerDefinitions/` — two modules; app-wide reach, file and array sources, later source wins, definitions override `addBinding()`, and the event gap
- `SetupMergerTest` — sources stack in order across setups, and a setup declaring none does not drop the originals

`composer test` green (quality + 926 unit / 240 integration / 291 feature).

Closes #575