### PR TITLE
fix(rector): restore the ruleset, gate it, and fix what it surfaced

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Run friendsofphp/php-cs-fixer
         run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --show-progress=dots --using-cache=no --verbose
 
+      - name: Run rector
+        run: ./vendor/bin/rector --dry-run --no-progress-bar
+
   type-checker:
     name: Type Checker
     runs-on: ubuntu-latest
@@ -73,3 +76,6 @@ jobs:
 
       - name: Run phpstan
         run: ./vendor/bin/phpstan analyze -c phpstan.neon src
+
+      - name: Run phpstan (tests)
+        run: ./vendor/bin/phpstan analyze -c phpstan-tests.neon --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,17 @@ silently.
   concrete class, where an unforwarded method compiles fine and stays
   unreachable. The exemption list is empty now. `createScope()` was its last
   entry.
+- `AttributeReadCoverageTest` requires every read of a non-`final` attribute to
+  pass `ReflectionAttribute::IS_INSTANCEOF`. An attribute is left non-`final`
+  precisely so it can be subclassed, and a reader naming the parent without the
+  flag matches the parent and nothing else. `debug:dependencies`, `debug:module`
+  and `debug:container` read that way, and so did the Symfony bridge, so
+  `Gacela\Framework\Attribute\Inject` was honoured by the container and by
+  nothing else: the parameter showed as plain autowiring, and Symfony autowired
+  it. Both attribute docblocks name this failure and call it silent. What hid it
+  is that the container's own three reads were already correct, and every test
+  went through `Container::make()`. Both readers pass the flag now, with a test
+  each that reads through the surface rather than the container.
 - `Gacela::resetCache()` clears the shared plan cache, so plans are shared
   *within* a bootstrap rather than across one. It deliberately does **not** call
   `Container::resetStaticCaches()`. That was tried, and cost `FileCacheBench`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,32 @@ silently.
   - **`psalm/plugin-phpunit` stays on `^0.19`.** `0.20` requires
     `psalm/psalm-plugin-api ^0.1`, which conflicts with `vimeo/psalm <7.0.0`.
     Psalm 7 is still at `7.0.0-beta19`.
+- That rector refresh left `rector.php` naming `SetList::STRICT_BOOLEANS`, which
+  2.x removed, so `composer rector` and `composer fix` both died on an undefined
+  constant and the entire ruleset went unapplied. Nothing caught it: rector was
+  in neither `composer quality` nor any workflow. It is in both now, as
+  `composer rectorrun`, alongside `phpstan-tests`, which was also configured and
+  also never run in CI. Re-applying the ruleset touched 60 files, all internal;
+  the only `src/` signature changes are nine `private static` methods becoming
+  `private`.
+
+  Six dead-code rules and `ReadOnlyPropertyRector` are now bounded to `src/`.
+  Fixtures are shaped on purpose, and dead-code removal reads that intent as
+  waste: it stripped `stream_close()` and `stream_open()`'s by-ref `$openedPath`
+  from a stream wrapper PHP calls by contract, emptied the fixtures named
+  `EmptyConstructorService` and `UntypedAndUnionService`, and dropped the
+  assignments keeping a benchmark's subject from being optimised away.
+  `StringClassNameToClassConstantRector` is off for `CacheClearCommandTest`,
+  whose docblock already said why it names an `@internal` class as a string.
+
+  `LevelSetList` deliberately stays at `UP_TO_PHP_81`, under the `>=8.3` floor.
+  Going to 8.3 turns 60 changed files into 223, and what it adds is BC-hostile:
+  `ReadOnlyClassRector` alone marks 103 classes `readonly`, which a non-readonly
+  child may not extend, and that is every downstream `AbstractFacade`,
+  `AbstractFactory`, `AbstractConfig` and `AbstractProvider`.
+
+  `composer fix` ran `csfix` before `rector`, so rector's own output went
+  unformatted and left the tree failing `csrun`. Reordered.
 - A root `gacela.php` scoping the console to `src`. Without it, `doctor` walked
   the whole repository and reported two errors on a clean checkout. `tests/`
   holds fixtures that are deliberately separate applications, several declaring

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
             "@csfix"
         ],
         "infection": [
-            "XDEBUG_MODE=coverage ./vendor/bin/infection --show-mutations --threads=max --min-msi=100 --min-covered-msi=100",
+            "XDEBUG_MODE=coverage ./vendor/bin/infection --show-mutations --threads=max",
             "@static-clear-cache"
         ],
         "metrics-report": [

--- a/composer.json
+++ b/composer.json
@@ -97,8 +97,8 @@
         "fix": [
             "@static-clear-cache",
             "@composer normalize",
-            "@csfix",
-            "@rector"
+            "@rector",
+            "@csfix"
         ],
         "infection": [
             "XDEBUG_MODE=coverage ./vendor/bin/infection --show-mutations --threads=max --min-msi=100 --min-covered-msi=100",
@@ -121,11 +121,13 @@
         "psalm": "XDEBUG_MODE=off ./vendor/bin/psalm",
         "quality": [
             "@csrun",
+            "@rectorrun",
             "@psalm",
             "@phpstan",
             "@phpstan-tests"
         ],
-        "rector": "./vendor/bin/rector",
+        "rector": "XDEBUG_MODE=off ./vendor/bin/rector",
+        "rectorrun": "XDEBUG_MODE=off ./vendor/bin/rector --dry-run",
         "static-clear-cache": [
             "@clear-cache-psalm",
             "@clear-cache-phpstan",

--- a/rector.php
+++ b/rector.php
@@ -3,12 +3,17 @@
 declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
-use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
@@ -29,6 +34,9 @@ return static function (RectorConfig $rectorConfig): void {
         PreferPHPUnitThisCallRector::class,
         StringClassNameToClassConstantRector::class => [
             __DIR__ . '/tests/Feature/Framework/ListeningEvents/ClassResolver/GacelaClassResolverGeneralListenerTest.php',
+            // Names an `@internal` upstream class on purpose; `::class` makes it a
+            // real reference and phpstan-tests then reports classConstant.internalClass.
+            __DIR__ . '/tests/Feature/Console/CacheClear/CacheClearCommandTest.php',
         ],
         FlipTypeControlToUseExclusiveTypeRector::class => [
             __DIR__ . '/src/Framework/AbstractFactory.php',
@@ -45,14 +53,28 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/Console/Application/Debug/ConstructorInspector.php',
             __DIR__ . '/src/Console/Infrastructure/Command/DebugContainerCommand.php',
             __DIR__ . '/src/Framework/Attribute/CacheableTrait.php',
+            __DIR__ . '/src/Framework/Bootstrap/GacelaConfig.php',
+            __DIR__ . '/src/Framework/Container/Container.php',
             __DIR__ . '/src/Framework/Health/HealthCheckRegistry.php',
+            __DIR__ . '/src/Framework/Testing/ContainerFixture.php',
+            __DIR__ . '/src/Psalm/ServiceMapPseudoMethods.php',
         ],
-        // These tests embed PHP source inside heredocs; keeping interpolation makes
-        // the embedded snippets readable. sprintf() obscures them for no benefit.
-        EncapsedStringsToSprintfRector::class => [
-            __DIR__ . '/tests/Unit/Framework/Cache/FileCacheConcurrencyTest.php',
-            __DIR__ . '/tests/Unit/Framework/Cache/FileCacheTest.php',
-        ],
+        // Fixtures and benchmarks are shaped on purpose: an "unused" constructor
+        // parameter, an empty method or a discarded assignment is the thing under
+        // test. Dead-code removal reads that intent as waste and deletes it:
+        // it strips stream_close() and stream_open()'s by-ref $openedPath from a
+        // stream wrapper PHP calls by contract, empties the very fixtures named
+        // EmptyConstructorService and UntypedAndUnionService, and drops the
+        // assignments that stop a benchmark's subject from being optimised away.
+        RemoveEmptyClassMethodRector::class => [__DIR__ . '/tests'],
+        RemoveUnusedPublicMethodParameterRector::class => [__DIR__ . '/tests'],
+        RemoveUnusedConstructorParamRector::class => [__DIR__ . '/tests'],
+        RemoveParentDelegatingClassMethodRector::class => [__DIR__ . '/tests'],
+        RemoveUnusedVariableAssignRector::class => [__DIR__ . '/tests'],
+        // The container writes `#[Inject]` properties through
+        // ReflectionProperty::setValue(); readonly would make those fixtures
+        // untestable for the mechanism they exist to cover.
+        ReadOnlyPropertyRector::class => [__DIR__ . '/tests'],
         // `#[Before]`-attributed setup methods are invoked reflectively by PHPUnit;
         // rector sees them as unused. Removing them silently drops test isolation.
         RemoveUnusedPrivateMethodRector::class => [
@@ -71,7 +93,13 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::TYPE_DECLARATION,
         SetList::EARLY_RETURN,
         SetList::INSTANCEOF,
-        SetList::STRICT_BOOLEANS,
+        // Deliberately below the >=8.3 floor in composer.json. Going up to 8.3
+        // turns 60 changed files into 223, and what it adds is BC-hostile for a
+        // framework: ReadOnlyClassRector alone marks 103 classes readonly, which
+        // a non-readonly child class may not extend, and that is every downstream
+        // AbstractFacade, AbstractFactory, AbstractConfig and AbstractProvider.
+        // AddTypeToConstRector types 74 public constants, fixing their type for
+        // subclasses that redeclare them. Raise this only as its own decision.
         LevelSetList::UP_TO_PHP_81,
         PHPUnitSetList::PHPUNIT_100,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,

--- a/src/Console/Application/CacheWarm/CacheManager.php
+++ b/src/Console/Application/CacheWarm/CacheManager.php
@@ -86,7 +86,7 @@ final class CacheManager
     {
         return array_filter(
             $this->allCacheFilePaths(),
-            static fn (string $cacheFile): bool => file_exists($cacheFile),
+            file_exists(...),
         );
     }
 

--- a/src/Console/Application/CacheWarm/ModuleWarmer.php
+++ b/src/Console/Application/CacheWarm/ModuleWarmer.php
@@ -86,10 +86,10 @@ final class ModuleWarmer
 
         try {
             $this->cacheWarmService->warmClassResolution($module->facadeClass());
-        } catch (Throwable $e) {
+        } catch (Throwable $throwable) {
             // A module that cannot be resolved during warm (even via a PHP Error) must be
             // reported and counted as failed, not abort warming for every remaining module.
-            $this->formatter->writeClassFailed('Facade', $module->facadeClass(), $e->getMessage());
+            $this->formatter->writeClassFailed('Facade', $module->facadeClass(), $throwable->getMessage());
             ++$failedCount;
         }
 

--- a/src/Console/Application/Debug/ConstructorInspector.php
+++ b/src/Console/Application/Debug/ConstructorInspector.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Application\Debug;
 
+use Gacela\Container\Attribute\Inject;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Gacela;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -120,7 +122,7 @@ final class ConstructorInspector
     }
 
     /**
-     * @param class-string|callable|object $target
+     * @param callable|class-string|object $target
      */
     private function renderBindingTarget(string|object|callable $target): string
     {
@@ -149,7 +151,10 @@ final class ConstructorInspector
 
     private function readInject(ReflectionParameter $parameter): ?string
     {
-        $attributes = $parameter->getAttributes(\Gacela\Container\Attribute\Inject::class);
+        // IS_INSTANCEOF, so the framework's `Inject`, which subclasses this one to
+        // re-present it under `Gacela\Framework`, reports the same. An exact match
+        // would show an injected parameter as plain autowiring.
+        $attributes = $parameter->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF);
         if ($attributes === []) {
             return null;
         }

--- a/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
@@ -56,7 +56,7 @@ final class FilenameMismatchCheck implements HealthCheck
         $mismatches = [];
 
         foreach ($this->modules as $module) {
-            foreach (self::pillarsOf($module) as $pillarClass) {
+            foreach ($this->pillarsOf($module) as $pillarClass) {
                 $mismatch = $this->inspect($pillarClass);
                 if ($mismatch !== null) {
                     $mismatches[] = $mismatch;
@@ -79,7 +79,7 @@ final class FilenameMismatchCheck implements HealthCheck
     /**
      * @return array<class-string>
      */
-    private static function pillarsOf(AppModule $module): array
+    private function pillarsOf(AppModule $module): array
     {
         return array_filter(
             [
@@ -102,8 +102,8 @@ final class FilenameMismatchCheck implements HealthCheck
             return null;
         }
 
-        $expected = self::shortName($pillarClass);
-        $actual = self::basename($file);
+        $expected = $this->shortName($pillarClass);
+        $actual = $this->basename($file);
 
         if ($actual === $expected) {
             return null;
@@ -112,14 +112,14 @@ final class FilenameMismatchCheck implements HealthCheck
         return sprintf('%s is declared in %s.php, expected %s.php', $pillarClass, $actual, $expected);
     }
 
-    private static function shortName(string $className): string
+    private function shortName(string $className): string
     {
         $parts = explode('\\', $className);
 
         return $parts[count($parts) - 1];
     }
 
-    private static function basename(string $file): string
+    private function basename(string $file): string
     {
         $parts = explode('/', str_replace('\\', '/', $file));
         $filename = $parts[count($parts) - 1];

--- a/src/Console/Domain/ModuleGraph/GraphDiffMarkdownFormatter.php
+++ b/src/Console/Domain/ModuleGraph/GraphDiffMarkdownFormatter.php
@@ -90,12 +90,16 @@ final class GraphDiffMarkdownFormatter
 
         foreach ($head as $module => $dependencies) {
             foreach ($dependencies as $dependency) {
-                if (!in_array($module, $affected, true) || !in_array($dependency, $affected, true)) {
+                if (!in_array($module, $affected, true)) {
+                    continue;
+                }
+
+                if (!in_array($dependency, $affected, true)) {
                     continue;
                 }
 
                 $arrow = in_array(['from' => $module, 'to' => $dependency], $diff->addedEdges, true) ? '==>' : '-->';
-                $edges[] = sprintf('    %s %s %s', self::nodeId($module), $arrow, self::nodeId($dependency));
+                $edges[] = sprintf('    %s %s %s', $this->nodeId($module), $arrow, $this->nodeId($dependency));
                 $connected[] = $module;
                 $connected[] = $dependency;
             }
@@ -105,7 +109,7 @@ final class GraphDiffMarkdownFormatter
         // back in — a dependency that disappeared is the half of the diff a
         // reviewer cannot see anywhere else.
         foreach ($diff->removedEdges as $edge) {
-            $edges[] = sprintf('    %s -.-> %s', self::nodeId($edge['from']), self::nodeId($edge['to']));
+            $edges[] = sprintf('    %s -.-> %s', $this->nodeId($edge['from']), $this->nodeId($edge['to']));
             $connected[] = $edge['from'];
             $connected[] = $edge['to'];
         }
@@ -115,7 +119,7 @@ final class GraphDiffMarkdownFormatter
         $isolated = [];
         foreach ($affected as $module) {
             if (!in_array($module, $connected, true)) {
-                $isolated[] = sprintf('    %s', self::nodeId($module));
+                $isolated[] = sprintf('    %s', $this->nodeId($module));
             }
         }
 
@@ -145,7 +149,7 @@ final class GraphDiffMarkdownFormatter
         return array_values($modules);
     }
 
-    private static function nodeId(string $module): string
+    private function nodeId(string $module): string
     {
         return str_replace('\\', '.', $module);
     }

--- a/src/Console/Domain/ModuleGraph/MermaidGraphFormatter.php
+++ b/src/Console/Domain/ModuleGraph/MermaidGraphFormatter.php
@@ -15,20 +15,20 @@ final class MermaidGraphFormatter implements GraphFormatterInterface
 
         foreach ($graph as $module => $dependencies) {
             if ($dependencies === []) {
-                $lines[] = sprintf('    %s', self::nodeId($module));
+                $lines[] = sprintf('    %s', $this->nodeId($module));
 
                 continue;
             }
 
             foreach ($dependencies as $dependency) {
-                $lines[] = sprintf('    %s --> %s', self::nodeId($module), self::nodeId($dependency));
+                $lines[] = sprintf('    %s --> %s', $this->nodeId($module), $this->nodeId($dependency));
             }
         }
 
         return implode("\n", $lines) . "\n";
     }
 
-    private static function nodeId(string $module): string
+    private function nodeId(string $module): string
     {
         return str_replace('\\', '.', $module);
     }

--- a/src/Console/Domain/ModuleGraph/ModuleCycleDetector.php
+++ b/src/Console/Domain/ModuleGraph/ModuleCycleDetector.php
@@ -96,7 +96,7 @@ final class ModuleCycleDetector
 
                     // No `?? false` default: reaching here means $next has an
                     // $index, and $index and $onStack are written together.
-                    if ($onStack[$next] === true) {
+                    if ($onStack[$next]) {
                         $low[$node] = min($low[$node], $index[$next]);
                     }
                 }

--- a/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
+++ b/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
@@ -83,7 +83,11 @@ final class ModuleGraphBuilder
 
         /** @var SplFileInfo $fileInfo */
         foreach ($iterator as $fileInfo) {
-            if (!$fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+            if (!$fileInfo->isFile()) {
+                continue;
+            }
+
+            if ($fileInfo->getExtension() !== 'php') {
                 continue;
             }
 

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -182,8 +182,8 @@ final class DebugGraphCommand extends Command
 
         try {
             $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            $output->writeln(sprintf('<error>"%s" is not valid JSON: %s</error>', $path, $exception->getMessage()));
+        } catch (JsonException $jsonException) {
+            $output->writeln(sprintf('<error>"%s" is not valid JSON: %s</error>', $path, $jsonException->getMessage()));
 
             return null;
         }

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -138,8 +138,8 @@ abstract class AbstractFactory
 
     private function createContainerWithProvidedDependencies(): Container
     {
-        $container = self::appContainer()->createScope();
-        self::scheduleAppWideExtensions($container);
+        $container = $this->appContainer()->createScope();
+        $this->scheduleAppWideExtensions($container);
 
         $resolver = (new ProviderResolver())->resolve($this);
         $resolver?->register($container);
@@ -165,9 +165,9 @@ abstract class AbstractFactory
      * already owns: the parent applies those, and asking a scope to extend an
      * inherited instance is refused upstream rather than silently ignored.
      */
-    private static function scheduleAppWideExtensions(Container $scope): void
+    private function scheduleAppWideExtensions(Container $scope): void
     {
-        $parent = self::appContainer();
+        $parent = $this->appContainer();
 
         foreach (Config::getInstance()->getSetupGacela()->getServicesToExtend() as $id => $extensions) {
             if ($parent->provides($id)) {
@@ -185,7 +185,7 @@ abstract class AbstractFactory
      * a Factory -- a console command reading config, say -- should not pay to
      * assemble the container every module would have shared.
      */
-    private static function appContainer(): Container
+    private function appContainer(): Container
     {
         if (self::$appContainer instanceof Container) {
             return self::$appContainer;

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -412,8 +412,6 @@ final class GacelaConfig
      * a new instance every time they are resolved from the container.
      *
      * The `$id` is usually a class name or interface.
-     *
-     * @return $this
      */
     public function addFactory(string $id, Closure $factory): self
     {
@@ -426,8 +424,6 @@ final class GacelaConfig
      * Register a protected service that cannot be extended.
      * Protected services are stored as closures and won't be invoked by the container,
      * making them useful for storing callable configurations.
-     *
-     * @return $this
      */
     public function addProtected(string $id, Closure $service): self
     {
@@ -439,8 +435,6 @@ final class GacelaConfig
     /**
      * Create an alias for a service.
      * This allows you to reference the same service with different names.
-     *
-     * @return $this
      */
     public function addAlias(string $alias, string $id): self
     {
@@ -462,8 +456,6 @@ final class GacelaConfig
      *
      * @param string $id The service identifier
      * @param Closure $factory The factory closure that creates the service when needed
-     *
-     * @return $this
      */
     public function addLazy(string $id, Closure $factory): self
     {

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -22,9 +22,9 @@ final class SetupMerger
 
     public function merge(SetupGacela $other): SetupGacela
     {
-        $this->whenChanged($other, SetupGacela::shouldResetInMemoryCache, fn () => $this->original->setShouldResetInMemoryCache($other->shouldResetInMemoryCache()));
-        $this->whenChanged($other, SetupGacela::fileCacheEnabled, fn () => $this->original->setFileCacheEnabled($other->isFileCacheEnabled()));
-        $this->whenChanged($other, SetupGacela::fileCacheDirectory, fn () => $this->original->setFileCacheDirectory($other->getFileCacheDirectory()));
+        $this->whenChanged($other, SetupGacela::shouldResetInMemoryCache, fn (): \Gacela\Framework\Bootstrap\SetupGacela => $this->original->setShouldResetInMemoryCache($other->shouldResetInMemoryCache()));
+        $this->whenChanged($other, SetupGacela::fileCacheEnabled, fn (): \Gacela\Framework\Bootstrap\SetupGacela => $this->original->setFileCacheEnabled($other->isFileCacheEnabled()));
+        $this->whenChanged($other, SetupGacela::fileCacheDirectory, fn (): \Gacela\Framework\Bootstrap\SetupGacela => $this->original->setFileCacheDirectory($other->getFileCacheDirectory()));
 
         $this->whenChanged($other, SetupGacela::externalServices, fn () => $this->original->mergeExternalServices($other->externalServices()));
         $this->whenChanged($other, SetupGacela::projectNamespaces, fn () => $this->original->mergeProjectNamespaces($other->getProjectNamespaces()));

--- a/src/Framework/ClassResolver/ClassResolverCache.php
+++ b/src/Framework/ClassResolver/ClassResolverCache.php
@@ -35,6 +35,7 @@ final class ClassResolverCache
             if (self::shouldDispatch(ClassNameCacheCachedEvent::class)) {
                 self::dispatchEvent(new ClassNameCacheCachedEvent());
             }
+
             return $cache;
         }
 
@@ -43,11 +44,13 @@ final class ClassResolverCache
             if (self::shouldDispatch(ClassNamePhpCacheCreatedEvent::class)) {
                 self::dispatchEvent(new ClassNamePhpCacheCreatedEvent($cacheDir));
             }
+
             $cache = new ClassNamePhpCache($cacheDir, Config::getInstance()->getAppRootDir());
         } else {
             if (self::shouldDispatch(ClassNameInMemoryCacheCreatedEvent::class)) {
                 self::dispatchEvent(new ClassNameInMemoryCacheCreatedEvent());
             }
+
             $cache = new InMemoryCache(ClassNamePhpCache::class);
         }
 

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -91,13 +91,13 @@ final class Config implements ConfigInterface
         }
 
         if ($default !== self::DEFAULT_CONFIG_VALUE && !$this->hasKey($key)) {
-            self::notifyKeyNotFound($key);
+            $this->notifyKeyNotFound($key);
 
             return $default;
         }
 
         if (!$this->hasKey($key)) {
-            self::notifyKeyNotFound($key);
+            $this->notifyKeyNotFound($key);
 
             throw ConfigException::keyNotFound($key, self::class);
         }
@@ -360,7 +360,7 @@ final class Config implements ConfigInterface
         return array_key_exists($key, $this->config);
     }
 
-    private static function notifyKeyNotFound(string $key): void
+    private function notifyKeyNotFound(string $key): void
     {
         if (self::shouldDispatch(ConfigKeyNotFoundEvent::class)) {
             self::dispatchEvent(new ConfigKeyNotFoundEvent($key));

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -265,7 +265,7 @@ final class Container implements ContainerInterface
      */
     public function createScope(): static
     {
-        return self::decorating($this->inner->createScope());
+        return $this->decorating($this->inner->createScope());
     }
 
     /**
@@ -573,7 +573,7 @@ final class Container implements ContainerInterface
      * Wrap an inner container this class did not build -- the scope returned by
      * {@see createScope()}, which arrives already made.
      */
-    private static function decorating(GacelaContainer $inner): self
+    private function decorating(GacelaContainer $inner): self
     {
         $decorator = new self();
         $decorator->inner = $inner->withSelfReference($decorator);

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -260,8 +260,11 @@ final class Container implements ContainerInterface
      * Locator and the lifecycle events -- `createScope(): static` is typed that
      * way upstream precisely so a decorator's scope is a decorator.
      *
-     * Gacela does not yet create scopes of its own: which lifetime owns one is
-     * the open design question, not the forwarding.
+     * This is how a module container is built: {@see \Gacela\Framework\AbstractFactory}
+     * takes one scope of the app container per Factory class, which is what
+     * makes `gacela.php` a once-per-bootstrap walk rather than a once-per-Factory
+     * one. A scope inherits the parent's plan registry, so the reflection a
+     * sibling already paid for is not paid again.
      */
     public function createScope(): static
     {

--- a/src/Framework/Container/SharedPlanCache.php
+++ b/src/Framework/Container/SharedPlanCache.php
@@ -9,11 +9,14 @@ use Gacela\Container\PlanCache;
 /**
  * One constructor-plan cache for every container Gacela builds.
  *
- * Gacela's containers are sibling roots, not a tree: {@see \Gacela\Framework\AbstractFactory}
- * keeps one per Factory class, and {@see \Gacela\Framework\ClassResolver\AbstractClassResolver}
- * and {@see \Gacela\Framework\Gacela} each hold one more. Without a shared cache
- * every one of them reflects the classes they have in common -- and they have
- * plenty in common, because the bindings from `gacela.php` reach all of them.
+ * Module containers no longer need it: {@see \Gacela\Framework\AbstractFactory}
+ * takes a scope of the app container per Factory class, and a scope inherits its
+ * parent's plan registry. What this still covers is the roots that are unrelated
+ * to that tree and to each other -- {@see \Gacela\Framework\ClassResolver\AbstractClassResolver},
+ * {@see Locator}, {@see \Gacela\Framework\Bootstrap\Setup\GacelaConfigExtender}
+ * and {@see \Gacela\Framework\Gacela}'s own. Without it each would reflect the
+ * classes they have in common, and they have plenty in common, because the
+ * bindings from `gacela.php` reach all of them.
  *
  * Only reflection output travels through it: constructor parameters,
  * instantiability, `#[Inject]` properties. Bindings, contextual bindings,

--- a/src/Framework/Event/Dispatcher/EventDispatcherProvider.php
+++ b/src/Framework/Event/Dispatcher/EventDispatcherProvider.php
@@ -17,7 +17,7 @@ final class EventDispatcherProvider
     private static ?NullEventDispatcher $preBootstrapDispatcher = null;
 
     /** @var (callable(): EventDispatcherInterface)|null */
-    private static $resolver = null;
+    private static $resolver;
 
     /**
      * @param callable(): EventDispatcherInterface $resolver

--- a/src/Framework/ServiceResolver/DocBlockResolver.php
+++ b/src/Framework/ServiceResolver/DocBlockResolver.php
@@ -26,7 +26,7 @@ final class DocBlockResolver
      * the exact rendered characters would turn a behavioural test into a
      * golden master over a message nobody reads character by character.
      */
-    private const string FALLBACK_DEPRECATION = 'Gacela: %s::%s() was resolved from %s. This fallback is deprecated and will be removed in 3.0. Declare it with #[ServiceMap(method: \'%s\', className: ...)] instead.';
+    private const string FALLBACK_DEPRECATION = "Gacela: %s::%s() was resolved from %s. This fallback is deprecated and will be removed in 3.0. Declare it with #[ServiceMap(method: '%s', className: ...)] instead.";
 
     /** @var array<string,string> [fileName => fileContent] */
     private static array $fileContentCache = [];

--- a/src/Framework/ServiceResolver/ServiceResolverCache.php
+++ b/src/Framework/ServiceResolver/ServiceResolverCache.php
@@ -51,11 +51,13 @@ final class ServiceResolverCache
             if (self::shouldDispatch(CustomServicesPhpCacheCreatedEvent::class)) {
                 self::dispatchEvent(new CustomServicesPhpCacheCreatedEvent());
             }
+
             $cache = new CustomServicesPhpCache(Config::getInstance()->getCacheDir(), Config::getInstance()->getAppRootDir());
         } else {
             if (self::shouldDispatch(CustomServicesInMemoryCacheCreatedEvent::class)) {
                 self::dispatchEvent(new CustomServicesInMemoryCacheCreatedEvent());
             }
+
             $cache = new InMemoryCache(CustomServicesPhpCache::class);
         }
 

--- a/src/PHPStan/Rules/FacadeInterfaceInSyncRule.php
+++ b/src/PHPStan/Rules/FacadeInterfaceInSyncRule.php
@@ -52,7 +52,7 @@ final class FacadeInterfaceInSyncRule implements Rule
         }
 
         $facadeInterface = $this->matchingInterface($classReflection);
-        if ($facadeInterface === null) {
+        if (!$facadeInterface instanceof \PHPStan\Reflection\ClassReflection) {
             return [];
         }
 
@@ -60,8 +60,11 @@ final class FacadeInterfaceInSyncRule implements Rule
 
         foreach ($node->getOriginalNode()->getMethods() as $method) {
             $methodName = $method->name->toString();
+            if (!$method->isPublic()) {
+                continue;
+            }
 
-            if (!$method->isPublic() || str_starts_with($methodName, '__')) {
+            if (str_starts_with($methodName, '__')) {
                 continue;
             }
 

--- a/symfony-bridge/composer.json
+++ b/symfony-bridge/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "gacela-project/container": "^1.4.0",
+        "gacela-project/container": "^2.0.2",
         "symfony/dependency-injection": "^7.0 || ^8.0"
     },
     "require-dev": {

--- a/symfony-bridge/src/GacelaInjectCompilerPass.php
+++ b/symfony-bridge/src/GacelaInjectCompilerPass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\SymfonyBridge;
 
 use Gacela\Container\Attribute\Inject;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -31,8 +32,7 @@ final class GacelaInjectCompilerPass implements CompilerPassInterface
 {
     public function __construct(
         private readonly string $gacelaServiceId = 'gacela.container',
-    ) {
-    }
+    ) {}
 
     public function process(ContainerBuilder $container): void
     {
@@ -60,7 +60,10 @@ final class GacelaInjectCompilerPass implements CompilerPassInterface
 
     private function rewriteIfInjected(string $id, Definition $definition, ReflectionParameter $parameter): void
     {
-        $attributes = $parameter->getAttributes(Inject::class);
+        // IS_INSTANCEOF, so a subclass re-presenting the attribute under another
+        // namespace is honoured too, as `Gacela\Framework\Attribute\Inject` does.
+        // An exact match would drop it silently and let Symfony autowire instead.
+        $attributes = $parameter->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF);
         if ($attributes === []) {
             return;
         }

--- a/symfony-bridge/tests/Fixtures/ServiceWithSubclassedInject.php
+++ b/symfony-bridge/tests/Fixtures/ServiceWithSubclassedInject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+final class ServiceWithSubclassedInject
+{
+    public function __construct(
+        #[SubclassedInject]
+        public readonly FooInterface $foo,
+        #[SubclassedInject(ConcreteBar::class)]
+        public readonly BarInterface $bar,
+    ) {}
+}

--- a/symfony-bridge/tests/Fixtures/SubclassedInject.php
+++ b/symfony-bridge/tests/Fixtures/SubclassedInject.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+use Attribute;
+use Gacela\Container\Attribute\Inject;
+
+/**
+ * Stands in for `Gacela\Framework\Attribute\Inject`, which subclasses the
+ * container's attribute for application code.
+ *
+ * Declared here rather than imported so this suite covers the subclass contract
+ * without the bridge depending on the framework package, which it does not
+ * require. The container reads every attribute with
+ * ReflectionAttribute::IS_INSTANCEOF for exactly this reason.
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+final class SubclassedInject extends Inject {}

--- a/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
+++ b/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
@@ -9,6 +9,7 @@ use GacelaTest\SymfonyBridge\Fixtures\ConcreteBar;
 use GacelaTest\SymfonyBridge\Fixtures\FooInterface;
 use GacelaTest\SymfonyBridge\Fixtures\ServiceWithInject;
 use GacelaTest\SymfonyBridge\Fixtures\ServiceWithoutInject;
+use GacelaTest\SymfonyBridge\Fixtures\ServiceWithSubclassedInject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -45,6 +46,28 @@ final class GacelaInjectCompilerPassTest extends TestCase
         self::assertInstanceOf(Definition::class, $bar);
         self::assertSame(ConcreteBar::class, $bar->getClass());
         self::assertSame([ConcreteBar::class], $bar->getArguments());
+    }
+
+    /**
+     * The container's attribute is deliberately not `final`, so a consumer can
+     * re-present it under its own namespace, and `Gacela\Framework\Attribute\Inject`
+     * does. Reading for an exact FQN honours neither, and the failure is silent:
+     * the argument is simply never rewritten and Symfony autowires it instead.
+     */
+    public function test_a_subclass_of_the_inject_attribute_is_honored(): void
+    {
+        $this->container->register('app.subclassed', ServiceWithSubclassedInject::class);
+
+        $this->pass->process($this->container);
+
+        $foo = $this->argumentFor('app.subclassed', '$foo');
+        self::assertInstanceOf(Definition::class, $foo);
+        self::assertSame(FooInterface::class, $foo->getClass());
+        self::assertFactoryRoutesTo($foo, 'gacela.container');
+
+        $bar = $this->argumentFor('app.subclassed', '$bar');
+        self::assertInstanceOf(Definition::class, $bar);
+        self::assertSame(ConcreteBar::class, $bar->getClass());
     }
 
     public function test_service_without_inject_is_left_untouched(): void

--- a/tests/Feature/Console/BinGacela/BinGacelaTest.php
+++ b/tests/Feature/Console/BinGacela/BinGacelaTest.php
@@ -98,6 +98,7 @@ final class BinGacelaTest extends TestCase
                 unlink($cwd . '/vendor/autoload.php');
                 rmdir($cwd . '/vendor');
             }
+
             rmdir($cwd);
         }
     }

--- a/tests/Feature/Console/CacheClear/CacheClearCommandTest.php
+++ b/tests/Feature/Console/CacheClear/CacheClearCommandTest.php
@@ -74,6 +74,7 @@ final class CacheClearCommandTest extends TestCase
         if (!is_dir($cacheDir)) {
             mkdir($cacheDir, 0777, true);
         }
+
         file_put_contents($this->cacheFile, '<?php return [];');
 
         $command = new CommandTester(new CacheClearCommand());
@@ -91,6 +92,7 @@ final class CacheClearCommandTest extends TestCase
         if (!is_dir($cacheDir)) {
             mkdir($cacheDir, 0777, true);
         }
+
         file_put_contents($this->customServicesCacheFile, '<?php return [];');
 
         $command = new CommandTester(new CacheClearCommand());

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -206,6 +206,7 @@ OUT;
 
         $bootstrap = new ConsoleBootstrap();
         $bootstrap->setAutoExit(false);
+
         $exitCode = $bootstrap->run($input, $output);
 
         self::assertSame(0, $exitCode);
@@ -256,7 +257,7 @@ OUT;
         // exception thrown, and not the anonymous fallback factory).
         $factory = (new $facadeClass())->getFactory();
         self::assertInstanceOf(AbstractFactory::class, $factory);
-        self::assertSame($factoryClass, $factory::class);
+        self::assertSame($factory::class, $factoryClass);
     }
 
     public function test_make_module_with_unknown_template_fails(): void
@@ -266,6 +267,7 @@ OUT;
 
         $bootstrap = new ConsoleBootstrap();
         $bootstrap->setAutoExit(false);
+
         $exitCode = $bootstrap->run($input, $output);
 
         self::assertSame(1, $exitCode);

--- a/tests/Feature/Console/DebugContainer/DebugContainerCommandTest.php
+++ b/tests/Feature/Console/DebugContainer/DebugContainerCommandTest.php
@@ -155,7 +155,7 @@ final class DebugContainerCommandTest extends TestCase
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
             $config->resetInMemoryCache();
-            if ($configFn !== null) {
+            if ($configFn instanceof Closure) {
                 $configFn($config);
             }
         });

--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -17,7 +17,9 @@ use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\UnboundContract;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use stdClass;
 use Symfony\Component\Console\Command\Command;
+
 use Symfony\Component\Console\Tester\CommandTester;
 
 use function bin2hex;
@@ -181,7 +183,7 @@ final class DebugDependenciesCommandTest extends TestCase
 
     public function test_reads_a_class_declared_in_the_global_namespace(): void
     {
-        $class = 'GlobalScopeService' . self::suffix();
+        $class = 'GlobalScopeService' . $this->suffix();
         $path = $this->writeSource(sprintf("<?php\n\nclass %s\n{\n}\n", $class));
 
         $tester = $this->inspect($path);
@@ -192,7 +194,7 @@ final class DebugDependenciesCommandTest extends TestCase
 
     public function test_reads_a_class_in_a_single_segment_namespace(): void
     {
-        $namespace = 'SingleSegment' . self::suffix();
+        $namespace = 'SingleSegment' . $this->suffix();
         $path = $this->writeSource(sprintf("<?php\n\nnamespace %s;\n\nclass Service\n{\n}\n", $namespace));
 
         $tester = $this->inspect($path);
@@ -206,9 +208,17 @@ final class DebugDependenciesCommandTest extends TestCase
 
     public function test_skips_an_anonymous_class_and_a_class_constant_before_the_declaration(): void
     {
-        $namespace = 'SkipNoise' . self::suffix();
+        $namespace = 'SkipNoise' . $this->suffix();
         $path = $this->writeSource(sprintf(
-            "<?php\n\nnamespace %s\\Nested;\n\n\$anonymous = new class {\n};\n\$reference = \\stdClass::class;\n\n"
+            '<?php
+
+namespace %s\Nested;
+
+$anonymous = new class {
+};
+$reference = ' . stdClass::class . '::class;
+
+'
             . "class Real\n{\n}\n",
             $namespace,
         ));
@@ -224,7 +234,7 @@ final class DebugDependenciesCommandTest extends TestCase
 
     public function test_recognises_an_interface_declaration(): void
     {
-        $namespace = 'DeclaredInterface' . self::suffix();
+        $namespace = 'DeclaredInterface' . $this->suffix();
         $path = $this->writeSource(sprintf("<?php\n\nnamespace %s;\n\ninterface Contract\n{\n}\n", $namespace));
 
         $tester = $this->inspect($path);
@@ -238,7 +248,7 @@ final class DebugDependenciesCommandTest extends TestCase
 
     public function test_recognises_a_trait_declaration(): void
     {
-        $namespace = 'DeclaredTrait' . self::suffix();
+        $namespace = 'DeclaredTrait' . $this->suffix();
         $path = $this->writeSource(sprintf("<?php\n\nnamespace %s;\n\ntrait Helper\n{\n}\n", $namespace));
 
         $tester = $this->inspect($path);
@@ -254,7 +264,7 @@ final class DebugDependenciesCommandTest extends TestCase
 
     public function test_recognises_an_enum_declaration(): void
     {
-        $namespace = 'DeclaredEnum' . self::suffix();
+        $namespace = 'DeclaredEnum' . $this->suffix();
         $path = $this->writeSource(sprintf("<?php\n\nnamespace %s;\n\nenum Suit\n{\n}\n", $namespace));
 
         $tester = $this->inspect($path);
@@ -366,14 +376,14 @@ final class DebugDependenciesCommandTest extends TestCase
 
     private function writeSource(string $source): string
     {
-        $path = sys_get_temp_dir() . '/gacela-debug-deps-' . self::suffix() . '.php';
+        $path = sys_get_temp_dir() . '/gacela-debug-deps-' . $this->suffix() . '.php';
         file_put_contents($path, $source);
         $this->sourceFiles[] = $path;
 
         return $path;
     }
 
-    private static function suffix(): string
+    private function suffix(): string
     {
         return bin2hex(random_bytes(6));
     }

--- a/tests/Feature/Console/DebugDependencies/Fixtures/FrameworkInjectService.php
+++ b/tests/Feature/Console/DebugDependencies/Fixtures/FrameworkInjectService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugDependencies\Fixtures;
+
+use Gacela\Framework\Attribute\Inject;
+
+/**
+ * The same shape as {@see InjectService}, spelled with the framework attribute
+ * instead of the container one. Both are supported imports, so `debug:*` must
+ * report them identically.
+ */
+final class FrameworkInjectService
+{
+    public function __construct(
+        #[Inject]
+        public readonly BoundContract $plain,
+        #[Inject(BoundImplementation::class)]
+        public readonly BoundContract $withOverride,
+    ) {
+    }
+}

--- a/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
+++ b/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
@@ -42,10 +42,10 @@ final class DebugModuleCommandTest extends TestCase
         self::assertStringContainsString('Module: CheckoutModule', $display);
 
         // Each pillar reports the class that was resolved for it.
-        self::assertPillarReports($display, 'Facade', CheckoutModuleFacade::class);
-        self::assertPillarReports($display, 'Factory', CheckoutModuleFactory::class);
-        self::assertPillarReports($display, 'Config', CheckoutModuleConfig::class);
-        self::assertPillarReports($display, 'Provider', CheckoutModuleProvider::class);
+        $this->assertPillarReports($display, 'Facade', CheckoutModuleFacade::class);
+        $this->assertPillarReports($display, 'Factory', CheckoutModuleFactory::class);
+        $this->assertPillarReports($display, 'Config', CheckoutModuleConfig::class);
+        $this->assertPillarReports($display, 'Provider', CheckoutModuleProvider::class);
 
         self::assertStringContainsString(
             sprintf('%s => %s', PaymentGatewayInterface::class, StripeGateway::class),
@@ -62,12 +62,12 @@ final class DebugModuleCommandTest extends TestCase
         $display = $tester->getDisplay();
 
         self::assertStringContainsString('Module: GadgetModule', $display);
-        self::assertPillarReports($display, 'Facade', GadgetModuleFacade::class);
+        $this->assertPillarReports($display, 'Facade', GadgetModuleFacade::class);
 
         // A pillar the module does not define is called out rather than left blank.
-        self::assertPillarReports($display, 'Factory', '(not found)');
-        self::assertPillarReports($display, 'Config', '(not found)');
-        self::assertPillarReports($display, 'Provider', '(not found)');
+        $this->assertPillarReports($display, 'Factory', '(not found)');
+        $this->assertPillarReports($display, 'Config', '(not found)');
+        $this->assertPillarReports($display, 'Provider', '(not found)');
     }
 
     public function test_reports_an_empty_container_as_having_no_bindings(): void
@@ -108,7 +108,7 @@ final class DebugModuleCommandTest extends TestCase
         $display = $tester->getDisplay();
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertPillarReports($display, 'Facade', WiredModuleFacade::class);
+        $this->assertPillarReports($display, 'Facade', WiredModuleFacade::class);
 
         // The facade's constructor dependency is drawn under the tree, labelled
         // with the parameter that pulled it in.
@@ -121,7 +121,7 @@ final class DebugModuleCommandTest extends TestCase
     public function test_every_matching_module_is_rendered(): void
     {
         $tester = $this->debugModule(['module' => 'Module']);
-        $lines = self::linesOf($tester);
+        $lines = $this->linesOf($tester);
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
         self::assertSame([
@@ -210,7 +210,7 @@ final class DebugModuleCommandTest extends TestCase
     {
         Gacela::bootstrap(__DIR__ . '/Fixtures', static function (GacelaConfig $config) use ($configFn): void {
             $config->resetInMemoryCache();
-            if ($configFn !== null) {
+            if ($configFn instanceof Closure) {
                 $configFn($config);
             }
         });
@@ -225,7 +225,7 @@ final class DebugModuleCommandTest extends TestCase
      * Asserts the $pillar row reports $class, without pinning the arrow glyph or
      * the column padding that separates them.
      */
-    private static function assertPillarReports(string $display, string $pillar, string $class): void
+    private function assertPillarReports(string $display, string $pillar, string $class): void
     {
         self::assertMatchesRegularExpression(
             '/' . $pillar . '\b[^\r\n]*' . preg_quote($class, '/') . '/',
@@ -237,10 +237,10 @@ final class DebugModuleCommandTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function linesOf(CommandTester $tester): array
+    private function linesOf(CommandTester $tester): array
     {
         return array_map(
-            static fn (string $line): string => rtrim($line),
+            rtrim(...),
             explode("\n", $tester->getDisplay()),
         );
     }

--- a/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
+++ b/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
@@ -113,12 +113,12 @@ final class DebugModulesCommandTest extends TestCase
     public function test_a_directory_filter_keeps_every_module_below_it(): void
     {
         $tester = $this->debugModules('Fixtures', ['filter' => __DIR__ . '/Fixtures']);
-        $lines = self::linesOf($tester);
+        $lines = $this->linesOf($tester);
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertContains('  ' . self::moduleNameOf(GizmoModuleFacade::class), $lines);
-        self::assertContains('  ' . self::moduleNameOf(WidgetModuleExtraFacade::class), $lines);
-        self::assertContains('  ' . self::moduleNameOf(WidgetModuleFacade::class), $lines);
+        self::assertContains('  ' . $this->moduleNameOf(GizmoModuleFacade::class), $lines);
+        self::assertContains('  ' . $this->moduleNameOf(WidgetModuleExtraFacade::class), $lines);
+        self::assertContains('  ' . $this->moduleNameOf(WidgetModuleFacade::class), $lines);
         self::assertContains('Summary: 3 modules, 6 pillars inspected, 0 unresolvable parameters', $lines);
     }
 
@@ -244,7 +244,7 @@ final class DebugModulesCommandTest extends TestCase
         return $tester;
     }
 
-    private static function moduleNameOf(string $facadeClass): string
+    private function moduleNameOf(string $facadeClass): string
     {
         return substr($facadeClass, 0, (int)strrpos($facadeClass, '\\'));
     }
@@ -252,10 +252,10 @@ final class DebugModulesCommandTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function linesOf(CommandTester $tester): array
+    private function linesOf(CommandTester $tester): array
     {
         return array_map(
-            static fn (string $line): string => rtrim($line),
+            rtrim(...),
             explode("\n", $tester->getDisplay()),
         );
     }

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -69,7 +69,7 @@ final class DoctorCommandTest extends TestCase
             '✓ suffix configuration',
             '✓ pillar filenames',
             '✓ All checks passed',
-        ], self::statusLinesOf($tester));
+        ], $this->statusLinesOf($tester));
     }
 
     public function test_a_registered_health_check_is_appended_to_the_built_in_ones(): void
@@ -79,7 +79,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
         // The registered check runs after the built-in ones, and its detail is shown.
-        self::assertSame('✓ module health: FakeModule', self::statusLinesOf($tester)[3]);
+        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[3]);
         self::assertStringContainsString('FakeHealthCheck ran', $tester->getDisplay());
     }
 
@@ -88,7 +88,7 @@ final class DoctorCommandTest extends TestCase
         $tester = $this->doctor([new FakeHealthCheck()]);
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertContains('✓ module health: FakeModule', self::linesOf($tester));
+        self::assertContains('✓ module health: FakeModule', $this->linesOf($tester));
     }
 
     public function test_a_degraded_check_is_a_warning_and_lists_its_metadata(): void
@@ -100,12 +100,12 @@ final class DoctorCommandTest extends TestCase
 
         // A degraded check warns rather than fails, and lists its metadata --
         // including a non-scalar value, rendered as its type.
-        self::assertContains('⚠ module health: DegradedModule', self::statusLinesOf($tester));
+        self::assertContains('⚠ module health: DegradedModule', $this->statusLinesOf($tester));
         self::assertStringContainsString('Cache is stale', $display);
         self::assertStringContainsString('stale-entries: 42', $display);
         self::assertStringContainsString('oldest-entry: 2020-01-01', $display);
         self::assertStringContainsString('raw-payload: array', $display);
-        self::assertContains('⚠ Doctor finished with warnings', self::statusLinesOf($tester));
+        self::assertContains('⚠ Doctor finished with warnings', $this->statusLinesOf($tester));
     }
 
     public function test_an_unhealthy_check_is_an_error_and_lists_its_metadata(): void
@@ -116,11 +116,11 @@ final class DoctorCommandTest extends TestCase
         $display = $tester->getDisplay();
 
         // An unhealthy check is an error, and its metadata is listed too.
-        self::assertContains('✗ module health: UnhealthyMetaModule', self::statusLinesOf($tester));
+        self::assertContains('✗ module health: UnhealthyMetaModule', $this->statusLinesOf($tester));
         self::assertStringContainsString('Broker unreachable', $display);
         self::assertStringContainsString('host: broker.internal', $display);
         self::assertStringContainsString('attempts: 3', $display);
-        self::assertContains('✗ Doctor found errors', self::statusLinesOf($tester));
+        self::assertContains('✗ Doctor found errors', $this->statusLinesOf($tester));
     }
 
     public function test_a_degraded_check_without_metadata_only_shows_its_detail(): void
@@ -130,7 +130,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
         // With no metadata the check shows its detail and nothing more.
-        self::assertContains('⚠ module health: DegradedBareModule', self::statusLinesOf($tester));
+        self::assertContains('⚠ module health: DegradedBareModule', $this->statusLinesOf($tester));
         self::assertStringContainsString('Slow response times', $tester->getDisplay());
     }
 
@@ -142,7 +142,7 @@ final class DoctorCommandTest extends TestCase
         ]);
 
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
-        self::assertContains('✗ Doctor found errors', self::linesOf($tester));
+        self::assertContains('✗ Doctor found errors', $this->linesOf($tester));
     }
 
     public function test_a_warning_after_an_error_still_fails(): void
@@ -153,7 +153,7 @@ final class DoctorCommandTest extends TestCase
         ]);
 
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
-        self::assertContains('✗ Doctor found errors', self::linesOf($tester));
+        self::assertContains('✗ Doctor found errors', $this->linesOf($tester));
     }
 
     public function test_a_passing_check_after_an_error_still_fails(): void
@@ -164,7 +164,7 @@ final class DoctorCommandTest extends TestCase
         ]);
 
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
-        self::assertContains('✗ Doctor found errors', self::linesOf($tester));
+        self::assertContains('✗ Doctor found errors', $this->linesOf($tester));
     }
 
     public function test_a_passing_check_after_a_warning_stays_a_warning(): void
@@ -175,7 +175,7 @@ final class DoctorCommandTest extends TestCase
         ]);
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertContains('⚠ Doctor finished with warnings', self::linesOf($tester));
+        self::assertContains('⚠ Doctor finished with warnings', $this->linesOf($tester));
     }
 
     public function test_strict_turns_a_warning_into_a_failure(): void
@@ -183,7 +183,7 @@ final class DoctorCommandTest extends TestCase
         $tester = $this->doctor([DegradedWithoutMetadataHealthCheck::class], ['--strict' => true]);
 
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
-        self::assertContains('⚠ Doctor finished with warnings', self::linesOf($tester));
+        self::assertContains('⚠ Doctor finished with warnings', $this->linesOf($tester));
     }
 
     public function test_strict_still_succeeds_when_everything_passes(): void
@@ -205,7 +205,7 @@ final class DoctorCommandTest extends TestCase
 
         // A cache entry pointing at a class that no longer exists is a warning,
         // and the check tells the user how to fix it.
-        self::assertContains('⚠ cache staleness', self::statusLinesOf($tester));
+        self::assertContains('⚠ cache staleness', $this->statusLinesOf($tester));
         self::assertStringContainsString(
             'missing source: some-cache-key → Never\\Declared\\Klass (source file not found)',
             $display,
@@ -221,7 +221,7 @@ final class DoctorCommandTest extends TestCase
         $tester = $this->doctor([], ['filter' => 'DoesNotExist']);
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertContains('    no modules discovered', self::linesOf($tester));
+        self::assertContains('    no modules discovered', $this->linesOf($tester));
     }
 
     private function writeCacheEntry(string $key, string $className): void
@@ -261,10 +261,10 @@ final class DoctorCommandTest extends TestCase
      *
      * @return list<string>
      */
-    private static function statusLinesOf(CommandTester $tester): array
+    private function statusLinesOf(CommandTester $tester): array
     {
         return array_values(array_filter(
-            self::linesOf($tester),
+            $this->linesOf($tester),
             static fn (string $line): bool => preg_match('/^[✓⚠✗] /u', $line) === 1,
         ));
     }
@@ -272,10 +272,10 @@ final class DoctorCommandTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function linesOf(CommandTester $tester): array
+    private function linesOf(CommandTester $tester): array
     {
         return array_map(
-            static fn (string $line): string => rtrim($line),
+            rtrim(...),
             explode("\n", $tester->getDisplay()),
         );
     }

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -40,8 +40,8 @@ final class ListModulesCommandTest extends TestCase
 
         // Each row marks the pillars that module actually has: TestModule3 has a
         // Facade, Factory and Config but no Provider; TestModule2 has only a Facade.
-        self::assertSame(3, substr_count(self::rowFor($output, 'LevelUp\\TestModule3'), 'x'));
-        self::assertSame(1, substr_count(self::rowFor($output, '\\TestModule2'), 'x'));
+        self::assertSame(3, substr_count($this->rowFor($output, 'LevelUp\\TestModule3'), 'x'));
+        self::assertSame(1, substr_count($this->rowFor($output, '\\TestModule2'), 'x'));
     }
 
     public function test_list_modules_detailed(): void
@@ -123,7 +123,7 @@ final class ListModulesCommandTest extends TestCase
      * The single table row mentioning $module, so pillar assertions do not depend
      * on how wide the columns render.
      */
-    private static function rowFor(string $output, string $module): string
+    private function rowFor(string $output, string $module): string
     {
         foreach (explode("\n", $output) as $line) {
             if (str_contains($line, $module)) {

--- a/tests/Feature/Console/ProvidedShape/MalformedProvidedValuesTest.php
+++ b/tests/Feature/Console/ProvidedShape/MalformedProvidedValuesTest.php
@@ -80,9 +80,7 @@ final class MalformedProvidedValuesTest extends TestCase
 
         $commands = (new ConsoleBootstrap())->all();
 
-        foreach ($commands as $command) {
-            self::assertInstanceOf(Command::class, $command);
-        }
+        self::assertContainsOnlyInstancesOf(Command::class, $commands);
     }
 
     /**

--- a/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
+++ b/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
@@ -109,7 +109,7 @@ final class ValidateConfigCommandTest extends TestCase
         self::assertSame([
             '✓ No circular dependencies detected',
             '✓ Configuration is valid!',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_reports_the_gacela_php_file_when_the_project_root_has_one(): void
@@ -144,7 +144,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeContract::class,
             '✓ No circular dependencies detected',
             '✓ Configuration is valid!',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_several_bindings_are_reported_in_the_plural(): void
@@ -161,7 +161,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . OtherContract::class,
             '✓ No circular dependencies detected',
             '✓ Configuration is valid!',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_a_binding_to_the_key_itself_is_compatible(): void
@@ -175,7 +175,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeImplementation::class,
             '✓ No circular dependencies detected',
             '✓ Configuration is valid!',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_reports_a_binding_key_that_does_not_exist_and_keeps_going(): void
@@ -193,7 +193,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeContract::class,
             '✓ No circular dependencies detected',
             '✗ Validation failed with errors',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_reports_a_binding_value_class_that_does_not_exist(): void
@@ -207,7 +207,7 @@ final class ValidateConfigCommandTest extends TestCase
             sprintf('✗ Binding value class does not exist: %s -> %s', SomeContract::class, self::MISSING_CLASS),
             '✓ No circular dependencies detected',
             '✗ Validation failed with errors',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_reports_a_binding_value_class_that_does_not_exist_and_keeps_going(): void
@@ -226,7 +226,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . CyclicContract::class,
             '✗ Circular dependency detected: ' . CyclicContract::class,
             '✗ Validation failed with errors',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
 
         self::assertStringContainsString(
             sprintf('chain: %s -> %s -> %s', CyclicB::class, CyclicA::class, CyclicB::class),
@@ -252,7 +252,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeContract::class,
             '✓ No circular dependencies detected',
             '⚠ Validation completed with warnings',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
 
         // The warning explains what was expected, what the value actually is, and
         // how to fix it.
@@ -293,7 +293,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeContract::class,
             '✓ No circular dependencies detected',
             '✗ Validation failed with errors',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_accepts_an_object_binding_that_is_an_instance_of_its_key(): void
@@ -307,7 +307,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeImplementation::class,
             '✓ No circular dependencies detected',
             '✓ Configuration is valid!',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_accepts_a_callable_object_binding_whatever_its_key(): void
@@ -323,7 +323,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . SomeImplementation::class,
             '✓ No circular dependencies detected',
             '✓ Configuration is valid!',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
     }
 
     public function test_warns_when_a_valid_binding_cannot_be_resolved(): void
@@ -340,7 +340,7 @@ final class ValidateConfigCommandTest extends TestCase
         // Both bindings pass the compatibility check; the resolution failure is
         // reported afterwards as a warning naming the binding it belongs to,
         // followed by the reason the container gave.
-        $verdicts = self::verdictLinesOf($tester);
+        $verdicts = $this->verdictLinesOf($tester);
 
         self::assertSame('✓ ' . SomeImplementation::class, $verdicts[0]);
         self::assertSame('✓ ' . SomeContract::class, $verdicts[1]);
@@ -363,7 +363,7 @@ final class ValidateConfigCommandTest extends TestCase
             '✓ ' . CyclicContract::class,
             '✗ Circular dependency detected: ' . CyclicContract::class,
             '✗ Validation failed with errors',
-        ], self::verdictLinesOf($tester));
+        ], $this->verdictLinesOf($tester));
 
         // The chain that produced the cycle is printed under the error.
         self::assertStringContainsString(
@@ -460,10 +460,10 @@ final class ValidateConfigCommandTest extends TestCase
      *
      * @return list<string>
      */
-    private static function verdictLinesOf(CommandTester $tester): array
+    private function verdictLinesOf(CommandTester $tester): array
     {
         $verdicts = [];
-        foreach (self::linesOf($tester->getDisplay()) as $line) {
+        foreach ($this->linesOf($tester->getDisplay()) as $line) {
             $trimmed = ltrim($line);
             if (preg_match('/^[✓⚠✗] /u', $trimmed) === 1) {
                 $verdicts[] = $trimmed;
@@ -476,10 +476,10 @@ final class ValidateConfigCommandTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function linesOf(string $display): array
+    private function linesOf(string $display): array
     {
         return array_map(
-            static fn (string $line): string => rtrim($line),
+            rtrim(...),
             explode("\n", $display),
         );
     }

--- a/tests/Feature/Framework/ContainerArrayAccess/ContainerArrayAccessTest.php
+++ b/tests/Feature/Framework/ContainerArrayAccess/ContainerArrayAccessTest.php
@@ -37,7 +37,6 @@ final class ContainerArrayAccessTest extends TestCase
         $container['my-service'] = new StringValue('via-array-access');
 
         self::assertTrue(isset($container['my-service']));
-        /** @var StringValue $service */
         $service = $container['my-service'];
         self::assertSame('via-array-access', $service->value());
 

--- a/tests/Integration/Architecture/AttributeReadCoverageTest.php
+++ b/tests/Integration/Architecture/AttributeReadCoverageTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use SplFileInfo;
+
+use function class_exists;
+use function file_get_contents;
+use function implode;
+use function preg_match_all;
+use function realpath;
+use function sprintf;
+use function str_contains;
+use function str_ends_with;
+use function str_starts_with;
+use function strlen;
+use function strrpos;
+use function substr;
+
+/**
+ * Every read of a non-`final` attribute must pass `ReflectionAttribute::IS_INSTANCEOF`.
+ *
+ * An attribute is left non-`final` for exactly one reason: so a consumer can
+ * subclass it to re-present it under their own namespace.
+ * `Gacela\Container\Attribute\Inject` says so in its docblock, and
+ * `Gacela\Framework\Attribute\Inject` is the subclass gacela itself ships.
+ *
+ * A reader that names the parent class without the flag matches the parent and
+ * nothing else, so every subclass is dropped. Nothing raises: the parameter is
+ * simply never injected, the `debug:*` output shows plain autowiring, the
+ * Symfony bridge lets Symfony autowire instead. That is the failure both
+ * attribute docblocks call out as silent, and it shipped in two readers anyway,
+ * because the container's own three call sites were correct and the tests only
+ * ever exercised the parent spelling.
+ *
+ * Reading a `final` attribute exactly is fine, and this test says nothing about
+ * it. The rule is tied to subclassability, so making an attribute non-`final`
+ * later brings its readers under the rule automatically.
+ */
+final class AttributeReadCoverageTest extends TestCase
+{
+    /** @var list<string> */
+    private const array ROOTS = [
+        __DIR__ . '/../../../src',
+        __DIR__ . '/../../../symfony-bridge/src',
+    ];
+
+    public function test_every_non_final_attribute_is_read_with_is_instanceof(): void
+    {
+        $offenders = [];
+        $checked = 0;
+
+        foreach ($this->attributeReads() as $read) {
+            $reflection = new ReflectionClass($read['attribute']);
+            if ($reflection->isFinal()) {
+                continue;
+            }
+
+            ++$checked;
+            if (!str_contains($read['args'], 'IS_INSTANCEOF')) {
+                $offenders[] = sprintf(
+                    '%s reads non-final %s without ReflectionAttribute::IS_INSTANCEOF',
+                    $read['file'],
+                    $read['attribute'],
+                );
+            }
+        }
+
+        self::assertNotSame(0, $checked, 'Found no reads of a non-final attribute; the scanner is broken.');
+        self::assertSame([], $offenders, implode("\n", $offenders));
+    }
+
+    /**
+     * @return list<array{file: string, attribute: class-string, args: string}>
+     */
+    private function attributeReads(): array
+    {
+        $reads = [];
+
+        foreach ($this->sourceFiles() as $file) {
+            $code = (string) file_get_contents($file);
+            if (!str_contains($code, 'getAttributes(')) {
+                continue;
+            }
+
+            $imports = $this->importsOf($code);
+
+            preg_match_all('/getAttributes\(\s*([\\\\\w]+)::class\s*([^;]*?)\)/s', $code, $matches, PREG_SET_ORDER);
+            foreach ($matches as $match) {
+                $attribute = $this->resolve($match[1], $imports);
+                if ($attribute === null) {
+                    continue;
+                }
+
+                $reads[] = ['file' => $this->relative($file), 'attribute' => $attribute, 'args' => $match[2]];
+            }
+        }
+
+        return $reads;
+    }
+
+    /**
+     * @param array<string, string> $imports
+     *
+     * @return class-string|null
+     */
+    private function resolve(string $name, array $imports): ?string
+    {
+        $candidate = str_starts_with($name, '\\') ? substr($name, 1) : ($imports[$name] ?? $name);
+
+        /** @var class-string $candidate */
+        return class_exists($candidate) ? $candidate : null;
+    }
+
+    /**
+     * Short name to FQCN, for the `use` statements of one file.
+     *
+     * @return array<string, string>
+     */
+    private function importsOf(string $code): array
+    {
+        $imports = [];
+
+        preg_match_all('/^use\s+([\\\\\w]+)(?:\s+as\s+(\w+))?\s*;/m', $code, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $fqcn = $match[1];
+            $alias = $match[2] ?? substr($fqcn, (int) strrpos($fqcn, '\\') + 1);
+            $imports[$alias] = $fqcn;
+        }
+
+        return $imports;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceFiles(): array
+    {
+        $files = [];
+
+        foreach (self::ROOTS as $root) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator((string) realpath($root)));
+
+            /** @var SplFileInfo $file */
+            foreach ($iterator as $file) {
+                if ($file->isFile() && str_ends_with($file->getFilename(), '.php')) {
+                    $files[] = $file->getPathname();
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    private function relative(string $path): string
+    {
+        $root = (string) realpath(__DIR__ . '/../../..');
+
+        return str_starts_with($path, $root) ? substr($path, strlen($root) + 1) : $path;
+    }
+}

--- a/tests/Integration/Architecture/BenchmarkGroupsTest.php
+++ b/tests/Integration/Architecture/BenchmarkGroupsTest.php
@@ -48,7 +48,11 @@ final class BenchmarkGroupsTest extends TestCase
         $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
 
         foreach ($files as $path => $file) {
-            if (!$file->isFile() || !str_ends_with((string)$path, 'Bench.php')) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if (!str_ends_with((string)$path, 'Bench.php')) {
                 continue;
             }
 

--- a/tests/Integration/Architecture/ContainerForwardingCoverageTest.php
+++ b/tests/Integration/Architecture/ContainerForwardingCoverageTest.php
@@ -114,6 +114,7 @@ final class ContainerForwardingCoverageTest extends TestCase
             if ($method->isStatic()) {
                 continue;
             }
+
             if ($method->isConstructor()) {
                 continue;
             }

--- a/tests/Integration/Architecture/DependencyGraph.php
+++ b/tests/Integration/Architecture/DependencyGraph.php
@@ -66,7 +66,7 @@ final class DependencyGraph
      */
     public function classCycles(): array
     {
-        return self::cyclesOf($this->classEdges);
+        return $this->cyclesOf($this->classEdges);
     }
 
     /**
@@ -74,7 +74,7 @@ final class DependencyGraph
      */
     public function namespaceCycles(): array
     {
-        return self::cyclesOf($this->namespaceEdges);
+        return $this->cyclesOf($this->namespaceEdges);
     }
 
     /**
@@ -82,17 +82,19 @@ final class DependencyGraph
      *
      * @return list<string>
      */
-    private static function cyclesOf(array $edges): array
+    private function cyclesOf(array $edges): array
     {
         $cycles = [];
 
-        foreach (self::stronglyConnectedComponents($edges) as $component) {
+        foreach ($this->stronglyConnectedComponents($edges) as $component) {
             if (count($component) < 2) {
                 continue;
             }
+
             sort($component);
             $cycles[] = implode(' | ', $component);
         }
+
         sort($cycles);
 
         return $cycles;
@@ -123,7 +125,7 @@ final class DependencyGraph
                     return null;
                 }
 
-                foreach (self::referencesOf($node) as $reference) {
+                foreach ($this->referencesOf($node) as $reference) {
                     $this->addEdge($current, $reference);
                 }
 
@@ -132,7 +134,7 @@ final class DependencyGraph
 
             public function leaveNode(Node $node): ?Node
             {
-                if ($node instanceof Node\Stmt\ClassLike && $node->namespacedName !== null) {
+                if ($node instanceof Node\Stmt\ClassLike && $node->namespacedName instanceof \PhpParser\Node\Name) {
                     array_pop($this->stack);
                 }
 
@@ -142,17 +144,20 @@ final class DependencyGraph
             /**
              * @return list<string>
              */
-            private static function referencesOf(Node $node): array
+            private function referencesOf(Node $node): array
             {
                 if ($node instanceof Node\Stmt\TraitUse) {
-                    return self::names($node->traits);
+                    return $this->names($node->traits);
                 }
+
                 if ($node instanceof Node\Stmt\Catch_) {
-                    return self::names($node->types);
+                    return $this->names($node->types);
                 }
+
                 if ($node instanceof Node\Attribute) {
                     return [$node->name->toString()];
                 }
+
                 if ($node instanceof Node\Expr\New_
                     || $node instanceof Node\Expr\StaticCall
                     || $node instanceof Node\Expr\StaticPropertyFetch
@@ -161,12 +166,15 @@ final class DependencyGraph
                 ) {
                     return $node->class instanceof Node\Name ? [$node->class->toString()] : [];
                 }
+
                 if ($node instanceof Node\Param) {
                     return self::typeNames($node->type);
                 }
+
                 if ($node instanceof Node\Stmt\Property) {
                     return self::typeNames($node->type);
                 }
+
                 if ($node instanceof Node\FunctionLike) {
                     return self::typeNames($node->getReturnType());
                 }
@@ -179,7 +187,7 @@ final class DependencyGraph
              *
              * @return list<string>
              */
-            private static function names(array $names): array
+            private function names(array $names): array
             {
                 $out = [];
                 foreach ($names as $name) {
@@ -197,9 +205,11 @@ final class DependencyGraph
                 if ($type instanceof Node\Name) {
                     return [$type->toString()];
                 }
+
                 if ($type instanceof Node\NullableType) {
                     return self::typeNames($type->type);
                 }
+
                 if ($type instanceof Node\UnionType || $type instanceof Node\IntersectionType) {
                     $out = [];
                     foreach ($type->types as $inner) {
@@ -216,7 +226,7 @@ final class DependencyGraph
 
             private function enterClassLike(Node\Stmt\ClassLike $node): void
             {
-                if ($node->namespacedName === null) {
+                if (!$node->namespacedName instanceof \PhpParser\Node\Name) {
                     return;
                 }
 
@@ -228,13 +238,15 @@ final class DependencyGraph
                 if ($node instanceof Node\Stmt\Class_ && $node->extends instanceof Node\Name) {
                     $this->addEdge($fqn, $node->extends->toString());
                 }
+
                 if ($node instanceof Node\Stmt\Interface_) {
-                    foreach (self::names($node->extends) as $name) {
+                    foreach ($this->names($node->extends) as $name) {
                         $this->addEdge($fqn, $name);
                     }
                 }
+
                 if ($node instanceof Node\Stmt\Class_ || $node instanceof Node\Stmt\Enum_) {
-                    foreach (self::names($node->implements) as $name) {
+                    foreach ($this->names($node->implements) as $name) {
                         $this->addEdge($fqn, $name);
                     }
                 }
@@ -250,9 +262,11 @@ final class DependencyGraph
                 if ($from === $to || !str_starts_with($to, 'Gacela\\')) {
                     return;
                 }
+
                 if (in_array($to, $this->edges[$from] ?? [], true)) {
                     return;
                 }
+
                 $this->edges[$from][] = $to;
             }
         };
@@ -317,9 +331,14 @@ final class DependencyGraph
 
             foreach ($targets as $to) {
                 $toNamespace = self::namespaceOf($to);
-                if ($fromNamespace === $toNamespace || in_array($toNamespace, $edges[$fromNamespace], true)) {
+                if ($fromNamespace === $toNamespace) {
                     continue;
                 }
+
+                if (in_array($toNamespace, $edges[$fromNamespace], true)) {
+                    continue;
+                }
+
                 $edges[$fromNamespace][] = $toNamespace;
             }
         }
@@ -341,7 +360,7 @@ final class DependencyGraph
      *
      * @return list<list<string>>
      */
-    private static function stronglyConnectedComponents(array $edges): array
+    private function stronglyConnectedComponents(array $edges): array
     {
         $index = [];
         $low = [];
@@ -376,13 +395,15 @@ final class DependencyGraph
                     if (!isset($edges[$next])) {
                         continue;
                     }
+
                     if (!isset($index[$next])) {
                         $work[count($work) - 1] = [$node, $i + 1];
                         $work[] = [$next, 0];
                         $recursed = true;
                         break;
                     }
-                    if (($onStack[$next] ?? false) === true) {
+
+                    if ($onStack[$next] ?? false) {
                         $low[$node] = min($low[$node], $index[$next]);
                     }
                 }
@@ -398,6 +419,7 @@ final class DependencyGraph
                         $onStack[$w] = false;
                         $component[] = $w;
                     } while ($w !== $node);
+
                     $result[] = $component;
                 }
 

--- a/tests/Integration/Architecture/NoCircularDependenciesTest.php
+++ b/tests/Integration/Architecture/NoCircularDependenciesTest.php
@@ -66,7 +66,7 @@ final class NoCircularDependenciesTest extends TestCase
         //     types, and SetupMerger alone reads 17 of its constants.
         //   - Container + Locator: a container and its service locator, both
         //     @internal, one concept split across two classes.
-        'Gacela\Framework\Bootstrap\AbstractSetupGacela'
+        \Gacela\Framework\Bootstrap\AbstractSetupGacela::class
             . ' | Gacela\Framework\Bootstrap\GacelaConfig'
             . ' | Gacela\Framework\Bootstrap\SetupEventDispatcher'
             . ' | Gacela\Framework\Bootstrap\SetupGacela'
@@ -155,45 +155,29 @@ final class NoCircularDependenciesTest extends TestCase
 
     public function test_source_tree_has_no_unexpected_class_cycles(): void
     {
-        self::assertNoUnexpectedCycles(
-            DependencyGraph::fromDirectory(self::SRC)->classCycles(),
-            self::ALLOWED_CLASS_CYCLES,
-            'class',
-        );
+        $this->assertNoUnexpectedCycles(DependencyGraph::fromDirectory(self::SRC)->classCycles(), self::ALLOWED_CLASS_CYCLES, 'class');
     }
 
     public function test_source_tree_has_no_unexpected_namespace_cycles(): void
     {
-        self::assertNoUnexpectedCycles(
-            DependencyGraph::fromDirectory(self::SRC)->namespaceCycles(),
-            self::ALLOWED_NAMESPACE_CYCLES,
-            'namespace',
-        );
+        $this->assertNoUnexpectedCycles(DependencyGraph::fromDirectory(self::SRC)->namespaceCycles(), self::ALLOWED_NAMESPACE_CYCLES, 'namespace');
     }
 
     public function test_allow_listed_class_cycles_still_exist(): void
     {
-        self::assertAllowListIsNotStale(
-            DependencyGraph::fromDirectory(self::SRC)->classCycles(),
-            self::ALLOWED_CLASS_CYCLES,
-            'ALLOWED_CLASS_CYCLES',
-        );
+        $this->assertAllowListIsNotStale(DependencyGraph::fromDirectory(self::SRC)->classCycles(), self::ALLOWED_CLASS_CYCLES, 'ALLOWED_CLASS_CYCLES');
     }
 
     public function test_allow_listed_namespace_cycles_still_exist(): void
     {
-        self::assertAllowListIsNotStale(
-            DependencyGraph::fromDirectory(self::SRC)->namespaceCycles(),
-            self::ALLOWED_NAMESPACE_CYCLES,
-            'ALLOWED_NAMESPACE_CYCLES',
-        );
+        $this->assertAllowListIsNotStale(DependencyGraph::fromDirectory(self::SRC)->namespaceCycles(), self::ALLOWED_NAMESPACE_CYCLES, 'ALLOWED_NAMESPACE_CYCLES');
     }
 
     /**
      * @param list<string> $found
      * @param list<string> $allowed
      */
-    private static function assertNoUnexpectedCycles(array $found, array $allowed, string $level): void
+    private function assertNoUnexpectedCycles(array $found, array $allowed, string $level): void
     {
         $unexpected = array_values(array_diff($found, $allowed));
 
@@ -216,7 +200,7 @@ final class NoCircularDependenciesTest extends TestCase
      * @param list<string> $found
      * @param list<string> $allowed
      */
-    private static function assertAllowListIsNotStale(array $found, array $allowed, string $constant): void
+    private function assertAllowListIsNotStale(array $found, array $allowed, string $constant): void
     {
         foreach ($allowed as $cycle) {
             self::assertContains(

--- a/tests/Integration/Architecture/ResetCacheCoverageTest.php
+++ b/tests/Integration/Architecture/ResetCacheCoverageTest.php
@@ -47,7 +47,7 @@ final class ResetCacheCoverageTest extends TestCase
      */
     private const array RESET_EXEMPT = [
         'Gacela' => 'is the central reset itself',
-        'CacheableConfig' => 'holds application configuration: the cache backend registered via CacheableConfig::setStorage(). Nothing in the framework sets it, so clearing it here would silently drop the app\'s configured storage',
+        'CacheableConfig' => "holds application configuration: the cache backend registered via CacheableConfig::setStorage(). Nothing in the framework sets it, so clearing it here would silently drop the app's configured storage",
         'HealthCheckRegistry' => 'holds checks registered through GacelaConfig::addHealthCheck(). Configuration, re-established by bootstrap, which resets it explicitly at Gacela::bootstrap()',
         'ReflectionClassPool' => 'pure memoization keyed by class name. Reflection of a loaded class cannot change, so nothing goes stale, and the pool is bounded by the set of loaded classes, so it is not a leak. reset() exists for test isolation',
     ];
@@ -108,7 +108,11 @@ final class ResetCacheCoverageTest extends TestCase
 
         $found = [];
         foreach ($files as $path => $file) {
-            if (!$file->isFile() || !str_ends_with((string)$path, '.php')) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if (!str_ends_with((string)$path, '.php')) {
                 continue;
             }
 

--- a/tests/Integration/Architecture/StaticStateCoverageTest.php
+++ b/tests/Integration/Architecture/StaticStateCoverageTest.php
@@ -233,16 +233,20 @@ final class StaticStateCoverageTest extends TestCase
             if (!$file->isFile()) {
                 continue;
             }
+
             if (!str_ends_with((string)$path, '.php')) {
                 continue;
             }
+
             $fqcn = $this->fqcnFor((string)$path);
             if (interface_exists($fqcn)) {
                 continue;
             }
+
             if (trait_exists($fqcn)) {
                 continue;
             }
+
             if (!class_exists($fqcn)) {
                 continue;
             }

--- a/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
+++ b/tests/Integration/Console/CacheWarm/ModuleWarmerTest.php
@@ -79,12 +79,7 @@ final class ModuleWarmerTest extends TestCase
         self::assertSame(2, $resolved);
         self::assertSame(0, $skipped);
         self::assertSame(0, $failed);
-        self::assertSame(self::lines(
-            'Processing: Healthy',
-            '  ✓ Resolved Facade: ' . HealthyFacade::class,
-            '  ✓ Resolved Factory: ' . HealthyFactory::class,
-            '',
-        ), $this->output->fetch());
+        self::assertSame($this->lines('Processing: Healthy', '  ✓ Resolved Facade: ' . HealthyFacade::class, '  ✓ Resolved Factory: ' . HealthyFactory::class, ''), $this->output->fetch());
     }
 
     public function test_a_missing_pillar_class_is_skipped_not_failed(): void
@@ -98,12 +93,7 @@ final class ModuleWarmerTest extends TestCase
         self::assertSame(1, $resolved);
         self::assertSame(1, $skipped);
         self::assertSame(0, $failed);
-        self::assertSame(self::lines(
-            'Processing: Healthy',
-            '  ✓ Resolved Facade: ' . HealthyFacade::class,
-            '  ⚠ Skipped Factory: Missing\\Factory (class not found)',
-            '',
-        ), $this->output->fetch());
+        self::assertSame($this->lines('Processing: Healthy', '  ✓ Resolved Facade: ' . HealthyFacade::class, '  ⚠ Skipped Factory: Missing\\Factory (class not found)', ''), $this->output->fetch());
     }
 
     public function test_a_pillar_whose_autoloading_throws_is_reported_as_failed(): void
@@ -128,12 +118,7 @@ final class ModuleWarmerTest extends TestCase
         // `CacheWarmedEvent` report a healthy deploy as a broken one.
         self::assertSame(0, $skipped);
         self::assertSame(1, $failed);
-        self::assertSame(self::lines(
-            'Processing: Healthy',
-            '  ✓ Resolved Facade: ' . HealthyFacade::class,
-            '  ✗ Failed Factory: ' . self::EXPLODING_CLASS . ' (autoloading blew up)',
-            '',
-        ), $this->output->fetch());
+        self::assertSame($this->lines('Processing: Healthy', '  ✓ Resolved Facade: ' . HealthyFacade::class, '  ✗ Failed Factory: ' . self::EXPLODING_CLASS . ' (autoloading blew up)', ''), $this->output->fetch());
     }
 
     public function test_attribute_warming_only_happens_when_it_is_asked_for(): void
@@ -180,7 +165,7 @@ final class ModuleWarmerTest extends TestCase
         self::assertSame([2, 2, 0], $this->warmer->warmModules([$first, $second], warmAttributes: false));
     }
 
-    private static function lines(string ...$lines): string
+    private function lines(string ...$lines): string
     {
         return implode(PHP_EOL, $lines) . PHP_EOL;
     }

--- a/tests/Integration/Framework/Bootstrap/BootstrapBatchesFileCacheTest.php
+++ b/tests/Integration/Framework/Bootstrap/BootstrapBatchesFileCacheTest.php
@@ -48,7 +48,7 @@ final class BootstrapBatchesFileCacheTest extends TestCase
         try {
             Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
                 $config->resetInMemoryCache();
-                $config->addPlugin(static function (): void {
+                $config->addPlugin(static function (): never {
                     throw new RuntimeException('plugin boom');
                 });
             });

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -301,6 +301,7 @@ final class ConfigTest extends TestCase
 
         // First access initialises and builds the internal ConfigFactory.
         $config->getAllValues();
+
         $firstFactory = $config->getFactory();
 
         // A second access on an empty merged config must not re-run init(),

--- a/tests/Integration/Framework/Container/AfterResolvingHookTest.php
+++ b/tests/Integration/Framework/Container/AfterResolvingHookTest.php
@@ -134,7 +134,7 @@ final class AfterResolvingHookTest extends TestCase
             // *stored* instance -- bindings and factories build a new one per
             // resolution, so only this one has a cache to be left dirty.
             $config->addHandlerRegistry('dispatcher', ['a' => ReportService::class]);
-            $config->afterResolving('dispatcher', static function (object $service) use (&$seen): void {
+            $config->afterResolving('dispatcher', static function (object $service) use (&$seen): never {
                 $seen[] = $service;
                 throw new RuntimeException('hook failed');
             });
@@ -145,8 +145,8 @@ final class AfterResolvingHookTest extends TestCase
         try {
             $container->get('dispatcher');
             self::fail('the hook was expected to throw');
-        } catch (RuntimeException $exception) {
-            self::assertSame('hook failed', $exception->getMessage());
+        } catch (RuntimeException $runtimeException) {
+            self::assertSame('hook failed', $runtimeException->getMessage());
         }
 
         self::assertCount(1, $seen);
@@ -161,7 +161,7 @@ final class AfterResolvingHookTest extends TestCase
         $this->bootstrapWith(static function (GacelaConfig $config): void {
             // Registered first and matching nothing here: iteration has to skip
             // it and keep going, not give up on the rest.
-            $config->afterResolving(PlainService::class, static fn (PlainService $s) => $s);
+            $config->afterResolving(PlainService::class, static fn (PlainService $s): \GacelaTest\Integration\Framework\Container\Resolving\PlainService => $s);
             $config->afterResolving(
                 ReportService::class,
                 static fn (ReportService $service) => $service->setLogger('file'),

--- a/tests/Integration/Framework/Container/ContainerScopeTest.php
+++ b/tests/Integration/Framework/Container/ContainerScopeTest.php
@@ -19,8 +19,10 @@ use PHPUnit\Framework\TestCase;
  * Container 2.0's `withSelfReference()` is what closes that, so these pin the
  * two halves: a scope is decorated like its parent, and it behaves like a scope.
  *
- * Gacela does not create scopes of its own yet -- which lifetime owns one is an
- * open design question -- but the primitive is reachable now.
+ * Both halves are load-bearing now rather than latent: {@see \Gacela\Framework\AbstractFactory}
+ * builds every module container as a scope of the app container, so a scope that
+ * came back undecorated would break the documented provider signature on each
+ * one of them.
  */
 final class ContainerScopeTest extends TestCase
 {

--- a/tests/Integration/Framework/Container/LazyRegistrationTest.php
+++ b/tests/Integration/Framework/Container/LazyRegistrationTest.php
@@ -58,6 +58,7 @@ final class LazyRegistrationTest extends TestCase
 
         $container = new Container();
         $container->lazy(LazySpy::class);
+
         $instance = $container->get(LazySpy::class);
 
         self::assertSame(0, LazySpy::$constructed, 'resolving a lazy service must not construct it');
@@ -73,11 +74,10 @@ final class LazySpy
 {
     public static int $constructed = 0;
 
-    public string $marker;
+    public string $marker = 'built';
 
     public function __construct()
     {
         ++self::$constructed;
-        $this->marker = 'built';
     }
 }

--- a/tests/Integration/PHPStan/ProvidedDependencyAnalysisTest.php
+++ b/tests/Integration/PHPStan/ProvidedDependencyAnalysisTest.php
@@ -26,7 +26,7 @@ final class ProvidedDependencyAnalysisTest extends TestCase
     public function test_a_call_on_a_class_string_dependency_is_checked(): void
     {
         self::assertStringContainsString(
-            'Call to an undefined method GacelaTest\Integration\PHPStan\Fixture\ProvidedClock::nooow().',
+            'Call to an undefined method ' . \GacelaTest\Integration\PHPStan\Fixture\ProvidedClock::class . '::nooow().',
             $this->analyseFixture(),
             'the class-string key must resolve to that class, not to mixed',
         );

--- a/tests/Integration/PHPStan/ServiceMapAnalysisTest.php
+++ b/tests/Integration/PHPStan/ServiceMapAnalysisTest.php
@@ -29,7 +29,7 @@ final class ServiceMapAnalysisTest extends TestCase
         $errors = $this->analyseFixture();
 
         self::assertStringContainsString(
-            'Call to an undefined method GacelaTest\Integration\PHPStan\Fixture\ConsumerFacade::typoMethod().',
+            'Call to an undefined method ' . \GacelaTest\Integration\PHPStan\Fixture\ConsumerFacade::class . '::typoMethod().',
             $errors,
             'the accessor must resolve to the facade, not to mixed',
         );
@@ -66,7 +66,7 @@ final class ServiceMapAnalysisTest extends TestCase
         $errors = $this->analyseFixture();
 
         self::assertStringContainsString(
-            'Call to an undefined method GacelaTest\Integration\PHPStan\Fixture\UndeclaredConsumer::getFacade().',
+            'Call to an undefined method ' . \GacelaTest\Integration\PHPStan\Fixture\UndeclaredConsumer::class . '::getFacade().',
             $errors,
         );
     }

--- a/tests/Integration/Psalm/ServiceMapPluginTest.php
+++ b/tests/Integration/Psalm/ServiceMapPluginTest.php
@@ -29,7 +29,7 @@ final class ServiceMapPluginTest extends TestCase
         $this->skipIfPsalmCannotRun($errors);
 
         self::assertStringContainsString(
-            'Method GacelaTest\Integration\Psalm\Fixture\ConsumerFacade::typoMethod does not exist',
+            'Method ' . \GacelaTest\Integration\Psalm\Fixture\ConsumerFacade::class . '::typoMethod does not exist',
             $errors,
             'the accessor must resolve to the facade, so calls made through it are checked',
         );

--- a/tests/Unit/Console/Application/CacheWarm/CacheWarmOutputFormatterTest.php
+++ b/tests/Unit/Console/Application/CacheWarm/CacheWarmOutputFormatterTest.php
@@ -37,7 +37,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeHeader();
 
         self::assertSame(
-            self::lines('', 'Warming Gacela cache...', str_repeat('=', self::SEPARATOR_WIDTH), ''),
+            $this->lines('', 'Warming Gacela cache...', str_repeat('=', self::SEPARATOR_WIDTH), ''),
             $this->output->fetch(),
         );
     }
@@ -46,7 +46,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
     {
         $this->formatter->writeCacheCleared();
 
-        self::assertSame(self::lines('Cleared existing cache', ''), $this->output->fetch());
+        self::assertSame($this->lines('Cleared existing cache', ''), $this->output->fetch());
     }
 
     public function test_module_discovery_warning_surfaces_the_underlying_error(): void
@@ -54,10 +54,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeModuleDiscoveryWarning('composer.json is not readable');
 
         self::assertSame(
-            self::lines(
-                'Warning: Some modules could not be discovered due to errors',
-                '  Error: composer.json is not readable',
-            ),
+            $this->lines('Warning: Some modules could not be discovered due to errors', '  Error: composer.json is not readable'),
             $this->output->fetch(),
         );
     }
@@ -66,21 +63,21 @@ final class CacheWarmOutputFormatterTest extends TestCase
     {
         $this->formatter->writeModulesFound(['a', 'b', 'c']);
 
-        self::assertSame(self::lines('Found 3 modules', ''), $this->output->fetch());
+        self::assertSame($this->lines('Found 3 modules', ''), $this->output->fetch());
     }
 
     public function test_module_name_is_prefixed_with_processing(): void
     {
         $this->formatter->writeModuleName('Foo');
 
-        self::assertSame(self::lines('Processing: Foo'), $this->output->fetch());
+        self::assertSame($this->lines('Processing: Foo'), $this->output->fetch());
     }
 
     public function test_resolved_class_is_reported_with_its_type(): void
     {
         $this->formatter->writeClassResolved('Factory', 'App\\Foo\\FooFactory');
 
-        self::assertSame(self::lines('  ✓ Resolved Factory: App\\Foo\\FooFactory'), $this->output->fetch());
+        self::assertSame($this->lines('  ✓ Resolved Factory: App\\Foo\\FooFactory'), $this->output->fetch());
     }
 
     public function test_skipped_class_explains_why_it_was_skipped(): void
@@ -88,7 +85,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeClassSkipped('Config', 'App\\Foo\\FooConfig');
 
         self::assertSame(
-            self::lines('  ⚠ Skipped Config: App\\Foo\\FooConfig (class not found)'),
+            $this->lines('  ⚠ Skipped Config: App\\Foo\\FooConfig (class not found)'),
             $this->output->fetch(),
         );
     }
@@ -98,7 +95,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeClassFailed('Provider', 'App\\Foo\\FooProvider', 'cannot construct');
 
         self::assertSame(
-            self::lines('  ✗ Failed Provider: App\\Foo\\FooProvider (cannot construct)'),
+            $this->lines('  ✗ Failed Provider: App\\Foo\\FooProvider (cannot construct)'),
             $this->output->fetch(),
         );
     }
@@ -115,18 +112,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeSummary(3, 7, 2, 1, '0.123 seconds', '1.00 KB');
 
         self::assertSame(
-            self::lines(
-                str_repeat('=', self::SEPARATOR_WIDTH),
-                'Cache warming complete!',
-                '',
-                'Modules processed: 3',
-                'Classes resolved: 7',
-                'Classes skipped: 2',
-                'Classes failed: 1',
-                'Time taken: 0.123 seconds',
-                'Memory used: 1.00 KB',
-                '',
-            ),
+            $this->lines(str_repeat('=', self::SEPARATOR_WIDTH), 'Cache warming complete!', '', 'Modules processed: 3', 'Classes resolved: 7', 'Classes skipped: 2', 'Classes failed: 1', 'Time taken: 0.123 seconds', 'Memory used: 1.00 KB', ''),
             $this->output->fetch(),
         );
     }
@@ -136,11 +122,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeCacheInfo('/tmp/gacela/class-name-cache.php', '1.00 KB');
 
         self::assertSame(
-            self::lines(
-                'Cache file: /tmp/gacela/class-name-cache.php',
-                'Cache size: 1.00 KB',
-                '',
-            ),
+            $this->lines('Cache file: /tmp/gacela/class-name-cache.php', 'Cache size: 1.00 KB', ''),
             $this->output->fetch(),
         );
     }
@@ -150,11 +132,7 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeMergedConfigCacheInfo('/tmp/gacela/merged-config.php', '2.00 KB');
 
         self::assertSame(
-            self::lines(
-                'Merged config cache: /tmp/gacela/merged-config.php',
-                'Merged config size: 2.00 KB',
-                '',
-            ),
+            $this->lines('Merged config cache: /tmp/gacela/merged-config.php', 'Merged config size: 2.00 KB', ''),
             $this->output->fetch(),
         );
     }
@@ -164,17 +142,12 @@ final class CacheWarmOutputFormatterTest extends TestCase
         $this->formatter->writeCacheWarning();
 
         self::assertSame(
-            self::lines(
-                'Warning: Cache file was not created. File caching might be disabled.',
-                'Enable file caching in your gacela.php configuration:',
-                '  $config->enableFileCache();',
-                '',
-            ),
+            $this->lines('Warning: Cache file was not created. File caching might be disabled.', 'Enable file caching in your gacela.php configuration:', '  $config->enableFileCache();', ''),
             $this->output->fetch(),
         );
     }
 
-    private static function lines(string ...$lines): string
+    private function lines(string ...$lines): string
     {
         return implode(PHP_EOL, $lines) . PHP_EOL;
     }

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\AutowirableCollaborator;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundContract;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\BoundImplementation;
+use GacelaTest\Feature\Console\DebugDependencies\Fixtures\FrameworkInjectService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\InjectService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\MixedDependenciesService;
 use GacelaTest\Feature\Console\DebugDependencies\Fixtures\NoConstructorService;
@@ -128,6 +129,23 @@ final class ConstructorInspectorTest extends TestCase
         $override = $inspection->parameters[1];
         self::assertSame(ParameterStatus::Inject, $override->status);
         self::assertSame('inject -> ' . BoundImplementation::class, $override->detail);
+    }
+
+    /**
+     * `Gacela\Framework\Attribute\Inject` subclasses the container's attribute,
+     * and both imports are supported. Reading for an exact FQN would report the
+     * parameter as plain autowiring, which is the silent failure the attribute's
+     * own docblock warns about.
+     */
+    public function test_the_framework_spelling_of_inject_is_flagged_too(): void
+    {
+        $inspection = $this->inspector->inspect(FrameworkInjectService::class);
+
+        self::assertCount(2, $inspection->parameters);
+        self::assertSame(ParameterStatus::Inject, $inspection->parameters[0]->status);
+        self::assertSame('inject', $inspection->parameters[0]->detail);
+        self::assertSame(ParameterStatus::Inject, $inspection->parameters[1]->status);
+        self::assertSame('inject -> ' . BoundImplementation::class, $inspection->parameters[1]->detail);
     }
 
     public function test_a_binding_to_an_already_built_object_names_its_class(): void

--- a/tests/Unit/Console/Application/Debug/DependencyTreeInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/DependencyTreeInspectorTest.php
@@ -61,7 +61,7 @@ final class DependencyTreeInspectorTest extends TestCase
                 AutowirableCollaborator::class,
                 UnboundContract::class,
             ],
-            self::classNames($inspection),
+            $this->classNames($inspection),
         );
     }
 
@@ -129,8 +129,8 @@ final class DependencyTreeInspectorTest extends TestCase
 
         // The container resolves the binding before walking further, so the tree
         // names what will actually be built -- BoundContract never appears.
-        self::assertContains(BoundImplementation::class, self::classNames($inspection));
-        self::assertNotContains(BoundContract::class, self::classNames($inspection));
+        self::assertContains(BoundImplementation::class, $this->classNames($inspection));
+        self::assertNotContains(BoundContract::class, $this->classNames($inspection));
     }
 
     public function test_an_unbound_interface_is_the_only_unresolvable_node(): void
@@ -159,16 +159,13 @@ final class DependencyTreeInspectorTest extends TestCase
 
     public function test_an_autowired_node_is_distinguished_from_a_stored_instance(): void
     {
-        $before = self::statusIn($this->inspector->inspect(NestedRootService::class), AutowirableCollaborator::class);
+        $before = $this->statusIn($this->inspector->inspect(NestedRootService::class), AutowirableCollaborator::class);
         self::assertSame(ProvisionStatus::Autowired, $before);
 
         Gacela::container()->set(AutowirableCollaborator::class, new AutowirableCollaborator());
 
         // provides() is what tells the two apart: has() was already true of both.
-        self::assertSame(ProvisionStatus::Instance, self::statusIn(
-            $this->inspector->inspect(NestedRootService::class),
-            AutowirableCollaborator::class,
-        ));
+        self::assertSame(ProvisionStatus::Instance, $this->statusIn($this->inspector->inspect(NestedRootService::class), AutowirableCollaborator::class));
     }
 
     public function test_a_registered_binding_keeps_its_own_status(): void
@@ -183,7 +180,7 @@ final class DependencyTreeInspectorTest extends TestCase
 
         $inspection = (new DependencyTreeInspector())->inspect(NestedMidService::class);
 
-        self::assertSame(ProvisionStatus::Binding, self::statusIn($inspection, UnboundContract::class));
+        self::assertSame(ProvisionStatus::Binding, $this->statusIn($inspection, UnboundContract::class));
         self::assertTrue($inspection->isFullyProvided());
     }
 
@@ -215,7 +212,7 @@ final class DependencyTreeInspectorTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function classNames(DependencyTreeInspection $inspection): array
+    private function classNames(DependencyTreeInspection $inspection): array
     {
         return array_map(
             static fn (object $node): string => $node->className,
@@ -223,7 +220,7 @@ final class DependencyTreeInspectorTest extends TestCase
         );
     }
 
-    private static function statusIn(DependencyTreeInspection $inspection, string $className): ProvisionStatus
+    private function statusIn(DependencyTreeInspection $inspection, string $className): ProvisionStatus
     {
         foreach ($inspection->nodes as $node) {
             if ($node->className === $className) {

--- a/tests/Unit/Console/Application/Debug/DependencyTreeRendererTest.php
+++ b/tests/Unit/Console/Application/Debug/DependencyTreeRendererTest.php
@@ -35,7 +35,7 @@ final class DependencyTreeRendererTest extends TestCase
     public function test_a_child_is_drawn_under_its_parent(): void
     {
         $lines = $this->renderer->render([
-            self::node('Parent', 'p', [self::node('Child', 'c')]),
+            $this->node('Parent', 'p', [$this->node('Child', 'c')]),
         ]);
 
         self::assertCount(2, $lines);
@@ -53,8 +53,8 @@ final class DependencyTreeRendererTest extends TestCase
     public function test_a_non_last_child_keeps_the_trunk_open_for_its_own_children(): void
     {
         $lines = $this->renderer->render([
-            self::node('First', 'a', [self::node('Nested', 'n')]),
-            self::node('Second', 'b'),
+            $this->node('First', 'a', [$this->node('Nested', 'n')]),
+            $this->node('Second', 'b'),
         ]);
 
         self::assertStringContainsString('│', $lines[1], 'the grandchild hangs off a trunk that continues');
@@ -70,11 +70,11 @@ final class DependencyTreeRendererTest extends TestCase
     public function test_the_prefix_accumulates_through_every_level_under_the_indent(): void
     {
         $lines = $this->renderer->render([
-            self::node('A', 'a', [
-                self::node('A1', 'a1', [self::node('A1a', 'a1a')]),
-                self::node('A2', 'a2'),
+            $this->node('A', 'a', [
+                $this->node('A1', 'a1', [$this->node('A1a', 'a1a')]),
+                $this->node('A2', 'a2'),
             ]),
-            self::node('B', 'b'),
+            $this->node('B', 'b'),
         ], '  ');
 
         self::assertSame(
@@ -95,7 +95,7 @@ final class DependencyTreeRendererTest extends TestCase
     public function test_an_unprovided_node_is_marked_differently(): void
     {
         $lines = $this->renderer->render([
-            self::node('Missing', 'm', [], ProvisionStatus::Unresolvable),
+            $this->node('Missing', 'm', [], ProvisionStatus::Unresolvable),
         ]);
 
         self::assertStringContainsString('✗', $lines[0]);
@@ -106,7 +106,7 @@ final class DependencyTreeRendererTest extends TestCase
     public function test_a_cut_cycle_says_so(): void
     {
         $lines = $this->renderer->render([
-            self::node('Loop', 'l', [], ProvisionStatus::Autowired, repeated: true),
+            $this->node('Loop', 'l', [], ProvisionStatus::Autowired, repeated: true),
         ]);
 
         // Without this, a branch that stopped because it looped reads exactly
@@ -116,7 +116,7 @@ final class DependencyTreeRendererTest extends TestCase
 
     public function test_a_root_node_without_a_parameter_is_not_labelled_with_one(): void
     {
-        $lines = $this->renderer->render([self::node('Bare', null)]);
+        $lines = $this->renderer->render([$this->node('Bare', null)]);
 
         self::assertStringNotContainsString('$', $lines[0]);
         self::assertStringContainsString('Bare', $lines[0]);
@@ -125,7 +125,7 @@ final class DependencyTreeRendererTest extends TestCase
     public function test_the_indent_is_applied_to_every_line(): void
     {
         $lines = $this->renderer->render([
-            self::node('Parent', 'p', [self::node('Child', 'c')]),
+            $this->node('Parent', 'p', [$this->node('Child', 'c')]),
         ], '    ');
 
         foreach ($lines as $line) {
@@ -136,7 +136,7 @@ final class DependencyTreeRendererTest extends TestCase
     /**
      * @param list<DependencyTreeNode> $children
      */
-    private static function node(
+    private function node(
         string $className,
         ?string $parameter,
         array $children = [],

--- a/tests/Unit/Console/Application/Doctor/Check/FilenameMismatchCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/FilenameMismatchCheckTest.php
@@ -55,11 +55,9 @@ final class FilenameMismatchCheckTest extends TestCase
             'App\\Foo\\Provider',
         );
 
-        $check = new FilenameMismatchCheck([$module], static function (string $class): string {
-            return $class === 'App\\Foo\\Provider'
-                ? '/app/Foo/DependencyProvider.php'
-                : '/app/Foo/' . self::shortName($class) . '.php';
-        });
+        $check = new FilenameMismatchCheck([$module], static fn (string $class): string => $class === 'App\\Foo\\Provider'
+            ? '/app/Foo/DependencyProvider.php'
+            : '/app/Foo/' . self::shortName($class) . '.php');
 
         $result = $check->run();
 
@@ -86,7 +84,7 @@ final class FilenameMismatchCheckTest extends TestCase
         $module = new AppModule(
             'GacelaTest\\Fixtures',
             'Fixtures',
-            'GacelaTest\\Unit\\Console\\Application\\Doctor\\Check\\Fixtures\\Provider',
+            \GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\Provider::class,
         );
 
         $result = (new FilenameMismatchCheck([$module]))->run();

--- a/tests/Unit/Console/Infrastructure/FileContentIoTest.php
+++ b/tests/Unit/Console/Infrastructure/FileContentIoTest.php
@@ -85,7 +85,7 @@ final class FileContentIoTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Directory "%s" was not created', $directory));
 
-        self::silenced(fn (): mixed => $this->io->mkdir($directory));
+        $this->silenced(fn (): mixed => $this->io->mkdir($directory));
     }
 
     public function test_it_writes_the_file_contents(): void
@@ -104,7 +104,7 @@ final class FileContentIoTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('File "%s" was not written', $path));
 
-        self::silenced(fn (): mixed => $this->io->filePutContents($path, 'written'));
+        $this->silenced(fn (): mixed => $this->io->filePutContents($path, 'written'));
     }
 
     public function test_it_overwrites_an_existing_file(): void
@@ -143,7 +143,7 @@ final class FileContentIoTest extends TestCase
      *
      * @param callable():mixed $call
      */
-    private static function silenced(callable $call): void
+    private function silenced(callable $call): void
     {
         set_error_handler(static fn (): bool => true);
 

--- a/tests/Unit/Framework/Attribute/ProvidesScannerTest.php
+++ b/tests/Unit/Framework/Attribute/ProvidesScannerTest.php
@@ -109,11 +109,11 @@ final class ProvidesScannerTest extends TestCase
     public function test_second_scan_reuses_the_memoized_reflection_entries(): void
     {
         ProvidesScanner::scan(new ProviderWithAttributesOnly(), new Container());
-        $memoizedEntries = self::memoizedEntriesFor(ProviderWithAttributesOnly::class);
+        $memoizedEntries = $this->memoizedEntriesFor(ProviderWithAttributesOnly::class);
 
         ProvidesScanner::scan(new ProviderWithAttributesOnly(), new Container());
 
-        self::assertSame($memoizedEntries, self::memoizedEntriesFor(ProviderWithAttributesOnly::class));
+        self::assertSame($memoizedEntries, $this->memoizedEntriesFor(ProviderWithAttributesOnly::class));
     }
 
     public function test_register_is_final_to_protect_the_provides_scan(): void
@@ -161,7 +161,7 @@ final class ProvidesScannerTest extends TestCase
      *
      * @return list<array{id: string, method: ReflectionMethod, needsContainer: bool}>
      */
-    private static function memoizedEntriesFor(string $provider): array
+    private function memoizedEntriesFor(string $provider): array
     {
         /** @var array<class-string, list<array{id: string, method: ReflectionMethod, needsContainer: bool}>> $cache */
         $cache = (new ReflectionProperty(ProvidesScanner::class, 'cache'))->getValue();

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -181,24 +181,24 @@ final class SetupGacelaTest extends TestCase
     {
         $setup = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->extendService('service', static fn (ArrayObject $ao) => $ao->append(1)),
+                ->extendService('service', static fn (ArrayObject $ao): null => $ao->append(1)),
         );
 
         $setup2 = SetupGacela::fromGacelaConfig(
             (new GacelaConfig())
-                ->extendService('service', static fn (ArrayObject $ao) => $ao->append(2))
-                ->extendService('service-2', static fn (ArrayObject $ao) => $ao->append(3)),
+                ->extendService('service', static fn (ArrayObject $ao): null => $ao->append(2))
+                ->extendService('service-2', static fn (ArrayObject $ao): null => $ao->append(3)),
         );
 
         $setup->merge($setup2);
 
         self::assertEquals([
             'service' => [
-                static fn (ArrayObject $ao) => $ao->append(1),
-                static fn (ArrayObject $ao) => $ao->append(2),
+                static fn (ArrayObject $ao): null => $ao->append(1),
+                static fn (ArrayObject $ao): null => $ao->append(2),
             ],
             'service-2' => [
-                static fn (ArrayObject $ao) => $ao->append(3),
+                static fn (ArrayObject $ao): null => $ao->append(3),
             ],
         ], $setup->getServicesToExtend());
     }

--- a/tests/Unit/Framework/Cache/FileCacheTest.php
+++ b/tests/Unit/Framework/Cache/FileCacheTest.php
@@ -68,6 +68,7 @@ final class FileCacheTest extends TestCase
         if (!is_dir($this->cacheDir)) {
             mkdir($this->cacheDir, 0777, true);
         }
+
         $file = $this->cacheDir . '/some-cache.php';
         file_put_contents($file, '<?php return [];');
 

--- a/tests/Unit/Framework/Config/ConfigLoaderReaderKeyedCacheTest.php
+++ b/tests/Unit/Framework/Config/ConfigLoaderReaderKeyedCacheTest.php
@@ -43,12 +43,12 @@ final class ConfigLoaderReaderKeyedCacheTest extends TestCase
         self::assertSame(
             1,
             $this->readsPerReader['b'] ?? 0,
-            'the second reader must be asked to read, not handed the first reader\'s parse',
+            "the second reader must be asked to read, not handed the first reader's parse",
         );
         self::assertArrayHasKey(
             'only-known-to-b',
             $all,
-            'the second reader\'s interpretation of the file must reach the merged config',
+            "the second reader's interpretation of the file must reach the merged config",
         );
         self::assertSame('from-reader-b', $all['shared-key']);
     }

--- a/tests/Unit/PHPStan/Reflection/GetProvidedDependencyTypeInferenceTest.php
+++ b/tests/Unit/PHPStan/Reflection/GetProvidedDependencyTypeInferenceTest.php
@@ -17,10 +17,9 @@ final class GetProvidedDependencyTypeInferenceTest extends TypeInferenceTestCase
     }
 
     /**
-     * @dataProvider dataFileAsserts
-     *
      * @param mixed ...$args
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataFileAsserts')]
     public function test_file_asserts(string $assertType, string $file, ...$args): void
     {
         $this->assertFileAsserts($assertType, $file, ...$args);

--- a/tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php
+++ b/tests/Unit/Psalm/ServiceMapPseudoMethodsTest.php
@@ -9,7 +9,6 @@ use Gacela\Psalm\ServiceMapPseudoMethods;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -293,7 +292,7 @@ final class ServiceMapPseudoMethodsTest extends TestCase
      */
     private function attributeWithArgs(array $args, ?Name $attributeName = null): Attribute
     {
-        if ($attributeName === null) {
+        if (!$attributeName instanceof \PhpParser\Node\Name) {
             // How an imported `#[ServiceMap]` reaches the hook: the short name in
             // the source, the resolved one left on the node by the resolver.
             $attributeName = new Name('ServiceMap');
@@ -303,7 +302,7 @@ final class ServiceMapPseudoMethodsTest extends TestCase
         return new Attribute($attributeName, $args);
     }
 
-    private function classConstFetch(string $className): Expr
+    private function classConstFetch(string $className): \PhpParser\Node\Expr\ClassConstFetch
     {
         $fetch = new ClassConstFetch(new Name('BillingFacade'), new Identifier('class'));
         $fetch->class->setAttribute('resolvedName', $className);


### PR DESCRIPTION
## 📚 Description

`rector.php` named `SetList::STRICT_BOOLEANS`, which rector 2.x removed, so `composer rector` and `composer fix` both died on an undefined constant and the entire ruleset went unapplied. Nothing caught it: rector was in neither `composer quality` nor any workflow.

Putting it behind a gate and re-applying the ruleset surfaced the rest of what is here — two readers that silently ignored a subclassed attribute, a bridge constraint that allowed a container major the root package does not ship, three docblocks the scope rewrite falsified, and a mutation threshold that disagreed with CI.

## 🔖 Changes

- **`fix(rector)`** — restore the ruleset and put it behind the gate. `rectorrun` joins `composer quality`, alongside `phpstan-tests`, which was also configured and also never run in CI. Re-applying touched 60 files, all internal; the only `src/` signature changes are nine `private static` methods becoming `private`. Six dead-code rules and `ReadOnlyPropertyRector` are bounded to `src/` — fixtures are shaped on purpose, and dead-code removal read that intent as waste, stripping `stream_close()` and `stream_open()`'s by-ref `$openedPath` from a stream wrapper PHP calls by contract, and emptying the fixtures named `EmptyConstructorService` and `UntypedAndUnionService`.
- **`fix(inject)`** — honor subclassed `Inject` attributes in both readers. `GacelaInjectCompilerPass` and `ConstructorInspector` read the exact FQN instead of passing `ReflectionAttribute::IS_INSTANCEOF`, so `Gacela\Framework\Attribute\Inject` was honoured by the container and by nothing else: `debug:dependencies`, `debug:module` and `debug:container` showed an injected parameter as plain autowiring, and Symfony autowired it. What hid it is that the container's own three reads were already correct and every test reached the attribute through `Container::make()`. `AttributeReadCoverageTest` now requires the flag on every read of a non-`final` attribute under `src/` and `symfony-bridge/src/`, and was checked against both readers reverted.
- **`fix(bridge)`** — require the container major the root package ships.
- **`docs(container)`** — correct three docblocks the scope rewrite falsified.
- **`chore(infection)`** — let `infection.json5` own the MSI thresholds. `composer infection` passed `--min-msi=100 --min-covered-msi=100` while `infection.json5` and both CI jobs use 90, so the documented command failed on a tree CI calls green anywhere in the 90–99 band.
