### PR TITLE
feat: type getProvidedDependency() by class-string under Psalm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Type `getProvidedDependency(Foo::class)` under Psalm too, matching the PHPStan extension
+
 ### Changed
 
 - Resolve graph imports through a name index instead of comparing every import to every module

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -64,6 +64,8 @@ A string key (`$this->getProvidedDependency('some.service')`) still returns
 `mixed`. Nothing in the type system says what it resolves to, and inventing a
 type there would be worse than `mixed` — a guess the analyser then trusts.
 
+The Psalm plugin does the same; see [Psalm](#psalm) below.
+
 A Factory may also declare its dependencies in its **constructor**; pillars are
 resolved through the container, so autowiring applies to the Factory itself:
 
@@ -238,6 +240,21 @@ PHPStan extension in `phpstan-gacela.neon`.
 
 The plugin cannot be delivered through the XInclude above: XInclude replaces a
 single element, and `<plugins>` lives elsewhere in your config.
+
+### Typed provided dependencies
+
+The same `<plugins>` block also types `getProvidedDependency()` when the key is a
+class-string, so the `@var` above every call site can go:
+
+```php
+// Psalm knows this is a Clock, and checks the call on it.
+$clock = $this->getProvidedDependency(Clock::class);
+```
+
+A string key (`'some.service'`) still returns `mixed`, exactly as under PHPStan.
+Nothing in the type system says what it resolves to, and a guess would be worse
+than `mixed`: `mixed` is honestly unknown, a guess is confidently wrong and then
+trusted.
 
 
 ## Troubleshooting

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -31,6 +31,18 @@ parameters:
         -
             identifier: parameter.internalClass
             path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php
+        # Same reason for the return-type handler, which registers against the
+        # codebase rather than the dispatcher: Methods and MethodReturnTypeProvider
+        # are both internal, and has() is the only way to observe the registration.
+        -
+            identifier: property.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php
+        -
+            identifier: return.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php
+        -
+            identifier: classConstant.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php
         # ProvidesScanner's memo is a private static with no public accessor, and
         # reading it is the only way to observe that a repeated scan is skipped.
         -

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -24,7 +24,9 @@ final class Plugin implements PluginEntryPointInterface
         // Psalm checks class_exists($handler, false) -- autoloading disabled --
         // so the handler has to be loaded before it can be registered.
         require_once __DIR__ . '/ServiceMapPseudoMethods.php';
+        require_once __DIR__ . '/ProvidedDependencyReturnType.php';
 
         $registration->registerHooksFromClass(ServiceMapPseudoMethods::class);
+        $registration->registerHooksFromClass(ProvidedDependencyReturnType::class);
     }
 }

--- a/src/Psalm/ProvidedDependencyReturnType.php
+++ b/src/Psalm/ProvidedDependencyReturnType.php
@@ -50,19 +50,11 @@ final class ProvidedDependencyReturnType implements MethodReturnTypeProviderInte
             return null;
         }
 
-        $className = self::constantStringArgument($event, $args[0]);
+        $className = self::resolvableClassName($event, $args[0]);
 
         // Returning null rather than mixed leaves the declared return type in
         // place, and lets another plugin have a go at the same call.
         if ($className === null) {
-            return null;
-        }
-
-        // Resolved through the autoloader rather than Psalm's own codebase so
-        // that this and the PHPStan extension answer identically for the same
-        // key -- two analysers disagreeing about what a Provider supplies would
-        // be worse than either of them being conservative.
-        if (!class_exists($className) && !interface_exists($className)) {
             return null;
         }
 
@@ -72,18 +64,26 @@ final class ProvidedDependencyReturnType implements MethodReturnTypeProviderInte
     /**
      * Read through the inferred type, not the AST, so a class-string held in a
      * variable resolves the same as one written at the call site.
+     *
+     * A union is scanned rather than sampled: the PHPStan extension walks every
+     * constant string it is given and stops at the first that names something,
+     * so a `Foo::class|'some.service'` has to answer `Foo` here too.
      */
-    private static function constantStringArgument(
-        MethodReturnTypeProviderEvent $event,
-        Arg $arg,
-    ): ?string {
+    private static function resolvableClassName(MethodReturnTypeProviderEvent $event, Arg $arg): ?string
+    {
         $type = $event->getSource()->getNodeTypeProvider()->getType($arg->value);
         if (!$type instanceof Union) {
             return null;
         }
 
         foreach ($type->getLiteralStrings() as $literal) {
-            return $literal->value;
+            // Resolved through the autoloader rather than Psalm's own codebase
+            // so that this and the PHPStan extension answer identically for the
+            // same key -- two analysers disagreeing about what a Provider
+            // supplies would be worse than either being conservative.
+            if (class_exists($literal->value) || interface_exists($literal->value)) {
+                return $literal->value;
+            }
         }
 
         return null;

--- a/src/Psalm/ProvidedDependencyReturnType.php
+++ b/src/Psalm/ProvidedDependencyReturnType.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\Framework\AbstractFactory;
+use PhpParser\Node\Arg;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+use function class_exists;
+use function count;
+use function interface_exists;
+
+/**
+ * Types `getProvidedDependency(Foo::class)` as `Foo`, the way
+ * {@see \Gacela\PHPStan\Reflection\GetProvidedDependencyReturnTypeExtension}
+ * does for PHPStan.
+ *
+ * The signature returns `mixed` because the key is a plain string, so every call
+ * site restores the type by hand with a `@var` the analyser has to take on faith
+ * -- and which keeps claiming the old type after the Provider changes. When the
+ * key *is* a class-string, the type was never unknown; it was thrown away at the
+ * boundary.
+ *
+ * A string key (`'some.service'`) still returns `mixed`. Nothing in the type
+ * system says what it resolves to, and a guess would be worse than `mixed`:
+ * `mixed` is honestly unknown, a guess is confidently wrong and trusted.
+ */
+final class ProvidedDependencyReturnType implements MethodReturnTypeProviderInterface
+{
+    private const METHOD = 'getprovideddependency';
+
+    public static function getClassLikeNames(): array
+    {
+        return [AbstractFactory::class];
+    }
+
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== self::METHOD) {
+            return null;
+        }
+
+        $args = $event->getCallArgs();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $className = self::constantStringArgument($event, $args[0]);
+
+        // Returning null rather than mixed leaves the declared return type in
+        // place, and lets another plugin have a go at the same call.
+        if ($className === null) {
+            return null;
+        }
+
+        // Resolved through the autoloader rather than Psalm's own codebase so
+        // that this and the PHPStan extension answer identically for the same
+        // key -- two analysers disagreeing about what a Provider supplies would
+        // be worse than either of them being conservative.
+        if (!class_exists($className) && !interface_exists($className)) {
+            return null;
+        }
+
+        return new Union([new TNamedObject($className)]);
+    }
+
+    /**
+     * Read through the inferred type, not the AST, so a class-string held in a
+     * variable resolves the same as one written at the call site.
+     */
+    private static function constantStringArgument(
+        MethodReturnTypeProviderEvent $event,
+        Arg $arg,
+    ): ?string {
+        $type = $event->getSource()->getNodeTypeProvider()->getType($arg->value);
+        if (!$type instanceof Union) {
+            return null;
+        }
+
+        foreach ($type->getLiteralStrings() as $literal) {
+            return $literal->value;
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/Psalm/Fixture/ProvidedClock.php
+++ b/tests/Integration/Psalm/Fixture/ProvidedClock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\Fixture;
+
+final class ProvidedClock
+{
+    public function now(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Integration/Psalm/Fixture/ProvidedFactory.php
+++ b/tests/Integration/Psalm/Fixture/ProvidedFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\Fixture;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * Asks for its dependency by class-string, with no `@var` in sight. Without the
+ * plugin both calls below are made on `mixed`, which is not a checked call --
+ * the typo would pass silently.
+ *
+ * @extends AbstractFactory<\Gacela\Framework\AbstractConfig>
+ */
+final class ProvidedFactory extends AbstractFactory
+{
+    public function callsAKnownMethod(): int
+    {
+        return $this->getProvidedDependency(ProvidedClock::class)->now();
+    }
+
+    public function callsAMethodThatDoesNotExist(): int
+    {
+        return $this->getProvidedDependency(ProvidedClock::class)->typoOnTheClock();
+    }
+}

--- a/tests/Integration/Psalm/Fixture/StringKeyFactory.php
+++ b/tests/Integration/Psalm/Fixture/StringKeyFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\Fixture;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * Kept apart from `ProvidedFactory` so the two can be asserted on separately:
+ * nothing in the type system says what a string key resolves to, so this call
+ * stays `mixed` and Psalm says so.
+ *
+ * @extends AbstractFactory<\Gacela\Framework\AbstractConfig>
+ */
+final class StringKeyFactory extends AbstractFactory
+{
+    public function callsThroughAStringKey(): int
+    {
+        return $this->getProvidedDependency('some.service')->now();
+    }
+}

--- a/tests/Integration/Psalm/ProvidedDependencyPluginTest.php
+++ b/tests/Integration/Psalm/ProvidedDependencyPluginTest.php
@@ -36,7 +36,13 @@ final class ProvidedDependencyPluginTest extends PsalmFixtureTestCase
     {
         $this->skipIfPsalmCannotRun($this->analyseFixture());
 
-        self::assertStringNotContainsString('MixedMethodCall', $this->errorsIn('ProvidedFactory.php'));
+        $errors = $this->errorsIn('ProvidedFactory.php');
+
+        // Without this, a filter that matches nothing makes the real assertion
+        // below pass against an empty string -- which is how the windows path
+        // separator went unnoticed the first time.
+        self::assertNotSame('', $errors, 'precondition: psalm reported on this fixture at all');
+        self::assertStringNotContainsString('MixedMethodCall', $errors);
     }
 
     /**

--- a/tests/Integration/Psalm/ProvidedDependencyPluginTest.php
+++ b/tests/Integration/Psalm/ProvidedDependencyPluginTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm;
+
+use GacelaTest\Integration\Psalm\Fixture\ProvidedClock;
+
+/**
+ * Runs Psalm for real against Factories that ask for their dependencies with no
+ * `@var` in sight.
+ *
+ * The unit test proves the hook returns the right type. This proves the thing
+ * that actually matters: with a real return type, Psalm checks the calls made
+ * *on* the provided dependency. `getProvidedDependency()` is declared `mixed`,
+ * and a `mixed` call is not a checked one.
+ */
+final class ProvidedDependencyPluginTest extends PsalmFixtureTestCase
+{
+    public function test_a_call_on_a_class_string_dependency_is_checked(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'Method ' . ProvidedClock::class . '::typoOnTheClock does not exist',
+            $this->errorsIn('ProvidedFactory.php'),
+            'the class-string key must resolve to that class, not to mixed',
+        );
+    }
+
+    /**
+     * The other half, and the one that fails without the plugin: an untyped
+     * accessor makes every call through it a `MixedMethodCall`, valid or not.
+     */
+    public function test_a_class_string_dependency_is_not_left_mixed(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringNotContainsString('MixedMethodCall', $this->errorsIn('ProvidedFactory.php'));
+    }
+
+    /**
+     * Nothing in the type system says what `'some.service'` resolves to. Psalm
+     * reporting a `MixedMethodCall` there is the honest answer, and pinning it
+     * keeps a future change from quietly inventing a type instead.
+     */
+    public function test_a_string_key_dependency_stays_mixed(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString('MixedMethodCall', $this->errorsIn('StringKeyFactory.php'));
+    }
+}

--- a/tests/Integration/Psalm/PsalmFixtureTestCase.php
+++ b/tests/Integration/Psalm/PsalmFixtureTestCase.php
@@ -40,14 +40,17 @@ abstract class PsalmFixtureTestCase extends TestCase
      * Every line of Psalm's text output starts with the absolute path it
      * concerns, so filtering on the basename separates two fixtures without
      * anchoring a test to a line or column that moves whenever the fixture is
-     * edited.
+     * edited. The separator has to come from `DIRECTORY_SEPARATOR`: Psalm prints
+     * `D:\a\gacela\...` on windows, and a hard-coded `/` quietly matched
+     * nothing there, which made every *negative* assertion pass against an empty
+     * string.
      */
     final protected function errorsIn(string $fixtureBasename): string
     {
         $lines = [];
 
         foreach (explode("\n", $this->analyseFixture()) as $line) {
-            if (str_contains($line, '/' . $fixtureBasename . ':')) {
+            if (str_contains($line, DIRECTORY_SEPARATOR . $fixtureBasename . ':')) {
                 $lines[] = $line;
             }
         }

--- a/tests/Integration/Psalm/PsalmFixtureTestCase.php
+++ b/tests/Integration/Psalm/PsalmFixtureTestCase.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm;
+
+use PHPUnit\Framework\TestCase;
+
+use function escapeshellarg;
+use function explode;
+use function implode;
+use function shell_exec;
+use function sprintf;
+use function str_contains;
+use function substr;
+
+/**
+ * Runs the plugin end-to-end through a real `vendor/bin/psalm`, over
+ * `Fixture/psalm-fixture.xml`.
+ *
+ * That is the strongest proof available -- an in-process test drives a hook,
+ * this drives Psalm -- but it is also the slowest, so the run is shared: the
+ * fixture set and the config are the same for every test here, so the output is
+ * too, and analysing once per process is enough.
+ */
+abstract class PsalmFixtureTestCase extends TestCase
+{
+    private const ROOT = __DIR__ . '/../../..';
+
+    private static ?string $output = null;
+
+    final protected function analyseFixture(): string
+    {
+        return self::$output ??= $this->runPsalm();
+    }
+
+    /**
+     * Only the findings for one fixture file.
+     *
+     * Every line of Psalm's text output starts with the absolute path it
+     * concerns, so filtering on the basename separates two fixtures without
+     * anchoring a test to a line or column that moves whenever the fixture is
+     * edited.
+     */
+    final protected function errorsIn(string $fixtureBasename): string
+    {
+        $lines = [];
+
+        foreach (explode("\n", $this->analyseFixture()) as $line) {
+            if (str_contains($line, '/' . $fixtureBasename . ':')) {
+                $lines[] = $line;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Psalm converts *any* PHP error into a RuntimeException via its own error
+     * handler, so a deprecation raised while autoloading an unrelated vendor
+     * class takes the whole run down -- `error_reporting` cannot prevent it.
+     *
+     * At `--prefer-lowest` on PHP 8.5 the amphp packages (transitive
+     * dependencies of infection) do exactly that, so Psalm cannot run in this
+     * project on that one matrix cell at all, with or without the plugin.
+     *
+     * Skipped rather than failed there, but only when the crash is *not* ours:
+     * a crash mentioning Gacela is a plugin bug and must still fail.
+     */
+    final protected function skipIfPsalmCannotRun(string $output): void
+    {
+        if (!str_contains($output, 'crashed due to an uncaught Throwable')) {
+            return;
+        }
+
+        if (str_contains($output, 'Gacela\\Psalm')) {
+            return;
+        }
+
+        // Only the tail: the run emits hundreds of kilobytes of vendor
+        // deprecations before the crash, and the crash is the last thing in it.
+        self::markTestSkipped('Psalm cannot run in this dependency set: ' . substr($output, -2000));
+    }
+
+    private function runPsalm(): string
+    {
+        // No `-d error_reporting=...` here: Psalm re-execs itself through
+        // xdebug-handler before it analyses anything, and the restarted process
+        // does not inherit the flag. Deprecation noise is therefore dealt with
+        // where it lands -- see skipIfPsalmCannotRun().
+        $command = sprintf(
+            '%s --config=%s --no-progress --no-cache --output-format=text 2>&1',
+            escapeshellarg(self::ROOT . '/vendor/bin/psalm'),
+            escapeshellarg(__DIR__ . '/Fixture/psalm-fixture.xml'),
+        );
+
+        return (string)shell_exec($command);
+    }
+}

--- a/tests/Integration/Psalm/ServiceMapPluginTest.php
+++ b/tests/Integration/Psalm/ServiceMapPluginTest.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Psalm;
 
-use PHPUnit\Framework\TestCase;
-
-use function escapeshellarg;
-use function shell_exec;
-use function sprintf;
-use function str_contains;
+use GacelaTest\Integration\Psalm\Fixture\ConsumerFacade;
 
 /**
  * Runs Psalm for real against a fixture that declares its pillar with
@@ -19,17 +14,15 @@ use function str_contains;
  * without the plugin and prove nothing. Without the docblock the plugin is the
  * only thing that can type the accessor.
  */
-final class ServiceMapPluginTest extends TestCase
+final class ServiceMapPluginTest extends PsalmFixtureTestCase
 {
-    private const ROOT = __DIR__ . '/../../..';
-
     public function test_a_call_on_the_resolved_facade_is_checked(): void
     {
         $errors = $this->analyseFixture();
         $this->skipIfPsalmCannotRun($errors);
 
         self::assertStringContainsString(
-            'Method ' . \GacelaTest\Integration\Psalm\Fixture\ConsumerFacade::class . '::typoMethod does not exist',
+            'Method ' . ConsumerFacade::class . '::typoMethod does not exist',
             $errors,
             'the accessor must resolve to the facade, so calls made through it are checked',
         );
@@ -49,47 +42,5 @@ final class ServiceMapPluginTest extends TestCase
         $this->skipIfPsalmCannotRun($errors);
 
         self::assertStringNotContainsString('UndefinedMagicMethod', $errors);
-    }
-
-    /**
-     * Psalm converts *any* PHP error into a RuntimeException via its own error
-     * handler, so a deprecation raised while autoloading an unrelated vendor
-     * class takes the whole run down -- `error_reporting` cannot prevent it.
-     *
-     * At `--prefer-lowest` on PHP 8.5 the amphp packages (transitive
-     * dependencies of infection) do exactly that, so Psalm cannot run in this
-     * project on that one matrix cell at all, with or without the plugin.
-     *
-     * Skipped rather than failed there, but only when the crash is *not* ours:
-     * a crash mentioning Gacela is a plugin bug and must still fail.
-     */
-    private function skipIfPsalmCannotRun(string $output): void
-    {
-        if (!str_contains($output, 'crashed due to an uncaught Throwable')) {
-            return;
-        }
-
-        if (str_contains($output, 'Gacela\\Psalm')) {
-            return;
-        }
-
-        // Only the tail: the run emits hundreds of kilobytes of vendor
-        // deprecations before the crash, and the crash is the last thing in it.
-        self::markTestSkipped('Psalm cannot run in this dependency set: ' . substr($output, -2000));
-    }
-
-    private function analyseFixture(): string
-    {
-        // No `-d error_reporting=...` here: Psalm re-execs itself through
-        // xdebug-handler before it analyses anything, and the restarted process
-        // does not inherit the flag. Deprecation noise is therefore dealt with
-        // where it lands -- see skipIfPsalmCannotRun().
-        $command = sprintf(
-            '%s --config=%s --no-progress --no-cache --output-format=text 2>&1',
-            escapeshellarg(self::ROOT . '/vendor/bin/psalm'),
-            escapeshellarg(__DIR__ . '/Fixture/psalm-fixture.xml'),
-        );
-
-        return (string)shell_exec($command);
     }
 }

--- a/tests/Unit/Psalm/Fixture/ProvidedClock.php
+++ b/tests/Unit/Psalm/Fixture/ProvidedClock.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm\Fixture;
+
+/**
+ * A resolvable class name for the return-type hook to answer with. It only has
+ * to exist -- the hook types the key, it does not read the class.
+ */
+final class ProvidedClock
+{
+    public function now(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/Psalm/Fixture/ProvidedContract.php
+++ b/tests/Unit/Psalm/Fixture/ProvidedContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm\Fixture;
+
+/**
+ * An interface is as resolvable as a class, and is the more common thing for a
+ * Provider to hand out.
+ */
+interface ProvidedContract
+{
+    public function run(): void;
+}

--- a/tests/Unit/Psalm/PluginTest.php
+++ b/tests/Unit/Psalm/PluginTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\Psalm;
 
+use Gacela\Framework\AbstractFactory;
 use Gacela\Psalm\Plugin;
 use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
 use Psalm\Config;
+use Psalm\Internal\Codebase\Methods;
 use Psalm\Internal\EventDispatcher;
+use Psalm\Internal\Provider\MethodReturnTypeProvider;
 use Psalm\PluginRegistrationSocket;
 use ReflectionClass;
 use SimpleXMLElement;
@@ -20,6 +24,8 @@ use SimpleXMLElement;
  */
 final class PluginTest extends TestCase
 {
+    private ?MethodReturnTypeProvider $returnTypes = null;
+
     public function test_it_registers_the_pseudo_method_handler(): void
     {
         $dispatcher = new EventDispatcher();
@@ -32,6 +38,20 @@ final class PluginTest extends TestCase
         (new Plugin())($this->socket($dispatcher));
 
         self::assertTrue($dispatcher->hasAfterClassLikeVisitHandlers());
+    }
+
+    public function test_it_registers_the_provided_dependency_return_type_handler(): void
+    {
+        $returnTypes = $this->returnTypeProvider();
+
+        self::assertFalse(
+            $returnTypes->has(AbstractFactory::class),
+            'precondition: nothing is registered for the factory before the plugin runs',
+        );
+
+        (new Plugin())($this->socket(new EventDispatcher()));
+
+        self::assertTrue($returnTypes->has(AbstractFactory::class));
     }
 
     public function test_it_ignores_the_optional_plugin_config(): void
@@ -60,7 +80,33 @@ final class PluginTest extends TestCase
         $socketReflection = new ReflectionClass(PluginRegistrationSocket::class);
         $socket = $socketReflection->newInstanceWithoutConstructor();
         $socketReflection->getProperty('config')->setValue($socket, $config);
+        $socketReflection->getProperty('codebase')->setValue($socket, $this->codebase());
 
         return $socket;
+    }
+
+    /**
+     * A return-type provider registers against the codebase rather than the
+     * event dispatcher, so the socket needs one -- but only the two fields the
+     * registration walks through.
+     */
+    private function codebase(): Codebase
+    {
+        $methods = (new ReflectionClass(Methods::class))->newInstanceWithoutConstructor();
+        $methods->return_type_provider = $this->returnTypeProvider();
+
+        $codebase = (new ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+        $codebase->methods = $methods;
+
+        return $codebase;
+    }
+
+    /**
+     * Its handlers live in a static, so constructing one is also how the
+     * registry is emptied between tests.
+     */
+    private function returnTypeProvider(): MethodReturnTypeProvider
+    {
+        return $this->returnTypes ??= new MethodReturnTypeProvider();
     }
 }

--- a/tests/Unit/Psalm/ProvidedDependencyReturnTypeTest.php
+++ b/tests/Unit/Psalm/ProvidedDependencyReturnTypeTest.php
@@ -92,6 +92,22 @@ final class ProvidedDependencyReturnTypeTest extends TestCase
     }
 
     /**
+     * The PHPStan extension walks every constant string it is given and stops at
+     * the first that names something, so a union has to answer the same here --
+     * sampling only the first would depend on which branch Psalm happened to
+     * order first.
+     */
+    public function test_a_union_is_scanned_past_a_key_that_names_nothing(): void
+    {
+        $type = $this->returnTypeFor(new Union([
+            new TLiteralString('some.service'),
+            new TLiteralString(ProvidedClock::class),
+        ]));
+
+        self::assertSame(ProvidedClock::class, (string)$type);
+    }
+
+    /**
      * The key is read through the inferred type rather than the AST, so one held
      * in a variable resolves the same as one written at the call site.
      */

--- a/tests/Unit/Psalm/ProvidedDependencyReturnTypeTest.php
+++ b/tests/Unit/Psalm/ProvidedDependencyReturnTypeTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Psalm\ProvidedDependencyReturnType;
+use GacelaTest\Unit\Psalm\Fixture\ProvidedClock;
+use GacelaTest\Unit\Psalm\Fixture\ProvidedContract;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\NodeTypeProvider;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\StatementsSource;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * Drives the Psalm hook directly, in-process.
+ *
+ * `ProvidedDependencyPluginTest` runs the same thing through a real
+ * `vendor/bin/psalm`, which is the stronger proof -- but it is a subprocess, so
+ * coverage cannot see it and every mutant here would count as untested.
+ */
+final class ProvidedDependencyReturnTypeTest extends TestCase
+{
+    private ?Config $previousConfig = null;
+
+    /**
+     * Building any Psalm type reads the global config for its string-length
+     * limit, and a unit test has no analysis to have initialised one. The
+     * defaults on the class are all this needs.
+     */
+    protected function setUp(): void
+    {
+        $instance = new ReflectionProperty(Config::class, 'instance');
+        $this->previousConfig = $instance->getValue();
+        $instance->setValue(null, (new ReflectionClass(Config::class))->newInstanceWithoutConstructor());
+    }
+
+    protected function tearDown(): void
+    {
+        (new ReflectionProperty(Config::class, 'instance'))->setValue(null, $this->previousConfig);
+    }
+
+    public function test_it_applies_to_the_factory_base_class(): void
+    {
+        self::assertSame([AbstractFactory::class], ProvidedDependencyReturnType::getClassLikeNames());
+    }
+
+    public function test_a_class_string_key_is_typed_as_that_class(): void
+    {
+        $type = $this->returnTypeFor($this->literal(ProvidedClock::class));
+
+        self::assertSame(ProvidedClock::class, (string)$type);
+    }
+
+    /**
+     * An interface is as resolvable as a class, and is the more common thing for
+     * a Provider to hand out.
+     */
+    public function test_an_interface_key_is_typed_too(): void
+    {
+        $type = $this->returnTypeFor($this->literal(ProvidedContract::class));
+
+        self::assertSame(ProvidedContract::class, (string)$type);
+    }
+
+    /**
+     * Nothing in the type system says what `'some.service'` resolves to, and a
+     * guess would be worse than mixed: mixed is honestly unknown, a guess is
+     * confidently wrong and then trusted.
+     */
+    public function test_a_plain_string_key_is_left_alone(): void
+    {
+        self::assertNull($this->returnTypeFor($this->literal('some.service')));
+    }
+
+    public function test_a_name_that_resolves_to_nothing_is_left_alone(): void
+    {
+        self::assertNull($this->returnTypeFor($this->literal('App\Nope\NotAClass')));
+    }
+
+    /**
+     * The key is read through the inferred type rather than the AST, so one held
+     * in a variable resolves the same as one written at the call site.
+     */
+    public function test_a_key_that_is_not_a_literal_is_left_alone(): void
+    {
+        self::assertNull($this->returnTypeFor(new Union([new TString()])));
+    }
+
+    public function test_an_argument_psalm_could_not_type_is_left_alone(): void
+    {
+        self::assertNull($this->returnTypeFor(null));
+    }
+
+    public function test_another_method_on_the_factory_is_left_alone(): void
+    {
+        self::assertNull($this->returnTypeFor($this->literal(ProvidedClock::class), method: 'creatething'));
+    }
+
+    public function test_a_call_without_arguments_is_left_alone(): void
+    {
+        self::assertNull($this->returnTypeFor($this->literal(ProvidedClock::class), args: []));
+    }
+
+    /**
+     * `getProvidedDependency()` takes one key. Two arguments is not a call this
+     * hook understands, so it says nothing rather than reading the first.
+     */
+    public function test_a_call_with_two_arguments_is_left_alone(): void
+    {
+        $args = [
+            new Arg($this->classConstFetch()),
+            new Arg($this->classConstFetch()),
+        ];
+
+        self::assertNull($this->returnTypeFor($this->literal(ProvidedClock::class), args: $args));
+    }
+
+    /**
+     * @param list<Arg>|null $args
+     */
+    private function returnTypeFor(
+        ?Union $argumentType,
+        string $method = 'getprovideddependency',
+        ?array $args = null,
+    ): ?Union {
+        $args ??= [new Arg($this->classConstFetch())];
+
+        $typeProvider = $this->createStub(NodeTypeProvider::class);
+        $typeProvider->method('getType')->willReturn($argumentType);
+
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getNodeTypeProvider')->willReturn($typeProvider);
+
+        return ProvidedDependencyReturnType::getMethodReturnType(
+            $this->event($method, $args, $source),
+        );
+    }
+
+    /**
+     * The event is a value object; the hook reads three of its nine fields, and
+     * the constructor also demands a `Codebase`, which is final and wants a whole
+     * analysis context. Bypassing it keeps the test about the hook.
+     *
+     * @param list<Arg> $args
+     */
+    private function event(string $method, array $args, StatementsSource $source): MethodReturnTypeProviderEvent
+    {
+        $reflection = new ReflectionClass(MethodReturnTypeProviderEvent::class);
+        $event = $reflection->newInstanceWithoutConstructor();
+
+        $reflection->getProperty('method_name_lowercase')->setValue($event, $method);
+        $reflection->getProperty('source')->setValue($event, $source);
+        // getCallArgs() reads them off the call node rather than storing them.
+        $reflection->getProperty('stmt')->setValue(
+            $event,
+            new MethodCall(new Variable('this'), new Identifier('getProvidedDependency'), $args),
+        );
+
+        return $event;
+    }
+
+    private function literal(string $value): Union
+    {
+        return new Union([new TLiteralString($value)]);
+    }
+
+    private function classConstFetch(): \PhpParser\Node\Expr\ClassConstFetch
+    {
+        return new ClassConstFetch(new Name('Whatever'), new Identifier('class'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

PHPStan has typed `getProvidedDependency(Foo::class)` as `Foo` since 2.0. Psalm
left it `mixed`, so a Psalm project keeps the `@var` above every call site — an
assertion the analyser takes on faith, and which goes on claiming the old type
after the Provider changes. That annotation is exactly what
`GetProvidedDependencyReturnTypeExtension` was written to make unnecessary.

A `mixed` call is not a checked call: it switches off analysis of everything
reached through it, not just the accessor.

Closes #641

## 🔖 Changes

- Add `Gacela\Psalm\ProvidedDependencyReturnType`, a
  `MethodReturnTypeProviderInterface` handler on `AbstractFactory`
- Register it from `Gacela\Psalm\Plugin`, which consumers already declare — no
  config change on their side
- Read the key through the **inferred type**, not the AST, so a class-string
  held in a variable resolves like one written at the call site. This matches
  what the PHPStan extension does with `Scope::getType()`
- Scan the whole union rather than sampling its first branch: PHPStan walks
  every constant string and stops at the first that names something, so
  `Foo::class|'some.service'` answers `Foo` under both
- Resolve names through the autoloader (`class_exists`/`interface_exists`)
  rather than Psalm's own codebase, so the two analysers cannot disagree about
  what a Provider supplies
- Document it in `docs/static-analysis.md`, and cross-link from the PHPStan
  section that previously read as though this were PHPStan-only
- Extract `PsalmFixtureTestCase` from `ServiceMapPluginTest`, memoising the
  subprocess run. Six integration tests now share one 1.5s Psalm run instead of
  the three the old shape would have grown to six

A string key still returns `mixed`, deliberately. Nothing in the type system
says what `'some.service'` resolves to; a guess would be worse than `mixed`,
because `mixed` is honestly unknown while a guess is confidently wrong and then
trusted.

## 🧪 Testing

- `ProvidedDependencyReturnTypeTest` drives the hook in-process, which is what
  puts it under the mutation gate — the subprocess test below is invisible to
  coverage
- `ProvidedDependencyPluginTest` runs a real `vendor/bin/psalm` over two fixture
  factories, asserting per file rather than per line:
  - `ProvidedFactory` — the typo is reported as `UndefinedMethod`, **and** no
    `MixedMethodCall` remains, which is the half that fails without the plugin
  - `StringKeyFactory` — `MixedMethodCall` is still reported, pinning the
    deliberate non-change
- Verified non-vacuous: with the handler unregistered, both `ProvidedFactory`
  calls come back `MixedMethodCall` and the typo goes unreported
- Infection over `src/Psalm`: **100% MSI**, 66 mutations, 0 escaped
- `phpstan-tests.neon` gains three `*.internalClass` ignores for `PluginTest`,
  alongside the two already there for the same reason: a return-type provider
  registers against `Codebase::$methods`, and `MethodReturnTypeProvider::has()`
  is the only way to observe that it landed
