### PR TITLE
chore(deps): container 2.0.1, and gate the resolution benchmarks again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 A foundation major. The runtime change is two lines — PHP `>=8.3` and
-`gacela-project/container` `^2.0.0`, up from a `0.x`. Most of what follows comes
+`gacela-project/container` `^2.0.1`, up from a `0.x`. Most of what follows comes
 from the second: `#[Lazy]`, `#[Inject]` on properties, PSR-11-correct `has()`,
 and container exceptions where 0.x emitted raw PHP errors.
 
@@ -119,7 +119,7 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
 
 ### Changed
 
-- **`gacela-project/container` `^2.0.0`** (was `^0.10.0`). `Container` is
+- **`gacela-project/container` `^2.0.1`** (was `^0.10.0`). `Container` is
   `final`, so Gacela decorates it by composition. Two of its fixes land in
   Gacela's own path: a class-string sharing a name with a function was *invoked*
   instead of instantiated, and `has()` remembered a negative, so a class
@@ -142,16 +142,17 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
     container. A scope is now a decorator like its parent, so it keeps the
     Locator and the lifecycle events.
 
-  One caveat, measured and reported rather than absorbed quietly: container
-  2.0 resolves 11-28% slower **cold** than 1.5.0 —
+  One caveat, measured and reported rather than absorbed quietly, and since
+  fixed: container 2.0.0 resolved 11-28% slower **cold** than 1.5.0 —
   [container#181](https://github.com/gacela-project/container/issues/181),
   root-caused to the per-class argument builder being composed on a class's
-  first resolution, so a container that builds a class once pays for a shortcut
-  it never takes. Gacela's own benchmarks are unaffected: bootstrap, config
-  init, class resolution, the resolver cache, event dispatch and the file
-  caches all moved within ±8% and bootstrap came out ~3% faster. Only the
-  benchmarks that construct raw containers in a loop show it, and those are
-  reported rather than gating until it is fixed.
+  first resolution, so a container that builds a class once paid for a shortcut
+  it never takes. **Container 2.0.1 defers composition to the second
+  construction**; the four benchmarks that show it now measure +2.1 to +3.5%
+  against 1.5.0 over 20 paired samples, and are gating again. Gacela's own
+  benchmarks never moved: bootstrap, config init, class resolution, the
+  resolver cache, event dispatch and the file caches all stayed within ±8% and
+  bootstrap came out ~3% faster.
 
   `load()`/`loadFile()` return the ids they registered and take an optional
   per-id callback, which closes a gap `loadDefinitions()` shipped with:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "gacela-project/container": "^2.0"
+        "gacela-project/container": "^2.0.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a131edc92f2d6d073245e9d7af304007",
+    "content-hash": "833cc19ac8ce1bee0f963bc2f45d4fe1",
     "packages": [
         {
             "name": "gacela-project/container",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "bd2b021019de16d2078146fb42cf6ac96c3ba8b7"
+                "reference": "85fd8a5dff36e58de98a982918141f70ff60c241"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/bd2b021019de16d2078146fb42cf6ac96c3ba8b7",
-                "reference": "bd2b021019de16d2078146fb42cf6ac96c3ba8b7",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/85fd8a5dff36e58de98a982918141f70ff60c241",
+                "reference": "85fd8a5dff36e58de98a982918141f70ff60c241",
                 "shasum": ""
             },
             "require": {
@@ -73,7 +73,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/container/issues",
-                "source": "https://github.com/gacela-project/container/tree/2.0.0"
+                "source": "https://github.com/gacela-project/container/tree/2.0.1"
             },
             "funding": [
                 {
@@ -81,7 +81,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-08-01T11:59:07+00:00"
+            "time": "2026-08-01T17:31:02+00:00"
         },
         {
             "name": "psr/container",

--- a/tests/Benchmark/Container/ContainerResolutionBench.php
+++ b/tests/Benchmark/Container/ContainerResolutionBench.php
@@ -11,7 +11,6 @@ use GacelaTest\Benchmark\Container\Fixtures\DeepD;
 use GacelaTest\Benchmark\Container\Fixtures\InjectConsumer;
 use GacelaTest\Benchmark\Container\Fixtures\ServiceInterface;
 use GacelaTest\Benchmark\Container\Fixtures\SimpleClass;
-use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\Groups;
 
 /**
@@ -22,27 +21,22 @@ use PhpBench\Attributes\Groups;
  *
  * Sampling: inherits the phpbench.json defaults — see tests/Benchmark/README.md.
  *
- * **Informational, not gating.** Every subject here times
- * `gacela-project/container`'s resolution path rather than Gacela's own code,
- * so its floor moves whenever that package does — and the guard compares
- * against the *base branch*, which makes a dependency major an automatic
- * failure no change on this side can answer. Adopting container 2.0 measured
- * +11-28% across these four, reported upstream as
- * [container#181](https://github.com/gacela-project/container/issues/181).
+ * Every subject here times `gacela-project/container`'s resolution path rather
+ * than Gacela's own code, so its floor moves whenever that package does — and
+ * the guard compares against the *base branch*, which makes a dependency major
+ * an automatic failure no change on this side can answer. That is what
+ * happened on the container 2.0 bump: these four measured +11-28%, they were
+ * demoted to `informational` while the number they track belonged to someone
+ * else, and the cause was
+ * [container#181](https://github.com/gacela-project/container/issues/181) — a
+ * per-class argument builder composed on a class's *first* resolution, which a
+ * container built once per revolution pays for and never uses again.
  *
- * They still run and still get reported on every pull request; they are simply
- * not a merge blocker while the number they track belongs to someone else.
- * Move back to `gate` once #181 lands and the floor is stable again.
- *
- * This demotes one measurement, not the guard. Every subject that times
- * Gacela's own paths stays in `gate` -- bootstrap, config init, class
- * resolution, the resolver cache, event dispatch, the file caches -- and on the
- * 2.0 bump each of those moved within +-8%, most within +-4%, with bootstrap
- * ~3% faster. The regression is confined to constructing raw containers in a
- * tight loop, which is what these four do and what Gacela does not.
+ * Fixed in container 2.0.1 and gating again: against 1.5.0 the four now measure
+ * +2.1 to +3.5% (20 paired samples), inside the 10% budget. Expect to demote
+ * them again for the next container major, and to restore them the same way.
  */
-#[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
-#[Groups(['informational', 'container'])]
+#[Groups(['gate', 'container'])]
 final class ContainerResolutionBench
 {
     /**


### PR DESCRIPTION
Picks up [container 2.0.1](https://github.com/gacela-project/container/releases/tag/2.0.1), which fixes [container#181](https://github.com/gacela-project/container/issues/181), and puts `ContainerResolutionBench` back in the `gate` group.

## Why it was demoted

Container 2.0.0 composed a per-class argument builder on a class's **first** resolution. Composing walks the whole graph below the class and allocates a closure per node — so a container that constructs a class once pays for a shortcut it never takes. These four subjects build a fresh `Container` per revolution, which is exactly that shape, and measured +11-28%.

Container 2.0.1 defers composition to the second construction, and reads a settled answer inline instead of calling into the resolver per construction.

## Measured

This benchmark, container 1.5.0 against 2.0.1, 20 paired samples alternating with a discarded warm-up before every measurement, PHP 8.5, opcache on, JIT off:

| subject | 1.5.0 → 2.0.0 | 1.5.0 → 2.0.1 |
|---|---|---|
| `bench_resolve_no_dependencies` | +20.4% | **+2.5%** |
| `bench_resolve_with_inject_attribute` | +15.3% | **+3.5%** |
| `bench_resolve_with_bindings` | +26.8% | **+3.2%** |
| `bench_resolve_deep_chain` | +11.7% | **+2.1%** |

Inside the 10% budget, so the gate goes back on.

## Also

Floors the constraint at `^2.0.1` rather than `^2.0`, so no install resolves the version carrying the regression.

The docblock keeps the reason these subjects are fragile — they time someone else's code, compared against the base branch, which makes a dependency major an automatic failure no change here can answer. Next container major can be demoted and restored the same way; that is now written down rather than rediscovered.

## Validation

`composer test` — all suites green (263 + 296 tests). The 5/7 deprecations are Gacela's own `DocBlockResolver` use-statement fallback, pre-existing and unrelated. `composer quality` — php-cs-fixer, Psalm and PHPStan all clean.