### PR TITLE
ref: rename DocBlockResolverCache to ServiceResolverCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,12 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
   - **`psalm/plugin-phpunit` stays on `^0.19`.** `0.20` requires
     `psalm/psalm-plugin-api ^0.1`, which conflicts with `vimeo/psalm <7.0.0`,
     and Psalm 7 is still at `7.0.0-beta19`.
+- `DocBlockResolverCache` is `ServiceResolverCache`. It caches resolved custom
+  services and decides whether a PHP file or an in-memory map backs them --
+  nothing about it is docblock-specific, and every symbol it touches says so
+  (`CustomServicesPhpCache`, and the three `CustomServices*` events). The name
+  now matches both what it does and its counterpart, `ClassResolverCache`.
+  Internal, so no migration.
 - `symfony-bridge/composer.json` matches the root package it ships from.
 - A root `gacela.php` scoping the console to `src`. Without it `doctor` walked
   the whole repository and reported two errors on a clean checkout: `tests/`

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -29,7 +29,7 @@ use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Exception\ServiceNotFoundException;
 use Gacela\Framework\Health\HealthCheckRegistry;
-use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
+use Gacela\Framework\ServiceResolver\ServiceResolverCache;
 
 use function is_string;
 use function sprintf;
@@ -203,7 +203,7 @@ final class Gacela
         GacelaFileCache::resetCache();
         AbstractPhpFileCache::resetCache();
         WritableDirectory::resetCache();
-        DocBlockResolverCache::resetCache();
+        ServiceResolverCache::resetCache();
         ClassResolverCache::resetCache();
         ConfigFactory::resetCache();
         PathFinder::resetCache();

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -68,7 +68,7 @@ final class DocBlockResolver
     private function getClassName(string $method): string
     {
         $cacheKey = $this->generateCacheKey($method);
-        $cache = DocBlockResolverCache::getCacheInstance();
+        $cache = ServiceResolverCache::getCacheInstance();
 
         if (!$cache->has($cacheKey)) {
             $className = $this->getClassFromDoc($method);

--- a/src/Framework/ServiceResolver/ServiceResolverCache.php
+++ b/src/Framework/ServiceResolver/ServiceResolverCache.php
@@ -14,7 +14,18 @@ use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesInMemoryCacheCreate
 use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesPhpCacheCreatedEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 
-final class DocBlockResolverCache
+/**
+ * Holds the cache of resolved custom services, and decides what backs it: a
+ * PHP file when the project has file caching on, an in-memory map otherwise.
+ *
+ * The counterpart of {@see \Gacela\Framework\ClassResolver\ClassResolverCache},
+ * which does the same for resolved class names.
+ *
+ * Was `DocBlockResolverCache`, which named the wrong thing: nothing here is
+ * docblock-specific, and every symbol it touches says custom services --
+ * `CustomServicesPhpCache` and the three `CustomServices*` events.
+ */
+final class ServiceResolverCache
 {
     use EventDispatchingCapabilities;
 

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -126,7 +126,7 @@ trait ContainerFixture
      *
      * This resets the current singletons first and then re-applies the
      * captured in-memory cache. It does not rerun the bootstrap cycle,
-     * so any derived caches (e.g. DocBlockResolverCache) stay empty and
+     * so any derived caches (e.g. ServiceResolverCache) stay empty and
      * will be lazily rebuilt.
      */
     protected function restoreContainerState(ContainerSnapshot $snapshot): void

--- a/tests/Benchmark/README.md
+++ b/tests/Benchmark/README.md
@@ -84,7 +84,7 @@ resolution), say so in the class docblock.
 Benches share one process per subject, and the repository shares one machine:
 
 - Reset global state in setup (`resetInMemoryCache()`, `Config::resetInstance()`,
-  `DocBlockResolverCache::resetCache()`, ...) so subjects don't leak into each
+  `ServiceResolverCache::resetCache()`, ...) so subjects don't leak into each
   other.
 - **Never enable the file cache without an explicit directory.** With no
   directory the cache falls back to `sys_get_temp_dir()`, which is shared with

--- a/tests/Benchmark/ServiceResolver/DocBlockResolverBench.php
+++ b/tests/Benchmark/ServiceResolver/DocBlockResolverBench.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace GacelaTest\Benchmark\ServiceResolver;
 
 use Gacela\Framework\Gacela;
-use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
+use Gacela\Framework\ServiceResolver\ServiceResolverCache;
 use PhpBench\Attributes\AfterMethods;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 
 /**
  * Attribute-based vs phpdoc-based service resolution, single and repeated
- * (repeated variants exercise the DocBlockResolverCache).
+ * (repeated variants exercise the ServiceResolverCache).
  *
  * Sampling: inherits the phpbench.json defaults — see tests/Benchmark/README.md.
  */
@@ -25,12 +25,12 @@ final class DocBlockResolverBench
     {
         Gacela::bootstrap(__DIR__);
 
-        DocBlockResolverCache::resetCache();
+        ServiceResolverCache::resetCache();
     }
 
     public function tearDown(): void
     {
-        DocBlockResolverCache::resetCache();
+        ServiceResolverCache::resetCache();
     }
 
     /**

--- a/tests/Integration/Framework/ServiceResolver/ServiceResolverCacheTest.php
+++ b/tests/Integration/Framework/ServiceResolver/ServiceResolverCacheTest.php
@@ -12,10 +12,10 @@ use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesInMemoryCacheCreate
 use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesPhpCacheCreatedEvent;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
-use Gacela\Framework\ServiceResolver\DocBlockResolverCache;
+use Gacela\Framework\ServiceResolver\ServiceResolverCache;
 use PHPUnit\Framework\TestCase;
 
-final class DocBlockResolverCacheTest extends TestCase
+final class ServiceResolverCacheTest extends TestCase
 {
     /** @var list<class-string> */
     private static array $inMemoryEvents = [];
@@ -45,7 +45,7 @@ final class DocBlockResolverCacheTest extends TestCase
 
     public function test_no_project_cached_enabled(): void
     {
-        DocBlockResolverCache::getCacheInstance();
+        ServiceResolverCache::getCacheInstance();
 
         self::assertSame([
             CustomServicesInMemoryCacheCreatedEvent::class,
@@ -54,8 +54,8 @@ final class DocBlockResolverCacheTest extends TestCase
 
     public function test_no_project_cached_enabled_and_cached(): void
     {
-        DocBlockResolverCache::getCacheInstance();
-        DocBlockResolverCache::getCacheInstance();
+        ServiceResolverCache::getCacheInstance();
+        ServiceResolverCache::getCacheInstance();
 
         self::assertSame([
             CustomServicesInMemoryCacheCreatedEvent::class,
@@ -71,7 +71,7 @@ final class DocBlockResolverCacheTest extends TestCase
                 $config->enableFileCache();
             }));
 
-        DocBlockResolverCache::getCacheInstance();
+        ServiceResolverCache::getCacheInstance();
 
         self::assertSame([
             CustomServicesPhpCacheCreatedEvent::class,


### PR DESCRIPTION
## 📚 Description

The last non-release item on #503 — *"finish the `DocBlock*` → `Service*` internal rename (public trait already renamed; guts still legacy-named)"* — which that issue parked on a naming decision, because a blanket rename would make things **less** accurate.

The decision turns out to be narrower than all-or-nothing. Going through the family, exactly one name describes something the class does not do.

| class | verdict |
|---|---|
| `DocBlockParser` | accurate — parses docblocks |
| `UseBlockParser` | accurate — parses use statements |
| `DocBlockResolver` | accurate — still reads both, as the deprecated fallback behind `#[ServiceMap]` |
| `DocBlockServiceResolver` | accurate |
| `DocBlockResolvable` | accurate |
| **`DocBlockResolverCache`** | **misnomer** |

`DocBlockResolverCache` caches **resolved custom services** and decides what backs them — a PHP file when project caching is on, an in-memory map otherwise. Nothing about it is docblock-specific, and every symbol it touches says so: `CustomServicesPhpCache`, `CustomServicesCacheCachedEvent`, `CustomServicesInMemoryCacheCreatedEvent`, `CustomServicesPhpCacheCreatedEvent`.

It is also the exact counterpart of `ClassResolver\ClassResolverCache`, which does the identical job for resolved class *names* — same shape, same responsibility, matching namespace. So `ServiceResolverCache` is the name that already existed by convention.

## 🔖 Scope

Deliberately one class. The others keep their names for the reason #503 recorded: renaming `DocBlockParser` to something `Service*` would describe it *worse*. That reasoning was right; it just applied to five of the six.

Internal — no migration note needed. Every reference updated across 7 files, including the benchmark and its README, and the test file renamed with it.

## ✅ Checks

`composer test` green (946 / 265 / 296), `composer quality` green.

Related to #503