### PR TITLE
docs(container): say that afterResolving fires per resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,7 @@ silently.
   **after** the imperative registrations, so a file overrides `addBinding()`.
   Tags accumulate instead. Paths are used as given, so write them with
   `__DIR__`. No YAML: pass `Yaml::parseFile(...)`.
-- **`GacelaConfig::afterResolving()`** runs a callback on an instance after the
-  container builds it:
+- **`GacelaConfig::afterResolving()`** runs a callback on a resolved instance:
   ```php
   $config->afterResolving(
       LoggerAwareInterface::class,
@@ -50,8 +49,12 @@ silently.
   ```
   The id may name an **interface**, so one registration covers every
   implementation. It fires on `get()`, `getOrFail()` and `make()`, in
-  registration order. It costs nothing when unused. It does not fire for a
-  nested constructor dependency. A callback that throws evicts the instance.
+  registration order — **once per resolution, not once per instance**, so a
+  shared instance fetched three times runs the callback three times on the same
+  object. Write callbacks that are safe to repeat; the `setLogger()` above is,
+  and appending to a collection or bumping a counter is not. It costs nothing
+  when unused. It does not fire for a nested constructor dependency. A callback
+  that throws evicts the instance.
 - **`GacelaConfig::tag()`** groups services under a label, reaching every
   module's container:
   ```php

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -32,9 +32,9 @@ $db = $factory(); // Invoke when needed
 
 Protected services cannot be extended via `extendService()`.
 
-## Post-construction Hooks
+## Resolution Hooks
 
-Run a callback against an instance the moment it is built, without rebuilding it.
+Run a callback against an instance as it is resolved, without rebuilding it.
 
 ```php
 return static function (GacelaConfig $config): void {
@@ -54,6 +54,13 @@ registration order. A class the container autowires as a *nested* constructor
 dependency is not resolved at this level, so hooks do not fire for it. A callback
 that throws removes the instance rather than leaving a half-wired one for the next
 caller, and a container with no hooks pays nothing per resolution.
+
+**A hook fires once per resolution, not once per instance.** A shared instance
+fetched three times runs the callback three times, on the same object — the
+constructor ran once, the hook ran three times. Write callbacks so that repeating
+them is harmless: the `setLogger()` example above is idempotent, whereas appending
+to a collection, incrementing a counter or registering a listener is not, and would
+need its own guard.
 
 Reach for `extendService()` instead when you need to *replace* what comes out, and
 for a [`ServiceResolvedEvent`](events.md) listener when you only want to observe.
@@ -532,7 +539,7 @@ Almost everything `gacela-project/container` offers now has a gacela entry point
 Four things that used to be listed here no longer belong to it: **service
 tagging** is `GacelaConfig::tag()` (see
 [getting a dependency](getting-a-dependency.md#collect-several-implementations)),
-**post-construction hooks** are `GacelaConfig::afterResolving()` (above),
+**resolution hooks** are `GacelaConfig::afterResolving()` (above),
 **`make()` with runtime parameters** is documented above as the supported way to
 override a constructor argument, and **`createScope()`** is what `AbstractFactory`
 builds every module container from.

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -366,8 +366,14 @@ final class GacelaConfig
     }
 
     /**
-     * Run a callback on an instance after the container builds it, receiving the
-     * instance and the container. Callbacks run in registration order.
+     * Run a callback on a resolved instance, receiving the instance and the
+     * container. Callbacks run in registration order.
+     *
+     * Fires **once per resolution, not once per instance**. A shared instance
+     * fetched three times runs the callback three times, on the same object. So
+     * the callback has to be idempotent: setting a property is safe, while
+     * appending to a collection, incrementing a counter or registering a
+     * listener will repeat. The example below is idempotent for that reason.
      *
      * Example:
      * ```php

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -64,7 +64,7 @@ final class Container implements ContainerInterface
     /**
      * Kept local rather than delegated to the inner container, whose 2.0
      * `afterResolving()` matches instances the same way but fires for *any*
-     * resolved value. A post-construction hook handed a string cannot wire it,
+     * resolved value. A resolution hook handed a string cannot wire it,
      * and a typed callback would TypeError -- see the object guard in
      * {@see fireAfterResolving()}. Reconciling the two is a behaviour decision,
      * not part of a dependency bump.
@@ -696,8 +696,8 @@ final class Container implements ContainerInterface
      * LoggerAwareInterface is built".
      *
      * A hook that throws takes the instance out of the container with it: a
-     * service whose post-construction wiring failed must not be served to the
-     * next caller as though it had succeeded.
+     * service whose hook wiring failed must not be served to the next caller as
+     * though it had succeeded.
      */
     private function fireAfterResolving(string $id, mixed $instance): void
     {

--- a/tests/Integration/Framework/Container/AfterResolvingHookTest.php
+++ b/tests/Integration/Framework/Container/AfterResolvingHookTest.php
@@ -87,8 +87,8 @@ final class AfterResolvingHookTest extends TestCase
 
         // This is the case the issue opens with, and the reason the hook checks
         // each instance rather than doing a map lookup on the requested id.
-        self::assertSame('file', $container->get(ReportService::class)?->logger());
-        self::assertSame('file', $container->get(InvoiceService::class)?->logger());
+        self::assertSame('file', $this->resolvedReportService()->logger());
+        self::assertSame('file', $this->resolvedInvoiceService()->logger());
     }
 
     public function test_a_service_that_does_not_match_is_left_alone(): void
@@ -118,7 +118,7 @@ final class AfterResolvingHookTest extends TestCase
             );
         });
 
-        self::assertSame(Container::class, Gacela::container()->get(ReportService::class)?->logger());
+        self::assertSame(Container::class, $this->resolvedReportService()->logger());
     }
 
     public function test_several_hooks_for_one_id_run_in_registration_order(): void
@@ -130,7 +130,7 @@ final class AfterResolvingHookTest extends TestCase
             ));
         });
 
-        self::assertSame('first+second', Gacela::container()->get(ReportService::class)?->logger());
+        self::assertSame('first+second', $this->resolvedReportService()->logger());
     }
 
     public function test_a_hook_runs_for_a_service_built_through_make(): void
@@ -205,7 +205,7 @@ final class AfterResolvingHookTest extends TestCase
             );
         });
 
-        self::assertSame('file', Gacela::container()->get(ReportService::class)?->logger());
+        self::assertSame('file', $this->resolvedReportService()->logger());
     }
 
     public function test_a_hook_does_not_fire_for_a_service_that_is_not_an_object(): void
@@ -246,19 +246,39 @@ final class AfterResolvingHookTest extends TestCase
             );
         });
 
-        self::assertSame('file', Gacela::container()->get(ReportService::class)?->logger());
+        self::assertSame('file', $this->resolvedReportService()->logger());
 
         // Re-bootstrapping without the hook must not keep firing the old one.
         $this->bootstrapWith(static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
         });
 
-        self::assertNull(Gacela::container()->get(ReportService::class)?->logger());
+        self::assertNull($this->resolvedReportService()->logger());
     }
 
     /**
      * @param callable(GacelaConfig):void $configFn
      */
+    /**
+     * Resolving through `?->` made a service that failed to resolve read as a
+     * null logger, so the assertion failed on the value instead of on the cause.
+     */
+    private function resolvedReportService(): ReportService
+    {
+        $service = Gacela::container()->get(ReportService::class);
+        self::assertInstanceOf(ReportService::class, $service);
+
+        return $service;
+    }
+
+    private function resolvedInvoiceService(): InvoiceService
+    {
+        $service = Gacela::container()->get(InvoiceService::class);
+        self::assertInstanceOf(InvoiceService::class, $service);
+
+        return $service;
+    }
+
     private function bootstrapWith(callable $configFn): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {

--- a/tests/Integration/Framework/Container/AfterResolvingHookTest.php
+++ b/tests/Integration/Framework/Container/AfterResolvingHookTest.php
@@ -37,6 +37,43 @@ final class AfterResolvingHookTest extends TestCase
         self::assertSame('file', $service->logger());
     }
 
+    /**
+     * Pins the semantics rather than asserting they are ideal. The hook fires
+     * per *resolution*, not per construction: a shared instance fetched three
+     * times runs the callback three times, on the one object the constructor
+     * built once.
+     *
+     * The container documents this upstream ("this runs on every resolution");
+     * what was wrong was Gacela's own construction-flavoured wording around it.
+     * A callback that is not idempotent — appending to a collection, bumping a
+     * counter, registering a listener — has to account for it.
+     */
+    public function test_a_hook_fires_once_per_resolution_not_once_per_instance(): void
+    {
+        $calls = 0;
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use (&$calls): void {
+            // Bound as an already-built instance, so the container hands the
+            // same object back every time and construction cannot be what
+            // drives the callback count.
+            $config->addBinding(ReportService::class, new ReportService());
+            $config->afterResolving(
+                ReportService::class,
+                static function () use (&$calls): void {
+                    ++$calls;
+                },
+            );
+        });
+
+        $container = Gacela::container();
+        $first = $container->get(ReportService::class);
+        $container->get(ReportService::class);
+        $third = $container->get(ReportService::class);
+
+        self::assertSame($first, $third, 'the container hands back one shared instance');
+        self::assertSame(3, $calls, 'but the hook ran once per get()');
+    }
+
     public function test_a_hook_registered_for_an_interface_runs_for_every_implementation(): void
     {
         $this->bootstrapWith(static function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

`afterResolving()` fires once per *resolution*, not once per construction: a shared instance fetched three times runs the callback three times on the one object the constructor built once. Everything around it said otherwise — CHANGELOG called it "a callback on an instance **after the container builds it**", the docs headed the section "**Post-construction** Hooks", and #568 introduced it as a post-construction hook. The one accurate sentence, *"it fires on `get()`, `getOrFail()` and `make()`"*, never said "every time" and sat after the construction framing. The documented example is idempotent, so it hides the difference.

Took **option 2** — document it, don't change it — for a reason worth stating: **the firing loop is not in this repo.** It lives in `gacela-project/container` (`Container::fireAfterResolving()`), whose own docblock already says *"this runs on every resolution"*. Upstream is explicit; Gacela's wording is what misled. Making it fire once per instance is an upstream behaviour decision, not something to slip in through a docs issue — and per-resolution is what comparable containers do.

If you want option 1 instead, that is a `gacela-project/container` change and I'll open it there.

## 🔖 Changes

- **`docs(container)`** — `GacelaConfig::afterResolving()`'s docblock, `docs/container-configuration.md` and the CHANGELOG entry all now state the per-resolution semantics and that callbacks must be safe to repeat: setting a property is, appending to a collection or bumping a counter is not. The docs section is retitled "Resolution Hooks", and two "post-construction" mentions in `Container.php` are reworded. No inbound links to the old `#post-construction-hooks` anchor exist.
- **`ref(test)`** — seven assertions reached the service via `get(...)?->logger()`, so a service that failed to resolve produced a *null logger* and the test failed on the value rather than the cause. A hook silently not running looked identical to a container that never built the service. Two helpers now assert the instance came back before reading from it.

## ✅ Verification

New test pins the semantics using the issue's own reproduction — binding an already-built instance so construction cannot be what drives the count. It asserts both halves: the container hands back one shared object, and the hook ran three times.

Worth recording: the first draft bound nothing and **failed**, because an autowired id builds fresh per `get()` — only an instance binding memoizes. So the "same instance" half of the issue depends on `addBinding` with a built object, which is exactly what the issue used.

Full suite green — 1516 tests. `composer quality` clean.

> CI could not run: GitHub Actions is under a [major outage](https://www.githubstatus.com/) and is dropping ~85% of webhook events, so no workflow run was created. Verified locally instead.

Closes #600
