### PR TITLE
chore(deps): container 2.0.2, phpstan 2.2.8, rector 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 A foundation major. The runtime change is two lines — PHP `>=8.3` and
-`gacela-project/container` `^2.0.1`, up from a `0.x`. Most of what follows comes
+`gacela-project/container` `^2.0.2`, up from a `0.x`. Most of what follows comes
 from the second: `#[Lazy]`, `#[Inject]` on properties, PSR-11-correct `has()`,
 and container exceptions where 0.x emitted raw PHP errors.
 
@@ -144,7 +144,7 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
   against 300 entries 18.0ms → 0.07ms — the scope column is flat. An application
   with little configuration sees none of that and pays ~2.5% on warm class
   resolution for the fall-through.
-- **`gacela-project/container` `^2.0.1`** (was `^0.10.0`). `Container` is
+- **`gacela-project/container` `^2.0.2`** (was `^0.10.0`). `Container` is
   `final`, so Gacela decorates it by composition. Two of its fixes land in
   Gacela's own path: a class-string sharing a name with a function was *invoked*
   instead of instantiated, and `has()` remembered a negative, so a class
@@ -281,11 +281,16 @@ Migration is three mechanical renames. See [UPGRADE.md](UPGRADE.md), and run
     `PHPUnit\Runner\Version::id() >= 12` — so it activates only under PHPUnit
     12. This package requires `nikic/php-parser` directly for its PHPStan
     rules, so whichever loads first, the other redeclares:
-    `Cannot redeclare interface PhpParser\NodeVisitor`. Reproduced on
-    `phpunit/phpunit:^12.0`; the whole unit suite fatals before the first test.
+    `Cannot redeclare interface PhpParser\NodeVisitor`. Re-reproduced on
+    `phpunit/phpunit:12.5.33` against `rector/rector:2.6.1`, which still ships
+    the gate; the whole unit suite fatals before the first test.
   - **`psalm/plugin-phpunit` stays on `^0.19`.** `0.20` requires
     `psalm/psalm-plugin-api ^0.1`, which conflicts with `vimeo/psalm <7.0.0`,
     and Psalm 7 is still at `7.0.0-beta19`.
+- The container's constructor-plan type aliases moved to `PlanRegistry`, which
+  holds them, from `DependencyResolver`, which builds them, so the decorator's
+  `@psalm-import-type CompiledPlans` follows them. That symbol only exists from
+  container 2.0.2, which is why the floor is `^2.0.2` rather than `^2.0.1`.
 - `DocBlockResolverCache` is `ServiceResolverCache`. It caches resolved custom
   services and decides whether a PHP file or an in-memory map backs them —
   nothing about it is docblock-specific, and every symbol it touches says so

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,7 @@ The whole runtime change is two lines, and almost everything below follows from 
 
 ```diff
 -"php": ">=8.1",  "gacela-project/container": "^0.10.0"
-+"php": ">=8.3",  "gacela-project/container": "^2.0.1"
++"php": ">=8.3",  "gacela-project/container": "^2.0.2"
 ```
 
 **Your container stops being a 0.x.** This is the reason, and it is not available to you on 1.x at any version — `Gacela\Container\Container` became `final` at 1.0, so crossing that line is breaking by construction. What it buys:
@@ -159,7 +159,7 @@ This is worth doing regardless of the error. A suppressed call was never a *type
 
 ### 6. Only if you type-hinted the concrete container
 
-`gacela-project/container` moved to `^2.0.1` (was `^0.10.0`), and `Gacela\Container\Container` is `final` from 1.0. `Gacela\Framework\Container\Container` therefore decorates it by composition instead of extending it — which is what its docblock always claimed it did.
+`gacela-project/container` moved to `^2.0.2` (was `^0.10.0`), and `Gacela\Container\Container` is `final` from 1.0. `Gacela\Framework\Container\Container` therefore decorates it by composition instead of extending it — which is what its docblock always claimed it did.
 
 It still implements `ContainerInterface`. **This only affects code that passed a Gacela container somewhere the concrete `Gacela\Container\Container` was type-hinted:**
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "gacela-project/container": "^2.0.1"
+        "gacela-project/container": "^2.0.2"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "833cc19ac8ce1bee0f963bc2f45d4fe1",
+    "content-hash": "e14d318f516f64dcc74d6f2829a1f17f",
     "packages": [
         {
             "name": "gacela-project/container",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "85fd8a5dff36e58de98a982918141f70ff60c241"
+                "reference": "e9ac0b6b5c6b0eb8724e04b8e9cbc829f43c6707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/85fd8a5dff36e58de98a982918141f70ff60c241",
-                "reference": "85fd8a5dff36e58de98a982918141f70ff60c241",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/e9ac0b6b5c6b0eb8724e04b8e9cbc829f43c6707",
+                "reference": "e9ac0b6b5c6b0eb8724e04b8e9cbc829f43c6707",
                 "shasum": ""
             },
             "require": {
@@ -26,11 +26,10 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.75",
-                "infection/infection": "^0.31",
+                "infection/infection": "^0.31 || ^0.34",
                 "phpbench/phpbench": "^1.4",
                 "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^12.5",
-                "psalm/plugin-phpunit": "^0.19",
                 "symfony/var-dumper": "^6.4 || ^7.0",
                 "symfony/yaml": "^6.4 || ^7.0",
                 "vimeo/psalm": "^6.16"
@@ -73,7 +72,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/container/issues",
-                "source": "https://github.com/gacela-project/container/tree/2.0.1"
+                "source": "https://github.com/gacela-project/container/tree/2.0.2"
             },
             "funding": [
                 {
@@ -81,7 +80,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-08-01T17:31:02+00:00"
+            "time": "2026-08-06T08:42:24+00:00"
         },
         {
             "name": "psr/container",
@@ -4088,11 +4087,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.7",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
-                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -4148,7 +4147,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-29T17:39:32+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
@@ -5507,16 +5506,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.5.9",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "858b1fb95d94f658b54c01080bf7b6ae97274536"
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/858b1fb95d94f658b54c01080bf7b6ae97274536",
-                "reference": "858b1fb95d94f658b54c01080bf7b6ae97274536",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
                 "shasum": ""
             },
             "require": {
@@ -5555,7 +5554,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.5.9"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
             },
             "funding": [
                 {
@@ -5563,7 +5562,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-30T22:10:00+00:00"
+            "time": "2026-08-03T17:30:34+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -5845,16 +5844,16 @@
         },
         {
             "name": "sanmai/pipeline",
-            "version": "7.9",
+            "version": "7.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/pipeline.git",
-                "reference": "d7046ecce91ae57fca403be694888371a21250eb"
+                "reference": "a8e4e57a6031efc7a92defd13fed9c1c4c73fc71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/d7046ecce91ae57fca403be694888371a21250eb",
-                "reference": "d7046ecce91ae57fca403be694888371a21250eb",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/a8e4e57a6031efc7a92defd13fed9c1c4c73fc71",
+                "reference": "a8e4e57a6031efc7a92defd13fed9c1c4c73fc71",
                 "shasum": ""
             },
             "require": {
@@ -5869,7 +5868,7 @@
                 "php-coveralls/php-coveralls": "^2.4.1",
                 "phpstan/extension-installer": "^1.4",
                 "phpstan/phpstan": "^2",
-                "phpunit/phpunit": ">=9.4 <12",
+                "phpunit/phpunit": "^11 || ^12",
                 "sanmai/phpstan-rules": "^0.3.11",
                 "sanmai/phpunit-double-colon-syntax": "^0.1.1",
                 "vimeo/psalm": ">=2"
@@ -5901,7 +5900,7 @@
             "description": "General-purpose collections pipeline",
             "support": {
                 "issues": "https://github.com/sanmai/pipeline/issues",
-                "source": "https://github.com/sanmai/pipeline/tree/7.9"
+                "source": "https://github.com/sanmai/pipeline/tree/7.10"
             },
             "funding": [
                 {
@@ -5909,7 +5908,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-16T11:54:05+00:00"
+            "time": "2026-08-03T04:56:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9198,5 +9197,5 @@
     "platform-overrides": {
         "php": "8.3.16"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -44,7 +44,7 @@ use function is_string;
  * @psalm-import-type Binding from \Gacela\Container\ContainerInterface
  * @psalm-import-type BindingsMap from \Gacela\Container\ContainerInterface as ContainerBindingsMap
  * @psalm-import-type StatsArray from \Gacela\Container\ContainerInterface
- * @psalm-import-type CompiledPlans from \Gacela\Container\DependencyResolver
+ * @psalm-import-type CompiledPlans from \Gacela\Container\PlanRegistry
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
  */


### PR DESCRIPTION
## 📚 Description

Takes every dependency as far as it can currently go before the 2.0 cut, and re-verifies the two majors this package holds back rather than carrying their recorded reasons over on trust.

Opened as a pull request rather than pushed to `main` because the PHPBench perf gate and the full Infection run only fire on pull requests — a container bump is exactly the change that gate exists for.

## 🔖 Changes

- **`gacela-project/container` `^2.0.1` → `^2.0.2`.** 2.0.2 moves the six constructor-plan type aliases to `PlanRegistry`, which holds them, from `DependencyResolver`, which builds them, so `Container`'s `@psalm-import-type CompiledPlans` follows them. The floor rises to `^2.0.2` rather than staying `^2.0.1`: `PlanRegistry` does not exist in 2.0.1, so on the old floor the import dangles and Psalm reports `InvalidTypeImport`. Nothing else in the release touches this package — the rest is the container's own tests, CLI help and internal dedupe
- **`phpstan/phpstan` 2.2.7 → 2.2.8**, **`rector/rector` 2.5.9 → 2.6.1**, **`sanmai/pipeline` 7.9 → 7.10** (transitive)
- Recorded the alias move and the raised floor in the changelog, and updated the two `^2.0.1` spellings in `UPGRADE.md`

### The two held majors, re-verified

Both were re-checked against this lockfile, not assumed:

- **`phpunit` stays on `^10.5`.** Rector 2.6.1 still ships the gate — `bootstrap.php` requires `preload.php` when `PHPUnit\Runner\Version::id() >= 12`. Installed `phpunit/phpunit:12.5.33` in a throwaway worktree and ran the unit suite: `PHP Fatal error: Cannot redeclare interface PhpParser\NodeVisitor`, thrown from `rector/rector/preload.php:31` before the first test. Unchanged from the recorded reason, on a newer rector
- **`psalm/plugin-phpunit` stays on `^0.19`.** `0.20.2` requires `psalm/psalm-plugin-api ^0.1`, whose `0.1.0` declares `conflict: {vimeo/psalm: <7.0.0}`. Psalm's latest stable is `6.16.1`; 7.0 is still at `7.0.0-beta19`

`gacela-project/container` dropped `psalm/plugin-phpunit` in 2.0.2 as typing test code its config never analyses. That does not transfer here: `psalm.xml` analyses `src`, and `src` ships `GacelaTestCase` and `ContainerFixture`, which are PHPUnit code. The plugin is earning its place in this package.

## ✅ Verification

- `composer test` green locally: cs-fixer, Psalm, PHPStan, and 946 + 265 + 296 tests
- `composer validate --check-lock` clean
