### PR TITLE
fix(testing): restore every field the container snapshot captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 - Preserve every health check registered for a module and aggregate duplicate
   results to the worst reported level.
+- `ContainerFixture::restoreContainerState()` restored a quarter of what
+  `captureContainerState()` records. The snapshot captures the resolver caches,
+  the active config values, the application root and the cache directory, and
+  restore reset Gacela and then put back only the resolver caches — leaving
+  `Config::getInstance()` throwing on a state the API had just said it restored.
+  All four are restored now. The `initialized` flag is restored with them,
+  because `get()` re-runs `init()` while it is false and would have overwritten
+  the values from disk. A snapshot taken before bootstrap still creates no
+  `Config` instance, since inventing one hands back state the caller never had.
 - Module discovery ignored any facade that did not extend `AbstractFacade`
   *directly*. `AllAppModulesFinder` compared the immediate parent by name, so a
   project with its own base facade in between — `RealFacade extends

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Testing;
 
 use FilesystemIterator;
+use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
@@ -139,6 +140,8 @@ trait ContainerFixture
                 $cache->put($cacheKey, $className);
             }
         }
+
+        $this->restoreConfigState($snapshot);
     }
 
     /**
@@ -175,6 +178,46 @@ trait ContainerFixture
         }
 
         $this->containerTempDirs = [];
+    }
+
+    /**
+     * Puts back the config values, application root and cache directory the
+     * snapshot captured. Without this, `restoreContainerState()` left
+     * `Config::getInstance()` throwing, and a snapshot advertised as
+     * restorable restored a quarter of what it recorded.
+     *
+     * A fresh `SetupGacela` is used rather than the one that was active:
+     * a setup holds closures, and this snapshot is deliberately limited to
+     * data that survives serialization. Only the captured values are put back,
+     * so no service object is constructed by restoring.
+     */
+    private function restoreConfigState(ContainerSnapshot $snapshot): void
+    {
+        $appRootDir = $snapshot->appRootDir();
+        $cacheDir = $snapshot->cacheDir();
+
+        if ($appRootDir === null && $cacheDir === null && $snapshot->config() === []) {
+            // Captured before Gacela was bootstrapped: there is no config state
+            // to restore, and creating one would invent an instance the caller
+            // never had.
+            return;
+        }
+
+        $config = Config::createWithSetup(new SetupGacela());
+
+        self::writePrivateProperty($config, 'config', $snapshot->config());
+        // init() re-reads the config files and would overwrite what was just
+        // restored, and get() runs it whenever this flag is false.
+        self::writePrivateProperty($config, 'initialized', true);
+
+        if ($appRootDir !== null) {
+            $config->setAppRootDir($appRootDir);
+            self::writeStaticProperty(Gacela::class, 'appRootDir', $appRootDir);
+        }
+
+        if ($cacheDir !== null) {
+            self::writePrivateProperty($config, 'cacheDir', $cacheDir);
+        }
     }
 
     private function registerContainerTempDirsCleanup(): void
@@ -240,5 +283,28 @@ trait ContainerFixture
         $prop = $reflection->getProperty($property);
 
         return $prop->getValue();
+    }
+
+    private static function writePrivateProperty(object $object, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($object);
+        if (!$reflection->hasProperty($property)) {
+            return;
+        }
+
+        $reflection->getProperty($property)->setValue($object, $value);
+    }
+
+    /**
+     * @param  class-string  $className
+     */
+    private static function writeStaticProperty(string $className, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionClass($className);
+        if (!$reflection->hasProperty($property)) {
+            return;
+        }
+
+        $reflection->getProperty($property)->setValue(null, $value);
     }
 }

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -12,6 +12,7 @@ use Gacela\Framework\Gacela;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
+use ReflectionProperty;
 use RuntimeException;
 use SplFileInfo;
 
@@ -260,14 +261,7 @@ trait ContainerFixture
 
     private static function readPrivateProperty(object $object, string $property): mixed
     {
-        $reflection = new ReflectionClass($object);
-        if (!$reflection->hasProperty($property)) {
-            return null;
-        }
-
-        $prop = $reflection->getProperty($property);
-
-        return $prop->getValue($object);
+        return self::propertyOf($object, $property)?->getValue($object);
     }
 
     /**
@@ -275,24 +269,12 @@ trait ContainerFixture
      */
     private static function readStaticProperty(string $className, string $property): mixed
     {
-        $reflection = new ReflectionClass($className);
-        if (!$reflection->hasProperty($property)) {
-            return null;
-        }
-
-        $prop = $reflection->getProperty($property);
-
-        return $prop->getValue();
+        return self::propertyOf($className, $property)?->getValue();
     }
 
     private static function writePrivateProperty(object $object, string $property, mixed $value): void
     {
-        $reflection = new ReflectionClass($object);
-        if (!$reflection->hasProperty($property)) {
-            return;
-        }
-
-        $reflection->getProperty($property)->setValue($object, $value);
+        self::propertyOf($object, $property)?->setValue($object, $value);
     }
 
     /**
@@ -300,11 +282,22 @@ trait ContainerFixture
      */
     private static function writeStaticProperty(string $className, string $property, mixed $value): void
     {
-        $reflection = new ReflectionClass($className);
-        if (!$reflection->hasProperty($property)) {
-            return;
-        }
+        self::propertyOf($className, $property)?->setValue(null, $value);
+    }
 
-        $reflection->getProperty($property)->setValue(null, $value);
+    /**
+     * Null rather than throwing when the property is absent: these helpers
+     * reach into framework internals, and a fixture must not break a test suite
+     * because a private field was renamed.
+     *
+     * @param  class-string|object  $target
+     */
+    private static function propertyOf(string|object $target, string $property): ?ReflectionProperty
+    {
+        $reflection = new ReflectionClass($target);
+
+        return $reflection->hasProperty($property)
+            ? $reflection->getProperty($property)
+            : null;
     }
 }

--- a/tests/Unit/Framework/Testing/ContainerFixtureTest.php
+++ b/tests/Unit/Framework/Testing/ContainerFixtureTest.php
@@ -21,6 +21,7 @@ use ReflectionClass;
 
 use stdClass;
 
+use function dirname;
 use function sprintf;
 
 final class ContainerFixtureTest extends TestCase
@@ -190,6 +191,134 @@ final class ContainerFixtureTest extends TestCase
 
         self::assertSame(__DIR__, $snapshot->appRootDir());
         self::assertSame($cacheDir, $snapshot->cacheDir());
+    }
+
+    /**
+     * The snapshot records config values, app root and cache dir, and restore
+     * used to drop all three -- leaving Config::getInstance() throwing on a
+     * state the API says it just restored.
+     */
+    public function test_restore_container_state_reinstates_config_values(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfigKeyValue('restored-key', 'restored-value');
+        });
+        $snapshot = $this->captureContainerState();
+
+        $this->resetContainer();
+
+        $this->restoreContainerState($snapshot);
+
+        self::assertSame('restored-value', Config::getInstance()->get('restored-key'));
+    }
+
+    public function test_restore_container_state_reinstates_the_app_root_and_cache_dir(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+        $cacheDir = Config::getInstance()->getCacheDir();
+        $snapshot = $this->captureContainerState();
+
+        $this->resetContainer();
+
+        $this->restoreContainerState($snapshot);
+
+        self::assertSame(__DIR__, Gacela::rootDir());
+        self::assertSame(__DIR__, Config::getInstance()->getAppRootDir());
+        self::assertSame($cacheDir, Config::getInstance()->getCacheDir());
+    }
+
+    /**
+     * The case the fixture exists for: swap state out, bootstrap something
+     * else, then put the original back. Restoring has to win over whatever the
+     * second bootstrap left behind.
+     */
+    public function test_restore_container_state_wins_over_a_different_bootstrap(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfigKeyValue('which', 'first');
+        });
+        $snapshot = $this->captureContainerState();
+
+        Gacela::bootstrap(dirname(__DIR__), static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addAppConfigKeyValue('which', 'second');
+        });
+        self::assertSame('second', Config::getInstance()->get('which'));
+
+        $this->restoreContainerState($snapshot);
+
+        self::assertSame('first', Config::getInstance()->get('which'));
+        self::assertSame(__DIR__, Gacela::rootDir());
+    }
+
+    /**
+     * The cache dir has to be restored explicitly, not merely recomputed.
+     * `getCacheDir()` derives a default from the *setup*, and restore builds a
+     * fresh `SetupGacela` -- so a non-default directory is only preserved if
+     * the captured value is actually written back.
+     */
+    public function test_restore_container_state_reinstates_a_non_default_cache_dir(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(true, 'custom-cache-dir');
+        });
+
+        // Materialise it, so the snapshot captures a value rather than null.
+        $cacheDir = Config::getInstance()->getCacheDir();
+        // A fresh SetupGacela, which is what restore builds, would compute this
+        // instead -- so the assertion below can only pass if the captured value
+        // was written back rather than recomputed.
+        self::assertNotSame(sys_get_temp_dir(), $cacheDir);
+
+        $snapshot = $this->captureContainerState();
+        $this->resetContainer();
+
+        $this->restoreContainerState($snapshot);
+
+        self::assertSame($cacheDir, Config::getInstance()->getCacheDir());
+    }
+
+    /**
+     * Only the app root was ever established: no config values were read and
+     * the cache dir was never materialised. There is still state worth
+     * restoring, so the "nothing captured" shortcut must not trigger.
+     */
+    public function test_restore_container_state_reinstates_an_app_root_captured_on_its_own(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $snapshot = $this->captureContainerState();
+        self::assertSame(__DIR__, $snapshot->appRootDir());
+        self::assertNull($snapshot->cacheDir());
+        self::assertSame([], $snapshot->config());
+
+        $this->resetContainer();
+        $this->restoreContainerState($snapshot);
+
+        // Asserted through Config rather than Gacela::rootDir(): resetCache()
+        // drops the Config instance but leaves Gacela's own static app root
+        // standing, so rootDir() answers the same with or without a restore.
+        self::assertSame(__DIR__, Config::getInstance()->getAppRootDir());
+    }
+
+    /**
+     * A snapshot taken before bootstrap has nothing to restore, and inventing a
+     * Config instance would hand the caller state they never had.
+     */
+    public function test_restore_container_state_without_captured_config_creates_no_instance(): void
+    {
+        $snapshot = $this->captureContainerState();
+
+        $this->restoreContainerState($snapshot);
+
+        self::assertNull(self::readStaticProperty(Config::class, 'instance'));
     }
 
     public function test_restore_container_state_reinstates_in_memory_cache(): void

--- a/tests/Unit/Framework/Testing/ContainerFixtureTest.php
+++ b/tests/Unit/Framework/Testing/ContainerFixtureTest.php
@@ -321,6 +321,24 @@ final class ContainerFixtureTest extends TestCase
         self::assertNull(self::readStaticProperty(Config::class, 'instance'));
     }
 
+    /**
+     * The reflection helpers reach into framework internals, so a private field
+     * that gets renamed has to degrade to a no-op rather than take a whole test
+     * suite down with an Error.
+     */
+    public function test_the_reflection_helpers_tolerate_a_property_that_does_not_exist(): void
+    {
+        $object = new stdClass();
+
+        self::assertNull(self::readPrivateProperty($object, 'nothingHere'));
+        self::assertNull(self::readStaticProperty(Config::class, 'nothingHere'));
+
+        self::writePrivateProperty($object, 'nothingHere', 'value');
+        self::writeStaticProperty(Config::class, 'nothingHere', 'value');
+
+        self::assertFalse(property_exists($object, 'nothingHere'));
+    }
+
     public function test_restore_container_state_reinstates_in_memory_cache(): void
     {
         (new InMemoryCache('to-restore'))->put('Foo', 'Bar');


### PR DESCRIPTION
## 📚 Description

`captureContainerState()` records four things — the resolver caches, the active config values, the application root and the cache directory. `restoreContainerState()` reset Gacela and then put back **only the resolver caches**, so `Config::getInstance()` threw on a state the API had just said it restored.

Took the "restore everything" branch of the issue rather than narrowing the API, since the acceptance criteria ask for the captured values to be readable after restore.

## 🔖 Changes

- **`fix(testing)`** — all four captured fields are restored. A fresh `SetupGacela` is used rather than the one that was active: a setup holds closures and this snapshot is deliberately limited to serializable data, so only captured values are put back and **no service object is constructed by restoring**. A snapshot taken before bootstrap still creates no `Config` instance — inventing one hands back state the caller never had.
- **`ref(testing)`** — `propertyOf()` replaces the "reflect, bail if absent, fetch" preamble that four reflection helpers each carried.
- **`test(testing)`** — covers the missing-property path those helpers promise.

## 🔍 The part that is easy to miss

`Config::get()` re-runs `init()` while `initialized` is false. Restoring the config array **without that flag** would have it silently overwritten from disk on the first read — the values would be back for exactly as long as nobody looked at them. The flag is restored with them.

## ✅ Verification

I wrote the fix before the tests, so I checked the tests were not vacuous by disabling `restoreConfigState()` and re-running: **3 errors, all `"You have to call createWithSetup() first"`**.

**Two tests were weak until mutation testing said so, both for the same reason — they asserted through something that survives a reset:**

| weak assertion | why it proved nothing |
|---|---|
| `getCacheDir()` matches the snapshot | it derives a default from the setup, and the app root is restored too, so a default-valued cache dir reads the same whether or not it was written back. The test configures a non-default one now. |
| `Gacela::rootDir()` matches the snapshot | `resetCache()` calls `Config::resetInstance()` but **never clears `Gacela::$appRootDir`** — so `rootDir()` answers identically with or without a restore. The assertion goes through `Config` now. |

That second one is worth knowing beyond this PR: `Gacela::rootDir()` is not a reliable signal that a reset happened.

Mutation score on `ContainerFixture`: **58/58 killed, 100% MSI**. Full suite green — 1557 tests, verified on two random seeds. `composer quality` clean.

Closes #619
