### PR TITLE
fix(doctor): check the merged config cache against its sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Preserve every health check registered for a module and aggregate duplicate
   results to the worst reported level.
+- `doctor` reported "all cache entries are fresh" while the merged configuration
+  was stale. `CacheStalenessCheck` inspected only the class-name and
+  custom-service caches and never looked at `gacela-merged-config-*.php`, which
+  keeps serving values after a source config file changes. It now compares the
+  merged cache against every file that contributes to it — base patterns,
+  environment patterns and local overrides alike. The source list comes from
+  `ConfigLoader::sourceFiles()` rather than from paths the check derives itself,
+  so it cannot drift from what the loader actually reads.
 - `make:module` and `make:file` corrupted the target directory when the module
   name repeated the namespace text. `CommandArgumentsParser` replaced the
   namespace with `str_replace()` across the whole string, so `App/Application`

--- a/infection.json5
+++ b/infection.json5
@@ -123,6 +123,10 @@
                 "Gacela\\Console\\Application\\CacheWarm\\CacheManager::getCacheFileSize",
                 "Gacela\\Console\\Application\\CacheWarm\\CacheManager::getExistingCacheFilesWithSize",
                 "Gacela\\Console\\Application\\Doctor\\Check\\CacheStalenessCheck::run",
+                // Same reason as ::run above, for the merged-config sources:
+                // filemtime() only returns false for a file that vanished
+                // between the is_file() check right above and the call itself.
+                "Gacela\\Console\\Application\\Doctor\\Check\\CacheStalenessCheck::mergedConfigStaleness",
             ],
         },
         LessThan: {
@@ -309,7 +313,13 @@
             ignore: ["Gacela\\Console\\Domain\\CommandArguments\\CommandArgumentsParser::foundPsr4"],
         },
         UnwrapArrayValues: {
-            ignore: ["Gacela\\Console\\Domain\\ModuleGraph\\GraphDiffMarkdownFormatter::affectedModules"],
+            ignore: [
+                "Gacela\\Console\\Domain\\ModuleGraph\\GraphDiffMarkdownFormatter::affectedModules",
+                // sourceFiles() keys nothing: array_values() only restores the
+                // list shape the return type declares after array_unique()
+                // punched holes in the keys, and every consumer foreaches it.
+                "Gacela\\Framework\\Config\\ConfigLoader::sourceFiles",
+            ],
         },
         // hrtime(true) is an int; dividing by a float yields a float either way.
         // Same for the bootstrap-duration event, and getFloat()'s widening

--- a/infection.json5
+++ b/infection.json5
@@ -122,10 +122,11 @@
                 "Gacela\\Framework\\Cache\\FileCache::stats",
                 "Gacela\\Console\\Application\\CacheWarm\\CacheManager::getCacheFileSize",
                 "Gacela\\Console\\Application\\CacheWarm\\CacheManager::getExistingCacheFilesWithSize",
-                "Gacela\\Console\\Application\\Doctor\\Check\\CacheStalenessCheck::run",
-                // Same reason as ::run above, for the merged-config sources:
-                // filemtime() only returns false for a file that vanished
-                // between the is_file() check right above and the call itself.
+                // Both halves of CacheStalenessCheck, which used to be one
+                // ::run(). filemtime() only returns false for a file that
+                // vanished between the is_file() check right above and the call
+                // itself, so the cast cannot change the outcome.
+                "Gacela\\Console\\Application\\Doctor\\Check\\CacheStalenessCheck::resolvedClassStaleness",
                 "Gacela\\Console\\Application\\Doctor\\Check\\CacheStalenessCheck::mergedConfigStaleness",
             ],
         },

--- a/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
+++ b/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
@@ -54,6 +54,36 @@ final class CacheStalenessCheck implements HealthCheck
             return CheckResult::ok($this->name(), 'no cache directory — nothing to check');
         }
 
+        [$classStale, $classMissing] = $this->resolvedClassStaleness();
+        [$mergedStale, $mergedMissing] = $this->mergedConfigStaleness();
+
+        $stale = [...$classStale, ...$mergedStale];
+        $missing = [...$classMissing, ...$mergedMissing];
+
+        if ($stale === [] && $missing === []) {
+            return CheckResult::ok($this->name(), 'all cache entries are fresh');
+        }
+
+        $details = [
+            ...array_map(static fn (string $entry): string => 'stale: ' . $entry, $stale),
+            ...array_map(static fn (string $entry): string => 'missing source: ' . $entry, $missing),
+        ];
+
+        return CheckResult::warn(
+            $this->name(),
+            $details,
+            'run `bin/gacela cache:clear && bin/gacela cache:warm` to rebuild',
+        );
+    }
+
+    /**
+     * The caches that map a key to a class name, checked against the file each
+     * class is declared in.
+     *
+     * @return array{0: list<string>, 1: list<string>}
+     */
+    private function resolvedClassStaleness(): array
+    {
         $stale = [];
         $missing = [];
 
@@ -85,28 +115,7 @@ final class CacheStalenessCheck implements HealthCheck
             }
         }
 
-        [$mergedStale, $mergedMissing] = $this->mergedConfigStaleness();
-        $stale = [...$stale, ...$mergedStale];
-        $missing = [...$missing, ...$mergedMissing];
-
-        if ($stale === [] && $missing === []) {
-            return CheckResult::ok($this->name(), 'all cache entries are fresh');
-        }
-
-        $details = [];
-        foreach ($stale as $entry) {
-            $details[] = 'stale: ' . $entry;
-        }
-
-        foreach ($missing as $entry) {
-            $details[] = 'missing source: ' . $entry;
-        }
-
-        return CheckResult::warn(
-            $this->name(),
-            $details,
-            'run `bin/gacela cache:clear && bin/gacela cache:warm` to rebuild',
-        );
+        return [$stale, $missing];
     }
 
     /**

--- a/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
+++ b/src/Console/Application/Doctor/Check/CacheStalenessCheck.php
@@ -10,6 +10,7 @@ use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use Gacela\Framework\Config\MergedConfigCache;
 use ReflectionClass;
 
 use function sprintf;
@@ -21,11 +22,15 @@ final class CacheStalenessCheck implements HealthCheck
 
     /**
      * @param null|Closure(string):?string $sourceFileResolver resolves a class-name to its source file path
+     * @param null|MergedConfigCache $mergedConfigCache the merged-config cache to check, when there is one
+     * @param list<string> $mergedConfigSources every file that contributes to the merged config
      */
     public function __construct(
         private readonly string $cacheDir,
         ?Closure $sourceFileResolver = null,
         private readonly string $appRootDir = '',
+        private readonly ?MergedConfigCache $mergedConfigCache = null,
+        private readonly array $mergedConfigSources = [],
     ) {
         $this->sourceFileResolver = $sourceFileResolver ?? static function (string $className): ?string {
             if (!class_exists($className) && !interface_exists($className)) {
@@ -80,6 +85,10 @@ final class CacheStalenessCheck implements HealthCheck
             }
         }
 
+        [$mergedStale, $mergedMissing] = $this->mergedConfigStaleness();
+        $stale = [...$stale, ...$mergedStale];
+        $missing = [...$missing, ...$mergedMissing];
+
         if ($stale === [] && $missing === []) {
             return CheckResult::ok($this->name(), 'all cache entries are fresh');
         }
@@ -98,5 +107,42 @@ final class CacheStalenessCheck implements HealthCheck
             $details,
             'run `bin/gacela cache:clear && bin/gacela cache:warm` to rebuild',
         );
+    }
+
+    /**
+     * The merged configuration cache keeps serving values after a source config
+     * file changes, so it can be stale while every class-name entry above is
+     * fresh — which is how doctor came to report "all cache entries are fresh"
+     * on a stale configuration.
+     *
+     * The sources are the ones `ConfigLoader` itself would read, so the base
+     * patterns, the environment patterns and the local overrides are all
+     * covered without this check re-deriving any paths of its own.
+     *
+     * @return array{0: list<string>, 1: list<string>}
+     */
+    private function mergedConfigStaleness(): array
+    {
+        if (!$this->mergedConfigCache instanceof MergedConfigCache || !$this->mergedConfigCache->exists()) {
+            return [[], []];
+        }
+
+        $cacheMtime = (int) filemtime($this->mergedConfigCache->filename());
+
+        $stale = [];
+        $missing = [];
+
+        foreach ($this->mergedConfigSources as $source) {
+            if (!is_file($source)) {
+                $missing[] = 'merged config ← ' . $source;
+                continue;
+            }
+
+            if ((int) filemtime($source) > $cacheMtime) {
+                $stale[] = 'merged config ← ' . $source;
+            }
+        }
+
+        return [$stale, $missing];
     }
 }

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -12,7 +12,9 @@ use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Console\ConsoleFacade;
+use Gacela\Framework\Config\AppEnv;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\MergedConfigCache;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\ServiceResolver\ServiceMap;
@@ -78,10 +80,17 @@ final class DoctorCommand extends Command
     {
         $config = Config::getInstance();
         $modules = $this->getFacade()->findAllAppModules($filter);
-        $suffixTypes = $config->getFactory()->createGacelaFileConfig()->getSuffixTypes();
+        $configFactory = $config->getFactory();
+        $suffixTypes = $configFactory->createGacelaFileConfig()->getSuffixTypes();
 
         $checks = [
-            new CacheStalenessCheck($config->getCacheDir(), null, $config->getAppRootDir()),
+            new CacheStalenessCheck(
+                $config->getCacheDir(),
+                null,
+                $config->getAppRootDir(),
+                new MergedConfigCache($config->getCacheDir(), AppEnv::current(), $config->getAppRootDir()),
+                $configFactory->createConfigLoader()->sourceFiles(),
+            ),
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules),
         ];

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -41,18 +41,56 @@ final class ConfigLoader
     }
 
     /**
+     * Every file `loadAll()` would read, in the order it reads them.
+     *
+     * Exposed so `doctor` can compare the merged-config cache against its
+     * sources without re-deriving the patterns — a second copy of this logic
+     * would drift, and the check would then be answering about different files
+     * than the ones actually loaded.
+     *
+     * @return list<string>
+     */
+    public function sourceFiles(): array
+    {
+        $files = [];
+
+        foreach ($this->gacelaConfigFile->getConfigItems() as $configItem) {
+            foreach ($this->patternsOf($configItem) as $pattern) {
+                foreach ($this->pathFinder->matchingPattern($pattern) as $absolutePath) {
+                    $files[] = $absolutePath;
+                }
+            }
+
+            // Unlike the patterns, the local path is not globbed, so it is only
+            // a source when it is actually there.
+            $local = $this->pathNormalizer->normalizePathLocal($configItem);
+            if (is_file($local)) {
+                $files[] = $local;
+            }
+        }
+
+        return array_values(array_unique($files));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function patternsOf(GacelaConfigItem $configItem): array
+    {
+        return [
+            $this->pathNormalizer->normalizePathPattern($configItem),
+            $this->pathNormalizer->normalizePathPatternWithEnvironment($configItem),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function loadConfigsFromPatterns(GacelaConfigItem $configItem): array
     {
-        $patterns = [
-            $this->pathNormalizer->normalizePathPattern($configItem),
-            $this->pathNormalizer->normalizePathPatternWithEnvironment($configItem),
-        ];
-
         $mergedConfigs = [];
 
-        foreach ($patterns as $pattern) {
+        foreach ($this->patternsOf($configItem) as $pattern) {
             foreach ($this->pathFinder->matchingPattern($pattern) as $absolutePath) {
                 $mergedConfigs[] = $this->readConfigWithCache($absolutePath, $configItem);
             }

--- a/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
@@ -9,9 +9,11 @@ use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
+use Gacela\Framework\Config\MergedConfigCache;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function dirname;
 use function file_put_contents;
 use function is_string;
 use function mkdir;
@@ -33,9 +35,18 @@ final class CacheStalenessCheckTest extends TestCase
 
     protected function tearDown(): void
     {
+        // Depth-first: the merged-config tests write into a `config/` subdir,
+        // and a non-empty directory cannot be removed.
+        foreach ((array) glob($this->tempDir . '/*/*') as $file) {
+            if (is_string($file)) {
+                @unlink($file);
+            }
+        }
+
         foreach ((array) glob($this->tempDir . '/*') as $file) {
             if (is_string($file)) {
                 @unlink($file);
+                @rmdir($file);
             }
         }
 
@@ -231,6 +242,164 @@ final class CacheStalenessCheckTest extends TestCase
 
         self::assertSame(CheckStatus::Ok, $result->status);
         self::assertSame(['all cache entries are fresh'], $result->details);
+    }
+
+    /**
+     * The merged configuration cache keeps serving values after a source config
+     * file changes, so doctor reported "all cache entries are fresh" while the
+     * active configuration was stale.
+     */
+    public function test_a_config_source_newer_than_the_merged_cache_is_reported(): void
+    {
+        $source = $this->writeConfigSource('config/default.php', time());
+        $this->writeMergedConfigCache(time() - 120);
+
+        $result = $this->checkWithMergedConfig([$source])->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['stale: merged config ← ' . $source], $result->details);
+        self::assertSame('run `bin/gacela cache:clear && bin/gacela cache:warm` to rebuild', $result->remediation);
+    }
+
+    /**
+     * The environment file is a separate pattern from the base one, and was
+     * equally invisible.
+     */
+    public function test_a_stale_environment_config_source_is_reported(): void
+    {
+        $source = $this->writeConfigSource('config/default.dev.php', time());
+        $this->writeMergedConfigCache(time() - 120);
+
+        $result = $this->checkWithMergedConfig([$source])->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['stale: merged config ← ' . $source], $result->details);
+    }
+
+    /**
+     * The local override is merged last and wins over everything, so a stale one
+     * is the most misleading of the three.
+     */
+    public function test_a_stale_local_override_source_is_reported(): void
+    {
+        $source = $this->writeConfigSource('config/local.php', time());
+        $this->writeMergedConfigCache(time() - 120);
+
+        $result = $this->checkWithMergedConfig([$source])->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['stale: merged config ← ' . $source], $result->details);
+    }
+
+    public function test_a_merged_cache_newer_than_every_source_stays_ok(): void
+    {
+        $base = $this->writeConfigSource('config/default.php', time() - 120);
+        $local = $this->writeConfigSource('config/local.php', time() - 120);
+        $this->writeMergedConfigCache(time());
+
+        $result = $this->checkWithMergedConfig([$base, $local])->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['all cache entries are fresh'], $result->details);
+    }
+
+    /**
+     * A source the cache was built from and that has since been deleted changes
+     * the merged result just as much as an edited one.
+     */
+    public function test_a_config_source_that_no_longer_exists_is_reported(): void
+    {
+        $this->writeMergedConfigCache(time());
+
+        $result = $this->checkWithMergedConfig([$this->tempDir . '/config/gone.php'])->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['missing source: merged config ← ' . $this->tempDir . '/config/gone.php'],
+            $result->details,
+        );
+    }
+
+    /**
+     * A config file written in the same second the cache was warmed is the
+     * normal outcome of `cache:warm`, so it must not be reported as stale --
+     * the same rule the class-name cache already follows.
+     */
+    public function test_a_config_source_with_the_same_mtime_as_the_merged_cache_is_not_stale(): void
+    {
+        $when = time() - 60;
+        $source = $this->writeConfigSource('config/default.php', $when);
+        $this->writeMergedConfigCache($when);
+
+        self::assertSame(CheckStatus::Ok, $this->checkWithMergedConfig([$source])->run()->status);
+    }
+
+    /**
+     * A deleted source must not stop the scan: the sources after it are equally
+     * capable of being stale, and reporting only the first hides the rest.
+     */
+    public function test_a_missing_config_source_does_not_hide_the_sources_after_it(): void
+    {
+        $gone = $this->tempDir . '/config/gone.php';
+        $stale = $this->writeConfigSource('config/default.php', time());
+        $this->writeMergedConfigCache(time() - 120);
+
+        $result = $this->checkWithMergedConfig([$gone, $stale])->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            [
+                'stale: merged config ← ' . $stale,
+                'missing source: merged config ← ' . $gone,
+            ],
+            $result->details,
+        );
+    }
+
+    /**
+     * Without a merged cache on disk there is nothing to be stale against: the
+     * next bootstrap rebuilds it from the sources.
+     */
+    public function test_sources_are_not_checked_when_no_merged_cache_exists(): void
+    {
+        $this->writeConfigSource('config/default.php', time());
+
+        $result = $this->checkWithMergedConfig([$this->tempDir . '/config/default.php'])->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+    }
+
+    /**
+     * @param list<string> $sources
+     */
+    private function checkWithMergedConfig(array $sources): HealthCheck
+    {
+        return new CacheStalenessCheck(
+            $this->tempDir,
+            static fn (string $className): ?string => null,
+            '',
+            new MergedConfigCache($this->tempDir),
+            $sources,
+        );
+    }
+
+    private function writeConfigSource(string $relativePath, int $mtime): string
+    {
+        $path = $this->tempDir . '/' . $relativePath;
+        @mkdir(dirname($path), 0o777, true);
+        file_put_contents($path, '<?php return [];');
+        touch($path, $mtime);
+
+        return $path;
+    }
+
+    private function writeMergedConfigCache(int $mtime): string
+    {
+        $file = (new MergedConfigCache($this->tempDir))->filename();
+        file_put_contents($file, '<?php return [];');
+        touch($file, $mtime);
+
+        return $file;
     }
 
     private function writeSource(int $mtime): string

--- a/tests/Unit/Framework/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Framework/Config/ConfigLoaderTest.php
@@ -12,8 +12,84 @@ use Gacela\Framework\Config\PathFinderInterface;
 use Gacela\Framework\Config\PathNormalizerInterface;
 use PHPUnit\Framework\TestCase;
 
+use function is_string;
+
 final class ConfigLoaderTest extends TestCase
 {
+    private string $tempDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/gacela-config-loader-' . uniqid('', true);
+        mkdir($this->tempDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ((array) glob($this->tempDir . '/*') as $file) {
+            if (is_string($file)) {
+                @unlink($file);
+            }
+        }
+
+        @rmdir($this->tempDir);
+    }
+
+    /**
+     * `doctor` compares the merged-config cache against these, so they have to
+     * be the files `loadAll()` reads and nothing else.
+     */
+    public function test_source_files_lists_the_pattern_matches_and_the_local_override(): void
+    {
+        $default = $this->writeFile('default.php');
+        $env = $this->writeFile('default.dev.php');
+        $local = $this->writeFile('local.php');
+
+        $loader = $this->loaderFor(
+            local: $local,
+            patternMatches: [$default],
+            envPatternMatches: [$env],
+        );
+
+        self::assertSame([$default, $env, $local], $loader->sourceFiles());
+    }
+
+    /**
+     * The local override is a computed path rather than a glob match, so it is
+     * usually absent. Listing it anyway would make `doctor` report a missing
+     * source on every application that does not use one.
+     */
+    public function test_source_files_omits_a_local_override_that_does_not_exist(): void
+    {
+        $default = $this->writeFile('default.php');
+
+        $loader = $this->loaderFor(
+            local: $this->tempDir . '/local.php',
+            patternMatches: [$default],
+            envPatternMatches: [],
+        );
+
+        self::assertSame([$default], $loader->sourceFiles());
+    }
+
+    /**
+     * The local file may also match a pattern -- the case `loadAll()` guards
+     * against reading twice. Here it must appear once.
+     */
+    public function test_source_files_lists_a_local_override_matching_a_pattern_once(): void
+    {
+        $default = $this->writeFile('default.php');
+        $local = $this->writeFile('local.php');
+
+        $loader = $this->loaderFor(
+            local: $local,
+            patternMatches: [$default, $local],
+            envPatternMatches: [],
+        );
+
+        self::assertSame([$default, $local], $loader->sourceFiles());
+    }
+
     public function test_load_all_skips_local_override_from_pattern_matches(): void
     {
         $reader = new class() implements ConfigReaderInterface {
@@ -54,5 +130,38 @@ final class ConfigLoaderTest extends TestCase
         // Without exclusion, the local path would be read in pattern matching AND in
         // loadLocalConfig. The exclusion guarantees it only enters via loadLocalConfig.
         self::assertSame(1, $reader->readCalls['/project/config/local.php'] ?? 0);
+    }
+
+    /**
+     * @param list<string> $patternMatches
+     * @param list<string> $envPatternMatches
+     */
+    private function loaderFor(string $local, array $patternMatches, array $envPatternMatches): ConfigLoader
+    {
+        $normalizer = $this->createStub(PathNormalizerInterface::class);
+        $normalizer->method('normalizePathPattern')->willReturn('pattern');
+        $normalizer->method('normalizePathPatternWithEnvironment')->willReturn('pattern-env');
+        $normalizer->method('normalizePathLocal')->willReturn($local);
+
+        $pathFinder = $this->createStub(PathFinderInterface::class);
+        $pathFinder->method('matchingPattern')->willReturnMap([
+            ['pattern', $patternMatches],
+            ['pattern-env', $envPatternMatches],
+        ]);
+
+        $gacelaConfigFile = new GacelaConfigFile();
+        $gacelaConfigFile->setConfigItems([
+            new GacelaConfigItem('', '', $this->createStub(ConfigReaderInterface::class)),
+        ]);
+
+        return new ConfigLoader($gacelaConfigFile, $pathFinder, $normalizer);
+    }
+
+    private function writeFile(string $name): string
+    {
+        $path = $this->tempDir . '/' . $name;
+        file_put_contents($path, '<?php return [];');
+
+        return $path;
     }
 }


### PR DESCRIPTION
## 📚 Description

`CacheStalenessCheck` inspected the class-name and custom-service caches and nothing else, so `gacela-merged-config-*.php` was never looked at. That cache keeps serving values after a source config file changes — which is how `doctor` came to report *"all cache entries are fresh"* on a stale configuration, and it is the one cache whose staleness silently changes application behaviour.

## 🔖 Changes

- **`fix(doctor)`** — the merged cache is now compared against every file that contributes to it. The source list comes from the new `ConfigLoader::sourceFiles()`, **not** from paths the check derives itself: a second copy of the pattern logic would drift, and the check would then be answering about different files than the ones the loader reads. Base patterns, environment patterns and local overrides are covered because those are exactly what `loadAll()` walks.
- **`ref(doctor)`** — `run()` did the class-name cache inline and delegated the merged one, so two halves of the same question read as different kinds of code. Both are now `[stale, missing]` producers and `run()` is collect-then-report.

Two acceptance criteria fall out of reusing the loader's list rather than needing special handling:

- **newly added matching files** are already in `sourceFiles()` and are newer than the cache, so they report as stale on their own
- **a local override that does not exist** is not listed at all, so the majority of applications — which have none — get no false missing-source warning

## ✅ Verification

Nine new tests: stale base / environment / local sources, a fresh cache staying OK, a deleted source, no-merged-cache, plus three for `sourceFiles()` itself including the dedupe case that mirrors `loadAll()`'s existing "read the local file once" guard.

**Both mutants that escaped the first run were real bugs, not noise:**

| escaped | what it meant |
|---|---|
| `>` → `>=` | a source written in the same second as `cache:warm` — the normal outcome of warming — would report as stale |
| `continue` → `break` | one missing source would hide **every** source after it |

Both have a test now. Mutation score on the changed files: **87/87 killed, 100% MSI**. The three remaining ignores are the equivalent `(int) filemtime()` and `array_values()` shapes already ignored by name for their neighbours, with the same stated reasons.

One thing worth flagging from the refactor: extracting a method **silently invalidates** an infection `ignore` keyed on the old method name. The two `(int) filemtime` casts escaped again the moment they left `::run`, through no fault of the tests. The ignore moved with the code and the dead `::run` entry is deleted rather than left behind.

Full suite green — 1544 tests. `composer quality` clean.

Closes #617
