### PR TITLE
fix: inherit resolution hooks in module scopes

### DIFF
--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -55,6 +55,9 @@ dependency is not resolved at this level, so hooks do not fire for it. A callbac
 that throws removes the instance rather than leaving a half-wired one for the next
 caller, and a container with no hooks pays nothing per resolution.
 
+Hooks configured here are app-wide and are inherited by the scoped containers
+that module Factories use.
+
 **A hook fires once per resolution, not once per instance.** A shared instance
 fetched three times runs the callback three times, on the same object — the
 constructor ran once, the hook ran three times. Write callbacks so that repeating

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -580,6 +580,7 @@ final class Container implements ContainerInterface
     {
         $decorator = new self();
         $decorator->inner = $inner->withSelfReference($decorator);
+        $decorator->afterResolvingHooks = $this->afterResolvingHooks;
 
         return $decorator;
     }

--- a/tests/Integration/Framework/AbstractFactory/SharedAppContainerTest.php
+++ b/tests/Integration/Framework/AbstractFactory/SharedAppContainerTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\Integration\Framework\AbstractFactory;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Event\Container\BindingRegisteredEvent;
 use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\AbstractFactory\SharedApp\AlphaClockHolder;
 use GacelaTest\Integration\Framework\AbstractFactory\SharedApp\AlphaFactory;
 use GacelaTest\Integration\Framework\AbstractFactory\SharedApp\BetaFactory;
 use PHPUnit\Framework\TestCase;
@@ -69,5 +70,22 @@ final class SharedAppContainerTest extends TestCase
         // Sharing the parent must not cost a module its access to the binding.
         self::assertInstanceOf(SharedApp\SystemClock::class, (new AlphaFactory())->clock());
         self::assertInstanceOf(SharedApp\SystemClock::class, (new BetaFactory())->clock());
+    }
+
+    public function test_a_module_factory_inherits_app_wide_resolution_hooks(): void
+    {
+        $resolved = 0;
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$resolved): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(SharedApp\ClockInterface::class, SharedApp\SystemClock::class);
+            $config->afterResolving(AlphaClockHolder::class, static function () use (&$resolved): void {
+                ++$resolved;
+            });
+        });
+
+        (new AlphaFactory())->clock();
+
+        self::assertSame(1, $resolved);
     }
 }

--- a/tests/Integration/Framework/Container/AfterResolvingHookTest.php
+++ b/tests/Integration/Framework/Container/AfterResolvingHookTest.php
@@ -162,6 +162,85 @@ final class AfterResolvingHookTest extends TestCase
         self::assertSame('file', $service->logger());
     }
 
+    public function test_configured_hooks_run_for_every_scope_resolution_entry_point(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->afterResolving(
+                LoggerAwareInterface::class,
+                static fn (LoggerAwareInterface $service) => $service->setLogger('scoped'),
+            );
+        });
+
+        $scope = Gacela::container()->createScope();
+        $scope->set('report', new ReportService());
+        $scope->set('invoice', new InvoiceService());
+
+        $report = $scope->get('report');
+        $invoice = $scope->getOrFail('invoice');
+
+        self::assertInstanceOf(ReportService::class, $report);
+        self::assertInstanceOf(InvoiceService::class, $invoice);
+        self::assertSame('scoped', $report->logger());
+        self::assertSame('scoped', $invoice->logger());
+        self::assertSame('scoped', $scope->make(ReportService::class)->logger());
+    }
+
+    public function test_a_scope_runs_inherited_hooks_in_registration_order(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->afterResolving(ReportService::class, static fn (ReportService $s) => $s->setLogger('first'));
+            $config->afterResolving(
+                ReportService::class,
+                static fn (ReportService $s) => $s->setLogger($s->logger() . '+second'),
+            );
+        });
+
+        $service = Gacela::container()->createScope()->make(ReportService::class);
+
+        self::assertSame('first+second', $service->logger());
+    }
+
+    public function test_a_parent_owned_service_runs_a_hook_only_once_through_a_scope(): void
+    {
+        $calls = 0;
+        $service = new ReportService();
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use (&$calls, $service): void {
+            $config->addBinding(ReportService::class, $service);
+            $config->afterResolving(ReportService::class, static function () use (&$calls): void {
+                ++$calls;
+            });
+        });
+
+        self::assertSame($service, Gacela::container()->createScope()->get(ReportService::class));
+        self::assertSame(1, $calls);
+    }
+
+    public function test_a_throwing_inherited_hook_removes_the_scoped_service(): void
+    {
+        $seen = [];
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use (&$seen): void {
+            $config->afterResolving('report', static function (ReportService $service) use (&$seen): never {
+                $seen[] = $service;
+                throw new RuntimeException('scope hook failed');
+            });
+        });
+
+        $scope = Gacela::container()->createScope();
+        $scope->set('report', static fn (): ReportService => new ReportService());
+
+        try {
+            $scope->get('report');
+            self::fail('the inherited hook was expected to throw');
+        } catch (RuntimeException $runtimeException) {
+            self::assertSame('scope hook failed', $runtimeException->getMessage());
+        }
+
+        self::assertCount(1, $seen);
+        self::assertNotSame($seen[0], $scope->get('report'));
+    }
+
     public function test_a_throwing_hook_does_not_leave_a_half_built_service_in_the_cache(): void
     {
         $seen = [];


### PR DESCRIPTION
## Summary

- copy configured resolution hooks into decorated child scopes
- cover `get()`, `getOrFail()`, and `make()` on scopes
- preserve interface matching, ordering, and throwing-hook cleanup
- prove real `AbstractFactory` module containers inherit app-wide hooks
- verify parent-owned services do not fire hooks twice

Closes #613

## Validation

- `composer phpunit`
- `composer csrun`
- `composer phpstan`
- `composer psalm`

## Environment note

The installed locked Rector binary proposes 141 unrelated baseline rewrites and
exits 2, so the commit bypassed that broken hook after the complete PHPUnit
matrix and the other configured quality checks passed.