### PR TITLE
fix(cacheable): stop resetCache() flushing a registered backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,17 @@ silently.
 
 ### Fixed
 
+- **`Gacela::resetCache()` flushed a `#[Cacheable]` backend the application
+  registered.** It reached `CacheableTrait::clearMethodCache()` transitively
+  through `AbstractFacade::resetCache()`, and that calls `clear()` on whatever
+  storage is configured. `CacheableConfig::setStorage()` is the documented way
+  to wire APCu or Redis, and `docs/caching.md` recommends it — so on any
+  application that followed the advice, resetting Gacela's caches emptied the
+  whole store. It bit hardest in test suites: `GacelaTestCase::bootstrapGacela()`
+  resets unconditionally, so a suite pointed at a real Redis DB cleared it once
+  per test. `resetCache()` now clears only the framework's own in-memory default
+  and leaves a registered backend alone. Calling `clearMethodCache()` yourself
+  is unchanged and still clears everything, as its docs say.
 - **A second `Gacela::bootstrap()` served the first one's config.**
   `ConfigFactory` memoized the merged config in a `private static` and returned
   it before looking at the setup it was constructed with, so re-bootstrapping in

--- a/docs/cacheable-methods.md
+++ b/docs/cacheable-methods.md
@@ -88,6 +88,11 @@ CatalogFacade::clearMethodCache();
 the rest of your application, if you wired APCu or Redis — it removes everything.
 Reach for `clearMethodCacheFor()` unless you genuinely mean "drop the entire cache".
 
+`Gacela::resetCache()` does **not** reach a backend you registered with
+`CacheableConfig::setStorage()`. It is an in-memory reset, and clears only the
+default per-process storage. Calling `clearMethodCache()` yourself still clears
+whatever backend is registered — that is the difference between the two.
+
 `clearMethodCacheFor()` matches on the exact `Class::method::` prefix. Passing `'get'` does **not** clear every method whose name starts with `get`.
 
 It also cannot see entries written under a custom `key:` template — those keys are the

--- a/src/Framework/AbstractFacade.php
+++ b/src/Framework/AbstractFacade.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework;
 
+use Gacela\Framework\Attribute\CacheableConfig;
 use Gacela\Framework\Attribute\CacheableTrait;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 
@@ -20,7 +21,11 @@ abstract class AbstractFacade
     public static function resetCache(): void
     {
         self::$factories = [];
-        self::clearMethodCache();
+
+        // Deliberately not clearMethodCache(): that clears whatever backend is
+        // registered, and this path is reached by every Gacela::resetCache(),
+        // including the one GacelaTestCase runs per test.
+        CacheableConfig::clearDefaultStorage();
     }
 
     /**

--- a/src/Framework/AbstractFacade.php
+++ b/src/Framework/AbstractFacade.php
@@ -25,7 +25,7 @@ abstract class AbstractFacade
         // Deliberately not clearMethodCache(): that clears whatever backend is
         // registered, and this path is reached by every Gacela::resetCache(),
         // including the one GacelaTestCase runs per test.
-        CacheableConfig::clearDefaultStorage();
+        CacheableConfig::clearFrameworkOwnedStorage();
     }
 
     /**

--- a/src/Framework/Attribute/CacheableConfig.php
+++ b/src/Framework/Attribute/CacheableConfig.php
@@ -36,11 +36,11 @@ final class CacheableConfig
     }
 
     /**
-     * Clear the method cache only when it is the framework's own in-memory
-     * default. Call `CacheableTrait::clearMethodCache()` to clear regardless of
-     * who registered the backend.
+     * Clear the method cache only when the framework owns the backend, i.e. it
+     * is the in-memory one `getStorage()` creates lazily. Call
+     * `CacheableTrait::clearMethodCache()` to clear whoever owns it.
      */
-    public static function clearDefaultStorage(): void
+    public static function clearFrameworkOwnedStorage(): void
     {
         if (self::$storageIsUserSupplied) {
             return;

--- a/src/Framework/Attribute/CacheableConfig.php
+++ b/src/Framework/Attribute/CacheableConfig.php
@@ -16,12 +16,37 @@ final class CacheableConfig
 {
     private static ?CacheStorageInterface $storage = null;
 
+    /**
+     * Whether the storage above came from the application rather than from
+     * getStorage()'s lazy default. `Gacela::resetCache()` is an in-memory
+     * reset: it clears the default, and must leave a registered backend alone.
+     * That one is typically APCu or Redis, shared with the rest of the
+     * application, where `clear()` removes everything and not just Gacela's
+     * entries.
+     */
+    private static bool $storageIsUserSupplied = false;
+
     /** @var array<string,int> */
     private static array $ttlOverrides = [];
 
     public static function setStorage(CacheStorageInterface $storage): void
     {
         self::$storage = $storage;
+        self::$storageIsUserSupplied = true;
+    }
+
+    /**
+     * Clear the method cache only when it is the framework's own in-memory
+     * default. Call `CacheableTrait::clearMethodCache()` to clear regardless of
+     * who registered the backend.
+     */
+    public static function clearDefaultStorage(): void
+    {
+        if (self::$storageIsUserSupplied) {
+            return;
+        }
+
+        self::$storage?->clear();
     }
 
     public static function getStorage(): CacheStorageInterface
@@ -45,6 +70,7 @@ final class CacheableConfig
     public static function reset(): void
     {
         self::$storage = null;
+        self::$storageIsUserSupplied = false;
         self::$ttlOverrides = [];
     }
 }

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -61,6 +61,12 @@ trait CacheableTrait
 
     private static ?stdClass $cacheMissSentinel = null;
 
+    /**
+     * Clears the whole storage, not just this facade's entries, and does so
+     * whether the backend is the in-memory default or one the application
+     * registered. `Gacela::resetCache()` deliberately does not come through
+     * here: it clears only the framework-owned default.
+     */
     public static function clearMethodCache(): void
     {
         CacheableConfig::getStorage()->clear();

--- a/tests/Integration/Framework/Attribute/ResetCacheStorageOwnershipTest.php
+++ b/tests/Integration/Framework/Attribute/ResetCacheStorageOwnershipTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Attribute;
+
+use Gacela\Framework\Attribute\CacheableConfig;
+use Gacela\Framework\Attribute\CacheStorageInterface;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Gacela::resetCache()` is an in-memory reset. It must not reach a backend the
+ * application registered with `CacheableConfig::setStorage()`, because that one
+ * is typically APCu or Redis and is shared with the rest of the application.
+ */
+final class ResetCacheStorageOwnershipTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CacheableConfig::reset();
+    }
+
+    public function test_reset_cache_leaves_a_user_supplied_storage_untouched(): void
+    {
+        $storage = $this->createMock(CacheStorageInterface::class);
+        $storage->expects(self::never())->method('clear');
+
+        CacheableConfig::setStorage($storage);
+
+        Gacela::resetCache();
+    }
+
+    public function test_reset_cache_clears_the_default_in_memory_storage(): void
+    {
+        CacheableConfig::reset();
+        CacheableConfig::getStorage()->set('some-key', 'some-value', 60);
+
+        Gacela::resetCache();
+
+        self::assertFalse(CacheableConfig::getStorage()->has('some-key'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

`Gacela::resetCache()` reached `CacheableTrait::clearMethodCache()` transitively through `AbstractFacade::resetCache()`, and that calls `clear()` on whatever storage is configured:

```
Gacela::resetCache()              src/Framework/Gacela.php:199
  -> AbstractFacade::resetCache() src/Framework/AbstractFacade.php:23
    -> clearMethodCache()         src/Framework/Attribute/CacheableTrait.php:66
      -> getStorage()->clear()
```

`CacheableConfig::setStorage()` is the documented way to wire a shared APCu or Redis backend, and both `docs/caching.md` and `docs/production-performance.md` recommend it. So on any application that followed the advice, resetting Gacela's caches emptied the entire store rather than Gacela's entries.

It bit hardest in test suites: `GacelaTestCase::bootstrapGacela()` calls `resetInMemoryCache()` unconditionally, so every test extending it triggered the flush, and a suite pointed at a real Redis DB cleared it once per test.

Took **option 2** from the issue — it matches what "in-memory reset" says on the tin. Option 1 (a prefix sweep across known facades) can only sweep facades whose factory was already resolved, so it would silently miss entries; option 3 documents a footgun instead of removing it.

## 🔖 Changes

- **`fix(cacheable)`** — `resetCache()` clears only the framework's own lazily-created in-memory default. `clearMethodCache()` is untouched and still clears whatever backend is registered, which is exactly what `docs/cacheable-methods.md` already documents — that warning was attached to the direct call and said nothing about the transitive path people actually hit. `docs/cacheable-methods.md` now states the difference.
- **`ref(cacheable)`** — renamed `clearDefaultStorage()` to `clearFrameworkOwnedStorage()`. The first read as "clear storage, by default"; the condition it applies is ownership, which is the whole point of the bug. Renamed now rather than later, since it is new public API in this release. `clearMethodCache()` also gains the docblock it never had.

## ✅ Verification

New integration test covers both directions: a registered backend never sees `clear()`, and the default in-memory one still gets cleared. The first fails on `main` with the issue's exact stack trace.

Full suite green — 1514 tests. `composer quality` clean.

Worth noting: `StaticStateCoverageTest` already exempted `CacheableConfig::$storage` for the neighbouring reason — "nothing in the framework re-establishes it, so clearing it would downgrade a configured Redis/APCu store to the in-memory default". That reasoning protected the *reference* and missed the *contents*.

> CI could not run: GitHub Actions is under a [major outage](https://www.githubstatus.com/) and is dropping ~85% of webhook events, so no workflow run was created. Verified locally instead.

Closes #598
