### PR TITLE
fix(console): CacheWarmedEvent reports skipped modules as failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Two things it is deliberately not. It is **not a performance release** — the t
 
 Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md) — and run `vendor/bin/gacela doctor` on 1.21 first, because one of the three fails silently.
 
+### Fixed
+
+- **`CacheWarmedEvent` reported skipped modules as failed.** `cache:warm` passed its *skipped* count into the `failedCount` parameter, so any listener alerting on `failedCount() > 0` fired on a **successful** deploy. The two were never distinguished in the counters at all — `ModuleWarmer` incremented one `$skippedCount` both for a pillar class that is not there and for a pillar whose autoloading threw, even though the per-class output has always printed `⚠ Skipped` and `✗ Failed` separately. They are counted apart now: `failedCount()` is the number worth alerting on, and `CacheWarmedEvent::skippedCount()` reports the healthy one. Fixed before 2.0 because the event is public API and correcting the meaning of a getter after the tag would be a breaking change. The `cache:warm` summary gains a `Classes failed:` line for the same reason — the number exists now, and folding it into `Classes skipped:` was the same mislabelling in the other output channel
+
 ### Added
 
 - **`GacelaConfig::loadDefinitions()` — wiring as data.** The container has shipped `load(array)` and `loadFile(string)` since 1.0 and nothing in Gacela could reach either, so every binding had to be a method call inside a PHP closure. That is fine when a human writes it and wrong when the wiring is generated, shared between environments, or reviewed as a diff.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -194,6 +194,23 @@ That is the point of the change. The array came straight from the container pack
 
 Not to be confused with `Container::getStats()`, a different method on the container itself, which still returns the array and is unchanged for all of 1.x.
 
+### 10. Only if you listen to `CacheWarmedEvent`
+
+`failedCount()` now means what it says. In 1.x it received the **skipped** count, so a listener alerting on it fired on a healthy `cache:warm` — any module with a pillar class that is simply not there. The two are separate now:
+
+```php
+$config->registerSpecificListener(CacheWarmedEvent::class, static function (CacheWarmedEvent $event): void {
+    // 1.x: also true for a healthy warm. 2.0: only for a real failure.
+    if ($event->failedCount() > 0) {
+        alert($event->failedCount() . ' pillars failed to resolve');
+    }
+
+    $event->skippedCount(); // new: the pillars a module does not have
+});
+```
+
+No signature to change — `skippedCount` is a third constructor argument defaulting to `0`. If you were treating `failedCount()` as "skipped", read `skippedCount()` instead. The `cache:warm` summary gains a matching `Classes failed:` line, so anything scraping that output sees one extra row.
+
 ---
 
 ## Deprecated in 2.0, removed in 3.0

--- a/docs/events.md
+++ b/docs/events.md
@@ -130,7 +130,12 @@ All four resolver events extend `AbstractGacelaClassResolverEvent` and expose `c
 | Event | Fires when | Payload | Hot path |
 |---|---|---|---|
 | `CacheClearedEvent` | a Gacela cache file is deleted | `cacheFile()` | no |
-| `CacheWarmedEvent` | `bin/gacela cache:warm` finished | `moduleCount()`, `failedCount()` | no |
+| `CacheWarmedEvent` | `bin/gacela cache:warm` finished | `moduleCount()`, `failedCount()`, `skippedCount()` | no |
+
+`failedCount()` and `skippedCount()` are not the same number. A pillar class a
+module declares but does not have is *skipped* — a normal shape, not an error.
+A pillar that is there and blows up on resolution is *failed*. Alert on
+`failedCount()`.
 
 ## Cookbook
 

--- a/src/Console/Application/CacheWarm/CacheWarmOutputFormatter.php
+++ b/src/Console/Application/CacheWarm/CacheWarmOutputFormatter.php
@@ -75,6 +75,7 @@ final class CacheWarmOutputFormatter
         int $modulesCount,
         int $resolvedCount,
         int $skippedCount,
+        int $failedCount,
         string $timeTaken,
         string $memoryUsed,
     ): void {
@@ -84,6 +85,7 @@ final class CacheWarmOutputFormatter
         $this->output->writeln(sprintf('<fg=cyan>Modules processed:</> %d', $modulesCount));
         $this->output->writeln(sprintf('<fg=cyan>Classes resolved:</> %d', $resolvedCount));
         $this->output->writeln(sprintf('<fg=cyan>Classes skipped:</> %d', $skippedCount));
+        $this->output->writeln(sprintf('<fg=cyan>Classes failed:</> %d', $failedCount));
         $this->output->writeln(sprintf('<fg=cyan>Time taken:</> %s', $timeTaken));
         $this->output->writeln(sprintf('<fg=cyan>Memory used:</> %s', $memoryUsed));
         $this->output->writeln('');

--- a/src/Console/Application/CacheWarm/ModuleWarmer.php
+++ b/src/Console/Application/CacheWarm/ModuleWarmer.php
@@ -12,7 +12,12 @@ use Throwable;
  * optionally pre-warms its attribute cache, and reports progress through
  * the output formatter.
  *
- * @psalm-type WarmStats = array{int, int}
+ * A skip and a failure are counted apart. A pillar class that is not there is a
+ * normal module shape; a pillar whose autoloading throws is not. They already
+ * read differently in the output, and folding them into one counter is what let
+ * `CacheWarmedEvent` report a healthy warm as a broken one.
+ *
+ * @psalm-type WarmStats = array{int, int, int}
  */
 final class ModuleWarmer
 {
@@ -27,31 +32,34 @@ final class ModuleWarmer
      *
      * @param list<AppModule> $modules
      *
-     * @return WarmStats [resolvedCount, skippedCount]
+     * @return WarmStats [resolvedCount, skippedCount, failedCount]
      */
     public function warmModules(array $modules, bool $warmAttributes): array
     {
         $resolvedCount = 0;
         $skippedCount = 0;
+        $failedCount = 0;
 
         foreach ($modules as $module) {
-            [$resolved, $skipped] = $this->warmModule($module, $warmAttributes);
+            [$resolved, $skipped, $failed] = $this->warmModule($module, $warmAttributes);
             $resolvedCount += $resolved;
             $skippedCount += $skipped;
+            $failedCount += $failed;
         }
 
-        return [$resolvedCount, $skippedCount];
+        return [$resolvedCount, $skippedCount, $failedCount];
     }
 
     /**
      * Warm a single module's cache.
      *
-     * @return WarmStats [resolvedCount, skippedCount]
+     * @return WarmStats [resolvedCount, skippedCount, failedCount]
      */
     public function warmModule(AppModule $module, bool $warmAttributes): array
     {
         $resolvedCount = 0;
         $skippedCount = 0;
+        $failedCount = 0;
 
         $this->formatter->writeModuleName($module->moduleName());
 
@@ -72,7 +80,7 @@ final class ModuleWarmer
                 ++$skippedCount;
             } catch (Throwable $e) {
                 $this->formatter->writeClassFailed($classInfo['type'], $classInfo['className'], $e->getMessage());
-                ++$skippedCount;
+                ++$failedCount;
             }
         }
 
@@ -80,13 +88,13 @@ final class ModuleWarmer
             $this->cacheWarmService->warmClassResolution($module->facadeClass());
         } catch (Throwable $e) {
             // A module that cannot be resolved during warm (even via a PHP Error) must be
-            // reported and skipped, not abort warming for every remaining module.
+            // reported and counted as failed, not abort warming for every remaining module.
             $this->formatter->writeClassFailed('Facade', $module->facadeClass(), $e->getMessage());
-            ++$skippedCount;
+            ++$failedCount;
         }
 
         $this->formatter->writeEmptyLine();
 
-        return [$resolvedCount, $skippedCount];
+        return [$resolvedCount, $skippedCount, $failedCount];
     }
 }

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -78,16 +78,22 @@ final class CacheWarmCommand extends Command
         );
 
         if (self::shouldDispatch(CacheWarmedEvent::class)) {
-            self::dispatchEvent(new CacheWarmedEvent(count($modules), $failedCount, $skippedCount));
+            // Named, because three same-typed counters read positionally is what
+            // put the skipped count into failedCount in the first place.
+            self::dispatchEvent(new CacheWarmedEvent(
+                moduleCount: count($modules),
+                failedCount: $failedCount,
+                skippedCount: $skippedCount,
+            ));
         }
 
         $formatter->writeSummary(
-            count($modules),
-            $resolvedCount,
-            $skippedCount,
-            $failedCount,
-            $metrics->formatElapsedTime(),
-            $metrics->formatMemoryUsed(),
+            modulesCount: count($modules),
+            resolvedCount: $resolvedCount,
+            skippedCount: $skippedCount,
+            failedCount: $failedCount,
+            timeTaken: $metrics->formatElapsedTime(),
+            memoryUsed: $metrics->formatMemoryUsed(),
         );
 
         $this->displayCacheInfo($cacheManager, $formatter);

--- a/src/Console/Infrastructure/Command/CacheWarmCommand.php
+++ b/src/Console/Infrastructure/Command/CacheWarmCommand.php
@@ -71,20 +71,21 @@ final class CacheWarmCommand extends Command
 
         $formatter->writeModulesFound($modules);
 
-        [$resolvedCount, $skippedCount] = $this->warmInOneBatch(
+        [$resolvedCount, $skippedCount, $failedCount] = $this->warmInOneBatch(
             new ModuleWarmer($cacheWarmService, $formatter),
             $modules,
             $warmAttributes,
         );
 
         if (self::shouldDispatch(CacheWarmedEvent::class)) {
-            self::dispatchEvent(new CacheWarmedEvent(count($modules), $skippedCount));
+            self::dispatchEvent(new CacheWarmedEvent(count($modules), $failedCount, $skippedCount));
         }
 
         $formatter->writeSummary(
             count($modules),
             $resolvedCount,
             $skippedCount,
+            $failedCount,
             $metrics->formatElapsedTime(),
             $metrics->formatMemoryUsed(),
         );
@@ -102,7 +103,7 @@ final class CacheWarmCommand extends Command
      *
      * @param list<AppModule> $modules
      *
-     * @return array{0: int, 1: int}
+     * @return array{0: int, 1: int, 2: int} [resolvedCount, skippedCount, failedCount]
      */
     private function warmInOneBatch(ModuleWarmer $moduleWarmer, array $modules, bool $warmAttributes): array
     {

--- a/src/Framework/Event/Cache/CacheWarmedEvent.php
+++ b/src/Framework/Event/Cache/CacheWarmedEvent.php
@@ -8,11 +8,17 @@ use Gacela\Framework\Event\GacelaEventInterface;
 
 use function sprintf;
 
+/**
+ * A skip and a failure are separate counts on purpose: a pillar class a module
+ * does not have is a normal shape, and a listener alerting on
+ * `failedCount() > 0` must stay quiet for it.
+ */
 final class CacheWarmedEvent implements GacelaEventInterface
 {
     public function __construct(
         private readonly int $moduleCount,
         private readonly int $failedCount,
+        private readonly int $skippedCount = 0,
     ) {
     }
 
@@ -21,18 +27,31 @@ final class CacheWarmedEvent implements GacelaEventInterface
         return $this->moduleCount;
     }
 
+    /**
+     * Pillars that were found and blew up on resolution -- the count worth
+     * alerting on.
+     */
     public function failedCount(): int
     {
         return $this->failedCount;
     }
 
+    /**
+     * Pillars a module declares but does not have. Healthy, and not an error.
+     */
+    public function skippedCount(): int
+    {
+        return $this->skippedCount;
+    }
+
     public function toString(): string
     {
         return sprintf(
-            '%s {moduleCount:%d, failedCount:%d}',
+            '%s {moduleCount:%d, failedCount:%d, skippedCount:%d}',
             self::class,
             $this->moduleCount,
             $this->failedCount,
+            $this->skippedCount,
         );
     }
 }

--- a/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
+++ b/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
@@ -77,6 +77,32 @@ final class CacheWarmCommandTest extends TestCase
         self::assertInstanceOf(CacheWarmedEvent::class, $warmedEvents[0]);
         self::assertGreaterThanOrEqual(0, $warmedEvents[0]->moduleCount());
         self::assertGreaterThanOrEqual(0, $warmedEvents[0]->failedCount());
+        self::assertGreaterThanOrEqual(0, $warmedEvents[0]->skippedCount());
+    }
+
+    /**
+     * The event is the only place a listener can see the outcome, and a listener
+     * alerting on `failedCount() > 0` has to stay quiet on a healthy warm. This
+     * application warms without a single failure, so anything above zero here is
+     * the skipped count wearing the wrong name.
+     */
+    public function test_a_healthy_warm_reports_no_failures(): void
+    {
+        $warmedEvents = [];
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$warmedEvents): void {
+            $config->resetInMemoryCache();
+            $config->enableFileCache(__DIR__ . '/cache');
+            $config->registerSpecificListener(
+                CacheWarmedEvent::class,
+                static function (CacheWarmedEvent $event) use (&$warmedEvents): void {
+                    $warmedEvents[] = $event;
+                },
+            );
+        });
+
+        $this->command->execute([]);
+
+        self::assertSame(0, $warmedEvents[0]->failedCount());
     }
 
     public function test_cache_warm_creates_cache_file(): void
@@ -90,6 +116,7 @@ final class CacheWarmCommandTest extends TestCase
         self::assertStringContainsString('Modules processed:', $output);
         self::assertStringContainsString('Classes resolved:', $output);
         self::assertStringContainsString('Classes skipped:', $output);
+        self::assertStringContainsString('Classes failed:', $output);
         self::assertStringContainsString('Time taken:', $output);
         self::assertStringContainsString('Memory used:', $output);
     }
@@ -131,6 +158,7 @@ final class CacheWarmCommandTest extends TestCase
         self::assertMatchesRegularExpression('/Modules processed:\s+\d+/', $output);
         self::assertMatchesRegularExpression('/Classes resolved:\s+\d+/', $output);
         self::assertMatchesRegularExpression('/Classes skipped:\s+\d+/', $output);
+        self::assertMatchesRegularExpression('/Classes failed:\s+\d+/', $output);
         self::assertMatchesRegularExpression('/Time taken:\s+[\d.]+\s+seconds/', $output);
         self::assertMatchesRegularExpression('/Memory used:\s+[\d.]+\s+(B|KB|MB)/', $output);
     }

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerFacadeWarmTest.php
@@ -59,12 +59,13 @@ final class ModuleWarmerFacadeWarmTest extends TestCase
         $broken = new AppModule('Broken', 'Broken', BrokenFacade::class);
         $healthy = new AppModule('Healthy', 'Healthy', HealthyFacade::class, HealthyFactory::class);
 
-        [, $skippedCount] = $warmer->warmModules([$broken, $healthy], warmAttributes: false);
+        [, $skippedCount, $failedCount] = $warmer->warmModules([$broken, $healthy], warmAttributes: false);
 
         $resolved = implode('|', array_values(ClassNamePhpCache::all()));
 
         self::assertStringContainsString('HealthyFactory', $resolved, 'warming must continue past the broken module');
-        self::assertGreaterThanOrEqual(1, $skippedCount, 'the broken module must be counted as skipped');
+        self::assertGreaterThanOrEqual(1, $failedCount, 'the broken module must be counted as failed');
+        self::assertSame(0, $skippedCount, 'a facade that blew up is a failure, not a skip');
         self::assertStringContainsString(
             '✗ Failed Facade: ' . BrokenFacade::class,
             $output->fetch(),

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
@@ -74,10 +74,11 @@ final class ModuleWarmerTest extends TestCase
     {
         $module = new AppModule('Healthy', 'Healthy', HealthyFacade::class, HealthyFactory::class);
 
-        [$resolved, $skipped] = $this->warmer->warmModule($module, warmAttributes: false);
+        [$resolved, $skipped, $failed] = $this->warmer->warmModule($module, warmAttributes: false);
 
         self::assertSame(2, $resolved);
         self::assertSame(0, $skipped);
+        self::assertSame(0, $failed);
         self::assertSame(self::lines(
             'Processing: Healthy',
             '  ✓ Resolved Facade: ' . HealthyFacade::class,
@@ -92,10 +93,11 @@ final class ModuleWarmerTest extends TestCase
         $missingFactory = 'Missing\\Factory';
         $module = new AppModule('Healthy', 'Healthy', HealthyFacade::class, $missingFactory);
 
-        [$resolved, $skipped] = $this->warmer->warmModule($module, warmAttributes: false);
+        [$resolved, $skipped, $failed] = $this->warmer->warmModule($module, warmAttributes: false);
 
         self::assertSame(1, $resolved);
         self::assertSame(1, $skipped);
+        self::assertSame(0, $failed);
         self::assertSame(self::lines(
             'Processing: Healthy',
             '  ✓ Resolved Facade: ' . HealthyFacade::class,
@@ -116,13 +118,16 @@ final class ModuleWarmerTest extends TestCase
         try {
             $module = new AppModule('Healthy', 'Healthy', HealthyFacade::class, self::EXPLODING_CLASS);
 
-            [$resolved, $skipped] = $this->warmer->warmModule($module, warmAttributes: false);
+            [$resolved, $skipped, $failed] = $this->warmer->warmModule($module, warmAttributes: false);
         } finally {
             spl_autoload_unregister($autoloader);
         }
 
         self::assertSame(1, $resolved);
-        self::assertSame(1, $skipped);
+        // A failure is not a skip. Counting it as one is what made
+        // `CacheWarmedEvent` report a healthy deploy as a broken one.
+        self::assertSame(0, $skipped);
+        self::assertSame(1, $failed);
         self::assertSame(self::lines(
             'Processing: Healthy',
             '  ✓ Resolved Facade: ' . HealthyFacade::class,
@@ -155,7 +160,7 @@ final class ModuleWarmerTest extends TestCase
         $first = new AppModule('Healthy', 'Healthy', HealthyFacade::class, HealthyFactory::class);
         $second = new AppModule('Healthy', 'Healthy', HealthyFacade::class, $missingFactory);
 
-        self::assertSame([3, 1], $this->warmer->warmModules([$first, $second], warmAttributes: false));
+        self::assertSame([3, 1, 0], $this->warmer->warmModules([$first, $second], warmAttributes: false));
     }
 
     private static function lines(string ...$lines): string

--- a/tests/Unit/Console/Application/CacheWarm/CacheWarmOutputFormatterTest.php
+++ b/tests/Unit/Console/Application/CacheWarm/CacheWarmOutputFormatterTest.php
@@ -112,7 +112,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
 
     public function test_summary_lists_every_counter(): void
     {
-        $this->formatter->writeSummary(3, 7, 2, '0.123 seconds', '1.00 KB');
+        $this->formatter->writeSummary(3, 7, 2, 1, '0.123 seconds', '1.00 KB');
 
         self::assertSame(
             self::lines(
@@ -122,6 +122,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
                 'Modules processed: 3',
                 'Classes resolved: 7',
                 'Classes skipped: 2',
+                'Classes failed: 1',
                 'Time taken: 0.123 seconds',
                 'Memory used: 1.00 KB',
                 '',

--- a/tests/Unit/Framework/Event/Lifecycle/LifecycleEventGettersTest.php
+++ b/tests/Unit/Framework/Event/Lifecycle/LifecycleEventGettersTest.php
@@ -86,9 +86,25 @@ final class LifecycleEventGettersTest extends TestCase
 
     public function test_cache_warmed_event_exposes_counts(): void
     {
-        $event = new CacheWarmedEvent(10, 2);
+        $event = new CacheWarmedEvent(10, 2, 3);
 
         self::assertSame(10, $event->moduleCount());
         self::assertSame(2, $event->failedCount());
+        self::assertSame(3, $event->skippedCount());
+    }
+
+    /**
+     * A skip and a failure are not the same event -- a module with no Provider
+     * is a normal shape, not an error -- so the two counts have to be readable
+     * apart from each other and from the string form.
+     */
+    public function test_cache_warmed_event_tells_skipped_and_failed_apart_in_its_string_form(): void
+    {
+        $event = new CacheWarmedEvent(10, 2, 3);
+
+        self::assertSame(
+            CacheWarmedEvent::class . ' {moduleCount:10, failedCount:2, skippedCount:3}',
+            $event->toString(),
+        );
     }
 }

--- a/tests/Unit/Framework/Event/Lifecycle/LifecycleEventGettersTest.php
+++ b/tests/Unit/Framework/Event/Lifecycle/LifecycleEventGettersTest.php
@@ -94,9 +94,21 @@ final class LifecycleEventGettersTest extends TestCase
     }
 
     /**
-     * A skip and a failure are not the same event -- a module with no Provider
-     * is a normal shape, not an error -- so the two counts have to be readable
-     * apart from each other and from the string form.
+     * `skippedCount` is a third argument with a default so that constructing the
+     * event the 1.x way keeps working. The default has to be zero: anything else
+     * would have a listener reading a skip that never happened.
+     */
+    public function test_cache_warmed_event_defaults_the_skipped_count_to_zero(): void
+    {
+        $event = new CacheWarmedEvent(10, 2);
+
+        self::assertSame(0, $event->skippedCount());
+    }
+
+    /**
+     * A skip and a failure are not the same event -- a pillar class a module
+     * does not have is a normal shape, not an error -- so the two counts have to
+     * be readable apart from each other and from the string form.
      */
     public function test_cache_warmed_event_tells_skipped_and_failed_apart_in_its_string_form(): void
     {


### PR DESCRIPTION
## 📚 Description

`CacheWarmCommand` passed the **skipped** count into `CacheWarmedEvent`'s `failedCount` parameter, so any listener alerting on `failedCount() > 0` fired on a **successful** `cache:warm`.

Auditing the warmer showed the mislabelling starts one level lower: the counters never told a skip from a failure at all. `ModuleWarmer` incremented a single `$skippedCount` both for a pillar class that is not there and for a pillar whose autoloading threw — even though the per-class output has always printed `⚠ Skipped` and `✗ Failed` separately, and its own test docblock claimed the counters told them apart. So this takes the issue's **option (3)**: separate fields, because the batch warmer can distinguish the two cases once it stops throwing them into the same counter.

Fixed before 2.0 on purpose: `CacheWarmedEvent` is public API, and correcting the meaning of a getter after the tag is a breaking change.

## 🔖 Changes

- **`ModuleWarmer` returns `[resolved, skipped, failed]`.** A `ClassNotFoundException` is a skip; any other `Throwable` — including a facade whose warming blows up — is a failure. Same split for the per-module facade warm
- **`CacheWarmedEvent::skippedCount()`**, a third constructor argument defaulting to `0`, so no existing construction breaks. `failedCount()` now means what it says, and `toString()` reports both
- **`cache:warm` summary gains a `Classes failed:` line.** The number exists now, and feeding skipped+failed into a line labelled `Classes skipped:` was the same mislabelling in the other output channel — the issue's "(2) leaves a real gap" applied to the console as much as to the event
- **Named arguments at both call sites** (`ref` commit). Three same-typed ints passed positionally is the mechanism that produced this bug; naming them makes the next slot swap a compile error rather than a wrong number in someone's alerting
- Docs: `events.md` payload row plus a note on which count to alert on; `UPGRADE.md` §10 for anyone who was listening

## ✅ Tests

- `ModuleWarmerTest` — a missing pillar is `skipped:1, failed:0`; a pillar whose autoloading throws is `skipped:0, failed:1`. Both were `skipped:1` before, which is the bug in its original form. Accumulation across modules pinned as a 3-tuple
- `ModuleWarmerFacadeWarmTest` — a facade that blew up is counted as failed, not skipped
- `LifecycleEventGettersTest` — the three getters, and the string form telling skipped and failed apart
- `CacheWarmCommandTest` — a healthy warm reports `failedCount() === 0`, plus the new summary line
- `CacheWarmOutputFormatterTest` — the exact summary block

`composer test` green (quality + 927 unit / 240 integration / 292 feature).

## ⚠️ Behaviour change

Two, both intended and both inside the 2.0 major:

1. A listener that was reading `failedCount()` as "skipped" now gets the real failure count. `UPGRADE.md` §10 covers it.
2. `cache:warm` output has one extra row, which matters only to something scraping it.

Closes #576