### PR TITLE
ref(bridge): bring symfony-bridge under every tool and the mutation gate

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -75,7 +75,7 @@ jobs:
         run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --output-format=github
 
       - name: Run phpstan
-        run: ./vendor/bin/phpstan analyze -c phpstan.neon src
+        run: ./vendor/bin/phpstan analyze -c phpstan.neon --no-progress
 
       - name: Run phpstan (tests)
-        run: ./vendor/bin/phpstan analyze -c phpstan-tests.neon --no-progress
+        run: ./vendor/bin/phpstan analyze -c phpstan-tests.neon --no-progress --memory-limit=1G

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,10 @@ $finder = Finder::create()
     ->files()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests')
+    // symfony-bridge ships from this repo as its own package, so it is held to
+    // the same style and analysis as src/ and tests/.
+    ->in(__DIR__ . '/symfony-bridge/src')
+    ->in(__DIR__ . '/symfony-bridge/tests')
     ->ignoreVCSIgnored(true);
 
 return (new Config())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,20 @@ silently.
 
 ### Fixed
 
+- **`symfony-bridge` was outside every static analysis tool and the coverage
+  gate.** It ships from this repo as its own package, and phpstan, psalm,
+  php-cs-fixer, rector and phpunit's `<source>` all scoped to `src/` and
+  `tests/`, so only its 7 tests ran and nothing ever looked at the file. That is
+  how the `#[Inject]` subclass bug reached `main` — `GacelaInjectCompilerPass`
+  read the attribute by exact FQN, silently dropping every
+  `Gacela\Framework\Attribute\Inject` — and how the disjoint
+  `gacela-project/container: ^1.4.0` constraint survived. Both are now under all
+  five tools plus coverage and the mutation gate. The first run put the bridge at
+  87.8% MSI, under the 90 floor; the five escaped mutants are killed by tests
+  covering behaviour nobody asserted — that the generated argument definition is
+  private, that skipping an abstract definition does not stop the scan, and that
+  a builtin-typed `#[Inject]` parameter is left for Symfony. The bridge is at
+  100% MSI now.
 - **`doctor`'s filename check could not see the mismatch it exists to catch.**
   `FilenameMismatchCheck` drove off resolved pillar classes, and a class whose
   file basename does not match its short name does not autoload under PSR-4. So

--- a/infection.json5
+++ b/infection.json5
@@ -13,7 +13,11 @@
     timeout: 10,
     source: {
         directories: [
-            'src'
+            'src',
+            // Ships from this repo as its own package. phpunit.xml's <source>
+            // covers it too, so it is both measured and gated rather than
+            // measured only.
+            'symfony-bridge/src'
         ]
     },
     // 90, not 100: at 100 one equivalent mutant anywhere turns main red, and

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -5,6 +5,7 @@ parameters:
     level: 0
     paths:
         - %currentWorkingDirectory%/tests/
+        - %currentWorkingDirectory%/symfony-bridge/tests/
     excludePaths:
         - %currentWorkingDirectory%/tests/Unit/PHPStan/Rules/Fixture/*
         # Fixtures that are deliberately wrong: an attribute pointing at a class

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,7 @@ parameters:
     level: max
     paths:
         - %currentWorkingDirectory%/src/
+        - %currentWorkingDirectory%/symfony-bridge/src/
     parallel:
         maximumNumberOfProcesses: 4
     excludePaths:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,6 +30,7 @@
   <source>
     <include>
       <directory suffix=".php">src</directory>
+      <directory suffix=".php">symfony-bridge/src</directory>
     </include>
   </source>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,6 +12,7 @@
 >
     <projectFiles>
         <directory name="src"/>
+        <directory name="symfony-bridge/src"/>
         <ignoreFiles>
             <directory name="vendor"/>
         </ignoreFiles>

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,8 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/symfony-bridge/src',
+        __DIR__ . '/symfony-bridge/tests',
     ]);
 
     $rectorConfig->skip([

--- a/symfony-bridge/src/GacelaInjectCompilerPass.php
+++ b/symfony-bridge/src/GacelaInjectCompilerPass.php
@@ -32,18 +32,27 @@ final class GacelaInjectCompilerPass implements CompilerPassInterface
 {
     public function __construct(
         private readonly string $gacelaServiceId = 'gacela.container',
-    ) {}
+    ) {
+    }
 
     public function process(ContainerBuilder $container): void
     {
         foreach ($container->getDefinitions() as $id => $definition) {
-            if ($definition->isAbstract() || $definition->isSynthetic()) {
+            if ($definition->isAbstract()) {
+                continue;
+            }
+
+            if ($definition->isSynthetic()) {
                 continue;
             }
 
             /** @var class-string|null $class */
             $class = $definition->getClass();
-            if ($class === null || !class_exists($class)) {
+            if ($class === null) {
+                continue;
+            }
+
+            if (!class_exists($class)) {
                 continue;
             }
 

--- a/symfony-bridge/tests/Fixtures/ServiceWithBuiltinTypedInject.php
+++ b/symfony-bridge/tests/Fixtures/ServiceWithBuiltinTypedInject.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+/**
+ * `#[Inject]` on a builtin-typed parameter with no implementation override.
+ * There is no class to resolve, so the pass has to leave the argument alone
+ * rather than ask the container for a service called "string".
+ */
+final class ServiceWithBuiltinTypedInject
+{
+    public function __construct(
+        #[Inject] public readonly string $name,
+    ) {
+    }
+}

--- a/symfony-bridge/tests/Fixtures/ServiceWithSubclassedInject.php
+++ b/symfony-bridge/tests/Fixtures/ServiceWithSubclassedInject.php
@@ -11,5 +11,6 @@ final class ServiceWithSubclassedInject
         public readonly FooInterface $foo,
         #[SubclassedInject(ConcreteBar::class)]
         public readonly BarInterface $bar,
-    ) {}
+    ) {
+    }
 }

--- a/symfony-bridge/tests/Fixtures/SubclassedInject.php
+++ b/symfony-bridge/tests/Fixtures/SubclassedInject.php
@@ -17,4 +17,6 @@ use Gacela\Container\Attribute\Inject;
  * ReflectionAttribute::IS_INSTANCEOF for exactly this reason.
  */
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
-final class SubclassedInject extends Inject {}
+final class SubclassedInject extends Inject
+{
+}

--- a/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
+++ b/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
@@ -110,24 +110,14 @@ final class GacelaInjectCompilerPassTest extends TestCase
         $this->pass->process($this->container);
     }
 
-    public function test_abstract_definition_is_skipped(): void
-    {
-        $this->container
-            ->register('app.abstract', ServiceWithInject::class)
-            ->setAbstract(true);
-
-        $this->pass->process($this->container);
-
-        // Still no arguments set — abstract definitions are not rewritten.
-        self::assertSame([], $this->container->getDefinition('app.abstract')->getArguments());
-    }
-
     /**
-     * Skipping an abstract definition must not stop the scan. The definitions
-     * are walked in registration order, so an abstract one registered first
-     * would hide every service after it.
+     * Two things at once, because they share a setup and the second is what the
+     * first is for: an abstract definition is not rewritten, and skipping it
+     * does not stop the scan. Definitions are walked in registration order, so
+     * an abstract one registered first would otherwise hide every service after
+     * it.
      */
-    public function test_an_abstract_definition_does_not_stop_later_ones_being_rewritten(): void
+    public function test_an_abstract_definition_is_skipped_without_stopping_the_scan(): void
     {
         $this->container
             ->register('app.abstract', ServiceWithInject::class)

--- a/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
+++ b/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\SymfonyBridge;
 use Gacela\SymfonyBridge\GacelaInjectCompilerPass;
 use GacelaTest\SymfonyBridge\Fixtures\ConcreteBar;
 use GacelaTest\SymfonyBridge\Fixtures\FooInterface;
+use GacelaTest\SymfonyBridge\Fixtures\ServiceWithBuiltinTypedInject;
 use GacelaTest\SymfonyBridge\Fixtures\ServiceWithInject;
 use GacelaTest\SymfonyBridge\Fixtures\ServiceWithoutInject;
 use GacelaTest\SymfonyBridge\Fixtures\ServiceWithSubclassedInject;
@@ -39,7 +40,7 @@ final class GacelaInjectCompilerPassTest extends TestCase
         self::assertInstanceOf(Definition::class, $foo);
         self::assertSame(FooInterface::class, $foo->getClass());
         self::assertSame([FooInterface::class], $foo->getArguments());
-        self::assertFactoryRoutesTo($foo, 'gacela.container');
+        $this->assertFactoryRoutesTo($foo, 'gacela.container');
 
         // #[Inject(Concrete::class)] → routes the override instead.
         $bar = $this->argumentFor('app.service', '$bar');
@@ -63,7 +64,7 @@ final class GacelaInjectCompilerPassTest extends TestCase
         $foo = $this->argumentFor('app.subclassed', '$foo');
         self::assertInstanceOf(Definition::class, $foo);
         self::assertSame(FooInterface::class, $foo->getClass());
-        self::assertFactoryRoutesTo($foo, 'gacela.container');
+        $this->assertFactoryRoutesTo($foo, 'gacela.container');
 
         $bar = $this->argumentFor('app.subclassed', '$bar');
         self::assertInstanceOf(Definition::class, $bar);
@@ -86,8 +87,13 @@ final class GacelaInjectCompilerPassTest extends TestCase
             ->setArgument('$foo', 'already-set-by-symfony');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('app.service');
-        $this->expectExceptionMessage('$foo');
+        // Asserted whole rather than by fragment: the message names the service
+        // and the parameter so a build failure points at the line to change, and
+        // half of it going missing still contains every fragment worth grepping.
+        $this->expectExceptionMessage(
+            'Gacela #[Inject] conflicts with an existing Symfony argument on service "app.service" '
+            . 'parameter "$foo". Remove the Symfony argument or drop the #[Inject] attribute.',
+        );
 
         $this->pass->process($this->container);
     }
@@ -116,6 +122,55 @@ final class GacelaInjectCompilerPassTest extends TestCase
         self::assertSame([], $this->container->getDefinition('app.abstract')->getArguments());
     }
 
+    /**
+     * Skipping an abstract definition must not stop the scan. The definitions
+     * are walked in registration order, so an abstract one registered first
+     * would hide every service after it.
+     */
+    public function test_an_abstract_definition_does_not_stop_later_ones_being_rewritten(): void
+    {
+        $this->container
+            ->register('app.abstract', ServiceWithInject::class)
+            ->setAbstract(true);
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $this->pass->process($this->container);
+
+        self::assertSame([], $this->container->getDefinition('app.abstract')->getArguments());
+        self::assertInstanceOf(Definition::class, $this->argumentFor('app.service', '$foo'));
+    }
+
+    /**
+     * The generated factory definition is an implementation detail of the
+     * argument it fills, so it has no business being reachable from the
+     * container by id.
+     */
+    public function test_the_generated_argument_definition_is_not_public(): void
+    {
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $this->pass->process($this->container);
+
+        $foo = $this->argumentFor('app.service', '$foo');
+        self::assertInstanceOf(Definition::class, $foo);
+        self::assertFalse($foo->isPublic());
+    }
+
+    /**
+     * `#[Inject]` with no override on a builtin-typed parameter names no class,
+     * so there is nothing for Gacela to resolve and the argument is left for
+     * Symfony. Rewriting it would ask the container for a service called
+     * "string".
+     */
+    public function test_a_builtin_typed_parameter_is_left_alone(): void
+    {
+        $this->container->register('app.builtin', ServiceWithBuiltinTypedInject::class);
+
+        $this->pass->process($this->container);
+
+        self::assertSame([], $this->container->getDefinition('app.builtin')->getArguments());
+    }
+
     public function test_synthetic_definition_is_skipped(): void
     {
         $this->container
@@ -137,7 +192,7 @@ final class GacelaInjectCompilerPassTest extends TestCase
 
         $argument = $this->argumentFor('app.service', '$foo');
         self::assertInstanceOf(Definition::class, $argument);
-        self::assertFactoryRoutesTo($argument, 'custom.gacela.container');
+        $this->assertFactoryRoutesTo($argument, 'custom.gacela.container');
     }
 
     private function argumentFor(string $serviceId, string $namedKey): mixed
@@ -145,7 +200,7 @@ final class GacelaInjectCompilerPassTest extends TestCase
         return $this->container->getDefinition($serviceId)->getArgument($namedKey);
     }
 
-    private static function assertFactoryRoutesTo(Definition $argument, string $expectedServiceId): void
+    private function assertFactoryRoutesTo(Definition $argument, string $expectedServiceId): void
     {
         /** @var array{0: Reference, 1: string} $factory */
         $factory = $argument->getFactory();


### PR DESCRIPTION
## 📚 Description

`symfony-bridge/` ships from this repo as its own package and was analysed by nothing — phpstan, phpstan-tests, psalm, php-cs-fixer, rector and phpunit's `<source>` all scoped to `src/` and `tests/`. Only its 7 tests ran, and no tool ever read the file.

That is how the `#[Inject]` subclass bug reached `main`, and how the disjoint `gacela-project/container: ^1.4.0` constraint survived. Both are fixed; the gap that let them through was still open.

## 🔖 Changes

- **`ref(bridge)`** — `symfony-bridge/src` and `symfony-bridge/tests` added to all five tools, plus `<source>` in `phpunit.xml` and `source.directories` in `infection.json5`.
- **`ref(bridge)`** — folded the two abstract-definition tests into one; the new test was a strict superset of the existing one.

## 🔍 Two things the issue's work list did not mention

Both would have made this change silently do nothing:

1. **`infection.json5` needed the directory too.** `phpunit.xml`'s `<source>` only decides what is *measured*. Infection's own `source.directories` decides what is *mutated*, so the bridge would have been reported under coverage while the gate enforced nothing on it.

2. **Two CI steps had drifted from the composer scripts.** `code-style.yml` passed `src` to phpstan, and a CLI path argument **overrides** `paths` in the neon — so adding the bridge to `phpstan.neon` would have had no effect in CI. Separately the phpstan-tests step passed no `--memory-limit` while the composer script passes `1G`; the bridge's tests push it past the 128M default and the step crashed rather than reporting. Both now match the composer scripts.

## ✅ Verification

First gated run came in at **87.8% MSI**, under the 90 floor, with five escaped mutants. Four were real behaviour nobody asserted, and now do:

| escaped mutant | what it exposed |
|---|---|
| `FalseValue` on `setPublic(false)` | the generated argument `Definition` is an implementation detail and must not be reachable by id |
| `Continue_` → `break` on `isAbstract()` | an abstract definition registered first would hide **every** service after it |
| `LogicalOr` in `targetFor()` | `#[Inject]` on `string $name` names no class — rewriting it asks the container for a service called `"string"` |
| `Concat` / `ConcatOperandRemoval` | the conflict message was asserted by fragment, so half of it could vanish and every fragment still matched |

Bridge is now at **100% MSI, 43 of 43 mutants killed**. cs-fixer and rector had the expected small backlog for code neither had seen: three files reformatted, plus `LocallyCalledStaticMethodToNonStaticRector` on a test helper.

phpstan, phpstan-tests and psalm were clean on the bridge with no new baseline entries.

Full suite green — 1520 tests. `composer quality` clean.

> CI could not run: GitHub Actions is under a [major outage](https://www.githubstatus.com/) and is dropping ~85% of webhook events, so no workflow run was created. Verified locally instead — including the two CI steps above, which were run by hand.

Closes #601
