### PR TITLE
fix(doctor): find pillar filename mismatches on disk, not via resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,16 @@ silently.
 
 ### Fixed
 
+- **`doctor`'s filename check could not see the mismatch it exists to catch.**
+  `FilenameMismatchCheck` drove off resolved pillar classes, and a class whose
+  file basename does not match its short name does not autoload under PSR-4. So
+  the pillar came back `null`, `pillarsOf()` filtered it out, and `doctor`
+  reported "every pillar class matches its filename" and exited 0 on exactly the
+  module whose provider silently never runs. It only had teeth under classmap
+  autoloading. It now also reads the module directory — located from the facade,
+  which is what made the module discoverable — and compares each file's declared
+  class against its basename with a token scan, so the mismatch is found
+  precisely when the class does not resolve. Both rename directions are covered.
 - **`Gacela::resetCache()` flushed a `#[Cacheable]` backend the application
   registered.** It reached `CacheableTrait::clearMethodCache()` transitively
   through `AbstractFacade::resetCache()`, and that calls `clear()` on whatever

--- a/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
@@ -12,6 +12,8 @@ use ReflectionClass;
 
 use function count;
 use function explode;
+use function in_array;
+use function is_array;
 use function sprintf;
 
 /**
@@ -24,16 +26,28 @@ use function sprintf;
  */
 final class FilenameMismatchCheck implements HealthCheck
 {
+    private const PILLAR_SUFFIXES = ['Facade', 'Factory', 'Config', 'Provider'];
+
     /** @var Closure(class-string):?string */
     private readonly Closure $fileResolver;
+
+    /** @var Closure(string):list<string> */
+    private readonly Closure $directoryScanner;
+
+    /** @var Closure(string):?string */
+    private readonly Closure $declaredClassReader;
 
     /**
      * @param list<AppModule> $modules
      * @param null|Closure(class-string):?string $fileResolver resolves a class-name to its source file path
+     * @param null|Closure(string):list<string> $directoryScanner lists the php files in a directory
+     * @param null|Closure(string):?string $declaredClassReader reads the short class name a file declares
      */
     public function __construct(
         private readonly array $modules,
         ?Closure $fileResolver = null,
+        ?Closure $directoryScanner = null,
+        ?Closure $declaredClassReader = null,
     ) {
         $this->fileResolver = $fileResolver ?? static function (string $className): ?string {
             if (!class_exists($className)) {
@@ -44,6 +58,14 @@ final class FilenameMismatchCheck implements HealthCheck
 
             return $file === false ? null : $file;
         };
+
+        $this->directoryScanner = $directoryScanner ?? static function (string $directory): array {
+            $files = glob($directory . '/*.php');
+
+            return $files === false ? [] : $files;
+        };
+
+        $this->declaredClassReader = $declaredClassReader ?? $this->readDeclaredClass(...);
     }
 
     public function name(): string
@@ -62,7 +84,15 @@ final class FilenameMismatchCheck implements HealthCheck
                     $mismatches[] = $mismatch;
                 }
             }
+
+            foreach ($this->inspectDirectoryOf($module) as $mismatch) {
+                $mismatches[] = $mismatch;
+            }
         }
+
+        // The two passes overlap under classmap autoloading, where a mismatched
+        // class both resolves and is on disk.
+        $mismatches = array_values(array_unique($mismatches));
 
         if ($mismatches === []) {
             return CheckResult::ok($this->name(), 'every pillar class matches its filename');
@@ -74,6 +104,69 @@ final class FilenameMismatchCheck implements HealthCheck
             'rename the file to match the class — pillars resolve by filename, '
             . 'so `Provider` declared in `DependencyProvider.php` is never found',
         );
+    }
+
+    /**
+     * The short name of the class a file declares, without loading it — loading
+     * is the one thing that cannot work here, since a mismatched file does not
+     * autoload.
+     */
+    private function readDeclaredClass(string $file): ?string
+    {
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return null;
+        }
+
+        $tokens = token_get_all($contents);
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] !== T_CLASS) {
+                continue;
+            }
+
+            // `Foo::class` is a T_CLASS too, and an anonymous class has no name.
+            if ($index > 0 && $this->isDoubleColon($tokens[$index - 1])) {
+                continue;
+            }
+
+            $name = $this->nextClassName($tokens, $index);
+            if ($name !== null) {
+                return $name;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{0:int,1:string,2:int}|string $token
+     */
+    private function isDoubleColon(array|string $token): bool
+    {
+        return is_array($token) && $token[0] === T_DOUBLE_COLON;
+    }
+
+    /**
+     * @param list<array{0:int,1:string,2:int}|string> $tokens
+     */
+    private function nextClassName(array $tokens, int $index): ?string
+    {
+        for ($next = $index + 1, $total = count($tokens); $next < $total; ++$next) {
+            $token = $tokens[$next];
+
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return is_array($token) && $token[0] === T_STRING ? $token[1] : null;
+        }
+
+        return null;
     }
 
     /**
@@ -90,6 +183,74 @@ final class FilenameMismatchCheck implements HealthCheck
             ],
             static fn (?string $pillar): bool => $pillar !== null,
         );
+    }
+
+    /**
+     * The pass that sees the case this check exists for.
+     *
+     * A pillar whose file does not match its class cannot autoload under PSR-4,
+     * so it resolves to null, `pillarsOf()` drops it, and the pass above reports
+     * nothing on exactly the module whose provider silently never runs. Reading
+     * the directory instead finds it precisely when the class does not resolve.
+     *
+     * The module directory is taken from the facade, which is what made the
+     * module discoverable in the first place.
+     *
+     * @return list<string>
+     */
+    private function inspectDirectoryOf(AppModule $module): array
+    {
+        $facadeFile = ($this->fileResolver)($module->facadeClass());
+        if ($facadeFile === null) {
+            return [];
+        }
+
+        $mismatches = [];
+
+        foreach (($this->directoryScanner)($this->directoryOf($facadeFile)) as $file) {
+            $filename = $this->basename($file);
+            $declaredClass = ($this->declaredClassReader)($file);
+            if ($declaredClass === null) {
+                continue;
+            }
+
+            if ($declaredClass === $filename) {
+                continue;
+            }
+
+            if (!$this->carriesPillarSuffix($filename) && !$this->carriesPillarSuffix($declaredClass)) {
+                continue;
+            }
+
+            $mismatches[] = sprintf(
+                '%s\\%s is declared in %s.php, expected %s.php',
+                $module->fullModuleName(),
+                $declaredClass,
+                $filename,
+                $declaredClass,
+            );
+        }
+
+        return $mismatches;
+    }
+
+    private function carriesPillarSuffix(string $name): bool
+    {
+        foreach (self::PILLAR_SUFFIXES as $suffix) {
+            if (str_ends_with($name, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function directoryOf(string $file): string
+    {
+        $parts = explode('/', str_replace('\\', '/', $file));
+        array_pop($parts);
+
+        return implode('/', $parts);
     }
 
     /**

--- a/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/FilenameMismatchCheck.php
@@ -247,10 +247,21 @@ final class FilenameMismatchCheck implements HealthCheck
 
     private function directoryOf(string $file): string
     {
-        $parts = explode('/', str_replace('\\', '/', $file));
+        $parts = $this->pathSegments($file);
         array_pop($parts);
 
         return implode('/', $parts);
+    }
+
+    /**
+     * Splits on both separators, so a Windows path is handled the same as a
+     * POSIX one — `getFileName()` reports whichever the platform uses.
+     *
+     * @return non-empty-list<string>
+     */
+    private function pathSegments(string $file): array
+    {
+        return explode('/', str_replace('\\', '/', $file));
     }
 
     /**
@@ -282,7 +293,7 @@ final class FilenameMismatchCheck implements HealthCheck
 
     private function basename(string $file): string
     {
-        $parts = explode('/', str_replace('\\', '/', $file));
+        $parts = $this->pathSegments($file);
         $filename = $parts[count($parts) - 1];
 
         return str_ends_with($filename, '.php')

--- a/tests/Unit/Console/Application/Doctor/Check/FilenameMismatchCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/FilenameMismatchCheckTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\Unit\Console\Application\Doctor\Check;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\BrokenModule\BrokenModuleFacade;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -85,6 +86,29 @@ final class FilenameMismatchCheckTest extends TestCase
             'GacelaTest\\Fixtures',
             'Fixtures',
             \GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\Provider::class,
+        );
+
+        $result = (new FilenameMismatchCheck([$module]))->run();
+
+        self::assertSame(CheckStatus::Error, $result->status);
+        self::assertStringContainsString(
+            'is declared in DependencyProvider.php, expected Provider.php',
+            $result->details[0],
+        );
+    }
+
+    /**
+     * The case the check exists for, in the state it actually occurs in: the
+     * mismatched file is simply sitting in the module directory. It cannot
+     * autoload under PSR-4, so the pillar resolves to null and never reaches
+     * the check through the module's pillar list.
+     */
+    public function test_a_mismatched_file_is_found_even_though_its_class_cannot_autoload(): void
+    {
+        $module = new AppModule(
+            'GacelaTest\\Unit\\Console\\Application\\Doctor\\Check\\Fixtures\\BrokenModule',
+            'BrokenModule',
+            BrokenModuleFacade::class,
         );
 
         $result = (new FilenameMismatchCheck([$module]))->run();

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/BrokenModule/BrokenModuleFacade.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/BrokenModule/BrokenModuleFacade.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\BrokenModule;
+
+/**
+ * Resolves normally. It is what makes the module discoverable at all, and what
+ * the check uses to locate the directory its siblings live in.
+ */
+final class BrokenModuleFacade
+{
+}

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/BrokenModule/DependencyProvider.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/BrokenModule/DependencyProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\BrokenModule;
+
+/**
+ * The migration trap in its natural state: the class was renamed to `Provider`
+ * and the file stayed `DependencyProvider.php`. Nothing requires this file, and
+ * nothing can autoload it under PSR-4 — which is precisely why the check has to
+ * find it on disk rather than through a resolved class name.
+ */
+final class Provider
+{
+}


### PR DESCRIPTION
## 📚 Description

`FilenameMismatchCheck` exists to catch a pillar class whose file is named differently from the class. It could not see that case.

`pillarsOf()` drives off resolved classes, and under PSR-4 a class whose file basename does not match its short name does not autoload. So `providerClass()` came back `null`, `pillarsOf()` filtered it out, and `doctor` reported *"every pillar class matches its filename"* and exited 0 — on exactly the module whose provider silently never runs. The check only had teeth under classmap autoloading, where a class can live in any filename and still resolve.

Took the issue's **suggested fix**: drive the check from the filesystem.

## 🔖 Changes

- **`fix(doctor)`** — the check now also reads the module directory and compares each file's declared class against its basename, with a token scan rather than reflection, since loading is the one thing that cannot work here. The directory comes from the facade, which is what made the module discoverable in the first place. Both rename directions are covered: the comparison is between declared class and basename and does not care which of the two moved.

  The resolution pass is **kept rather than replaced** — it still covers classmap setups and a pillar living outside the module directory. The two overlap there, so results are deduplicated.

- **`ref(doctor)`** — `directoryOf()` and `basename()` had each grown their own copy of "normalise backslashes, split on `/`", so platform-path handling could be fixed in one and not the other. `pathSegments()` is now the single copy, typed `non-empty-list<string>` because `explode()` with a non-empty separator cannot return empty and `basename()` indexes `count()-1` directly.

## ✅ Verification

The new fixture is the trap in its natural state: a `BrokenModule` directory holding a resolvable facade next to `DependencyProvider.php` declaring `Provider`. Nothing requires that file and nothing can autoload it — which is precisely why the old check never saw it. On `main` the check returns `Ok`; it now returns `Error` naming the file.

All 9 pre-existing tests in the class still pass unchanged, including the injected-`fileResolver` ones and `test_every_pillar_is_inspected`.

Full suite green — 1515 tests. `composer quality` clean.

> CI could not run: GitHub Actions is under a [major outage](https://www.githubstatus.com/) and is dropping ~85% of webhook events, so no workflow run was created. Verified locally instead.

Closes #599
