### PR TITLE
fix(graph): normalize leading separators and match import keywords case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
   module. Each import is resolved by walking its own namespace segments against
   an index of module names — measured at 500 modules × 2000 imports, **20.3ms →
   0.5ms**, with identical results. Ordering and deduplication are unchanged.
+- The module graph dropped imports written with a leading separator.
+  `use \App\Billing\Invoice;` is legal PHP and names the same class, but the
+  separator was kept and no module namespace carries one, so the lookup missed
+  and the edge silently disappeared. The separator is stripped now.
+- `use FUNCTION` and `use Const` were read as class imports. PHP keywords are
+  case-insensitive and accept any whitespace after them, while the check
+  required lowercase and exactly one space. Outside a group this only produced
+  a name that matched nothing; inside a group it leaked a false edge onto the
+  group prefix. A class named `Functional` is still a class.
 - **`#[Cacheable(ttl: 0)]` cached nothing.** The two built-in caches disagreed
   about zero: `FileCache` documents and implements it as "no expiry" — its own
   default TTL is `0` — while `InMemoryCacheStorage`, the default backend for

--- a/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
+++ b/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
@@ -65,11 +65,9 @@ final class ModuleGraphBuilder
             }
         }
 
-        // sort() discards keys and reindexes; array_values() first would be a no-op.
-        $list = $dependencies;
-        sort($list);
+        sort($dependencies);
 
-        return $list;
+        return $dependencies;
     }
 
     /**

--- a/src/Console/Domain/ModuleGraph/PhpImportParser.php
+++ b/src/Console/Domain/ModuleGraph/PhpImportParser.php
@@ -9,7 +9,6 @@ use function explode;
 use function is_array;
 use function preg_match;
 use function preg_split;
-use function str_starts_with;
 use function token_get_all;
 use function trim;
 
@@ -22,11 +21,6 @@ use function trim;
  * correct it. Everything after that is text handling, because the body of a use
  * statement is a comma-separated list with an optional `prefix{...}` group and
  * optional `as` aliases -- and nothing else.
- *
- * The previous `/^use\s+([A-Za-z0-9_\\\\]+)/m` stopped at the first character
- * outside a name, so `use App\{Billing\Invoice, Orders\Order};` came back as
- * the bare prefix and produced no edge at all, and a group split across lines
- * was invisible.
  */
 final class PhpImportParser
 {
@@ -39,7 +33,9 @@ final class PhpImportParser
 
         foreach ($this->topLevelUseStatements($phpSource) as $statement) {
             foreach ($this->namesIn($statement) as $name) {
-                $imports[] = $name;
+                // `use \App\Billing\Invoice;` is legal and means the same import;
+                // the leading separator is not part of the name modules match on.
+                $imports[] = ltrim($name, '\\');
             }
         }
 
@@ -135,9 +131,14 @@ final class PhpImportParser
         return $names;
     }
 
+    /**
+     * The keywords are case-insensitive and any whitespace may follow them, so
+     * `use FUNCTION App\helper;` is the same statement as the lowercase form.
+     * Requiring the whitespace keeps a class named `Functional` a class.
+     */
     private function isNonClassImport(string $entry): bool
     {
-        return str_starts_with($entry, 'function ') || str_starts_with($entry, 'const ');
+        return preg_match('/^(?:function|const)\s/i', $entry) === 1;
     }
 
     /**

--- a/tests/Unit/Console/Domain/ModuleGraph/PhpImportParserTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/PhpImportParserTest.php
@@ -166,9 +166,60 @@ final class PhpImportParserTest extends TestCase
         self::assertSame(['App\Billing\Invoice', 'App\Orders\Order'], $this->parse($source));
     }
 
-    public function test_a_leading_separator_is_kept_verbatim(): void
+    /**
+     * A leading separator is legal and means the same import. Keeping it would
+     * make the name miss every module, because module names carry no separator.
+     */
+    public function test_a_leading_separator_is_dropped(): void
     {
-        self::assertSame(['App\Billing\Invoice'], $this->parse('<?php use App\Billing\Invoice;'));
+        self::assertSame(['App\Billing\Invoice'], $this->parse('<?php use \App\Billing\Invoice;'));
+    }
+
+    public function test_a_leading_separator_is_dropped_on_a_group_prefix(): void
+    {
+        self::assertSame(
+            ['App\Billing\Invoice', 'App\Orders\Order'],
+            $this->parse('<?php use \App\{Billing\Invoice, Orders\Order};'),
+        );
+    }
+
+    /**
+     * PHP keywords are case-insensitive, so the uppercase form is the same
+     * statement. Reading it as a class name leaks an edge from the group prefix.
+     */
+    public function test_an_uppercase_function_import_is_not_a_class_import(): void
+    {
+        self::assertSame([], $this->parse('<?php use FUNCTION App\Billing\calculate;'));
+    }
+
+    public function test_a_mixed_case_const_import_is_not_a_class_import(): void
+    {
+        self::assertSame([], $this->parse('<?php use Const App\Billing\RATE;'));
+    }
+
+    public function test_an_uppercase_function_entry_in_a_group_is_skipped(): void
+    {
+        self::assertSame(
+            ['App\Orders\Order'],
+            $this->parse('<?php use App\{FUNCTION Billing\total, Orders\Order};'),
+        );
+    }
+
+    /**
+     * The keyword may be followed by any whitespace, not only a single space.
+     */
+    public function test_a_function_import_split_after_the_keyword_is_skipped(): void
+    {
+        self::assertSame([], $this->parse("<?php use function\n    App\Billing\calculate;"));
+    }
+
+    /**
+     * The name starts with the keyword text, so only the required whitespace
+     * keeps this a class import rather than a skipped function import.
+     */
+    public function test_a_namespace_whose_name_starts_with_a_keyword_is_an_import(): void
+    {
+        self::assertSame(['Functional\Billing\Invoice'], $this->parse('<?php use Functional\Billing\Invoice;'));
     }
 
     public function test_a_file_with_no_imports(): void


### PR DESCRIPTION
## 📚 Description

Follow-up to #635. Two import forms the new parser still read wrong, both legal PHP, both found while reviewing the merged code.

**A leading separator lost the edge.** `use \App\Billing\Invoice;` is legal and names the same class, but the name was kept verbatim. Module names carry no leading separator, so the lookup walked `\App\Billing`, then `\App`, and matched nothing. The dependency disappeared without a trace.

**The keyword check was too strict.** PHP keywords are case-insensitive and accept any whitespace after them. The check required lowercase and exactly one space, so `use FUNCTION App\Billing\calculate;` came back as the class name `FUNCTION App\Billing\calculate`.

Outside a group that name matched nothing, so it was invisible. Inside a group it was not:

```php
use App\{FUNCTION Billing\total, Orders\Order};
```

yields `App\FUNCTION Billing\helper`, whose segments walk up to `App`. If `App` is a module, that is a **false edge** from a function import, against the acceptance criterion in #623.

## 🔖 Changes

- **`fix(graph)`** — imports drop a leading separator, so `use \App\Billing\Invoice;` resolves like the unprefixed form.
- **`fix(graph)`** — the `function` / `const` check is case-insensitive and accepts any whitespace. The whitespace is still required, so a namespace called `Functional` stays a class.
- **`ref(graph)`** — `dependenciesOf()` sorts its own array instead of copying it first.
- **`ref(graph)`** — dropped the docblock paragraph quoting the old regex. It described code that no longer exists and would drift.

## 🧪 Verification

Before the fix, against the merged parser:

| source | parsed as |
|---|---|
| `use FUNCTION App\Billing\helper;` | `FUNCTION App\Billing\helper` |
| `use Const App\Billing\LIMIT;` | `Const App\Billing\LIMIT` |
| `use function\n    App\Billing\helper;` | `function\n    App\Billing\helper` |
| `use App\{FUNCTION Billing\helper, Orders\Order};` | `App\FUNCTION Billing\helper`, `App\Orders\Order` |
| `use \App\Billing\Invoice;` | `\App\Billing\Invoice` |

All five return the correct result now, each covered by a test.

One existing test was replaced rather than added to. `test_a_leading_separator_is_kept_verbatim` asserted behavior its input never produced: the source had no leading separator, so it was a duplicate of `test_a_simple_import` under a name describing something else. It now uses a leading separator, and asserts the separator is dropped.

Full suite green: 1593 tests across unit, integration and feature. `php-cs-fixer`, `psalm`, `phpstan` and `phpstan-tests` all clean.

Related to #623
