### PR TITLE
fix(cache): scope the class-name and custom-services caches to the app root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ vendor/
 cachegacela-*
 tests/**/Users/
 gacela-local.php
-gacela-custom-services.php
-gacela-class-names.php
+gacela-custom-services*.php
+gacela-class-names*.php
 gacela-merged-config.php
 .gacelagacela-*.php
 mutation-report.html

--- a/infection.json5
+++ b/infection.json5
@@ -195,8 +195,14 @@
                 "Gacela\\PHPStan\\Rules\\ClassReflectionHelperTrait::shortClassName",
             ],
         },
+        // absoluteFilename() slices 12 hex characters out of a sha1 to scope a
+        // cache file to its app root. Which 12 is arbitrary: any fixed offset
+        // is equally stable, equally unique per root, and equally long, so
+        // moving it changes nothing observable. Killing it would mean asserting
+        // the digest, which pins the implementation rather than the behaviour.
         IncrementInteger: {
             ignore: [
+                "Gacela\\Framework\\ClassResolver\\Cache\\AbstractPhpFileCache::absoluteFilename",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",

--- a/src/Console/Application/CacheWarm/CacheManager.php
+++ b/src/Console/Application/CacheWarm/CacheManager.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Gacela\Console\Application\CacheWarm;
 
 use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Config\Config;
 
 use function array_filter;
 use function array_map;
+use function array_merge;
 use function file_exists;
 use function filesize;
 
@@ -33,7 +35,11 @@ final class CacheManager
      */
     public function getCacheFilePath(): string
     {
-        return $this->cacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
+        return AbstractPhpFileCache::absoluteFilename(
+            $this->cacheDir(),
+            ClassNamePhpCache::FILENAME,
+            Config::getInstance()->getAppRootDir(),
+        );
     }
 
     public function cacheFileExists(): bool
@@ -90,10 +96,20 @@ final class CacheManager
     private function allCacheFilePaths(): array
     {
         $cacheDir = $this->cacheDir();
+        $appRoot = Config::getInstance()->getAppRootDir();
 
-        return array_map(
-            static fn (string $filename): string => $cacheDir . DIRECTORY_SEPARATOR . $filename,
-            self::CACHE_FILENAMES,
+        // Both spellings: the app-scoped name `put()` writes, and the unscoped
+        // one written before the caches were scoped. `cache:clear` that left a
+        // legacy file behind would leave the stale answers it holds reachable.
+        return array_merge(
+            array_map(
+                static fn (string $filename): string => AbstractPhpFileCache::absoluteFilename($cacheDir, $filename, $appRoot),
+                self::CACHE_FILENAMES,
+            ),
+            array_map(
+                static fn (string $filename): string => $cacheDir . DIRECTORY_SEPARATOR . $filename,
+                self::CACHE_FILENAMES,
+            ),
         );
     }
 

--- a/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
+++ b/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
@@ -7,6 +7,7 @@ namespace Gacela\Console\Application\Doctor\Check;
 use Closure;
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use ReflectionClass;
@@ -24,6 +25,7 @@ final class CacheStalenessCheck implements HealthCheck
     public function __construct(
         private readonly string $cacheDir,
         ?Closure $sourceFileResolver = null,
+        private readonly string $appRootDir = '',
     ) {
         $this->sourceFileResolver = $sourceFileResolver ?? static function (string $className): ?string {
             if (!class_exists($className) && !interface_exists($className)) {
@@ -51,7 +53,7 @@ final class CacheStalenessCheck implements HealthCheck
         $missing = [];
 
         foreach ([ClassNamePhpCache::FILENAME, CustomServicesPhpCache::FILENAME] as $filename) {
-            $cacheFile = $this->cacheDir . DIRECTORY_SEPARATOR . $filename;
+            $cacheFile = AbstractPhpFileCache::absoluteFilename($this->cacheDir, $filename, $this->appRootDir);
             if (!is_file($cacheFile)) {
                 continue;
             }

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -81,7 +81,7 @@ final class DoctorCommand extends Command
         $suffixTypes = $config->getFactory()->createGacelaFileConfig()->getSuffixTypes();
 
         $checks = [
-            new CacheStalenessCheck($config->getCacheDir()),
+            new CacheStalenessCheck($config->getCacheDir(), null, $config->getAppRootDir()),
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules),
         ];

--- a/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
+++ b/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php
@@ -8,6 +8,9 @@ use Gacela\Framework\Cache\FileCache;
 
 use function array_keys;
 use function file_exists;
+use function sha1;
+use function str_ends_with;
+use function substr;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -26,6 +29,7 @@ abstract class AbstractPhpFileCache implements CacheInterface
 
     public function __construct(
         private readonly string $cacheDir,
+        private readonly string $appRootDir = '',
     ) {
         self::$cache[static::class] = $this->getExistingCache();
         self::$filenames[static::class] = $this->computeAbsoluteFilename();
@@ -171,6 +175,33 @@ abstract class AbstractPhpFileCache implements CacheInterface
         FileCache::writeAtomically(self::$filenames[static::class], self::$cache[static::class]);
     }
 
+    /**
+     * Where a cache file for this app lives.
+     *
+     * The cache dir can be shared between applications -- it defaults to the
+     * system temp dir -- so the filename embeds a hash of the app root. Without
+     * it two applications on one machine read and write the same file, and one
+     * silently serves the other's resolved class names. That is the defect
+     * `MergedConfigCache` was given this treatment for; these two caches were
+     * left behind, and a fresh install picking up another project's fixtures is
+     * what surfaced it.
+     *
+     * Public and static so the console agrees with the cache on the path:
+     * `cache:clear` and the staleness check have to look where `put()` wrote.
+     */
+    public static function absoluteFilename(string $cacheDir, string $baseFilename, string $appRootDir): string
+    {
+        if ($appRootDir === '') {
+            return $cacheDir . DIRECTORY_SEPARATOR . $baseFilename;
+        }
+
+        $base = str_ends_with($baseFilename, '.php')
+            ? substr($baseFilename, 0, -4)
+            : $baseFilename;
+
+        return $cacheDir . DIRECTORY_SEPARATOR . $base . '-' . substr(sha1($appRootDir), 0, 12) . '.php';
+    }
+
     abstract protected function getCacheFilename(): string;
 
     /**
@@ -192,6 +223,6 @@ abstract class AbstractPhpFileCache implements CacheInterface
 
     private function computeAbsoluteFilename(): string
     {
-        return $this->cacheDir . DIRECTORY_SEPARATOR . $this->getCacheFilename();
+        return self::absoluteFilename($this->cacheDir, $this->getCacheFilename(), $this->appRootDir);
     }
 }

--- a/src/Framework/ClassResolver/ClassResolverCache.php
+++ b/src/Framework/ClassResolver/ClassResolverCache.php
@@ -43,7 +43,7 @@ final class ClassResolverCache
             if (self::shouldDispatch(ClassNamePhpCacheCreatedEvent::class)) {
                 self::dispatchEvent(new ClassNamePhpCacheCreatedEvent($cacheDir));
             }
-            $cache = new ClassNamePhpCache($cacheDir);
+            $cache = new ClassNamePhpCache($cacheDir, Config::getInstance()->getAppRootDir());
         } else {
             if (self::shouldDispatch(ClassNameInMemoryCacheCreatedEvent::class)) {
                 self::dispatchEvent(new ClassNameInMemoryCacheCreatedEvent());

--- a/src/Framework/ServiceResolver/DocBlockResolverCache.php
+++ b/src/Framework/ServiceResolver/DocBlockResolverCache.php
@@ -40,7 +40,7 @@ final class DocBlockResolverCache
             if (self::shouldDispatch(CustomServicesPhpCacheCreatedEvent::class)) {
                 self::dispatchEvent(new CustomServicesPhpCacheCreatedEvent());
             }
-            $cache = new CustomServicesPhpCache(Config::getInstance()->getCacheDir());
+            $cache = new CustomServicesPhpCache(Config::getInstance()->getCacheDir(), Config::getInstance()->getAppRootDir());
         } else {
             if (self::shouldDispatch(CustomServicesInMemoryCacheCreatedEvent::class)) {
                 self::dispatchEvent(new CustomServicesInMemoryCacheCreatedEvent());

--- a/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
+++ b/tests/Feature/Console/CacheWarm/CacheWarmCommandTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Feature\Console\CacheWarm;
 
 use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Config\Config;
@@ -42,10 +43,17 @@ final class CacheWarmCommandTest extends TestCase
             $config->enableFileCache(__DIR__ . '/cache');
         });
 
-        $this->cacheFile = Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME;
+        $this->cacheFile = AbstractPhpFileCache::absoluteFilename(
+            Config::getInstance()->getCacheDir(),
+            ClassNamePhpCache::FILENAME,
+            Config::getInstance()->getAppRootDir(),
+        );
         $this->mergedConfigCacheFile = Config::getInstance()->mergedConfigCacheFilename();
-        $this->customServicesCacheFile = Config::getInstance()->getCacheDir()
-            . DIRECTORY_SEPARATOR . CustomServicesPhpCache::FILENAME;
+        $this->customServicesCacheFile = AbstractPhpFileCache::absoluteFilename(
+            Config::getInstance()->getCacheDir(),
+            CustomServicesPhpCache::FILENAME,
+            Config::getInstance()->getAppRootDir(),
+        );
 
         $this->removeGeneratedCaches();
 

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Feature\Console\Doctor;
 
 use Gacela\Console\Infrastructure\Command\DoctorCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Console\Doctor\Fixtures\DegradedWithMetadataHealthCheck;
@@ -48,7 +49,7 @@ final class DoctorCommandTest extends TestCase
     {
         putenv('GACELA_CACHE_DIR');
 
-        $cacheFile = $this->cacheDir . '/' . ClassNamePhpCache::FILENAME;
+        $cacheFile = AbstractPhpFileCache::absoluteFilename($this->cacheDir, ClassNamePhpCache::FILENAME, __DIR__);
         if (is_file($cacheFile)) {
             unlink($cacheFile);
         }
@@ -226,7 +227,7 @@ final class DoctorCommandTest extends TestCase
     private function writeCacheEntry(string $key, string $className): void
     {
         file_put_contents(
-            $this->cacheDir . '/' . ClassNamePhpCache::FILENAME,
+            AbstractPhpFileCache::absoluteFilename($this->cacheDir, ClassNamePhpCache::FILENAME, __DIR__),
             sprintf("<?php\n\nreturn %s;\n", var_export([$key => $className], true)),
         );
     }

--- a/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
+++ b/tests/Feature/Framework/FileCache/FileCacheFeatureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\FileCache;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Gacela;
@@ -43,8 +44,8 @@ final class FileCacheFeatureTest extends TestCase
         $facade = new Module\Facade();
         self::assertSame('name', $facade->getName());
 
-        self::assertFileExists(__DIR__ . '/custom/cache-dir/' . ClassNamePhpCache::FILENAME);
-        self::assertFileExists(__DIR__ . '/custom/cache-dir/' . CustomServicesPhpCache::FILENAME);
+        self::assertFileExists(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/cache-dir/', '/'), ClassNamePhpCache::FILENAME, __DIR__));
+        self::assertFileExists(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/cache-dir/', '/'), CustomServicesPhpCache::FILENAME, __DIR__));
     }
 
     public function test_custom_env_gacela_cache_dir(): void
@@ -59,11 +60,11 @@ final class FileCacheFeatureTest extends TestCase
         $facade = new Module\Facade();
         self::assertSame('name', $facade->getName());
 
-        self::assertFileExists(__DIR__ . '/custom/cache-dir/' . ClassNamePhpCache::FILENAME);
-        self::assertFileExists(__DIR__ . '/custom/cache-dir/' . CustomServicesPhpCache::FILENAME);
+        self::assertFileExists(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/cache-dir/', '/'), ClassNamePhpCache::FILENAME, __DIR__));
+        self::assertFileExists(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/cache-dir/', '/'), CustomServicesPhpCache::FILENAME, __DIR__));
 
-        self::assertFileDoesNotExist(__DIR__ . '/custom/this-will-be-overwritten/' . ClassNamePhpCache::FILENAME);
-        self::assertFileDoesNotExist(__DIR__ . '/custom/this-will-be-overwritten/' . CustomServicesPhpCache::FILENAME);
+        self::assertFileDoesNotExist(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/this-will-be-overwritten/', '/'), ClassNamePhpCache::FILENAME, __DIR__));
+        self::assertFileDoesNotExist(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/this-will-be-overwritten/', '/'), CustomServicesPhpCache::FILENAME, __DIR__));
     }
 
     public function test_custom_cache_dir_but_cache_disable(): void
@@ -76,7 +77,7 @@ final class FileCacheFeatureTest extends TestCase
         $facade = new Module\Facade();
         self::assertSame('name', $facade->getName());
 
-        self::assertFileDoesNotExist(__DIR__ . '/custom/cache-dir/' . ClassNamePhpCache::FILENAME);
-        self::assertFileDoesNotExist(__DIR__ . '/custom/cache-dir/' . CustomServicesPhpCache::FILENAME);
+        self::assertFileDoesNotExist(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/cache-dir/', '/'), ClassNamePhpCache::FILENAME, __DIR__));
+        self::assertFileDoesNotExist(AbstractPhpFileCache::absoluteFilename(rtrim(__DIR__ . '/custom/cache-dir/', '/'), CustomServicesPhpCache::FILENAME, __DIR__));
     }
 }

--- a/tests/Integration/Console/CacheWarm/CacheManagerTest.php
+++ b/tests/Integration/Console/CacheWarm/CacheManagerTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Integration\Console\CacheWarm;
 
 use Gacela\Console\Application\CacheWarm\CacheManager;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Config\Config;
@@ -53,11 +54,30 @@ final class CacheManagerTest extends TestCase
         @rmdir($this->cacheDir);
     }
 
-    public function test_cache_file_path_points_at_the_class_name_cache(): void
+    /**
+     * The path carries a hash of the app root. The cache dir can be shared --
+     * it defaults to the system temp dir -- and without the hash two
+     * applications on one machine read and write the same file.
+     */
+    public function test_cache_file_path_points_at_the_app_scoped_class_name_cache(): void
     {
         self::assertSame(
-            Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME,
+            AbstractPhpFileCache::absoluteFilename(
+                Config::getInstance()->getCacheDir(),
+                ClassNamePhpCache::FILENAME,
+                Config::getInstance()->getAppRootDir(),
+            ),
             $this->cacheManager->getCacheFilePath(),
+        );
+    }
+
+    public function test_two_app_roots_do_not_share_a_cache_file(): void
+    {
+        $dir = Config::getInstance()->getCacheDir();
+
+        self::assertNotSame(
+            AbstractPhpFileCache::absoluteFilename($dir, ClassNamePhpCache::FILENAME, '/srv/app-one'),
+            AbstractPhpFileCache::absoluteFilename($dir, ClassNamePhpCache::FILENAME, '/srv/app-two'),
         );
     }
 
@@ -117,7 +137,11 @@ final class CacheManagerTest extends TestCase
 
     private function writeCacheFile(string $filename, int $bytes): string
     {
-        $path = Config::getInstance()->getCacheDir() . DIRECTORY_SEPARATOR . $filename;
+        $path = AbstractPhpFileCache::absoluteFilename(
+            Config::getInstance()->getCacheDir(),
+            $filename,
+            Config::getInstance()->getAppRootDir(),
+        );
 
         if (!is_dir(dirname($path))) {
             mkdir(dirname($path), 0o777, true);

--- a/tests/Unit/Framework/ClassResolver/Cache/CacheFilenameScopingTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/CacheFilenameScopingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\ClassResolver\Cache;
+
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use PHPUnit\Framework\TestCase;
+
+use function basename;
+use function dirname;
+
+/**
+ * The cache directory defaults to the system temp dir, so it is shared by every
+ * application on the machine. The app-root hash in the filename is the only
+ * thing stopping two of them reading each other's resolved classes.
+ *
+ * These pin the shape rather than the digest: the exact hash is an
+ * implementation detail, but its presence, its length and what it is derived
+ * *from* are the behaviour.
+ */
+final class CacheFilenameScopingTest extends TestCase
+{
+    private const DIR = '/tmp/cache-dir';
+
+    public function test_the_file_lives_in_the_cache_dir_and_keeps_its_base_name(): void
+    {
+        $path = AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, '/srv/app');
+
+        self::assertSame(self::DIR, dirname($path));
+        self::assertMatchesRegularExpression('/^gacela-class-names-[0-9a-f]{12}\.php$/', basename($path));
+    }
+
+    /**
+     * Without an app root there is nothing to scope by, and the bare name is
+     * what every version before this wrote.
+     */
+    public function test_no_app_root_yields_the_unscoped_name(): void
+    {
+        self::assertSame(
+            self::DIR . '/' . ClassNamePhpCache::FILENAME,
+            AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, ''),
+        );
+    }
+
+    public function test_the_same_app_root_always_yields_the_same_file(): void
+    {
+        self::assertSame(
+            AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, '/srv/app'),
+            AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, '/srv/app'),
+        );
+    }
+
+    /**
+     * The whole point: two applications sharing one cache dir must not collide.
+     */
+    public function test_two_app_roots_never_share_a_file(): void
+    {
+        self::assertNotSame(
+            AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, '/srv/app-one'),
+            AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, '/srv/app-two'),
+        );
+    }
+
+    /**
+     * The suffix has to come from the app root and nothing else. Derived from
+     * the cache dir instead, it would be identical for exactly the applications
+     * it is meant to separate -- the ones sharing a directory.
+     */
+    public function test_the_suffix_follows_the_app_root_not_the_directory(): void
+    {
+        $here = basename(AbstractPhpFileCache::absoluteFilename('/tmp/one', ClassNamePhpCache::FILENAME, '/srv/app'));
+        $there = basename(AbstractPhpFileCache::absoluteFilename('/tmp/two', ClassNamePhpCache::FILENAME, '/srv/app'));
+
+        self::assertSame($here, $there);
+    }
+
+    public function test_each_cache_keeps_its_own_name(): void
+    {
+        $classNames = AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, '/srv/app');
+        $custom = AbstractPhpFileCache::absoluteFilename(self::DIR, 'gacela-custom-services.php', '/srv/app');
+
+        self::assertNotSame($classNames, $custom);
+        self::assertMatchesRegularExpression('/^gacela-custom-services-[0-9a-f]{12}\.php$/', basename($custom));
+    }
+}

--- a/tests/Unit/Framework/ClassResolver/Cache/CacheFilenameScopingTest.php
+++ b/tests/Unit/Framework/ClassResolver/Cache/CacheFilenameScopingTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 use function basename;
 use function dirname;
 
+use const DIRECTORY_SEPARATOR;
+
 /**
  * The cache directory defaults to the system temp dir, so it is shared by every
  * application on the machine. The app-root hash in the filename is the only
@@ -39,7 +41,7 @@ final class CacheFilenameScopingTest extends TestCase
     public function test_no_app_root_yields_the_unscoped_name(): void
     {
         self::assertSame(
-            self::DIR . '/' . ClassNamePhpCache::FILENAME,
+            self::DIR . DIRECTORY_SEPARATOR . ClassNamePhpCache::FILENAME,
             AbstractPhpFileCache::absoluteFilename(self::DIR, ClassNamePhpCache::FILENAME, ''),
         );
     }


### PR DESCRIPTION
## 📚 Description

Found during pre-release validation, by doing the thing CI cannot: installing Gacela into a **fresh consumer project** and running the CLI.

`doctor` in that brand-new project reported *this repository's* test fixtures:

```
⚠ cache staleness
    missing source: \GacelaTest\Integration\Architecture\StatefulFixture\Greeting\Facade → … (source file not found)
```

The consumer was reading the cache Gacela's own test suite had written.

## 🐛 Cause

The cache directory **defaults to the system temp dir**, so it is shared by every application on the machine. `MergedConfigCache` embeds a hash of the app root for precisely this reason, and its docblock states it:

> The cache dir can be shared between apps (it defaults to the system temp dir), so the filename embeds a hash of the app root: without it, every app using the shared default read and wrote the same file and silently served another app's merged config.

That reasoning applies identically to the other two caches, and they never got it:

```
gacela-merged-config-392d2c47b4a0.php   ← scoped
gacela-class-names.php                  ← not
gacela-custom-services.php              ← not
```

So this is the **1.18 merged-config fix applied to one of three caches**. Two applications sharing the default could serve each other's resolved class names — a Facade resolved in one reachable from the other.

## 🔖 Changes

- `AbstractPhpFileCache::absoluteFilename()` — one place that answers "where does this app's cache file live", used by the caches and by the console so they cannot disagree about the path
- The app root reaches `CacheStalenessCheck` by constructor rather than a `Config::getInstance()` call, which also keeps it unit-testable without bootstrapping
- **`cache:clear` removes both spellings.** An upgrade that left the unscoped file behind would leave its stale answers reachable

## ⚠️ Scope of impact

Real but bounded: it needs the default cache dir (no directory passed to `enableFileCache()`) **and** two Gacela applications under the same user. A project that passes its own directory — what the docs and `cache:warm` output steer you toward — was never affected. CI never sees it because one runner builds one project.

## ✅ Verification

The original symptom is gone: the consumer project's `doctor` now reports `✓ All checks passed`.

New tests pin both halves — that the path is app-scoped, and that two different app roots cannot produce the same filename. `composer test` green (940 / 263 / 296), `composer quality` green.