### PR TITLE
test(provider): drive the MissingContainerServiceKey fixture

### DIFF
--- a/tests/Feature/Framework/MissingFile/FeatureTest.php
+++ b/tests/Feature/Framework/MissingFile/FeatureTest.php
@@ -43,6 +43,24 @@ final class FeatureTest extends TestCase
     }
 
     /**
+     * The other half of the Provider story. `getProvidedDependency()` raises
+     * `ProviderNotFoundException` only when the module has no Provider at all;
+     * with a Provider that registers nothing, it falls through to the container
+     * and a key nobody provided comes back as `null`.
+     *
+     * Pinned rather than endorsed. `get()` returning null for an unknown id is
+     * the container's call -- `getOrFail()` is the one that throws -- but the
+     * silent null reaches the application through Gacela's own API, which is
+     * why this belongs here and not only upstream.
+     */
+    public function test_a_provided_dependency_nobody_registered_comes_back_null(): void
+    {
+        $facade = new MissingContainerServiceKey\Facade();
+
+        self::assertNull($facade->domainService());
+    }
+
+    /**
      * A Facade+Factory-only module -- what `make:module --minimal` scaffolds --
      * has no Provider, but make() autowires by type and needs no bindings.
      */

--- a/tests/Feature/Framework/MissingFile/MissingContainerServiceKey/Facade.php
+++ b/tests/Feature/Framework/MissingFile/MissingContainerServiceKey/Facade.php
@@ -11,8 +11,8 @@ use Gacela\Framework\AbstractFacade;
  */
 final class Facade extends AbstractFacade
 {
-    public function error(): void
+    public function domainService(): mixed
     {
-        $this->getFactory()->createDomainService();
+        return $this->getFactory()->createDomainService();
     }
 }

--- a/tests/Feature/Framework/MissingFile/MissingContainerServiceKey/Factory.php
+++ b/tests/Feature/Framework/MissingFile/MissingContainerServiceKey/Factory.php
@@ -8,8 +8,8 @@ use Gacela\Framework\AbstractFactory;
 
 final class Factory extends AbstractFactory
 {
-    public function createDomainService(): void
+    public function createDomainService(): mixed
     {
-        $this->getProvidedDependency('non-existing-service');
+        return $this->getProvidedDependency('non-existing-service');
     }
 }

--- a/tests/Feature/Framework/MissingFile/MissingContainerServiceKey/Provider.php
+++ b/tests/Feature/Framework/MissingFile/MissingContainerServiceKey/Provider.php
@@ -7,6 +7,17 @@ namespace GacelaTest\Feature\Framework\MissingFile\MissingContainerServiceKey;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 
+/**
+ * Empty on purpose, and the emptiness is the whole fixture.
+ *
+ * `getProvidedDependency()` raises `ProviderNotFoundException` when a module has
+ * no Provider at all — that path is covered by the `MissingProviderFile` sibling.
+ * This module needs a Provider that exists and registers *nothing*, so the call
+ * falls through to the container and returns null instead.
+ *
+ * Filling this method in, or deleting the class as dead weight, turns the test
+ * into a duplicate of the sibling without failing.
+ */
 final class Provider extends AbstractProvider
 {
     public function provideModuleDependencies(Container $container): void


### PR DESCRIPTION
## 📚 Description

`tests/Feature/Framework/MissingFile/MissingContainerServiceKey/` held three classes referenced by nothing, so it compiled nothing and asserted nothing while every sibling under `MissingFile/` has a test driving it.

**Took option 2 (write the test) rather than option 1 (delete), because the premise for deleting is only half right.**

The issue reasons that the behaviour "lives in `gacela-project/container`, not here". The null does come from the container, and `get()` returning null for an unknown id is genuinely the container's call — `getOrFail()` is the one that throws. But the fixture does not call `Container::get()`. It calls `getProvidedDependency()`, which is **Gacela's** API:

```php
protected function getProvidedDependency(string $key): mixed
{
    $container = $this->getContainer();

    if (self::$providerless[static::class]) {
        throw new ProviderNotFoundException(static::class);
    }

    return $container->get($key);   // ← null, silently
}
```

It raises `ProviderNotFoundException` only when the module has **no Provider at all**. With a Provider that registers *nothing* — which is exactly what this fixture has — it falls through, and the silent null reaches the application through this repo's surface. That is worth pinning here, and deleting the fixture would remove the only artifact pointing at it.

The behaviour is pinned, not endorsed. If `get()` ever throws upstream, this test is the thing that notices.

## 🔖 Changes

- **`test(provider)`** — the fixture is now driven by `test_a_provided_dependency_nobody_registered_comes_back_null()`. `Factory::createDomainService()` and `Facade::error()` both discarded the value, which is why nothing could assert on it; they return it now, and `error()` is `domainService()` since it never errored.
- **`ref(test)`** — recorded why the Provider must stay empty. That emptiness is what separates this module from the `MissingProviderFile` sibling, and nothing said so, so filling it in or deleting the class as dead weight would quietly turn the test into a copy of its neighbour and still pass.

## ✅ Verification

The issue's grep is now non-empty:

```console
$ grep -rn "MissingContainerServiceKey" tests/ | grep -v "^tests/Feature/Framework/MissingFile/MissingContainerServiceKey/"
tests/Feature/Framework/MissingFile/FeatureTest.php:58:        $facade = new MissingContainerServiceKey\Facade();
```

Full suite green — 1517 tests. `composer quality` clean.

> CI could not run: GitHub Actions is under a [major outage](https://www.githubstatus.com/) and is dropping ~85% of webhook events, so no workflow run was created. Verified locally instead.

Closes #602
