### PR TITLE
fix(console): discover facade subclasses and prune non-source trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 - Preserve every health check registered for a module and aggregate duplicate
   results to the worst reported level.
+- Module discovery ignored any facade that did not extend `AbstractFacade`
+  *directly*. `AllAppModulesFinder` compared the immediate parent by name, so a
+  project with its own base facade in between — `RealFacade extends
+  ProjectBaseFacade extends AbstractFacade`, a normal shape — lost every one of
+  those modules from `list:modules`, `doctor`, `debug:graph` and `cache:warm`,
+  silently. Any descendant counts now.
+- Module discovery walked directories it could never find a module in. With no
+  `appModulePaths` configured the scan starts at the project root, and `vendor`
+  was rejected only after each file had already been yielded, while `.git` was
+  not skipped at all. Excluded directories are pruned before the descent now:
+  on this repository that is 19,585 fewer files visited and 0.69s down to 0.09s.
+  The list stays deliberately narrow — hidden directories plus `vendor` and
+  `node_modules` — because guessing that a project's `build/` or `data/` holds
+  no modules is how discovery starts missing them. `data/` is a PSR-4 root in
+  this very repository.
 - `doctor` reported "all cache entries are fresh" while the merged configuration
   was stale. `CacheStalenessCheck` inspected only the class-name and
   custom-service caches and never looked at `gacela-merged-config-*.php`, which

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -8,6 +8,7 @@ use AppendIterator;
 use FilesystemIterator;
 use Gacela\Console\Domain\AllAppModules\AllAppModulesFinder;
 use Gacela\Console\Domain\AllAppModules\AppModuleCreator;
+use Gacela\Console\Domain\AllAppModules\ExcludedDirectories;
 use Gacela\Console\Domain\CommandArguments\CommandArgumentsParser;
 use Gacela\Console\Domain\CommandArguments\CommandArgumentsParserInterface;
 use Gacela\Console\Domain\FileContent\FileContentGenerator;
@@ -34,6 +35,7 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
 use OuterIterator;
+use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -225,12 +227,35 @@ final class ConsoleFactory extends AbstractFactory
     }
 
     /**
-     * @return RecursiveIteratorIterator<RecursiveDirectoryIterator>
+     * The two analysers infer different template arguments for the callback
+     * iterator -- psalm reads them off the callable's signature, phpstan's stub
+     * does not -- so no single annotation satisfies both. phpstan's view is
+     * written here and psalm is suppressed, matching how the caller above
+     * already handles the same disagreement.
+     *
+     * @psalm-suppress InvalidReturnType, InvalidReturnStatement
+     *
+     * @return RecursiveIteratorIterator<RecursiveCallbackFilterIterator<mixed, mixed, RecursiveDirectoryIterator>>
      */
     private function createRecursiveIteratorFor(string $dir): RecursiveIteratorIterator
     {
+        $excluded = new ExcludedDirectories();
+
         return new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            // Filtering recursively prunes: returning false for a directory
+            // stops the descent, instead of walking it and discarding the
+            // leaves afterwards. `$dir` itself is never offered to the filter,
+            // so an explicit appModulePaths entry pointing inside one of these
+            // still works.
+            //
+            // hasChildren() is asked of the inner iterator rather than of the
+            // current value, because a RecursiveDirectoryIterator yields plain
+            // strings under some flag combinations and only this reads the same
+            // either way.
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+                static fn (SplFileInfo|string $current, string $key, RecursiveDirectoryIterator $iterator): bool => !$iterator->hasChildren() || !$excluded->isExcluded($iterator->getFilename()),
+            ),
             RecursiveIteratorIterator::LEAVES_ONLY,
         );
     }

--- a/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
+++ b/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
@@ -109,12 +109,19 @@ final class AllAppModulesFinder
         return $dotPos !== false ? substr($filename, 0, $dotPos) : $filename;
     }
 
+    /**
+     * Any descendant counts, not only a direct child. A project that puts its
+     * own base facade in between -- `RealFacade extends ProjectBaseFacade
+     * extends AbstractFacade` -- is a normal shape, and comparing the immediate
+     * parent by name dropped every one of those modules from list, doctor,
+     * graph and cache-warm without saying so.
+     *
+     * isSubclassOf() is false for AbstractFacade itself, which is what we want:
+     * the base class is not a module.
+     */
     private function isFacade(AppModule $appModule): bool
     {
-        $rc = new ReflectionClass($appModule->facadeClass());
-        $parentClass = $rc->getParentClass();
-
-        return $parentClass !== false
-            && $parentClass->name === AbstractFacade::class;
+        return (new ReflectionClass($appModule->facadeClass()))
+            ->isSubclassOf(AbstractFacade::class);
     }
 }

--- a/src/Console/Domain/AllAppModules/ExcludedDirectories.php
+++ b/src/Console/Domain/AllAppModules/ExcludedDirectories.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\AllAppModules;
+
+use function in_array;
+
+/**
+ * Decides which directories the module scan refuses to descend into.
+ *
+ * With no `appModulePaths` configured the scan starts at the project root, so
+ * without pruning it walks everything: in this repository that is roughly
+ * 110,000 files, about 11,700 of them under `vendor`. Rejecting them after the
+ * fact still pays for the traversal.
+ *
+ * The rule is deliberately narrow. Anything hidden is skipped -- `.git`,
+ * `.idea`, `.phpunit.cache` and friends are tooling state, never PSR-4 source --
+ * plus the two dependency trees that are conventionally not source. Everything
+ * else is descended into, because guessing that a project's `build/` or `data/`
+ * holds no modules is how discovery starts silently missing them.
+ */
+final class ExcludedDirectories
+{
+    private const EXCLUDED_NAMES = ['vendor', 'node_modules'];
+
+    public function isExcluded(string $directoryName): bool
+    {
+        return str_starts_with($directoryName, '.')
+            || in_array($directoryName, self::EXCLUDED_NAMES, true);
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/CacheStalenessCheckTest.php
@@ -10,12 +10,12 @@ use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\ClassResolver\Cache\CustomServicesPhpCache;
 use Gacela\Framework\Config\MergedConfigCache;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function dirname;
 use function file_put_contents;
-use function is_string;
 use function mkdir;
 use function sys_get_temp_dir;
 use function time;
@@ -35,22 +35,7 @@ final class CacheStalenessCheckTest extends TestCase
 
     protected function tearDown(): void
     {
-        // Depth-first: the merged-config tests write into a `config/` subdir,
-        // and a non-empty directory cannot be removed.
-        foreach ((array) glob($this->tempDir . '/*/*') as $file) {
-            if (is_string($file)) {
-                @unlink($file);
-            }
-        }
-
-        foreach ((array) glob($this->tempDir . '/*') as $file) {
-            if (is_string($file)) {
-                @unlink($file);
-                @rmdir($file);
-            }
-        }
-
-        @rmdir($this->tempDir);
+        DirectoryUtil::removeDir($this->tempDir);
     }
 
     public function test_missing_cache_dir_returns_ok(): void

--- a/tests/Unit/Console/Domain/AllAppModules/AllAppModulesFinderTest.php
+++ b/tests/Unit/Console/Domain/AllAppModules/AllAppModulesFinderTest.php
@@ -75,6 +75,95 @@ final class AllAppModulesFinderTest extends TestCase
         }
     }
 
+    /**
+     * `RealFacade extends ProjectBaseFacade extends AbstractFacade` is a normal
+     * shape, and comparing the immediate parent by name dropped every module
+     * built that way from list, doctor, graph and cache-warm.
+     */
+    public function test_finds_a_facade_that_extends_abstract_facade_indirectly(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('indirectmodule');
+        $filePath = $tempDir . '/IndirectFacade.php';
+        $className = 'TempAllAppModulesIndirect\\IndirectFacade';
+
+        file_put_contents($filePath, <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempAllAppModulesIndirect;
+
+            use Gacela\Framework\AbstractFacade;
+
+            abstract class ProjectBaseFacade extends AbstractFacade
+            {
+            }
+
+            final class IndirectFacade extends ProjectBaseFacade
+            {
+            }
+            PHP);
+        require_once $filePath;
+
+        $fileInfo = $this->createStub(SplFileInfo::class);
+        $fileInfo->method('isFile')->willReturn(true);
+        $fileInfo->method('getExtension')->willReturn('php');
+        $fileInfo->method('getRealPath')->willReturn($filePath);
+        $fileInfo->method('getFilename')->willReturn('IndirectFacade.php');
+
+        $finder = new AllAppModulesFinder(
+            $this->iteratorFor($fileInfo),
+            $this->createAppModuleCreator(),
+        );
+
+        try {
+            $modules = $finder->findAllAppModules('');
+            self::assertCount(1, $modules);
+            self::assertSame($className, $modules[0]->facadeClass());
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    /**
+     * Widening to "any descendant" must not widen to "any class at all".
+     */
+    public function test_a_class_that_does_not_extend_abstract_facade_is_not_a_module(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('notafacade');
+        $filePath = $tempDir . '/PlainFacade.php';
+
+        file_put_contents($filePath, <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempAllAppModulesPlain;
+
+            final class PlainFacade
+            {
+            }
+            PHP);
+        require_once $filePath;
+
+        $fileInfo = $this->createStub(SplFileInfo::class);
+        $fileInfo->method('isFile')->willReturn(true);
+        $fileInfo->method('getExtension')->willReturn('php');
+        $fileInfo->method('getRealPath')->willReturn($filePath);
+        $fileInfo->method('getFilename')->willReturn('PlainFacade.php');
+
+        $finder = new AllAppModulesFinder(
+            $this->iteratorFor($fileInfo),
+            $this->createAppModuleCreator(),
+        );
+
+        try {
+            self::assertSame([], $finder->findAllAppModules(''));
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
     public function test_skips_dotfile_php_configs(): void
     {
         $tempDir = $this->createTempModuleDirectory('dotfile');

--- a/tests/Unit/Console/Domain/AllAppModules/ExcludedDirectoriesTest.php
+++ b/tests/Unit/Console/Domain/AllAppModules/ExcludedDirectoriesTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\AllAppModules;
+
+use Gacela\Console\Domain\AllAppModules\ExcludedDirectories;
+use PHPUnit\Framework\TestCase;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+use function dirname;
+use function file_put_contents;
+use function is_string;
+use function mkdir;
+use function sort;
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class ExcludedDirectoriesTest extends TestCase
+{
+    private string $tempDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/gacela-scan-' . uniqid('', true);
+        mkdir($this->tempDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursively($this->tempDir);
+    }
+
+    public function test_vendor_and_node_modules_are_excluded(): void
+    {
+        $excluded = new ExcludedDirectories();
+
+        self::assertTrue($excluded->isExcluded('vendor'));
+        self::assertTrue($excluded->isExcluded('node_modules'));
+    }
+
+    public function test_every_hidden_directory_is_excluded(): void
+    {
+        $excluded = new ExcludedDirectories();
+
+        self::assertTrue($excluded->isExcluded('.git'));
+        self::assertTrue($excluded->isExcluded('.idea'));
+        self::assertTrue($excluded->isExcluded('.phpunit.cache'));
+    }
+
+    /**
+     * Guessing that a project's `build/` or `data/` holds no modules is how
+     * discovery starts silently missing them.
+     */
+    public function test_ordinary_source_directories_are_allowed(): void
+    {
+        $excluded = new ExcludedDirectories();
+
+        self::assertFalse($excluded->isExcluded('src'));
+        self::assertFalse($excluded->isExcluded('build'));
+        self::assertFalse($excluded->isExcluded('data'));
+        self::assertFalse($excluded->isExcluded('vendors'));
+    }
+
+    /**
+     * The name is only consulted for something that can be descended into, so a
+     * *file* called `vendor` is still scanned.
+     */
+    public function test_a_file_named_like_an_excluded_directory_is_still_yielded(): void
+    {
+        $this->writeFile('src/Real/RealFacade.php');
+        file_put_contents($this->tempDir . '/vendor', '<?php');
+
+        $found = [];
+        foreach ($this->prunedIteratorForTempDir() as $fileInfo) {
+            $found[] = $fileInfo->getFilename();
+        }
+
+        sort($found);
+
+        self::assertSame(['RealFacade.php', 'vendor'], $found);
+    }
+
+    /**
+     * The point of pruning rather than filtering after the fact: an excluded
+     * directory is never descended into, so nothing inside it is ever yielded.
+     * A post-hoc filter would still pay for walking every one of those files.
+     */
+    public function test_nothing_inside_an_excluded_directory_is_ever_yielded(): void
+    {
+        $this->writeFile('src/Real/RealFacade.php');
+        $this->writeFile('vendor/pkg/deep/nested/VendorFacade.php');
+        $this->writeFile('node_modules/pkg/NodeFacade.php');
+        $this->writeFile('.git/objects/HiddenFacade.php');
+
+        $found = [];
+        foreach ($this->prunedIteratorForTempDir() as $fileInfo) {
+            $found[] = $fileInfo->getFilename();
+        }
+
+        sort($found);
+
+        self::assertSame(['RealFacade.php'], $found);
+    }
+
+    /**
+     * @return RecursiveIteratorIterator<RecursiveCallbackFilterIterator>
+     */
+    private function prunedIteratorForTempDir(): RecursiveIteratorIterator
+    {
+        $excluded = new ExcludedDirectories();
+
+        return new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($this->tempDir, RecursiveDirectoryIterator::SKIP_DOTS),
+                static fn (mixed $current, mixed $key, RecursiveDirectoryIterator $iterator): bool => !$iterator->hasChildren() || !$excluded->isExcluded($iterator->getFilename()),
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+    }
+
+    private function writeFile(string $relativePath): void
+    {
+        $path = $this->tempDir . '/' . $relativePath;
+        @mkdir(dirname($path), 0o777, true);
+        file_put_contents($path, '<?php');
+    }
+
+    private function removeRecursively(string $dir): void
+    {
+        foreach ((array) glob($dir . '/*') as $entry) {
+            if (!is_string($entry)) {
+                continue;
+            }
+
+            if (is_dir($entry)) {
+                $this->removeRecursively($entry);
+            } else {
+                @unlink($entry);
+            }
+        }
+
+        // glob() skips dot entries, and the fixture writes a `.git` tree.
+        foreach ((array) glob($dir . '/.*') as $entry) {
+            if (is_string($entry) && is_dir($entry) && !str_ends_with($entry, '.') && !str_ends_with($entry, '..')) {
+                $this->removeRecursively($entry);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Console/Domain/AllAppModules/ExcludedDirectoriesTest.php
+++ b/tests/Unit/Console/Domain/AllAppModules/ExcludedDirectoriesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Console\Domain\AllAppModules;
 
 use Gacela\Console\Domain\AllAppModules\ExcludedDirectories;
+use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
@@ -12,7 +13,6 @@ use RecursiveIteratorIterator;
 
 use function dirname;
 use function file_put_contents;
-use function is_string;
 use function mkdir;
 use function sort;
 use function sys_get_temp_dir;
@@ -30,7 +30,7 @@ final class ExcludedDirectoriesTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->removeRecursively($this->tempDir);
+        DirectoryUtil::removeDir($this->tempDir);
     }
 
     public function test_vendor_and_node_modules_are_excluded(): void
@@ -128,27 +128,4 @@ final class ExcludedDirectoriesTest extends TestCase
         file_put_contents($path, '<?php');
     }
 
-    private function removeRecursively(string $dir): void
-    {
-        foreach ((array) glob($dir . '/*') as $entry) {
-            if (!is_string($entry)) {
-                continue;
-            }
-
-            if (is_dir($entry)) {
-                $this->removeRecursively($entry);
-            } else {
-                @unlink($entry);
-            }
-        }
-
-        // glob() skips dot entries, and the fixture writes a `.git` tree.
-        foreach ((array) glob($dir . '/.*') as $entry) {
-            if (is_string($entry) && is_dir($entry) && !str_ends_with($entry, '.') && !str_ends_with($entry, '..')) {
-                $this->removeRecursively($entry);
-            }
-        }
-
-        @rmdir($dir);
-    }
 }


### PR DESCRIPTION
## 📚 Description

Two defects in module discovery — one silent, one slow.

**`isFacade()` accepted only a direct child of `AbstractFacade`.** It compared the immediate parent *by name*, so a project with its own base facade in between — `RealFacade extends ProjectBaseFacade extends AbstractFacade`, a normal shape — lost every one of those modules from `list:modules`, `doctor`, `debug:graph` and `cache:warm`, with nothing reporting the omission.

**The default scan walked directories it could never find a module in.** With no `appModulePaths`, the scan starts at the project root; `vendor` was rejected only *after* each file had been yielded, and `.git` was not skipped at all. The traversal was paid for either way.

## 🔖 Changes

- **`fix(console)`** — `isSubclassOf()` accepts any descendant, and is still false for `AbstractFacade` itself, which is not a module. A `RecursiveCallbackFilterIterator` prunes excluded directories before descending: returning false for a directory stops the descent.
- **`ref(test)`** — replaced hand-rolled temp-directory cleanup with the existing `DirectoryUtil::removeDir()`.

## 📊 Measured on this repository

| | leaves visited | time |
|---|---|---|
| before | 40,747 | 0.69s |
| after | 21,162 | 0.09s |

19,585 fewer files walked; **7.7× faster**.

## 🔍 Why the exclusion list is short

Hidden directories, `vendor`, `node_modules`. Nothing else — and that is a deliberate call, not laziness.

While measuring, the remaining 21,162 turned out to be dominated by `data/` (19,620 files of local infection reports). The tempting fix is to prune `data/`, `build/`, `coverage/` too. **`composer.json` maps `GacelaData\ => data/` in `autoload-dev` — `data/` is a PSR-4 root in this very repository.** A broader rule would have broken discovery in the package that shipped it, which is exactly the failure mode the first half of this issue is about.

## ✅ Verification

The pruning predicate is its own class so the behaviour can be **asserted rather than assumed**: the test builds a tree with facades under `vendor/`, `node_modules/` and `.git/` and proves none is ever yielded. A post-hoc filter would pass that same test while still walking every file — so the test uses `.git/`, which the old code had no rejection rule for at all, to isolate pruning from the pre-existing vendor check.

Two finder tests cover the inheritance change: an indirect subclass is found, and a class extending nothing still is not — widening to "any descendant" must not widen to "any class".

Mutation score on both changed classes: **54/54 killed, 100% MSI**. Full suite green — 1551 tests. `composer quality` clean.

One note for reviewers: psalm and phpstan infer different template arguments for `RecursiveCallbackFilterIterator` and no single annotation satisfies both, so phpstan's view is written and psalm suppressed — the same disagreement the calling method already handles that way.

Closes #618
