### PR TITLE
ref: expose Gacela\Framework\Attribute\Inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,17 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
   methods — writing plans to disk was measured a net loss — but they are
   reachable for an application that has measured its own case.
 
-- **`#[Inject]` targets properties**, not only constructor parameters, for
-  classes whose constructor is not yours to change.
+- **`Gacela\Framework\Attribute\Inject`** — application code no longer imports
+  a vendor namespace for the one attribute-first surface that required it. It
+  subclasses the container's attribute, and since attributes are read with
+  `ReflectionAttribute::IS_INSTANCEOF` both imports work side by side.
+
+  RFC-0001 planned this as a `class_alias()` and withdrew it the same day: an
+  exact-FQN read follows neither an alias nor a subclass, and the failure is
+  **silent** — the parameter simply never injected. Subclassing is supported
+  because the container now reads for it.
+- **`#[Inject]` targets properties and setters**, not only constructor
+  parameters, for classes whose constructor is not yours to change.
 - `#[Lazy]` joins `#[Inject]`, `#[Singleton]` and `#[Factory]` as an attribute
   honoured by `AbstractFactory::make()`.
 - `Container::provides()`, `taggedByKey()` and `taggedKeys()` are forwarded.

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -140,12 +140,17 @@ when the value should be built lazily.
 The container autowires constructor parameters by type-hint. For most cases
 that's all you need — declare the type, the container resolves it.
 
+`Gacela\Framework\Attribute\Inject` is the import to reach for — the same
+namespace as every other Gacela attribute. It subclasses the container's own,
+and the container reads attributes with `ReflectionAttribute::IS_INSTANCEOF`, so
+either import works and both may appear in one codebase.
+
 `#[Inject]` is the opt-in for the two cases autowiring alone can't express:
 disambiguating an interface with multiple possible concretes, and marking a
 parameter as explicitly container-owned for tooling like `debug:dependencies`.
 
 ```php
-use Gacela\Container\Attribute\Inject;
+use Gacela\Framework\Attribute\Inject;
 
 final class CatalogService
 {
@@ -314,7 +319,7 @@ final class PhelRunCommand extends Command
 After:
 
 ```php
-use Gacela\Container\Attribute\Inject;
+use Gacela\Framework\Attribute\Inject;
 
 final class PhelRunCommand extends Command
 {

--- a/src/Framework/Attribute/Inject.php
+++ b/src/Framework/Attribute/Inject.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Attribute;
+
+use Attribute;
+use Gacela\Container\Attribute\Inject as ContainerInject;
+
+/**
+ * Marks a constructor parameter, property or setter for injection, optionally
+ * naming the implementation to inject.
+ *
+ * Identical in behaviour to the container's own attribute, which it extends —
+ * it exists so application code imports `Gacela\Framework\*` like every other
+ * attribute-first surface Gacela exposes, instead of reaching into the
+ * container package:
+ *
+ * ```php
+ * use Gacela\Framework\Attribute\Inject;
+ *
+ * public function __construct(
+ *     #[Inject] private readonly LoggerInterface $logger,
+ *     #[Inject(RedisCache::class)] private readonly CacheInterface $cache,
+ * ) {}
+ * ```
+ *
+ * Either import works and both can appear in one codebase; the container reads
+ * attributes with `ReflectionAttribute::IS_INSTANCEOF`, so a subclass is
+ * honoured wherever the parent is.
+ *
+ * That flag is the whole reason this could not ship earlier. RFC-0001 planned a
+ * `class_alias()` and withdrew it the same day: an exact-FQN read follows
+ * neither an alias nor a subclass, and the failure is **silent** — the
+ * parameter is simply never injected. Subclassing is the supported path
+ * precisely because the container reads for it.
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+final class Inject extends ContainerInject
+{
+}

--- a/tests/Integration/Framework/Attribute/InjectAlias/CollaboratorInterface.php
+++ b/tests/Integration/Framework/Attribute/InjectAlias/CollaboratorInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute\InjectAlias;
+
+interface CollaboratorInterface
+{
+}

--- a/tests/Integration/Framework/Attribute/InjectAlias/InjectsOnMethod.php
+++ b/tests/Integration/Framework/Attribute/InjectAlias/InjectsOnMethod.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute\InjectAlias;
+
+use Gacela\Framework\Attribute\Inject;
+
+final class InjectsOnMethod
+{
+    private ?CollaboratorInterface $collaborator = null;
+
+    /**
+     * The attribute on the method marks it as a setter to call; the one on the
+     * parameter names what to pass. Both are the Gacela-namespaced subclass,
+     * which is the point of the test -- each is read by a different call site
+     * upstream.
+     */
+    #[Inject]
+    public function setCollaborator(
+        #[Inject(RedCollaborator::class)]
+        CollaboratorInterface $collaborator,
+    ): void {
+        $this->collaborator = $collaborator;
+    }
+
+    public function collaborator(): ?CollaboratorInterface
+    {
+        return $this->collaborator;
+    }
+}

--- a/tests/Integration/Framework/Attribute/InjectAlias/InjectsOnParameter.php
+++ b/tests/Integration/Framework/Attribute/InjectAlias/InjectsOnParameter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute\InjectAlias;
+
+use Gacela\Framework\Attribute\Inject;
+
+final class InjectsOnParameter
+{
+    public function __construct(
+        #[Inject(RedCollaborator::class)]
+        public readonly CollaboratorInterface $collaborator,
+    ) {
+    }
+}

--- a/tests/Integration/Framework/Attribute/InjectAlias/InjectsOnProperty.php
+++ b/tests/Integration/Framework/Attribute/InjectAlias/InjectsOnProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute\InjectAlias;
+
+use Gacela\Framework\Attribute\Inject;
+
+final class InjectsOnProperty
+{
+    #[Inject(RedCollaborator::class)]
+    private CollaboratorInterface $collaborator;
+
+    public function collaborator(): CollaboratorInterface
+    {
+        return $this->collaborator;
+    }
+}

--- a/tests/Integration/Framework/Attribute/InjectAlias/InjectsSpecificImplementation.php
+++ b/tests/Integration/Framework/Attribute/InjectAlias/InjectsSpecificImplementation.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute\InjectAlias;
+
+use Gacela\Framework\Attribute\Inject;
+
+final class InjectsSpecificImplementation
+{
+    public function __construct(
+        #[Inject(RedCollaborator::class)]
+        public readonly CollaboratorInterface $collaborator,
+    ) {
+    }
+}

--- a/tests/Integration/Framework/Attribute/InjectAlias/RedCollaborator.php
+++ b/tests/Integration/Framework/Attribute/InjectAlias/RedCollaborator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute\InjectAlias;
+
+final class RedCollaborator implements CollaboratorInterface
+{
+}

--- a/tests/Integration/Framework/Attribute/InjectAliasTest.php
+++ b/tests/Integration/Framework/Attribute/InjectAliasTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute;
+
+use Gacela\Framework\Container\Container;
+use GacelaTest\Integration\Framework\Attribute\InjectAlias\InjectsOnMethod;
+use GacelaTest\Integration\Framework\Attribute\InjectAlias\InjectsOnParameter;
+use GacelaTest\Integration\Framework\Attribute\InjectAlias\InjectsOnProperty;
+use GacelaTest\Integration\Framework\Attribute\InjectAlias\InjectsSpecificImplementation;
+use GacelaTest\Integration\Framework\Attribute\InjectAlias\RedCollaborator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Gacela\Framework\Attribute\Inject` re-presents the container's attribute
+ * under the namespace every other Gacela attribute lives in.
+ *
+ * The risk it carries is why these exist at all: the container reads attributes
+ * by type, and if it ever went back to an exact-FQN match the subclass would
+ * stop being honoured **silently** — no error, the dependency simply never
+ * arriving. RFC-0001 withdrew a `class_alias()` for exactly that reason. So
+ * each target the attribute declares is asserted separately.
+ */
+final class InjectAliasTest extends TestCase
+{
+    public function test_it_is_honoured_on_a_constructor_parameter(): void
+    {
+        $resolved = (new Container())->make(InjectsOnParameter::class);
+
+        self::assertInstanceOf(RedCollaborator::class, $resolved->collaborator);
+    }
+
+    public function test_it_is_honoured_on_a_property(): void
+    {
+        $resolved = (new Container())->make(InjectsOnProperty::class);
+
+        self::assertInstanceOf(RedCollaborator::class, $resolved->collaborator());
+    }
+
+    public function test_it_is_honoured_on_a_setter(): void
+    {
+        $resolved = (new Container())->make(InjectsOnMethod::class);
+
+        self::assertInstanceOf(RedCollaborator::class, $resolved->collaborator());
+    }
+
+    /**
+     * The argument form has to survive the subclass too -- it is the reason to
+     * reach for `#[Inject]` over plain autowiring.
+     */
+    public function test_the_implementation_argument_still_selects_the_concrete(): void
+    {
+        $resolved = (new Container())->make(InjectsSpecificImplementation::class);
+
+        self::assertInstanceOf(RedCollaborator::class, $resolved->collaborator);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Annotating a parameter, property or setter meant importing a **vendor** namespace into your own application code:

```php
use Gacela\Container\Attribute\Inject;   // not Gacela\Framework\*
```

Every other attribute-first surface Gacela exposes lives under `Gacela\Framework\*`. This one leaked the dependency's namespace into user code — and meant the import would have to change if the container were ever swapped or re-namespaced.

## 🔓 Why it works now

RFC-0001 planned exactly this as a `class_alias()` and **withdrew it the same day**: a runtime probe showed an exact-FQN attribute read follows neither an alias nor a subclass, and the failure mode is **silent** — the parameter is simply never injected, with nothing to say why.

Container 2.0 reads every attribute with `ReflectionAttribute::IS_INSTANCEOF` ([container#175](https://github.com/gacela-project/container/issues/175), closed), and made `Inject` non-final for precisely this purpose — its docblock now says *"a consumer may subclass this to re-present it under its own namespace"*.

So the supported path is a subclass, not an alias:

```php
use Gacela\Framework\Attribute\Inject;

public function __construct(
    #[Inject] private readonly LoggerInterface $logger,
    #[Inject(RedisCache::class)] private readonly CacheInterface $cache,
) {}
```

Both imports work, and both can appear in one codebase.

## ✅ Tests

`InjectAliasTest` asserts **each declared target separately** — parameter, property, setter — plus the `implementation` argument, which is the reason to reach for `#[Inject]` over plain autowiring.

That granularity is deliberate: the attribute declares three targets and the container reads them at three different call sites. If any one ever went back to an exact-FQN match, the subclass would stop being honoured with no error at all. These fail instead.

One thing the tests taught me: on a setter the attribute goes in **two** places — on the method to mark it for calling, and on the parameter to name what to pass. A method-level `#[Inject(Impl::class)]` does not select the concrete for its own arguments; they resolve the same way a constructor's do.

Docs updated to the new import; `composer test` green (940 / 262 / 296).

Closes #577