### PR TITLE
ref: module containers as scopes of one app container (closes #539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,29 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
 
 ### Changed
 
+- **Module containers are scopes of one app container.** `AbstractFactory` built
+  one container per Factory class through `Container::withConfig()`, which walks
+  the whole of `gacela.php` — every binding, factory, alias, contextual binding,
+  tag and hook — and did it again for each. 79 walks in this repository alone,
+  and the cost grows with an application's wiring rather than with its number of
+  modules. Each module now gets a **scope** of one shared app container,
+  carrying only its own Provider.
+
+  Registration is not copied and a miss falls through, so a module still cannot
+  see a sibling's provider keys — which is what keeps two providers using the
+  same un-namespaced key from colliding. Module isolation is unchanged: two
+  modules resolving the same app-wide binding still get one instance each.
+
+  `extendService()` is app-wide configuration but often decorates a service a
+  *module's* Provider registers, into that module's scope where a parent-held
+  extension cannot reach it. Each scope now schedules those itself, skipping
+  ids the parent owns.
+
+  The saving is on container construction and scales with how much there is to
+  re-walk: 79 containers against 25 app-wide entries go 1.55ms → 0.06ms, and
+  against 300 entries 18.0ms → 0.07ms — the scope column is flat. An application
+  with little configuration sees none of that and pays ~2.5% on warm class
+  resolution for the fall-through.
 - **`gacela-project/container` `^2.0.1`** (was `^0.10.0`). `Container` is
   `final`, so Gacela decorates it by composition. Two of its fixes land in
   Gacela's own path: a class-string sharing a name with a function was *invoked*

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -25,6 +25,23 @@ abstract class AbstractFactory
     private static array $containers = [];
 
     /**
+     * The app-wide configuration, resolved once and shared by every module.
+     *
+     * Each module container used to be built by `Container::withConfig()`, which
+     * walks the whole of `gacela.php` -- every binding, factory, alias,
+     * contextual binding, tag and hook -- and does it again per Factory class.
+     * Only the module's own Provider differs. That is 79 walks in this
+     * repository alone, and the cost grows with the application's wiring rather
+     * than with the number of modules.
+     *
+     * A module now gets a *scope* of this instead: registration is not copied,
+     * a miss falls through, and anything the module registers shadows the parent
+     * for that module alone -- which is what keeps two providers using the same
+     * un-namespaced key from colliding.
+     */
+    private static ?Container $appContainer = null;
+
+    /**
      * Modules that resolved no Provider at all. Their container is still usable
      * for make(), which autowires by type, but getProvidedDependency() has
      * nothing to read from and reports the missing Provider instead.
@@ -43,6 +60,7 @@ abstract class AbstractFactory
     {
         self::$containers = [];
         self::$providerless = [];
+        self::$appContainer = null;
     }
 
     /**
@@ -105,7 +123,8 @@ abstract class AbstractFactory
 
     private function createContainerWithProvidedDependencies(): Container
     {
-        $container = Container::withConfig(Config::getInstance());
+        $container = self::appContainer()->createScope();
+        self::scheduleAppWideExtensions($container);
 
         $resolver = (new ProviderResolver())->resolve($this);
         $resolver?->register($container);
@@ -120,6 +139,40 @@ abstract class AbstractFactory
         self::$providerless[static::class] = $resolver === null;
 
         return $container;
+    }
+
+    /**
+     * `extendService()` is app-wide configuration, but the service it decorates
+     * is often registered by a *module's* Provider -- into that module's scope,
+     * where an extension held by the parent can never reach it.
+     *
+     * So each scope schedules the extensions itself, skipping any id the parent
+     * already owns: the parent applies those, and asking a scope to extend an
+     * inherited instance is refused upstream rather than silently ignored.
+     */
+    private static function scheduleAppWideExtensions(Container $scope): void
+    {
+        $parent = self::appContainer();
+
+        foreach (Config::getInstance()->getSetupGacela()->getServicesToExtend() as $id => $extensions) {
+            if ($parent->provides($id)) {
+                continue;
+            }
+
+            foreach ($extensions as $extension) {
+                $scope->extend($id, $extension);
+            }
+        }
+    }
+
+    /**
+     * Built on first use rather than at bootstrap: a process that never touches
+     * a Factory -- a console command reading config, say -- should not pay to
+     * assemble the container every module would have shared.
+     */
+    private static function appContainer(): Container
+    {
+        return self::$appContainer ??= Container::withConfig(Config::getInstance());
     }
 
     private function notifyProviderRegistered(string $providerClass): void

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -54,6 +54,21 @@ abstract class AbstractFactory
     private array $instances = [];
 
     /**
+     * Adopt the container bootstrap already built from this configuration,
+     * instead of walking `gacela.php` a second time to reach the same result.
+     *
+     * Pushed in by {@see Gacela::bootstrap()} rather than pulled: a Factory
+     * reaching for `Gacela::container()` would make the framework's entry point
+     * a dependency of every module's factory, which is a cycle.
+     *
+     * @internal
+     */
+    public static function useAppContainer(Container $container): void
+    {
+        self::$appContainer = $container;
+    }
+
+    /**
      * @internal
      */
     public static function resetCache(): void
@@ -172,7 +187,15 @@ abstract class AbstractFactory
      */
     private static function appContainer(): Container
     {
-        return self::$appContainer ??= Container::withConfig(Config::getInstance());
+        if (self::$appContainer instanceof Container) {
+            return self::$appContainer;
+        }
+
+        // Only reached when nothing bootstrapped: `Gacela::bootstrap()` hands
+        // its container down through useAppContainer(), so a bootstrapped
+        // application walks `gacela.php` once and modules become scopes of what
+        // it already built.
+        return self::$appContainer = Container::withConfig(Config::getInstance());
     }
 
     private function notifyProviderRegistered(string $providerClass): void

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -247,6 +247,7 @@ final class Gacela
     private static function runPlugins(Config $config): void
     {
         self::$mainContainer = Container::withConfig($config);
+        AbstractFactory::useAppContainer(self::$mainContainer);
 
         $plugins = $config->getSetupGacela()->getPlugins();
 

--- a/tests/Integration/Framework/AbstractFactory/SharedApp/AlphaClockHolder.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedApp/AlphaClockHolder.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory\SharedApp;
+
+final class AlphaClockHolder
+{
+    public function __construct(public readonly ClockInterface $clock)
+    {
+    }
+}

--- a/tests/Integration/Framework/AbstractFactory/SharedApp/AlphaFactory.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedApp/AlphaFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory\SharedApp;
+
+use Gacela\Framework\AbstractFactory;
+
+final class AlphaFactory extends AbstractFactory
+{
+    public function clock(): ClockInterface
+    {
+        return $this->make(AlphaClockHolder::class)->clock;
+    }
+}

--- a/tests/Integration/Framework/AbstractFactory/SharedApp/BetaClockHolder.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedApp/BetaClockHolder.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory\SharedApp;
+
+final class BetaClockHolder
+{
+    public function __construct(public readonly ClockInterface $clock)
+    {
+    }
+}

--- a/tests/Integration/Framework/AbstractFactory/SharedApp/BetaFactory.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedApp/BetaFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory\SharedApp;
+
+use Gacela\Framework\AbstractFactory;
+
+final class BetaFactory extends AbstractFactory
+{
+    public function clock(): ClockInterface
+    {
+        return $this->make(BetaClockHolder::class)->clock;
+    }
+}

--- a/tests/Integration/Framework/AbstractFactory/SharedApp/ClockInterface.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedApp/ClockInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory\SharedApp;
+
+interface ClockInterface
+{
+}

--- a/tests/Integration/Framework/AbstractFactory/SharedApp/SystemClock.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedApp/SystemClock.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory\SharedApp;
+
+final class SystemClock implements ClockInterface
+{
+}

--- a/tests/Integration/Framework/AbstractFactory/SharedAppContainerTest.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedAppContainerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\AbstractFactory;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\AbstractFactory\SharedApp\AlphaFactory;
+use GacelaTest\Integration\Framework\AbstractFactory\SharedApp\BetaFactory;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function array_count_values;
+
+/**
+ * Every module gets a scope of **one** app container, not a container of its
+ * own built from the same configuration.
+ *
+ * The point of the shared parent is that `gacela.php` is walked once rather
+ * than once per Factory class. Registering the app-wide bindings is the walk,
+ * and `BindingRegisteredEvent` is how it announces itself -- so counting those
+ * events across two modules is the observable form of "walked once".
+ */
+final class SharedAppContainerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        (new ReflectionClass(Gacela::class))->getMethod('resetCache')->invoke(null);
+    }
+
+    public function test_the_app_configuration_is_registered_once_for_every_module(): void
+    {
+        $registered = [];
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$registered): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(SharedApp\ClockInterface::class, SharedApp\SystemClock::class);
+            $config->registerSpecificListener(
+                BindingRegisteredEvent::class,
+                static function (BindingRegisteredEvent $event) use (&$registered): void {
+                    $registered[] = $event->id();
+                },
+            );
+        });
+
+        // Two modules, each building its own container.
+        (new AlphaFactory())->clock();
+        (new BetaFactory())->clock();
+
+        $counts = array_count_values($registered);
+
+        self::assertSame(
+            1,
+            $counts[SharedApp\ClockInterface::class] ?? 0,
+            'the app-wide binding was registered more than once, so the configuration is being '
+            . 'walked per module instead of shared',
+        );
+    }
+
+    public function test_each_module_still_resolves_the_app_wide_binding(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(SharedApp\ClockInterface::class, SharedApp\SystemClock::class);
+        });
+
+        // Sharing the parent must not cost a module its access to the binding.
+        self::assertInstanceOf(SharedApp\SystemClock::class, (new AlphaFactory())->clock());
+        self::assertInstanceOf(SharedApp\SystemClock::class, (new BetaFactory())->clock());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Step 3 of #539. `AbstractFactory` built one container per Factory class through `Container::withConfig()`, which walks the whole of `gacela.php` — every binding, factory, alias, contextual binding, tag and hook — and did it again for each. 79 walks in this repository alone, and the cost grows with an application's wiring rather than with its number of modules.

Each module now gets a **scope** of the container bootstrap already built.

## 🔖 What it took

- **Scopes, not copies.** Registration is not copied and a miss falls through, so a module still cannot see a sibling's provider keys — which is what stops two providers using the same un-namespaced key from colliding. Module isolation is unchanged: two modules resolving the same app-wide binding still get one instance each.

- **`extendService()` needed handling** — the "parent-owned vs scope-owned" question the issue flagged. It is app-wide configuration, but the service it decorates is often registered by a *module's* Provider into that module's scope, where a parent-held extension can never reach it. Each scope schedules those itself, skipping ids the parent owns; asking a scope to extend an inherited instance is refused upstream rather than silently ignored.

- **One container, not two.** The first pass shared a parent between Factory classes but built it itself, so `gacela.php` was still walked twice — once by bootstrap, once here. `SharedAppContainerTest` counts `BindingRegisteredEvent` across two modules and caught it: the app-wide binding was announced twice. `Gacela::bootstrap()` now hands its container down.

- **Pushed, not pulled.** Reaching for `Gacela::container()` from a Factory makes the framework's entry point a dependency of every module factory. `NoCircularDependenciesTest` rejected that as a cycle, correctly, so the container is handed down instead.

## 📊 The tradeoff

The saving is on container construction and scales with how much configuration there is to re-walk. 79 containers:

| app-wide entries | per-container | scopes |
|---|---|---|
| 25 | 1.553ms | 0.063ms |
| 300 | 18.04ms | 0.069ms |

The scope column is flat. This repository has almost no app-wide configuration, so it sees none of that and pays ~2.5% on warm class resolution for the fall-through — measured against `main` on container 2.0.1:

| benchmark | main | scopes | |
|---|---|---|---|
| `bench_class_resolving` | 1.101μs | 1.128μs | +2.5% |
| `bench_bootstrap_cold_rescan` | 42.43μs | 42.33μs | −0.2% |
| `bench_bootstrap_warm` | 27.62μs | 27.58μs | −0.2% |

So this pays for an application with real wiring and is roughly free for one without.

An earlier revision of this PR measured +5-7% and was held as a draft; that was against container 2.0.0, before [container#181](https://github.com/gacela-project/container/issues/181) was fixed and adopted in #592.

## ✅ Tests

`SharedAppContainerTest` pins that the app configuration is registered **once** across modules, and that sharing the parent does not cost a module its access to the binding. Full gate green: quality, 946 / 265 / 296, module cycles, mutation, perf.

Closes #539