### PR TITLE
docs(changelog): merge the entries describing one user-visible change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Preserve duplicate module health checks and aggregate them to the worst reported level
+- Inherit app-wide resolution hooks in module scopes, for `get()`, `getOrFail()` and `make()`
+- Exit non-zero from `cache:warm` when a warmup fails, so a broken deploy is not reported green
+- Validate config without constructing services, so `validate:config` has no side effects
 - Parse graph imports with the tokenizer: grouped, multiline, aliased and `\`-prefixed all resolve
 - Ignore `use function` and `use const` in the graph, whatever their case
 - Resolve graph imports through a name index instead of comparing every import to every module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,12 @@
 ## Unreleased
 
 - Preserve duplicate module health checks and aggregate them to the worst reported level
-- Parse module graph imports with the tokenizer, so grouped, multiline and aliased forms resolve
+- Parse graph imports with the tokenizer: grouped, multiline, aliased and `\`-prefixed all resolve
+- Ignore `use function` and `use const` in the graph, whatever their case
 - Resolve graph imports through a name index instead of comparing every import to every module
-- Strip a leading separator from graph imports, so `use \App\Foo;` still matches its module
-- Match `use function` and `use const` case-insensitively, and only as whole keywords
 - Treat `ttl: 0` as no expiry in `InMemoryCacheStorage`, matching `FileCache`
 - Let `bin/gacela` run from any subdirectory, bootstrapping with the project root
-- Record nested and recursive profiler spans instead of overwriting the outer start time
-- Drop in-flight profiler spans on `disable()`, so a later `enable()` cannot report a stale one
+- Record nested and recursive profiler spans, and drop in-flight ones on `disable()`
 - Restore config values, app root and cache dir in `ContainerFixture::restoreContainerState()`
 - Discover facades that extend `AbstractFacade` indirectly, not only direct children
 - Prune `vendor`, `node_modules` and hidden directories before descending in module discovery


### PR DESCRIPTION
Four bullets about the module graph and two about the profiler read as more changes than a reader experiences. The three graph-parsing ones were one fix in three parts — tokenizer rewrite, leading separator, keyword casing — and both profiler ones are the same span bookkeeping.

**14 entries → 12**, each still one line and under 98 characters, each mapping to one thing a user would notice.

No source changes.