### PR TITLE
docs(changelog): record why the two held majors are held

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,19 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
 - Raised the `nikic/php-parser` floor to `^5.4`: Psalm 6.16 reads
   `Property::$hooks`, which only exists from 5.4.
 - Refreshed the toolchain: `infection` `^0.29` → `^0.34`, plus phpstan and
-  rector. `phpunit` stays on `^10.5`.
+  rector. Two majors are held, each re-verified against the current lockfile
+  rather than taken on trust:
+
+  - **`phpunit` stays on `^10.5`.** Rector ships a composer `files` autoload
+    that preloads its own bundled `nikic/php-parser`, gated on
+    `PHPUnit\Runner\Version::id() >= 12` — so it activates only under PHPUnit
+    12. This package requires `nikic/php-parser` directly for its PHPStan
+    rules, so whichever loads first, the other redeclares:
+    `Cannot redeclare interface PhpParser\NodeVisitor`. Reproduced on
+    `phpunit/phpunit:^12.0`; the whole unit suite fatals before the first test.
+  - **`psalm/plugin-phpunit` stays on `^0.19`.** `0.20` requires
+    `psalm/psalm-plugin-api ^0.1`, which conflicts with `vimeo/psalm <7.0.0`,
+    and Psalm 7 is still at `7.0.0-beta19`.
 - `symfony-bridge/composer.json` matches the root package it ships from.
 - A root `gacela.php` scoping the console to `src`. Without it `doctor` walked
   the whole repository and reported two errors on a clean checkout: `tests/`


### PR DESCRIPTION
## 📚 Description

Dependency check requested before the release. **Everything is current** — `gacela-project/container` is at `2.0.1`, the latest, and `composer update` reports nothing to modify.

Two majors remain held, and I re-verified both against the current lockfile rather than trusting the notes. Both still hold — but the *reason* for one of them had been lost.

## 🔖 What changed

An earlier compression pass of the changelog kept `` `phpunit` stays on `^10.5` `` and dropped why. That reason is the only part that stops someone re-attempting the upgrade, so it is back — and now more precise than the note it replaces, because I reproduced it:

**PHPUnit 12** is blocked by **rector**, specifically. Rector ships a composer `files` autoload whose entire body is gated on PHPUnit 12 or later:

```php
if (
    defined('PHPUNIT_COMPOSER_INSTALL')
    && ! interface_exists(Node::class, false)
    && ! class_exists(Version::class, false)
    && class_exists(Version::class, true) && (int) Version::id() >= 12
) {
    require_once __DIR__ . '/preload.php';   // rector's own nikic/php-parser
}
```

This package requires `nikic/php-parser` **directly**, for the PHPStan rules. So under PHPUnit 12 there are two copies in play and whichever loads first, the other redeclares:

```
PHP Fatal error: Cannot redeclare interface PhpParser\NodeVisitor
  (previously declared in vendor/nikic/php-parser/lib/PhpParser/NodeVisitor.php:5)
  in vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeVisitor.php on line 6
```

The whole unit suite fatals before the first test. Reproduced on `phpunit/phpunit:^12.0` with `-W`, then reverted.

**`psalm/plugin-phpunit`** stays on `^0.19`: `0.20` requires `psalm/psalm-plugin-api ^0.1`, which conflicts with `vimeo/psalm <7.0.0`, and Psalm 7 is still `7.0.0-beta19`.

## ✅ Checks

No source changes. `composer test` green (946 / 265 / 296).