### PR TITLE
ci(infection): kill the escaped mutant and set the bar at 90

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -1,8 +1,13 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 #
-# Mutation testing guard: infection.json5 sets minMsi and minCoveredMsi to 100,
-# but nothing enforced them, so the score drifted below the bar twice without
-# anyone noticing. This job runs the same thresholds the config already declares.
+# Mutation testing guard: infection.json5 sets minMsi and minCoveredMsi, but
+# nothing enforced them, so the score drifted below the bar twice without
+# anyone noticing. This job runs the same thresholds the config declares.
+#
+# The bar is 90, not 100. At 100 a single equivalent mutant anywhere in src/
+# turns main red, and the fix is an `ignore` entry arguing with the tool rather
+# than a better test. 90 leaves room for that without letting the score rot:
+# the suite sits well above it, so a real regression still shows.
 #
 # A mutant that survives means the test suite asserts the shape of the code
 # rather than its behaviour: the line ran, but nothing checked the result.
@@ -16,7 +21,7 @@
 #   - pull requests mutate only the lines the branch changed. This is the run
 #     that matters: it fails on the PR that introduces an unkilled mutant, while
 #     the author still has the context to fix it.
-#   - a nightly (and every push to main) runs the whole suite at 100%. Drift is
+#   - a nightly (and every push to main) runs the whole suite. Drift is
 #     what this workflow was created for -- the score fell below the bar twice
 #     before anything enforced it -- and an incremental run cannot see a mutant
 #     that a *dependency* change resurrected in untouched code.
@@ -82,7 +87,7 @@ jobs:
         # --ignore-msi-with-no-mutations: a branch that changes only comments,
         # docs or dependencies still has files in the diff but no *mutable*
         # lines. Without this, infection generates zero mutants, computes MSI 0%
-        # and fails the 100% gate -- so a docblock fix could not be merged.
+        # and fails the gate -- so a docblock fix could not be merged.
         #
         # --map-source-class-to-test is deliberately NOT used. It picks test
         # files by *naming convention* (Foo -> FooTest), so a test named after
@@ -93,8 +98,8 @@ jobs:
         run: |
           vendor/bin/infection \
             --threads=max \
-            --min-msi=100 \
-            --min-covered-msi=100 \
+            --min-msi=90 \
+            --min-covered-msi=90 \
             --git-diff-lines \
             --git-diff-base=origin/${{ github.base_ref }} \
             --only-covering-test-cases \
@@ -104,7 +109,7 @@ jobs:
             --show-mutations=max
 
   full:
-    name: "Mutation testing (full, min MSI 100%)"
+    name: "Mutation testing (full, min MSI 90%)"
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -133,4 +138,4 @@ jobs:
       - name: Assert the mutation score has not regressed
         env:
           XDEBUG_MODE: coverage
-        run: vendor/bin/infection --threads=max --min-msi=100 --min-covered-msi=100 --no-progress --show-mutations=max
+        run: vendor/bin/infection --threads=max --min-msi=90 --min-covered-msi=90 --no-progress --show-mutations=max

--- a/infection.json5
+++ b/infection.json5
@@ -16,13 +16,16 @@
             'src'
         ]
     },
-    minMsi: 100,
-    minCoveredMsi: 100,
+    // 90, not 100: at 100 one equivalent mutant anywhere turns main red, and
+    // the fix becomes an `ignore` entry arguing with the tool rather than a
+    // better test. The suite sits well above 90, so a real regression shows.
+    minMsi: 90,
+    minCoveredMsi: 90,
     mutators: {
         '@default': true,
         // Ratcheting out of a blanket "Gacela\\Console\\*" ignore, namespace by
         // namespace (#529). Domain, Application and the root Console classes are
-        // done and enforced at 100%: that is where the real logic lives -- Tarjan,
+        // done and enforced: that is where the real logic lives -- Tarjan,
         // the JSON/graph formatters, the code that writes files into a user's
         // project.
         //

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
@@ -163,6 +163,23 @@ final class ModuleWarmerTest extends TestCase
         self::assertSame([3, 1, 0], $this->warmer->warmModules([$first, $second], warmAttributes: false));
     }
 
+    /**
+     * The test above has only one module skipping anything, so `+=` and `=`
+     * produce the same total and nothing distinguishes accumulating from
+     * overwriting -- which is exactly the mutant that escaped the full run.
+     * Two modules skipping one pillar each tell them apart: 2, not 1.
+     */
+    public function test_skipped_counts_accumulate_rather_than_overwrite(): void
+    {
+        /** @var class-string $missingFactory */
+        $missingFactory = 'Missing\\Factory';
+
+        $first = new AppModule('Healthy', 'Healthy', HealthyFacade::class, $missingFactory);
+        $second = new AppModule('Healthy', 'Healthy', HealthyFacade::class, $missingFactory);
+
+        self::assertSame([2, 2, 0], $this->warmer->warmModules([$first, $second], warmAttributes: false));
+    }
+
     private static function lines(string ...$lines): string
     {
         return implode(PHP_EOL, $lines) . PHP_EOL;


### PR DESCRIPTION
## 📚 Description

The Infection **full** run has failed on `main` since `967c6249` (#579). The changed-lines gate passed on every PR, so nothing caught it until the push to main.

## 🐛 The mutant

One escape, in code #579 added — `ModuleWarmer::warmModules()`:

```diff
 foreach ($modules as $module) {
     [$resolved, $skipped, $failed] = $this->warmModule($module, $warmAttributes);
     $resolvedCount += $resolved;
-    $skippedCount += $skipped;
+    $skippedCount = $skipped;
     $failedCount += $failed;
 }
```

It is a **real test hole**, not an equivalent mutant. `test_counts_are_accumulated_across_modules` used one healthy module and one with a missing pillar — so skipped was `0` then `1`, and `+=` and `=` both produce `1`. Nothing distinguished accumulating from overwriting.

Two modules skipping one pillar each do: `+=` gives 2, `=` gives 1. Added as its own test rather than changing the existing one, which still covers the mixed case that kills the `$resolvedCount` mutant.

Verified: `infection --filter=src/Console/Application/CacheWarm/ModuleWarmer.php` → 28 mutants, **all killed**, 100% MSI.

## 🔖 The threshold: 100 → 90

Dropped `minMsi`/`minCoveredMsi` from 100 to 90 in both jobs and in `infection.json5`, with the reason recorded next to each.

At 100, one equivalent mutant anywhere in `src/` turns `main` red, and the fix becomes an `ignore` entry arguing with the tool rather than a better test. This branch's own history has two of those already — `offsetSet($x, true)` → `false` on a `WeakMap` used as a set, where the value is never read.

Worth knowing: with the mutant killed, the full suite measures **100%** locally. So 90 is headroom for future equivalent mutants, not cover for a score that has actually dropped.

## 💬 One thing to consider

The two jobs earn their strictness differently, and this lowers both because that is what was asked.

The **changed-lines** gate at 100 caught three genuine test gaps in my own work today — an untested `= 0` default, and this mutant's sibling — each while the context was still fresh. It only ever judges the diff, so it does not go red for unrelated drift. If you want to keep one of them at 100, that is the one worth keeping; say the word and I will raise it back in a follow-up.

The **full** run is the one that benefits most from 90: it is the one that turns `main` red for something nobody touched.

## ✅ Checks

`composer quality` green; `composer test` green (932 / 247 / 296). Full `infection` run green locally at 100% MSI.