### PR TITLE
ref(console): one dependency tree, drawn the same way everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,16 +61,21 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
   `tag()` for an unkeyed set you iterate, `addHandlerRegistry()` for a keyed
   lookup that throws on a miss.
 
-- **`debug:dependencies --tree` draws an actual tree**, taken from the container
-  so bindings and contextual bindings are already applied:
+- **The dependency tree is an actual tree**, taken from the container so
+  bindings and contextual bindings are already applied:
   ```
   ├── ✓ $cacheWarmService: …\CacheWarmService (autowired)
   └── ✓ $formatter: …\CacheWarmOutputFormatter (autowired)
       └── ✗ $output: Symfony\…\OutputInterface (unresolvable)
   ```
   A missing dependency now says *whose* it is. A cycle is marked `(cycle)` and
-  cut. `Dependencies` counts distinct classes, so one pulled in by three parents
-  counts once and is drawn three times.
+  cut. Counts are of distinct classes, so one pulled in by three parents counts
+  once and is drawn three times.
+
+  All three commands that report it draw the same tree — `debug:dependencies
+  --tree`, `debug:module` and `debug:container`. The latter two printed a flat
+  list under a heading that said "tree", `debug:container` numbering it `1. 2.
+  3.`, and each rendered it its own way.
 
 - **`cache:clear` also clears the container's in-process memos** — reflection
   output held in statics that outlive every container and that no file holds.
@@ -191,6 +196,10 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
 - Refreshed the toolchain: `infection` `^0.29` → `^0.34`, plus phpstan and
   rector. `phpunit` stays on `^10.5`.
 - `symfony-bridge/composer.json` matches the root package it ships from.
+- A root `gacela.php` scoping the console to `src`. Without it `doctor` walked
+  the whole repository and reported two errors on a clean checkout: `tests/`
+  holds fixtures that are deliberately separate applications, several declaring
+  their own pillar suffixes, which look misnamed under the root config.
 - Removed Scrutinizer; it duplicated PHPStan, Psalm and php-cs-fixer, which
   already gate every pull request.
 

--- a/allowed-module-cycles.json
+++ b/allowed-module-cycles.json
@@ -1,9 +1,1 @@
-[
-    {
-        "modules": [
-            "GacelaTest\\Feature\\Console\\DebugGraphCheck\\CycleA",
-            "GacelaTest\\Feature\\Console\\DebugGraphCheck\\CycleB"
-        ],
-        "reason": "Deliberate fixture cycle: it is the input DebugGraphCheckTest asserts the cycle check against. Removing these modules must also remove this entry, which the check enforces."
-    }
-]
+[]

--- a/gacela.php
+++ b/gacela.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+/**
+ * Configuration for running Gacela's own console against this repository.
+ *
+ * Without it, `vendor/bin/gacela doctor` (and `list:modules`, `debug:modules`,
+ * `cache:warm`) walk the whole repository and pick up `tests/`, where the
+ * fixtures are deliberately *separate applications*: several declare their own
+ * `gacela.php` with custom pillar suffixes, so scanned under this config they
+ * look like misnamed modules. Doctor reported two such false errors on a clean
+ * checkout.
+ *
+ * `src` is where this package's own modules live, so that is what the console
+ * should see. Nothing else reads this file -- the test suite bootstraps each
+ * fixture from its own directory -- so it only affects the CLI.
+ */
+return static function (GacelaConfig $config): void {
+    $config->setAppModulePaths(['src']);
+};

--- a/src/Console/Application/Debug/DependencyTreeRenderer.php
+++ b/src/Console/Application/Debug/DependencyTreeRenderer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+use function array_merge;
+use function count;
+use function sprintf;
+
+/**
+ * Draws a {@see DependencyTreeNode} tree as indented lines.
+ *
+ * Three commands report the same graph -- `debug:dependencies --tree`,
+ * `debug:module` and `debug:container` -- and each used to render it its own
+ * way, two of them as a flat list under a heading that said "tree". Producing
+ * lines rather than writing to output keeps the drawing in one place while
+ * leaving each command its own indentation and framing.
+ */
+final class DependencyTreeRenderer
+{
+    /**
+     * @param list<DependencyTreeNode> $nodes
+     *
+     * @return list<string>
+     */
+    public function render(array $nodes, string $indent = ''): array
+    {
+        return $this->branch($nodes, $indent, '');
+    }
+
+    /**
+     * @param list<DependencyTreeNode> $nodes
+     *
+     * @return list<string>
+     */
+    private function branch(array $nodes, string $indent, string $prefix): array
+    {
+        $lines = [];
+        $lastIndex = count($nodes) - 1;
+
+        foreach ($nodes as $index => $node) {
+            $isLast = $index === $lastIndex;
+
+            $lines[] = $indent . $prefix . ($isLast ? '└── ' : '├── ') . $this->label($node);
+            $lines = array_merge(
+                $lines,
+                $this->branch($node->children, $indent, $prefix . ($isLast ? '    ' : '│   ')),
+            );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * A cut cycle is called out: a branch that simply stopped reads like one
+     * with nothing more to say.
+     */
+    private function label(DependencyTreeNode $node): string
+    {
+        $marker = $node->isProvided() ? '<fg=green>✓</>' : '<fg=red>✗</>';
+        $parameter = $node->parameter === null ? '' : sprintf('$%s: ', $node->parameter);
+        $cycle = $node->repeated ? ' <fg=yellow>(cycle)</>' : '';
+
+        return sprintf('%s %s%s (%s)%s', $marker, $parameter, $node->className, $node->status->value, $cycle);
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Infrastructure\Command;
 
+use Gacela\Console\Application\Debug\DependencyTreeInspector;
+use Gacela\Console\Application\Debug\DependencyTreeRenderer;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
@@ -95,22 +97,22 @@ final class DebugContainerCommand extends Command
 
         ConsoleSection::title($output, sprintf('Dependency Tree for %s', $className));
 
-        $dependencyTree = $this->getFacade()->getContainerDependencyTree($className);
+        $inspection = (new DependencyTreeInspector())->inspect($className);
 
-        if ($dependencyTree === []) {
+        if ($inspection->nodes === []) {
             $output->writeln(sprintf('Class "%s" has no dependencies', $className));
             $output->writeln('');
             return Command::SUCCESS;
         }
 
-        $counter = 1;
-        foreach ($dependencyTree as $dependency) {
-            $output->writeln(sprintf('%d. %s', $counter, $dependency));
-            ++$counter;
+        foreach ((new DependencyTreeRenderer())->render($inspection->tree) as $line) {
+            $output->writeln($line);
         }
 
         $output->writeln('');
-        $output->writeln(sprintf('<fg=cyan>Total Dependencies:</> %d', count($dependencyTree)));
+        // Distinct classes, so one pulled in by three parents counts once and
+        // is drawn three times.
+        $output->writeln(sprintf('<fg=cyan>Total Dependencies:</> %d', count($inspection->nodes)));
         $output->writeln('');
         $output->writeln('<comment>This tree shows only user-defined dependencies.</comment>');
         $output->writeln('');

--- a/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugDependenciesCommand.php
@@ -8,7 +8,7 @@ use Gacela\Console\Application\Debug\ConstructorInspection;
 use Gacela\Console\Application\Debug\ConstructorInspector;
 use Gacela\Console\Application\Debug\DependencyTreeInspection;
 use Gacela\Console\Application\Debug\DependencyTreeInspector;
-use Gacela\Console\Application\Debug\DependencyTreeNode;
+use Gacela\Console\Application\Debug\DependencyTreeRenderer;
 use Gacela\Console\Application\Debug\ParameterInspection;
 use Gacela\Console\Application\Debug\ParameterStatus;
 use PhpToken;
@@ -88,41 +88,15 @@ final class DebugDependenciesCommand extends Command
             return;
         }
 
-        $this->renderBranch($output, $inspection->tree, '');
+        foreach ((new DependencyTreeRenderer())->render($inspection->tree, '  ') as $line) {
+            $output->writeln($line);
+        }
 
         $output->writeln('');
         // Counted off the flat list, not the branches: a class three parents
         // pull in is one dependency drawn three times.
         $output->writeln(sprintf('<fg=cyan>Dependencies:</> %d', count($inspection->nodes)));
         $output->writeln('');
-    }
-
-    /**
-     * @param list<DependencyTreeNode> $nodes
-     */
-    private function renderBranch(OutputInterface $output, array $nodes, string $prefix): void
-    {
-        $lastIndex = count($nodes) - 1;
-
-        foreach ($nodes as $index => $node) {
-            $isLast = $index === $lastIndex;
-            $output->writeln('  ' . $prefix . ($isLast ? '└── ' : '├── ') . $this->formatNode($node));
-
-            $this->renderBranch($output, $node->children, $prefix . ($isLast ? '    ' : '│   '));
-        }
-    }
-
-    /**
-     * A cut cycle is called out: a branch that simply stopped reads like one
-     * with nothing more to say.
-     */
-    private function formatNode(DependencyTreeNode $node): string
-    {
-        $marker = $node->isProvided() ? '<fg=green>✓</>' : '<fg=red>✗</>';
-        $parameter = $node->parameter === null ? '' : sprintf('$%s: ', $node->parameter);
-        $cycle = $node->repeated ? ' <fg=yellow>(cycle)</>' : '';
-
-        return sprintf('%s %s%s (%s)%s', $marker, $parameter, $node->className, $node->status->value, $cycle);
     }
 
     private function renderInspection(OutputInterface $output, ConstructorInspection $inspection): void

--- a/src/Console/Infrastructure/Command/DebugModuleCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModuleCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Infrastructure\Command;
 
+use Gacela\Console\Application\Debug\DependencyTreeInspector;
+use Gacela\Console\Application\Debug\DependencyTreeRenderer;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\ServiceResolver\ServiceMap;
@@ -145,16 +147,16 @@ final class DebugModuleCommand extends Command
     {
         $output->writeln('  <fg=cyan>Dependency tree</> (Facade):');
 
-        $dependencyTree = $this->getFacade()->getContainerDependencyTree($module->facadeClass());
+        $inspection = (new DependencyTreeInspector())->inspect($module->facadeClass());
 
-        if ($dependencyTree === []) {
+        if ($inspection->tree === []) {
             $output->writeln('    (no dependencies)');
 
             return;
         }
 
-        foreach ($dependencyTree as $dependency) {
-            $output->writeln('    ' . $dependency);
+        foreach ((new DependencyTreeRenderer())->render($inspection->tree, '    ') as $line) {
+            $output->writeln($line);
         }
     }
 }

--- a/tests/Feature/Console/DebugContainer/DebugContainerCommandTest.php
+++ b/tests/Feature/Console/DebugContainer/DebugContainerCommandTest.php
@@ -103,10 +103,15 @@ final class DebugContainerCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
         self::assertStringContainsString('Dependency Tree for ' . MixedDependenciesService::class, $display);
 
-        // Every constructor dependency is listed, numbered from 1, and counted.
-        self::assertStringContainsString('1. ' . BoundImplementation::class, $display);
-        self::assertStringContainsString('2. ' . AutowirableCollaborator::class, $display);
-        self::assertStringContainsString('3. ' . UnboundContract::class, $display);
+        // Drawn where each sits, labelled with the parameter that pulled it in,
+        // and marked by whether the container can supply it.
+        self::assertStringContainsString('├── ✓ $bound: ' . BoundImplementation::class, $display);
+        self::assertStringContainsString('├── ✓ $collaborator: ' . AutowirableCollaborator::class, $display);
+        self::assertStringContainsString('├── ✗ $unbound: ' . UnboundContract::class, $display);
+
+        // The count is of distinct classes: AutowirableCollaborator satisfies
+        // two parameters, so it is drawn twice and counted once.
+        self::assertStringContainsString('└── ✓ $nullableCollaborator: ' . AutowirableCollaborator::class, $display);
         self::assertStringContainsString('Total Dependencies: 3', $display);
     }
 

--- a/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
+++ b/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
@@ -110,9 +110,10 @@ final class DebugModuleCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
         self::assertPillarReports($display, 'Facade', WiredModuleFacade::class);
 
-        // The facade's constructor dependency is reported under the tree.
+        // The facade's constructor dependency is drawn under the tree, labelled
+        // with the parameter that pulled it in.
         self::assertMatchesRegularExpression(
-            '/Dependency tree \(Facade\):\s*\R\s*' . preg_quote(WiredCollaborator::class, '/') . '/',
+            '/Dependency tree \(Facade\):\s*\R\s*└── ✓ \$\w+: ' . preg_quote(WiredCollaborator::class, '/') . '/u',
             $display,
         );
     }

--- a/tests/Unit/Console/Application/Debug/DependencyTreeRendererTest.php
+++ b/tests/Unit/Console/Application/Debug/DependencyTreeRendererTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Debug;
+
+use Gacela\Console\Application\Debug\DependencyTreeNode;
+use Gacela\Console\Application\Debug\DependencyTreeRenderer;
+use Gacela\Console\Application\Debug\ProvisionStatus;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The shape, not the characters. Which glyph draws a branch is a look; that a
+ * child is drawn *under* its parent, and that the last child closes the branch
+ * so the next line is not read as its sibling, is the behaviour.
+ */
+final class DependencyTreeRendererTest extends TestCase
+{
+    private DependencyTreeRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new DependencyTreeRenderer();
+    }
+
+    public function test_no_nodes_renders_nothing(): void
+    {
+        self::assertSame([], $this->renderer->render([]));
+    }
+
+    public function test_a_child_is_drawn_under_its_parent(): void
+    {
+        $lines = $this->renderer->render([
+            self::node('Parent', 'p', [self::node('Child', 'c')]),
+        ]);
+
+        self::assertCount(2, $lines);
+        self::assertStringContainsString('$p: Parent', $lines[0]);
+        self::assertStringContainsString('$c: Child', $lines[1]);
+
+        // The child is indented past its parent, which is what says "under".
+        self::assertStringStartsWith('    ', $lines[1]);
+    }
+
+    /**
+     * A middle child keeps the trunk open so the grandchild below it is not
+     * read as a sibling of the *next* branch.
+     */
+    public function test_a_non_last_child_keeps_the_trunk_open_for_its_own_children(): void
+    {
+        $lines = $this->renderer->render([
+            self::node('First', 'a', [self::node('Nested', 'n')]),
+            self::node('Second', 'b'),
+        ]);
+
+        self::assertStringContainsString('│', $lines[1], 'the grandchild hangs off a trunk that continues');
+        self::assertStringContainsString('└── ', $lines[2], 'the last sibling closes the branch');
+    }
+
+    public function test_an_unprovided_node_is_marked_differently(): void
+    {
+        $lines = $this->renderer->render([
+            self::node('Missing', 'm', [], ProvisionStatus::Unresolvable),
+        ]);
+
+        self::assertStringContainsString('✗', $lines[0]);
+        self::assertStringContainsString('(unresolvable)', $lines[0]);
+        self::assertStringNotContainsString('✓', $lines[0]);
+    }
+
+    public function test_a_cut_cycle_says_so(): void
+    {
+        $lines = $this->renderer->render([
+            self::node('Loop', 'l', [], ProvisionStatus::Autowired, repeated: true),
+        ]);
+
+        // Without this, a branch that stopped because it looped reads exactly
+        // like one that had nothing more to say.
+        self::assertStringContainsString('(cycle)', $lines[0]);
+    }
+
+    public function test_a_root_node_without_a_parameter_is_not_labelled_with_one(): void
+    {
+        $lines = $this->renderer->render([self::node('Bare', null)]);
+
+        self::assertStringNotContainsString('$', $lines[0]);
+        self::assertStringContainsString('Bare', $lines[0]);
+    }
+
+    public function test_the_indent_is_applied_to_every_line(): void
+    {
+        $lines = $this->renderer->render([
+            self::node('Parent', 'p', [self::node('Child', 'c')]),
+        ], '    ');
+
+        foreach ($lines as $line) {
+            self::assertStringStartsWith('    ', $line);
+        }
+    }
+
+    /**
+     * @param list<DependencyTreeNode> $children
+     */
+    private static function node(
+        string $className,
+        ?string $parameter,
+        array $children = [],
+        ProvisionStatus $status = ProvisionStatus::Autowired,
+        bool $repeated = false,
+    ): DependencyTreeNode {
+        return new DependencyTreeNode($className, $parameter, $status, $children, $repeated);
+    }
+}

--- a/tests/Unit/Console/Application/Debug/DependencyTreeRendererTest.php
+++ b/tests/Unit/Console/Application/Debug/DependencyTreeRendererTest.php
@@ -9,6 +9,10 @@ use Gacela\Console\Application\Debug\DependencyTreeRenderer;
 use Gacela\Console\Application\Debug\ProvisionStatus;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
+use function strpos;
+use function substr;
+
 /**
  * The shape, not the characters. Which glyph draws a branch is a look; that a
  * child is drawn *under* its parent, and that the last child closes the branch
@@ -55,6 +59,37 @@ final class DependencyTreeRendererTest extends TestCase
 
         self::assertStringContainsString('│', $lines[1], 'the grandchild hangs off a trunk that continues');
         self::assertStringContainsString('└── ', $lines[2], 'the last sibling closes the branch');
+    }
+
+    /**
+     * Three levels under an indent, which is the only shape that pins how the
+     * prefix accumulates: the indent has to lead every line, and each level has
+     * to carry its ancestors' trunks. Two levels, or no indent, leave the order
+     * and the accumulation indistinguishable.
+     */
+    public function test_the_prefix_accumulates_through_every_level_under_the_indent(): void
+    {
+        $lines = $this->renderer->render([
+            self::node('A', 'a', [
+                self::node('A1', 'a1', [self::node('A1a', 'a1a')]),
+                self::node('A2', 'a2'),
+            ]),
+            self::node('B', 'b'),
+        ], '  ');
+
+        self::assertSame(
+            [
+                '  ├── ',      // A: first of two roots
+                '  │   ├── ',  // A1: under A, which continues
+                '  │   │   └── ', // A1a: under A1, which also continues
+                '  │   └── ',  // A2: last under A
+                '  └── ',      // B: last root, closes
+            ],
+            array_map(
+                static fn (string $line): string => substr($line, 0, (int)strpos($line, '<')),
+                $lines,
+            ),
+        );
     }
 
     public function test_an_unprovided_node_is_marked_differently(): void


### PR DESCRIPTION
## 📚 Description

Found by running the console against this repository rather than reading it.

Two things came out of that:

1. **`vendor/bin/gacela doctor` reported errors on a clean checkout.**
2. **Two commands print a flat list under a heading that says "Dependency tree".**

## 🔖 One tree, one renderer

`debug:dependencies --tree`, `debug:module` and `debug:container` all report the container's dependency graph, and each rendered it its own way. Only the first drew a tree; `debug:container` numbered its list `1. 2. 3.`, which reads as a list because it was one.

All three now go through `DependencyTreeRenderer`:

```
├── ✓ $cacheWarmService: …\CacheWarmService (autowired)
└── ✓ $formatter: …\CacheWarmOutputFormatter (autowired)
    └── ✗ $output: Symfony\…\OutputInterface (unresolvable)
```

A dependency is drawn where it sits, labelled with the constructor parameter that pulled it in, and marked by whether the container can supply it — so a missing dependency says *whose* it is. A cycle is called out rather than silently cut.

Counts are unchanged and stay **distinct-class** counts. The feature test now pins that directly: `MixedDependenciesService` takes `AutowirableCollaborator` for two different parameters, so it is drawn twice and counted once.

The renderer returns lines rather than writing to output, which is what lets each command keep its own indentation — `debug:module` indents by four, the others by two — and lets the unit test check the shape without an `OutputInterface`.

## 🩺 `doctor` was crying wolf

On a clean checkout:

```
✗ suffix configuration
    Facade "GacelaTest\…\FacaModuleA" does not end with any configured Facade suffix [Facade]
    Facade "GacelaTest\…\FacadeModuleB" does not end with any configured Facade suffix [Facade]
```

Both are test fixtures. `tests/Feature/Framework/UsingCustomSuffixTypes/` is a **separate application** with its own `gacela.php` declaring exactly those suffixes — scanned under the root config, they look misnamed.

The framework already has the answer (`setAppModulePaths`); the repo just never used it. A root `gacela.php` scopes the console to `src`, and `doctor` is green. `list:modules` and `debug:modules` now report Gacela's own module instead of test fixtures.

Nothing else reads it: the test suite bootstraps each fixture from its own directory, and every benchmark bootstraps from its own `__DIR__` or a fixture root — checked, so the perf gate is untouched.

## ✅ Tests

- `DependencyTreeRendererTest` — the shape rather than the characters: a child is indented under its parent, a non-last child keeps the trunk open so its grandchild is not read as the next sibling, an unprovided node is marked differently, a cut cycle says so, and the indent reaches every line
- Two feature assertions updated from the old numbered list to the tree, one of them now pinning the drawn-twice-counted-once rule

`composer test` green (939 unit / 258 integration / 296 feature).

## 🔍 Tried and reverted

`ContextualBindingRegistrar`'s `class_exists()`/`interface_exists()` probes look like they re-derive a decision `give()` already makes — and at runtime they do: I checked both need kinds against eight value shapes and every one produced the identical injected value.

They are still not removable. They are what narrows `string` to `class-string` for Psalm, because `give()` is declared `mixed` but documented `callable|class-string|object`. Dropping them needs a suppression, so it was reverted rather than shipped with one. The root cause — `give()`'s declared surface being narrower than its real one — is recorded on [container#169](https://github.com/gacela-project/container/issues/169), and the class deletes cleanly once that lands.