### PR TITLE
docs: record what the container 2.0 perf regression does and does not touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,17 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
     container. A scope is now a decorator like its parent, so it keeps the
     Locator and the lifecycle events.
 
+  One caveat, measured and reported rather than absorbed quietly: container
+  2.0 resolves 11-28% slower **cold** than 1.5.0 —
+  [container#181](https://github.com/gacela-project/container/issues/181),
+  root-caused to the per-class argument builder being composed on a class's
+  first resolution, so a container that builds a class once pays for a shortcut
+  it never takes. Gacela's own benchmarks are unaffected: bootstrap, config
+  init, class resolution, the resolver cache, event dispatch and the file
+  caches all moved within ±8% and bootstrap came out ~3% faster. Only the
+  benchmarks that construct raw containers in a loop show it, and those are
+  reported rather than gating until it is fixed.
+
   `load()`/`loadFile()` return the ids they registered and take an optional
   per-id callback, which closes a gap `loadDefinitions()` shipped with:
   definitions now emit `BindingRegisteredEvent` like every other registration,

--- a/tests/Benchmark/Container/ContainerResolutionBench.php
+++ b/tests/Benchmark/Container/ContainerResolutionBench.php
@@ -33,6 +33,13 @@ use PhpBench\Attributes\Groups;
  * They still run and still get reported on every pull request; they are simply
  * not a merge blocker while the number they track belongs to someone else.
  * Move back to `gate` once #181 lands and the floor is stable again.
+ *
+ * This demotes one measurement, not the guard. Every subject that times
+ * Gacela's own paths stays in `gate` -- bootstrap, config init, class
+ * resolution, the resolver cache, event dispatch, the file caches -- and on the
+ * 2.0 bump each of those moved within +-8%, most within +-4%, with bootstrap
+ * ~3% faster. The regression is confined to constructing raw containers in a
+ * tight loop, which is what these four do and what Gacela does not.
  */
 #[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
 #[Groups(['informational', 'container'])]


### PR DESCRIPTION
## 📚 Description

Follow-up to the concern raised on #586. The regression is now **root-caused**, and its blast radius measured — both recorded where they will be read.

## 🔬 Root cause (reported as [container#181](https://github.com/gacela-project/container/issues/181))

It is the per-class argument builder from container #129. `$argBuilders` lives on the resolver, and a resolver belongs to one container — so a container that resolves a class **once** pays to compose a shortcut it never takes a second time.

Proven by disabling composition (always safe — falling back to the resolution path is correct by construction):

| subject | 1.5.0 | 2.0.0 | builders off |
|---|---|---|---|
| `resolve_no_dependencies` | 1.527μs | 1.842μs | **1.581μs** |
| `resolve_with_inject_attribute` | 2.973μs | 3.472μs | **2.979μs** |
| `resolve_with_bindings` | 2.964μs | 3.764μs | **3.080μs** |
| `resolve_deep_chain` | 4.953μs | 5.605μs | **5.032μs** |

**The optimisation is worth keeping.** Warm — one container, 200k resolutions — it is a **2.07× win** (0.833μs vs 1.721μs). This is a cold/warm tradeoff, not a mistake.

I also tried the obvious fix (compose on the *second* resolution) and reported it as a trap rather than proposing it: it loses the warm win entirely **and** is incorrect, because `composeBuilder()` recurses and a nested class on its own first visit returns `null`, caching the parent as permanently ineligible. Upstream's 787 tests all still passed with that patch, so nothing currently pins it.

## 📏 What it actually touches

This is the part that matters for shipping. On the 2.0 bump, every benchmark timing **Gacela's own paths**:

| | delta |
|---|---|
| `bench_bootstrap_warm` / `cold_rescan` | **-3.29% / -2.82%** (faster) |
| `bench_config_init_warm` / `cold` | -0.96% / -0.49% |
| `bench_resolver_cache_hit` | +0.01% |
| `bench_class_resolving` | +3.96% |
| `bench_gacela_global` | +5.55% |
| `FileCacheBench` | +7.32% / +8.16% |
| `EventDispatchBench` | +1.20% / -0.13% / +0.77% |
| `DocBlockResolverBench` | -0.62% / +0.98% / -2.64% / +0.04% |

All within ±8%, most within ±4%, bootstrap faster. The 11–28% appears only on the four subjects that construct raw containers in a tight loop — which is what those benchmarks do, and what Gacela does not.

## 🔖 Changes

- The bench file records that demoting those four demotes **one measurement, not the guard** — every Gacela-path subject stays gated.
- `CHANGELOG.md` states the regression, its cause, and its scope, rather than letting a release ship quietly on a slower floor.

No source changes; `composer test` green.