### PR TITLE
fix(console): strip only the matched psr-4 prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 - Preserve every health check registered for a module and aggregate duplicate
   results to the worst reported level.
+- `make:module` and `make:file` corrupted the target directory when the module
+  name repeated the namespace text. `CommandArgumentsParser` replaced the
+  namespace with `str_replace()` across the whole string, so `App/Application`
+  against `App\ => src/` generated into `src/srclication`. Only the matched
+  prefix is removed now. Two neighbouring shapes are fixed with it: a psr-4
+  target without a trailing slash was truncated by a character (`src` became
+  `sr`), and a target given as a list of directories — which Composer allows —
+  raised a `TypeError`. A list now resolves to its first directory, which is
+  where Composer itself looks first.
 
 ## [2.0.0](https://github.com/gacela-project/gacela/compare/1.21.0...2.0.0) - 2026-08-07
 

--- a/src/Console/ConsoleConfig.php
+++ b/src/Console/ConsoleConfig.php
@@ -9,9 +9,12 @@ use Gacela\Framework\AbstractConfig;
 use JsonException;
 
 /**
+ * A psr-4 target is a directory or a list of them; Composer accepts both, and
+ * assuming the string shape made an array-valued mapping a TypeError.
+ *
  * @psalm-type ComposerJsonContent = array{
- *     autoload?: array{"psr-4"?: array<string,string>},
- *     autoload-dev?: array{"psr-4"?: array<string,string>},
+ *     autoload?: array{"psr-4"?: array<string,string|list<string>>},
+ *     autoload-dev?: array{"psr-4"?: array<string,string|list<string>>},
  * }
  */
 final class ConsoleConfig extends AbstractConfig

--- a/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
@@ -8,6 +8,7 @@ use Gacela\Console\ConsoleConfig;
 use InvalidArgumentException;
 
 use function count;
+use function is_string;
 
 /**
  * @psalm-import-type ComposerJsonContent from ConsoleConfig
@@ -85,13 +86,48 @@ final class CommandArgumentsParser implements CommandArgumentsParserInterface
         return array_reverse($result);
     }
 
-    private function foundPsr4(string $psr4Key, string $psr4Value, string $desiredNamespace): CommandArguments
+    /**
+     * @param string|list<string> $psr4Value
+     */
+    private function foundPsr4(string $psr4Key, string|array $psr4Value, string $desiredNamespace): CommandArguments
     {
-        $rootDir = mb_substr($psr4Value, 0, -1);
-        $rootNamespace = mb_substr($psr4Key, 0, -1);
-        $targetDirectory = str_replace(['/', $rootNamespace, '\\'], ['\\', $rootDir, '/'], $desiredNamespace);
-        $namespace = str_replace([$rootDir, '/'], [$rootNamespace, '\\'], $targetDirectory);
+        $rootNamespace = rtrim($psr4Key, '\\');
+        $rootDir = rtrim($this->firstDirectoryOf($psr4Value), '/');
 
-        return new CommandArguments($namespace, $targetDirectory);
+        // Only the matched prefix is removed. Replacing the namespace text
+        // globally also rewrote it where it recurs inside the module name, so
+        // `App/Application` against `App\ => src/` produced `src/srclication`.
+        $prefixAsPath = str_replace('\\', '/', $rootNamespace);
+        $remainder = trim(mb_substr($desiredNamespace, mb_strlen($prefixAsPath)), '/');
+
+        return new CommandArguments(
+            $this->join('\\', $rootNamespace, str_replace('/', '\\', $remainder)),
+            $this->join('/', $rootDir, $remainder),
+        );
+    }
+
+    /**
+     * Composer allows a psr-4 target to be a single directory or a list of
+     * them. Only the first is used: it is where Composer itself looks first,
+     * and generating into any of the others would be a guess.
+     *
+     * @param string|list<string> $psr4Value
+     */
+    private function firstDirectoryOf(string|array $psr4Value): string
+    {
+        if (is_string($psr4Value)) {
+            return $psr4Value;
+        }
+
+        return $psr4Value[0] ?? '';
+    }
+
+    /**
+     * Joins the parts that are present, so a namespace root with nothing after
+     * it does not pick up a dangling separator.
+     */
+    private function join(string $separator, string ...$parts): string
+    {
+        return implode($separator, array_filter($parts, static fn (string $part): bool => $part !== ''));
     }
 }

--- a/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
@@ -41,17 +41,16 @@ final class CommandArgumentsParser implements CommandArgumentsParserInterface
         $psr4 = $this->composerJson['autoload']['psr-4'];
         $psr4Dev = $this->composerJson['autoload-dev']['psr-4'] ?? [];
 
-        $allPsr4Combinations = $this->allPossiblePsr4Combinations($desiredNamespace);
+        // `+` keeps the left operand on a duplicate key, which is the same
+        // precedence the two separate isset() chains encoded: autoload wins
+        // over autoload-dev for a namespace declared in both.
+        $psr4All = $psr4 + $psr4Dev;
 
-        foreach ($allPsr4Combinations as $psr4Combination) {
+        foreach ($this->allPossiblePsr4Combinations($desiredNamespace) as $psr4Combination) {
             $psr4Key = $psr4Combination . '\\';
 
-            if (isset($psr4[$psr4Key])) {
-                return $this->foundPsr4($psr4Key, $psr4[$psr4Key], $desiredNamespace);
-            }
-
-            if (isset($psr4Dev[$psr4Key])) {
-                return $this->foundPsr4($psr4Key, $psr4Dev[$psr4Key], $desiredNamespace);
+            if (isset($psr4All[$psr4Key])) {
+                return $this->foundPsr4($psr4Key, $psr4All[$psr4Key], $desiredNamespace);
             }
         }
 
@@ -59,12 +58,15 @@ final class CommandArgumentsParser implements CommandArgumentsParserInterface
     }
 
     /**
-     * Merge all possible psr-4 combinations and return them ordered by longer to shorter.
-     * This way we'll be able to find the longer match first.
-     * For example: App/TestModule/TestSubModule will produce an array such as:
+     * Every psr-4 prefix the requested namespace could match, longest first, so
+     * the most specific mapping wins.
+     *
+     * The input is slash-separated and the output is backslash-separated,
+     * because these are compared against psr-4 keys: `App/TestModule/TestSubModule`
+     * produces
      * [
-     *   'App/TestModule/TestSubModule',
-     *   'App/TestModule',
+     *   'App\TestModule\TestSubModule',
+     *   'App\TestModule',
      *   'App',
      * ]
      *

--- a/tests/Unit/Console/Domain/CommandArguments/CommandArgumentsParserTest.php
+++ b/tests/Unit/Console/Domain/CommandArguments/CommandArgumentsParserTest.php
@@ -120,6 +120,71 @@ final class CommandArgumentsParserTest extends TestCase
         self::assertSame('código/TestModule', $args->directory());
     }
 
+    /**
+     * The module name repeats the namespace text: "Application" starts with
+     * "App". Replacing the namespace globally rewrote that occurrence too, so
+     * the directory came back as `src/srclication`.
+     */
+    public function test_parse_module_name_that_repeats_the_namespace(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse('App/Application');
+
+        self::assertSame('App\Application', $args->namespace());
+        self::assertSame('src/Application', $args->directory());
+    }
+
+    /**
+     * Composer does not require the trailing slash on a psr-4 target. Cutting
+     * the last character unconditionally turned `src` into `sr`.
+     */
+    public function test_parse_psr4_target_without_a_trailing_slash(): void
+    {
+        $composerJson = json_decode(
+            '{"autoload":{"psr-4":{"App\\\\":"src"}}}',
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $args = (new CommandArgumentsParser($composerJson))->parse('App/TestModule');
+
+        self::assertSame('App\TestModule', $args->namespace());
+        self::assertSame('src/TestModule', $args->directory());
+    }
+
+    /**
+     * Composer allows a list of directories per namespace. Only the first is
+     * used: it is where Composer itself would look first, and generating into
+     * any of the others would be a guess.
+     */
+    public function test_parse_psr4_target_given_as_a_list_uses_the_first_directory(): void
+    {
+        $composerJson = json_decode(
+            '{"autoload":{"psr-4":{"App\\\\":["src/","generated/"]}}}',
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $args = (new CommandArgumentsParser($composerJson))->parse('App/TestModule');
+
+        self::assertSame('App\TestModule', $args->namespace());
+        self::assertSame('src/TestModule', $args->directory());
+    }
+
+    /**
+     * The namespace root on its own, with nothing after it.
+     */
+    public function test_parse_the_root_namespace_itself(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleOneLevelComposerJson());
+        $args = $parser->parse('App');
+
+        self::assertSame('App', $args->namespace());
+        self::assertSame('src', $args->directory());
+    }
+
     private function exampleOneLevelComposerJson(): array
     {
         $composerJson = <<<'JSON'


### PR DESCRIPTION
## 📚 Description

`CommandArgumentsParser::foundPsr4()` rewrote the requested namespace with global `str_replace()` calls, so the namespace text was replaced everywhere it occurred rather than at the front:

```
App/Application   with   App\ => src/     →   src/srclication
```

`"Application"` starts with `"App"`, and `str_replace` applies its arrays sequentially, so the second pass hit the module name too.

Two neighbouring assumptions in the same four lines were wrong for the same reason — they treated the psr-4 shape as fixed:

| input | before | now |
|---|---|---|
| `App\ => src/`, module `App/Application` | `src/srclication` | `src/Application` |
| `App\ => src` (no trailing slash) | `sr/TestModule` | `src/TestModule` |
| `App\ => ["src/", "generated/"]` | `TypeError` | `src/TestModule` |

## 🔖 Changes

- **`fix(console)`** — the rewrite is a prefix strip: take the matched key's length off the front and rejoin the remainder onto the root. Nothing else in the string is touched, so a module whose name repeats its namespace is no longer special.

  The trailing separator was removed with `mb_substr($v, 0, -1)`, which cuts a character whether or not it *is* a separator. `rtrim()` removes it only when present, and stays multibyte-safe because `/` and `\` cannot occur inside a UTF-8 sequence — the existing `Aplicación\ => código/` test still passes.

  A psr-4 target may be a list of directories. The first is used, which is where Composer itself looks first; picking any other would be a guess. The psalm type said `array<string,string>` and now says the shape Composer actually allows.

- **`ref(console)`** — two `isset()` branches did the same thing against two maps in a fixed order; merged with `+`, which keeps the left operand on a duplicate key and so encodes "autoload wins over autoload-dev" directly. And `allPossiblePsr4Combinations()`'s docblock claimed slash-separated output while the code has always joined with a backslash — the same separator confusion this issue is about, sitting in the comment right above it.

## ✅ Verification

Four new unit tests, one per acceptance criterion plus the root-namespace-alone case. The first three fail on `main` with exactly the values the issue reports (`src/srclication`, `sr/TestModule`, `TypeError`).

All 12 pre-existing tests in the class pass unchanged — longest-prefix selection, `autoload-dev`, and both multibyte cases.

Full suite green — 1533 tests. `composer quality` clean.

Closes #612
