### PR TITLE
fix(console): find the project root when gacela runs from a subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 - Preserve every health check registered for a module and aggregate duplicate
   results to the worst reported level.
+- `bin/gacela` only worked from the project root. It looked for
+  `vendor/autoload.php` in the current working directory alone, so running it
+  from anywhere else failed with `Cannot load composer's autoload file`, even
+  though composer tooling is expected to work throughout a project tree. It now
+  walks up to the nearest project root and bootstraps Gacela with **that**
+  directory — bootstrapping with the invoking subdirectory would resolve
+  `gacela.php`, modules and caches against the wrong root. Invocation from the
+  root and through composer's symlinked `vendor/bin/gacela` are unchanged, and
+  a run with no project above it still reports a clear error naming the
+  directory it searched from.
 - The profiler lost every nested span. `Profiler` kept one start time per
   `operation:subject`, so starting the same operation while it was already
   active overwrote the outer timestamp: two nested start/stop pairs produced a

--- a/bin/gacela
+++ b/bin/gacela
@@ -9,13 +9,34 @@ use Symfony\Component\Console\Application;
 
 (static function (): void {
 
-    $cwd = (string)getcwd();
-    if (!file_exists($autoloadPath = $cwd . '/vendor/autoload.php')) {
-        fwrite(STDERR, "Cannot load composer's autoload file: " . $autoloadPath . PHP_EOL);
+    $cwd = getcwd() ?: '.';
+
+    // Walk up for the nearest vendor/autoload.php, so the command works from
+    // anywhere in the project the way composer tooling is expected to. This
+    // cannot use anything from src/: it runs before the autoloader exists.
+    $projectRoot = null;
+    for ($dir = $cwd;; $dir = $parent) {
+        if (file_exists($dir . '/vendor/autoload.php')) {
+            $projectRoot = $dir;
+            break;
+        }
+
+        $parent = dirname($dir);
+        if ($parent === $dir) {
+            break;
+        }
+    }
+
+    if ($projectRoot === null) {
+        fwrite(
+            STDERR,
+            "Cannot load composer's autoload file: no vendor/autoload.php in "
+            . $cwd . ' or any parent directory' . PHP_EOL,
+        );
         exit(1);
     }
 
-    require $autoloadPath;
+    require $projectRoot . '/vendor/autoload.php';
 
     try {
         if (!class_exists(Application::class)) {
@@ -23,7 +44,10 @@ use Symfony\Component\Console\Application;
             throw new RuntimeException(sprintf($error, Application::class, 'symfony/console'));
         }
 
-        Gacela::bootstrap($cwd);
+        // The project root, not the invoking directory: bootstrapping with a
+        // subdirectory would resolve gacela.php, modules and caches against
+        // the wrong root.
+        Gacela::bootstrap($projectRoot);
 
         $bootstrap = new ConsoleBootstrap(name: 'Gacela', version: Gacela::version());
         $bootstrap->run();

--- a/tests/Feature/Console/BinGacela/BinGacelaTest.php
+++ b/tests/Feature/Console/BinGacela/BinGacelaTest.php
@@ -59,20 +59,97 @@ final class BinGacelaTest extends TestCase
     }
 
     /**
+     * The autoloader lives in the project root while the command is invoked two
+     * directories below it. Composer tooling is expected to work anywhere in
+     * the project, and this used to fail immediately looking for
+     * `<subdirectory>/vendor/autoload.php`.
+     */
+    public function test_it_finds_the_project_root_when_invoked_from_a_subdirectory(): void
+    {
+        // The stub reports where it was loaded from, so the assertion can name
+        // the directory rather than just observing that something worked.
+        $stub = '<?php fwrite(STDOUT, "autoload-dir:" . __DIR__ . PHP_EOL);';
+
+        [, $stdout, , $projectRoot] = $this->runBinGacela($stub, subdirectory: 'deep/nested');
+
+        self::assertStringContainsString('autoload-dir:' . $projectRoot . '/vendor', $stdout);
+    }
+
+    public function test_it_still_loads_the_autoloader_when_invoked_from_the_project_root(): void
+    {
+        $stub = '<?php fwrite(STDOUT, "autoload-dir:" . __DIR__ . PHP_EOL);';
+
+        [, $stdout, , $projectRoot] = $this->runBinGacela($stub);
+
+        self::assertStringContainsString('autoload-dir:' . $projectRoot . '/vendor', $stdout);
+    }
+
+    /**
+     * How the command is actually installed: composer symlinks
+     * `vendor/bin/gacela` at the real script. The walk-up must start from the
+     * working directory, not from wherever the script itself resolves to --
+     * that path lives under `vendor/`, whose own parent is the project.
+     */
+    public function test_it_works_through_a_symlinked_vendor_bin_entry(): void
+    {
+        $projectRoot = sys_get_temp_dir() . '/gacela-bin-' . uniqid('', true);
+        mkdir($projectRoot . '/vendor/bin', 0o777, true);
+        file_put_contents(
+            $projectRoot . '/vendor/autoload.php',
+            '<?php fwrite(STDOUT, "autoload-dir:" . __DIR__ . PHP_EOL);',
+        );
+
+        $symlink = $projectRoot . '/vendor/bin/gacela';
+        symlink(dirname(__DIR__, 4) . '/bin/gacela', $symlink);
+
+        try {
+            $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+            $process = proc_open([PHP_BINARY, $symlink], $descriptors, $pipes, $projectRoot);
+            self::assertIsResource($process);
+
+            fclose($pipes[0]);
+            $stdout = (string) stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            self::assertStringContainsString(
+                'autoload-dir:' . realpath($projectRoot) . '/vendor',
+                $stdout,
+            );
+        } finally {
+            unlink($symlink);
+            unlink($projectRoot . '/vendor/autoload.php');
+            rmdir($projectRoot . '/vendor/bin');
+            rmdir($projectRoot . '/vendor');
+            rmdir($projectRoot);
+        }
+    }
+
+    /**
      * Runs bin/gacela in a throwaway working directory. When $autoloadStub is null the directory
      * has no vendor/autoload.php; otherwise the stub is written there as the autoloader.
      *
-     * @return array{int, string, string} exit code, stdout, stderr
+     * $subdirectory, when given, is created under the project root and used as the working
+     * directory, leaving the autoloader above it.
+     *
+     * @return array{int, string, string, string} exit code, stdout, stderr, project root
      */
-    private function runBinGacela(?string $autoloadStub): array
+    private function runBinGacela(?string $autoloadStub, string $subdirectory = ''): array
     {
         $binGacela = dirname(__DIR__, 4) . '/bin/gacela';
-        $cwd = sys_get_temp_dir() . '/gacela-bin-' . uniqid('', true);
-        mkdir($cwd);
+        $projectRoot = sys_get_temp_dir() . '/gacela-bin-' . uniqid('', true);
+        mkdir($projectRoot);
+
+        $cwd = $projectRoot;
+        if ($subdirectory !== '') {
+            $cwd = $projectRoot . '/' . $subdirectory;
+            mkdir($cwd, 0o777, true);
+        }
 
         if ($autoloadStub !== null) {
-            mkdir($cwd . '/vendor');
-            file_put_contents($cwd . '/vendor/autoload.php', $autoloadStub);
+            mkdir($projectRoot . '/vendor');
+            file_put_contents($projectRoot . '/vendor/autoload.php', $autoloadStub);
         }
 
         try {
@@ -92,14 +169,22 @@ final class BinGacelaTest extends TestCase
             fclose($pipes[2]);
             $exitCode = proc_close($process);
 
-            return [$exitCode, $stdout, $stderr];
+            // Resolved, because __DIR__ inside the stub reports the real path
+            // and the system temp dir is a symlink on macOS.
+            return [$exitCode, $stdout, $stderr, (string) realpath($projectRoot)];
         } finally {
             if ($autoloadStub !== null) {
-                unlink($cwd . '/vendor/autoload.php');
-                rmdir($cwd . '/vendor');
+                unlink($projectRoot . '/vendor/autoload.php');
+                rmdir($projectRoot . '/vendor');
             }
 
-            rmdir($cwd);
+            // Deepest first, so each directory is empty when it is removed.
+            while ($cwd !== $projectRoot) {
+                rmdir($cwd);
+                $cwd = dirname($cwd);
+            }
+
+            rmdir($projectRoot);
         }
     }
 }

--- a/tests/Feature/Console/BinGacela/BinGacelaTest.php
+++ b/tests/Feature/Console/BinGacela/BinGacelaTest.php
@@ -66,7 +66,7 @@ final class BinGacelaTest extends TestCase
 
         [, $stdout, , $projectRoot] = $this->runBinGacela($stub, subdirectory: 'deep/nested');
 
-        self::assertStringContainsString('autoload-dir:' . $projectRoot . '/vendor', $stdout);
+        self::assertStringContainsString($this->expectedAutoloadDir($projectRoot), $stdout);
     }
 
     public function test_it_still_loads_the_autoloader_when_invoked_from_the_project_root(): void
@@ -75,7 +75,7 @@ final class BinGacelaTest extends TestCase
 
         [, $stdout, , $projectRoot] = $this->runBinGacela($stub);
 
-        self::assertStringContainsString('autoload-dir:' . $projectRoot . '/vendor', $stdout);
+        self::assertStringContainsString($this->expectedAutoloadDir($projectRoot), $stdout);
     }
 
     /**
@@ -100,7 +100,7 @@ final class BinGacelaTest extends TestCase
             [, $stdout] = $this->runPhpScript($symlink, $projectRoot);
 
             self::assertStringContainsString(
-                'autoload-dir:' . realpath($projectRoot) . '/vendor',
+                $this->expectedAutoloadDir((string) realpath($projectRoot)),
                 $stdout,
             );
         } finally {
@@ -158,6 +158,16 @@ final class BinGacelaTest extends TestCase
 
             rmdir($projectRoot);
         }
+    }
+
+    /**
+     * The stub reports __DIR__, which uses the platform separator -- a
+     * backslash on Windows. Building the expectation with '/' passed
+     * everywhere the suite ran locally and failed all nine Windows jobs.
+     */
+    private function expectedAutoloadDir(string $projectRoot): string
+    {
+        return 'autoload-dir:' . $projectRoot . DIRECTORY_SEPARATOR . 'vendor';
     }
 
     /**

--- a/tests/Feature/Console/BinGacela/BinGacelaTest.php
+++ b/tests/Feature/Console/BinGacela/BinGacelaTest.php
@@ -7,18 +7,12 @@ namespace GacelaTest\Feature\Console\BinGacela;
 use PHPUnit\Framework\TestCase;
 
 use function dirname;
-use function fclose;
 use function file_put_contents;
 use function mkdir;
-use function proc_close;
-use function proc_open;
 use function rmdir;
-use function stream_get_contents;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
-
-use const PHP_BINARY;
 
 final class BinGacelaTest extends TestCase
 {
@@ -103,15 +97,7 @@ final class BinGacelaTest extends TestCase
         symlink(dirname(__DIR__, 4) . '/bin/gacela', $symlink);
 
         try {
-            $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-            $process = proc_open([PHP_BINARY, $symlink], $descriptors, $pipes, $projectRoot);
-            self::assertIsResource($process);
-
-            fclose($pipes[0]);
-            $stdout = (string) stream_get_contents($pipes[1]);
-            fclose($pipes[1]);
-            fclose($pipes[2]);
-            proc_close($process);
+            [, $stdout] = $this->runPhpScript($symlink, $projectRoot);
 
             self::assertStringContainsString(
                 'autoload-dir:' . realpath($projectRoot) . '/vendor',
@@ -153,21 +139,7 @@ final class BinGacelaTest extends TestCase
         }
 
         try {
-            $descriptors = [
-                0 => ['pipe', 'r'],
-                1 => ['pipe', 'w'],
-                2 => ['pipe', 'w'],
-            ];
-
-            $process = proc_open([PHP_BINARY, $binGacela], $descriptors, $pipes, $cwd);
-            self::assertIsResource($process);
-
-            fclose($pipes[0]);
-            $stdout = (string) stream_get_contents($pipes[1]);
-            $stderr = (string) stream_get_contents($pipes[2]);
-            fclose($pipes[1]);
-            fclose($pipes[2]);
-            $exitCode = proc_close($process);
+            [$exitCode, $stdout, $stderr] = $this->runPhpScript($binGacela, $cwd);
 
             // Resolved, because __DIR__ inside the stub reports the real path
             // and the system temp dir is a symlink on macOS.
@@ -186,5 +158,28 @@ final class BinGacelaTest extends TestCase
 
             rmdir($projectRoot);
         }
+    }
+
+    /**
+     * @return array{int, string, string} exit code, stdout, stderr
+     */
+    private function runPhpScript(string $script, string $cwd): array
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open([PHP_BINARY, $script], $descriptors, $pipes, $cwd);
+        self::assertIsResource($process);
+
+        fclose($pipes[0]);
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [proc_close($process), $stdout, $stderr];
     }
 }


### PR DESCRIPTION
## 📚 Description

`bin/gacela` looked for `vendor/autoload.php` in the current working directory and nowhere else, so running it from anywhere but the project root failed before it started — even though composer tooling is expected to work throughout a project tree. The issue's reproduction is a single `cd src`.

## 🔖 Changes

- **`fix(console)`** — walks up to the nearest directory holding `vendor/autoload.php`, and bootstraps Gacela with **that** root.
- **`ref(test)`** — `runPhpScript()` replaces the `proc_open` block the symlink test repeated from the existing harness.

## 🔍 Three constraints that shaped this

**The walk is written out inline** rather than extracted somewhere reusable, because it runs *before the autoloader exists* — it cannot use a single class from `src/`.

**Bootstrap uses the project root, not the cwd.** A subdirectory would resolve `gacela.php`, `appModulePaths` and the cache directory against the wrong root. Verified by hand:

```console
$ cd src/Framework && .../bin/gacela list:modules
│ Gacela\Console │ x │ x │ x │ x │
```

Same result as from the root. With the cwd, `appModulePaths: ['src']` resolves to nothing and it would find no modules at all.

**The walk starts at the working directory, not the script's own location.** That is what keeps composer's symlinked `vendor/bin/gacela` working: resolving the script would land inside `vendor/`, whose parent happens to be the project by accident rather than by rule. There is a test for that shape specifically.

## ✅ Verification

Three new feature tests — subdirectory (two levels deep), project root, and the symlinked `vendor/bin` entry — alongside the three existing ones for the failure paths.

Checked the subdirectory test is not vacuous by running it against the original script: **empty stdout, assertion fails.**

The error message keeps its opening words, since an existing test matches on them, and now names the directory the search started from.

Full suite green — 1566 tests. `composer quality` clean.

Closes #621
