### PR TITLE
ci: add a manual re-run lever, and stop rector reading generated caches

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,6 +1,10 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 on:
+  # Manual re-run lever. The 2026-08-06 Actions incident throttled webhooks to
+  # ~15%, so pushes and pull requests silently created no run at all, and there
+  # was no way to ask for one after the fact.
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -27,6 +27,10 @@
 #     that a *dependency* change resurrected in untouched code.
 
 on:
+  # Manual re-run lever. The 2026-08-06 Actions incident throttled webhooks to
+  # ~15%, so pushes and pull requests silently created no run at all, and there
+  # was no way to ask for one after the fact.
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -27,10 +27,6 @@
 #     that a *dependency* change resurrected in untouched code.
 
 on:
-  # Manual re-run lever. The 2026-08-06 Actions incident throttled webhooks to
-  # ~15%, so pushes and pull requests silently created no run at all, and there
-  # was no way to ask for one after the fact.
-  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/module-cycles.yml
+++ b/.github/workflows/module-cycles.yml
@@ -12,6 +12,10 @@
 # that outlives what it allows stops being a record and becomes a mute button.
 
 on:
+  # Manual re-run lever. The 2026-08-06 Actions incident throttled webhooks to
+  # ~15%, so pushes and pull requests silently created no run at all, and there
+  # was no way to ask for one after the fact.
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 on:
+  # Manual re-run lever. The 2026-08-06 Actions incident throttled webhooks to
+  # ~15%, so pushes and pull requests silently created no run at all, and there
+  # was no way to ask for one after the fact.
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/rector.php
+++ b/rector.php
@@ -29,6 +29,14 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
+        // Gacela's own cache output, written into the fixture directories by
+        // running the suite. It is gitignored, but rector does not read
+        // .gitignore, so without this any developer who runs the tests and then
+        // commits gets a rector failure on generated files -- and the
+        // pre-commit hook runs `composer quality`, which now includes rector.
+        __DIR__ . '/tests/**/gacela-class-names*.php',
+        __DIR__ . '/tests/**/gacela-custom-services*.php',
+        __DIR__ . '/tests/**/gacela-merged-config*.php',
         __DIR__ . '/tests/Unit/PHPStan/Rules/Fixture',
         // assert() inside an anonymous class extending a non-TestCase parent
         // must not be rewritten to $this->assertSame().


### PR DESCRIPTION
## 📚 Description

Two things the 2026-08-06 Actions incident and the new rector gate exposed, both blocking a clean 2.0 cut.

**No way to ask for a CI run.** The incident throttled webhook delivery to ~15%, so pushes and pull requests created *no workflow run at all* — not a delayed one, none. Zero check-suites, so the PR UI rendered nothing rather than a pending row, and `release.sh`'s `verify_ci_green()` correctly refuses on a HEAD with no check-runs. With no `workflow_dispatch` there was no lever to request a run after the fact; the only re-trigger was closing and reopening a PR at ~15% odds per attempt.

**Rector tried to rewrite generated cache files.** Running the suite writes Gacela's own cache output into the fixture directories. Those files are gitignored, but rector does not read `.gitignore`, and rector joined `composer quality` in #603 — which the pre-commit hook runs. So any developer who ran the tests and then committed hit a rector failure on files they never wrote:

```
1) tests/Feature/Console/CacheWarm/cache/gacela-class-names-e9c478544ba9.php:1
2) tests/Feature/Console/CacheWarm/cache/gacela-custom-services-e9c478544ba9.php:1
```

I hit exactly this on the first commit of this branch.

## 🔖 Changes

- **`ci`** — `workflow_dispatch` on Tests, Code style, Infection and Module cycles. Not on `module-graph` or `phpbench`: both diff a PR base against its head and have nothing to compare outside that context.
- **`ci`** — rector skips the three generated cache patterns (`gacela-class-names*`, `gacela-custom-services*`, `gacela-merged-config*`) under `tests/`.

## ⚠️ Why this PR matters beyond its diff

**Four merges to `main` have zero CI check-runs**, because their webhooks were dropped during the incident:

| commit | PR | CI |
|---|---|---|
| `dfb84c92` | #610 phpunit ^12 + rector isolation | **none** |
| `f7a1c661` | #609 bridge under all tools | **none** |
| `adddbce0` | #607 | **none** |
| `99ecef4f` | #606 | **none** |

`97cfd08e`, `2eec75c3` and `4c07ec5d` did get runs, all green. This PR is the first to run the full matrix over the current tree — including the phpunit 12 migration, which is the riskiest thing on `main` and has never been exercised on CI's PHP 8.3/8.4/8.5 × lowest/locked/highest matrix.

Treat the checks here as the verification of `main`, not just of these two config edits.

Related to #503
