### PR TITLE
feat: enforce the Gacela architecture rules under Psalm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Type `getProvidedDependency(Foo::class)` under Psalm too, matching the PHPStan extension
+- Enforce the pillar rules under Psalm, each as its own suppressible issue type
 
 ### Changed
 

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -256,6 +256,38 @@ Nothing in the type system says what it resolves to, and a guess would be worse
 than `mixed`: `mixed` is honestly unknown, a guess is confidently wrong and then
 trusted.
 
+### Architecture rules
+
+The same `<plugins>` block enforces the pillar rules, the ones PHPStan gets from
+`phpstan-gacela.neon`. They are on by default and share their implementation with
+the PHPStan side, so the two analysers cannot drift apart on what counts as a
+violation.
+
+| Issue | Reports |
+|---|---|
+| `GacelaSuffixExtends` | a `*Facade`/`*Factory`/`*Provider`/`*Config` not extending its pillar base |
+| `GacelaFacadeOnlyDelegates` | inline logic in a facade method |
+| `GacelaFacadeInstantiation` | a factory building a Facade with `new` |
+| `GacelaFactoryFacadeAccess` | a factory calling `$this->getFacade()` |
+| `GacelaFacadeInterfaceDrift` | a public facade method missing from its `*FacadeInterface` |
+
+Each is its own issue type, so one can be turned off without losing the rest:
+
+```xml
+<issueHandlers>
+    <PluginIssue name="GacelaSuffixExtends">
+        <errorLevel type="suppress">
+            <directory name="src/Legacy"/>
+        </errorLevel>
+    </PluginIssue>
+</issueHandlers>
+```
+
+`psalm.xml` in this repository is a working example: Gacela analyses itself with
+the plugin it ships, and suppresses `GacelaSuffixExtends` under `src/Framework`
+for the same reason `phpstan.neon` does — the framework internals reuse the
+pillar words for things that are not pillars.
+
 
 ## Troubleshooting
 

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -17,6 +17,10 @@ parameters:
         # GetProvidedDependencyTypeInferenceTest, which does load the extension.
         - %currentWorkingDirectory%/tests/Unit/PHPStan/Reflection/TypeFixture/*
         - %currentWorkingDirectory%/tests/Integration/PHPStan/Fixture/*
+        # Modules that break the architecture rules on purpose, so that a real
+        # psalm run can be asserted to report them. A Factory calling
+        # $this->getFacade() is one of the things being reported.
+        - %currentWorkingDirectory%/tests/Integration/Psalm/RulesFixture/*
     ignoreErrors:
         - '#Class GacelaTest\\Unit\\Framework\\Container\\NonExisting not found.#'
         - '#has invalid type Totally\\Missing\\Type#'
@@ -43,6 +47,16 @@ parameters:
         -
             identifier: classConstant.internalClass
             path: %currentWorkingDirectory%/tests/Unit/Psalm/PluginTest.php
+        # StorageAnalysedClass is @internal because it is the Psalm half of a seam
+        # consumers never touch. Its test still has to build one: the alternative
+        # is reaching it only through a psalm subprocess, which coverage cannot
+        # see, and every mutant in it would count as untested.
+        -
+            identifier: new.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/StorageAnalysedClassTest.php
+        -
+            identifier: return.internalClass
+            path: %currentWorkingDirectory%/tests/Unit/Psalm/StorageAnalysedClassTest.php
         # ProvidesScanner's memo is a private static with no public accessor, and
         # reading it is the only way to observe that a repeated scan is skipped.
         -

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,6 +26,22 @@
     </plugins>
 
     <issueHandlers>
+        <!--
+            The suffix rule asks that a class named after a pillar extends the
+            matching base class. That is the contract for a consumer's *modules*.
+            Gacela's own framework internals reuse those words for things that
+            are not pillars: GacelaConfig is the bootstrap builder, ConfigFactory
+            builds config objects, EventDispatcherProvider is a static holder.
+
+            Scoped to src/Framework so the rule still applies to Gacela\Console,
+            which is a real Gacela module and does satisfy it. The same exemption,
+            for the same reason, is in phpstan.neon.
+        -->
+        <PluginIssue name="GacelaSuffixExtends">
+            <errorLevel type="suppress">
+                <directory name="src/Framework"/>
+            </errorLevel>
+        </PluginIssue>
         <DeprecatedClass errorLevel="suppress" />
         <MoreSpecificReturnType errorLevel="suppress" />
         <LessSpecificReturnStatement errorLevel="suppress" />

--- a/src/PHPStan/Rules/RuleErrors.php
+++ b/src/PHPStan/Rules/RuleErrors.php
@@ -30,8 +30,8 @@ final class RuleErrors
 
             // Left unset, PHPStan reports the line of the analysed node, which
             // is what every rule but the interface-drift one wants.
-            if ($violation->line !== null) {
-                $builder->line($violation->line);
+            if ($violation->node !== null) {
+                $builder->line($violation->node->getStartLine());
             }
 
             $errors[] = $builder->build();

--- a/src/Psalm/ClassRules.php
+++ b/src/Psalm/ClassRules.php
@@ -35,6 +35,11 @@ use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
  */
 final class ClassRules implements AfterClassLikeAnalysisInterface
 {
+    /** @var list<ClassAnalyserInterface>|null */
+    private static ?array $classAnalysers = null;
+
+    private static ?FacadeOnlyDelegatesAnalyser $facadeMethods = null;
+
     public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event): ?bool
     {
         $node = $event->getStmt();
@@ -45,7 +50,7 @@ final class ClassRules implements AfterClassLikeAnalysisInterface
             ReportedIssues::report($analyser->analyse($node, $class), $node, $source);
         }
 
-        $facadeMethods = new FacadeOnlyDelegatesAnalyser();
+        $facadeMethods = self::$facadeMethods ??= new FacadeOnlyDelegatesAnalyser();
         foreach ($node->getMethods() as $method) {
             ReportedIssues::report($facadeMethods->analyse($method, $class), $method, $source);
         }
@@ -54,11 +59,14 @@ final class ClassRules implements AfterClassLikeAnalysisInterface
     }
 
     /**
+     * Built once. The rules hold only their configuration, and this runs for
+     * every class-like in a project.
+     *
      * @return list<ClassAnalyserInterface>
      */
     private static function classAnalysers(): array
     {
-        return [
+        return self::$classAnalysers ??= [
             new SuffixExtendsAnalyser('Facade', AbstractFacade::class),
             new SuffixExtendsAnalyser('Factory', AbstractFactory::class),
             new SuffixExtendsAnalyser('Provider', AbstractProvider::class),

--- a/src/Psalm/ClassRules.php
+++ b/src/Psalm/ClassRules.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\AbstractProvider;
+use Gacela\StaticAnalysis\ClassAnalyserInterface;
+use Gacela\StaticAnalysis\Rules\FacadeInterfaceInSyncAnalyser;
+use Gacela\StaticAnalysis\Rules\FacadeOnlyDelegatesAnalyser;
+use Gacela\StaticAnalysis\Rules\FactoryDoesNotCallFacadeAnalyser;
+use Gacela\StaticAnalysis\Rules\SuffixExtendsAnalyser;
+use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
+
+/**
+ * Runs the Gacela architecture rules under Psalm.
+ *
+ * The rules themselves live in `Gacela\StaticAnalysis` and are the same objects
+ * `phpstan-gacela.neon` registers; this is the adapting, and nothing else. Two
+ * implementations of "what counts as a delegation" would drift, which is the
+ * failure `FacadeInterfaceInSyncAnalyser` exists to catch.
+ *
+ * The facade-method rule runs from here rather than from an
+ * `AfterFunctionLikeAnalysis` handler of its own: Psalm hands a function-like
+ * over without the class storage the rule needs, and the only routes back to it
+ * are `@internal` to Psalm. Walking the methods of a class already in hand costs
+ * nothing and keeps the plugin off Psalm's internals entirely.
+ *
+ * `CrossModuleViaFacadeAnalyser` is absent on purpose: it needs the consumer's
+ * root namespace, so it is registered from plugin config rather than by default.
+ */
+final class ClassRules implements AfterClassLikeAnalysisInterface
+{
+    public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event): ?bool
+    {
+        $node = $event->getStmt();
+        $source = $event->getStatementsSource();
+        $class = new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase());
+
+        foreach (self::classAnalysers() as $analyser) {
+            ReportedIssues::report($analyser->analyse($node, $class), $node, $source);
+        }
+
+        $facadeMethods = new FacadeOnlyDelegatesAnalyser();
+        foreach ($node->getMethods() as $method) {
+            ReportedIssues::report($facadeMethods->analyse($method, $class), $method, $source);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<ClassAnalyserInterface>
+     */
+    private static function classAnalysers(): array
+    {
+        return [
+            new SuffixExtendsAnalyser('Facade', AbstractFacade::class),
+            new SuffixExtendsAnalyser('Factory', AbstractFactory::class),
+            new SuffixExtendsAnalyser('Provider', AbstractProvider::class),
+            new SuffixExtendsAnalyser('Config', AbstractConfig::class),
+            new FactoryDoesNotCallFacadeAnalyser(),
+            new FacadeInterfaceInSyncAnalyser(),
+        ];
+    }
+}

--- a/src/Psalm/Issue/GacelaCrossModuleAccess.php
+++ b/src/Psalm/Issue/GacelaCrossModuleAccess.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A reference from one module into another that does not go through a Facade.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaCrossModuleAccess" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaCrossModuleAccess extends PluginIssue
+{
+}

--- a/src/Psalm/Issue/GacelaFacadeInstantiation.php
+++ b/src/Psalm/Issue/GacelaFacadeInstantiation.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A Factory building a Facade with `new`, bypassing the Provider.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaFacadeInstantiation" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaFacadeInstantiation extends PluginIssue
+{
+}

--- a/src/Psalm/Issue/GacelaFacadeInterfaceDrift.php
+++ b/src/Psalm/Issue/GacelaFacadeInterfaceDrift.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A public Facade method missing from the `*FacadeInterface` the Facade
+ * implements, which consumers holding the interface cannot reach.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaFacadeInterfaceDrift" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaFacadeInterfaceDrift extends PluginIssue
+{
+}

--- a/src/Psalm/Issue/GacelaFacadeOnlyDelegates.php
+++ b/src/Psalm/Issue/GacelaFacadeOnlyDelegates.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Logic inside a Facade method.
+ *
+ * A Facade method is a name for something the Factory does; logic living in it
+ * is logic no other module can reach and no test can address directly.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaFacadeOnlyDelegates" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaFacadeOnlyDelegates extends PluginIssue
+{
+}

--- a/src/Psalm/Issue/GacelaFactoryFacadeAccess.php
+++ b/src/Psalm/Issue/GacelaFactoryFacadeAccess.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A Factory calling `$this->getFacade()`.
+ *
+ * Same-module access goes through the Factory itself; cross-module access goes
+ * through the Provider.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaFactoryFacadeAccess" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaFactoryFacadeAccess extends PluginIssue
+{
+}

--- a/src/Psalm/Issue/GacelaSuffixExtends.php
+++ b/src/Psalm/Issue/GacelaSuffixExtends.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A class named after a pillar -- `*Facade`, `*Factory`, `*Provider`, `*Config` --
+ * that does not extend the matching base class.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaSuffixExtends" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaSuffixExtends extends PluginIssue
+{
+}

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -25,8 +25,10 @@ final class Plugin implements PluginEntryPointInterface
         // so the handler has to be loaded before it can be registered.
         require_once __DIR__ . '/ServiceMapPseudoMethods.php';
         require_once __DIR__ . '/ProvidedDependencyReturnType.php';
+        require_once __DIR__ . '/ClassRules.php';
 
         $registration->registerHooksFromClass(ServiceMapPseudoMethods::class);
         $registration->registerHooksFromClass(ProvidedDependencyReturnType::class);
+        $registration->registerHooksFromClass(ClassRules::class);
     }
 }

--- a/src/Psalm/ReportedIssues.php
+++ b/src/Psalm/ReportedIssues.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\Psalm\Issue\GacelaCrossModuleAccess;
+use Gacela\Psalm\Issue\GacelaFacadeInstantiation;
+use Gacela\Psalm\Issue\GacelaFacadeInterfaceDrift;
+use Gacela\Psalm\Issue\GacelaFacadeOnlyDelegates;
+use Gacela\Psalm\Issue\GacelaFactoryFacadeAccess;
+use Gacela\Psalm\Issue\GacelaSuffixExtends;
+use Gacela\StaticAnalysis\Violation;
+use PhpParser\Node;
+use Psalm\CodeLocation;
+use Psalm\Issue\PluginIssue;
+use Psalm\IssueBuffer;
+use Psalm\StatementsSource;
+
+use function array_keys;
+
+/**
+ * Turns the host-agnostic findings into Psalm's own issue objects.
+ *
+ * PHPStan suppresses on an error identifier; Psalm suppresses on an issue class
+ * name. This is where one becomes the other, and the only place that mapping
+ * exists.
+ *
+ * The map has to cover every identifier a rule can produce, or that rule ships
+ * with no way to turn it off. `ReportedIssuesTest` is what holds it complete;
+ * at analysis time an unknown identifier is skipped rather than crashing a
+ * consumer's run over a mistake of ours.
+ *
+ * @internal
+ */
+final class ReportedIssues
+{
+    /** @var array<string, class-string<PluginIssue>> */
+    private const BY_IDENTIFIER = [
+        'gacela.suffixExtends' => GacelaSuffixExtends::class,
+        'gacela.facadeOnlyDelegates' => GacelaFacadeOnlyDelegates::class,
+        'gacela.factoryInstantiatesFacade' => GacelaFacadeInstantiation::class,
+        'gacela.factoryCallsGetFacade' => GacelaFactoryFacadeAccess::class,
+        'gacela.facadeInterfaceDrift' => GacelaFacadeInterfaceDrift::class,
+        'gacela.crossModuleWithoutFacade' => GacelaCrossModuleAccess::class,
+    ];
+
+    /**
+     * @param list<Violation> $violations
+     * @param Node            $analysedNode the node to locate a finding at when
+     *                                      it carries none of its own
+     */
+    public static function report(array $violations, Node $analysedNode, StatementsSource $source): void
+    {
+        foreach ($violations as $violation) {
+            $issue = self::issueFor($violation->identifier);
+            if ($issue === null) {
+                continue;
+            }
+
+            IssueBuffer::maybeAdd(
+                new $issue(
+                    $violation->message,
+                    new CodeLocation($source, $violation->node ?? $analysedNode),
+                ),
+                $source->getSuppressedIssues(),
+            );
+        }
+    }
+
+    /**
+     * The identifiers this can report, for the test that holds the map complete
+     * against the rules.
+     *
+     * @return list<string>
+     */
+    public static function mappedIdentifiers(): array
+    {
+        return array_keys(self::BY_IDENTIFIER);
+    }
+
+    /**
+     * @return class-string<PluginIssue>|null
+     */
+    public static function issueFor(string $identifier): ?string
+    {
+        return self::BY_IDENTIFIER[$identifier] ?? null;
+    }
+}

--- a/src/Psalm/StorageAnalysedClass.php
+++ b/src/Psalm/StorageAnalysedClass.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\StaticAnalysis\AnalysedClassInterface;
+use Psalm\Codebase;
+use Psalm\Storage\ClassLikeStorage;
+
+use function array_values;
+use function strtolower;
+
+/**
+ * The {@see AnalysedClassInterface} seam, answered from Psalm's class storage.
+ *
+ * The PHPStan counterpart is `Gacela\PHPStan\Rules\ReflectionAnalysedClass`;
+ * between the two of them they are the entire host-specific half of the
+ * architecture rules.
+ *
+ * @internal
+ */
+final class StorageAnalysedClass implements AnalysedClassInterface
+{
+    public function __construct(
+        private readonly ClassLikeStorage $storage,
+        private readonly Codebase $codebase,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return $this->storage->name;
+    }
+
+    public function extendsClass(string $parent): bool
+    {
+        // Keyed by lowercase name, and it holds the whole ancestry rather than
+        // the immediate parent -- which is what the rules ask about.
+        return isset($this->storage->parent_classes[strtolower($parent)]);
+    }
+
+    public function interfaceNames(): array
+    {
+        return array_values($this->storage->class_implements);
+    }
+
+    public function interfaceHasMethod(string $interface, string $method): bool
+    {
+        return $this->codebase->methodExists($interface . '::' . $method);
+    }
+}

--- a/src/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyser.php
+++ b/src/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyser.php
@@ -69,7 +69,7 @@ final class FacadeInterfaceInSyncAnalyser implements ClassAnalyserInterface
                     $facadeInterface,
                 ),
                 'gacela.facadeInterfaceDrift',
-                $method->getStartLine(),
+                $method,
             );
         }
 

--- a/src/StaticAnalysis/Violation.php
+++ b/src/StaticAnalysis/Violation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\StaticAnalysis;
 
+use PhpParser\Node;
+
 /**
  * One finding, in terms every host analyser can express.
  *
@@ -14,15 +16,18 @@ namespace Gacela\StaticAnalysis;
 final class Violation
 {
     /**
-     * @param string   $identifier stable, dot-separated, e.g. `gacela.suffixExtends`
-     * @param int|null $line       only when the finding belongs to a line other
-     *                             than the analysed node's own, as with a method
-     *                             reported inside its class
+     * @param string    $identifier stable, dot-separated, e.g. `gacela.suffixExtends`
+     * @param Node|null $node       the node the finding belongs to, when that is
+     *                              not the one being analysed -- as with a method
+     *                              reported from inside its class. A node rather
+     *                              than a line number because Psalm locates an
+     *                              issue by its exact source span, and a line
+     *                              cannot be widened back into one
      */
     public function __construct(
         public readonly string $message,
         public readonly string $identifier,
-        public readonly ?int $line = null,
+        public readonly ?Node $node = null,
     ) {
     }
 }

--- a/tests/Integration/Psalm/ArchitectureRulesTest.php
+++ b/tests/Integration/Psalm/ArchitectureRulesTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm;
+
+/**
+ * Runs Psalm for real over a set of deliberately broken modules.
+ *
+ * The analysers have host-free unit tests of their own; what this proves is the
+ * half those cannot -- that the rules are registered, that Psalm's storage
+ * answers the seam correctly, and that each finding arrives as its own issue
+ * type so a consumer can suppress one without losing the rest.
+ */
+final class ArchitectureRulesTest extends PsalmFixtureTestCase
+{
+    public function test_a_pillar_named_class_must_extend_its_base(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaSuffixExtends: Class ' . RulesFixture\BadFacade::class . ' should extend Gacela\Framework\AbstractFacade',
+            $this->errorsIn('BadFacade.php'),
+        );
+    }
+
+    public function test_a_facade_method_may_only_delegate(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaFacadeOnlyDelegates: Facade method ' . RulesFixture\LogicFacade::class . '::doesArithmetic()',
+            $this->errorsIn('LogicFacade.php'),
+        );
+    }
+
+    public function test_a_factory_may_not_instantiate_a_facade(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaFacadeInstantiation: Factory ' . RulesFixture\BadWiringFactory::class,
+            $this->errorsIn('BadWiringFactory.php'),
+        );
+    }
+
+    /**
+     * Reported separately from the instantiation above: they are different
+     * mistakes with different corrections, so a factory making both hears about
+     * both.
+     */
+    public function test_a_factory_may_not_call_get_facade(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaFactoryFacadeAccess: Factory ' . RulesFixture\BadWiringFactory::class,
+            $this->errorsIn('BadWiringFactory.php'),
+        );
+    }
+
+    public function test_a_public_facade_method_missing_from_its_interface_is_reported(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaFacadeInterfaceDrift: Facade method ' . RulesFixture\DriftedFacade::class . '::forgotten()',
+            $this->errorsIn('DriftedFacade.php'),
+        );
+    }
+
+    /**
+     * The finding belongs to the drifted method, not to the class, because the
+     * class's own line names no method to go and declare.
+     */
+    public function test_the_interface_drift_is_located_on_the_method(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString('DriftedFacade.php:19:', $this->errorsIn('DriftedFacade.php'));
+    }
+
+    /**
+     * The half that would go unnoticed: a rule that fires on everything is not a
+     * rule. Both clean fixtures are as much a module as the broken ones.
+     */
+    public function test_a_module_that_follows_the_rules_is_silent(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('Gacela', $errors, 'precondition: the rules ran at all');
+        self::assertSame('', $this->errorsIn('CleanFacade.php'));
+        self::assertSame('', $this->errorsIn('CleanFactory.php'));
+    }
+
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/RulesFixture/psalm-rules-fixture.xml';
+    }
+}

--- a/tests/Integration/Psalm/Fixture/ConsumerFacade.php
+++ b/tests/Integration/Psalm/Fixture/ConsumerFacade.php
@@ -6,10 +6,13 @@ namespace GacelaTest\Integration\Psalm\Fixture;
 
 use Gacela\Framework\AbstractFacade;
 
+/**
+ * @extends AbstractFacade<ConsumerFactory>
+ */
 final class ConsumerFacade extends AbstractFacade
 {
     public function knownMethod(): string
     {
-        return 'known';
+        return $this->getFactory()->createKnown();
     }
 }

--- a/tests/Integration/Psalm/Fixture/ConsumerFactory.php
+++ b/tests/Integration/Psalm/Fixture/ConsumerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\Fixture;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @extends AbstractFactory<\Gacela\Framework\AbstractConfig>
+ */
+final class ConsumerFactory extends AbstractFactory
+{
+    public function createKnown(): string
+    {
+        return 'known';
+    }
+}

--- a/tests/Integration/Psalm/ProvidedDependencyPluginTest.php
+++ b/tests/Integration/Psalm/ProvidedDependencyPluginTest.php
@@ -56,4 +56,9 @@ final class ProvidedDependencyPluginTest extends PsalmFixtureTestCase
 
         self::assertStringContainsString('MixedMethodCall', $this->errorsIn('StringKeyFactory.php'));
     }
+
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/Fixture/psalm-fixture.xml';
+    }
 }

--- a/tests/Integration/Psalm/PsalmFixtureTestCase.php
+++ b/tests/Integration/Psalm/PsalmFixtureTestCase.php
@@ -15,24 +15,29 @@ use function str_contains;
 use function substr;
 
 /**
- * Runs the plugin end-to-end through a real `vendor/bin/psalm`, over
- * `Fixture/psalm-fixture.xml`.
+ * Runs the plugin end-to-end through a real `vendor/bin/psalm`.
  *
  * That is the strongest proof available -- an in-process test drives a hook,
- * this drives Psalm -- but it is also the slowest, so the run is shared: the
- * fixture set and the config are the same for every test here, so the output is
- * too, and analysing once per process is enough.
+ * this drives Psalm -- but it is also the slowest, so each config is analysed
+ * once per process and its output shared by every test that asks for it.
  */
 abstract class PsalmFixtureTestCase extends TestCase
 {
     private const ROOT = __DIR__ . '/../../..';
 
-    private static ?string $output = null;
+    /** @var array<string, string> */
+    private static array $outputs = [];
 
     final protected function analyseFixture(): string
     {
-        return self::$output ??= $this->runPsalm();
+        return self::$outputs[static::configPath()] ??= $this->runPsalm();
     }
+
+    /**
+     * The psalm config to analyse. One per fixture set, so a set of deliberately
+     * broken modules cannot leak its findings into a test about something else.
+     */
+    abstract protected static function configPath(): string;
 
     /**
      * Only the findings for one fixture file.
@@ -94,7 +99,7 @@ abstract class PsalmFixtureTestCase extends TestCase
         $command = sprintf(
             '%s --config=%s --no-progress --no-cache --output-format=text 2>&1',
             escapeshellarg(self::ROOT . '/vendor/bin/psalm'),
-            escapeshellarg(__DIR__ . '/Fixture/psalm-fixture.xml'),
+            escapeshellarg(static::configPath()),
         );
 
         return (string)shell_exec($command);

--- a/tests/Integration/Psalm/RulesFixture/BadFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/BadFacade.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+/**
+ * Named after the pillar, extends nothing.
+ */
+final class BadFacade
+{
+}

--- a/tests/Integration/Psalm/RulesFixture/BadWiringFactory.php
+++ b/tests/Integration/Psalm/RulesFixture/BadWiringFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * Both halves of the factory rule, which are different mistakes with different
+ * corrections.
+ *
+ * @extends AbstractFactory<\Gacela\Framework\AbstractConfig>
+ */
+final class BadWiringFactory extends AbstractFactory
+{
+    public function createFromFacade(): CleanFacade
+    {
+        return new CleanFacade();
+    }
+
+    public function reachesForTheFacade(): string
+    {
+        return $this->getFacade()->doThing();
+    }
+}

--- a/tests/Integration/Psalm/RulesFixture/CleanFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/CleanFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<CleanFactory>
+ */
+final class CleanFacade extends AbstractFacade
+{
+    public function doThing(): string
+    {
+        return $this->getFactory()->createThing();
+    }
+}

--- a/tests/Integration/Psalm/RulesFixture/CleanFactory.php
+++ b/tests/Integration/Psalm/RulesFixture/CleanFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @extends AbstractFactory<\Gacela\Framework\AbstractConfig>
+ */
+final class CleanFactory extends AbstractFactory
+{
+    public function createThing(): string
+    {
+        return 'thing';
+    }
+}

--- a/tests/Integration/Psalm/RulesFixture/DriftedFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/DriftedFacade.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<CleanFactory>
+ */
+final class DriftedFacade extends AbstractFacade implements DriftedFacadeInterface
+{
+    public function declared(): string
+    {
+        return $this->getFactory()->createThing();
+    }
+
+    public function forgotten(): string
+    {
+        return $this->getFactory()->createThing();
+    }
+}

--- a/tests/Integration/Psalm/RulesFixture/DriftedFacadeInterface.php
+++ b/tests/Integration/Psalm/RulesFixture/DriftedFacadeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+interface DriftedFacadeInterface
+{
+    public function declared(): string;
+}

--- a/tests/Integration/Psalm/RulesFixture/LogicFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/LogicFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<CleanFactory>
+ */
+final class LogicFacade extends AbstractFacade
+{
+    public function doesArithmetic(): int
+    {
+        return 1 + 1;
+    }
+}

--- a/tests/Integration/Psalm/RulesFixture/psalm-rules-fixture.xml
+++ b/tests/Integration/Psalm/RulesFixture/psalm-rules-fixture.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+    Deliberately broken modules, analysed to prove the Gacela rules fire under
+    Psalm. errorLevel 1 so nothing here is downgraded to a warning.
+-->
+<psalm errorLevel="1" resolveFromConfigFile="true" findUnusedBaselineEntry="false" findUnusedCode="false">
+    <projectFiles>
+        <directory name="."/>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Gacela\Psalm\Plugin"/>
+    </plugins>
+
+    <issueHandlers>
+        <!-- Not what these fixtures are about, and the project's own psalm.xml
+             suppresses it too. -->
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>

--- a/tests/Integration/Psalm/ServiceMapPluginTest.php
+++ b/tests/Integration/Psalm/ServiceMapPluginTest.php
@@ -43,4 +43,9 @@ final class ServiceMapPluginTest extends PsalmFixtureTestCase
 
         self::assertStringNotContainsString('UndefinedMagicMethod', $errors);
     }
+
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/Fixture/psalm-fixture.xml';
+    }
 }

--- a/tests/Unit/Psalm/PluginTest.php
+++ b/tests/Unit/Psalm/PluginTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\Psalm;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Psalm\ClassRules;
 use Gacela\Psalm\Plugin;
 use PHPUnit\Framework\TestCase;
 use Psalm\Codebase;
@@ -52,6 +53,15 @@ final class PluginTest extends TestCase
         (new Plugin())($this->socket(new EventDispatcher()));
 
         self::assertTrue($returnTypes->has(AbstractFactory::class));
+    }
+
+    public function test_it_registers_the_class_level_architecture_rules(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        (new Plugin())($this->socket($dispatcher));
+
+        self::assertContains(ClassRules::class, $dispatcher->after_classlike_checks);
     }
 
     public function test_it_ignores_the_optional_plugin_config(): void

--- a/tests/Unit/Psalm/ReportedIssuesTest.php
+++ b/tests/Unit/Psalm/ReportedIssuesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Psalm\ReportedIssues;
+use PHPUnit\Framework\TestCase;
+use Psalm\Issue\PluginIssue;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function array_diff;
+use function array_unique;
+use function array_values;
+use function class_exists;
+use function file_get_contents;
+use function is_subclass_of;
+use function preg_match_all;
+use function sort;
+
+/**
+ * Holds the identifier-to-issue map complete in **both** directions.
+ *
+ * PHPStan reports an identifier; Psalm reports an issue class, and that class
+ * name is what a consumer suppresses on. A rule whose identifier is missing from
+ * the map is a rule with no way to turn it off, and it would go unnoticed --
+ * nothing else fails when a violation is quietly dropped.
+ *
+ * The other direction matters just as much: a map entry that no rule produces
+ * any more is a suppression key that silently stopped meaning anything.
+ */
+final class ReportedIssuesTest extends TestCase
+{
+    private const RULES_DIR = __DIR__ . '/../../../src/StaticAnalysis/Rules';
+
+    public function test_every_identifier_a_rule_reports_has_an_issue_class(): void
+    {
+        self::assertSame(
+            [],
+            array_values(array_diff($this->identifiersInRules(), ReportedIssues::mappedIdentifiers())),
+            'a rule reports an identifier Psalm has no issue class for, so it cannot be suppressed',
+        );
+    }
+
+    public function test_the_map_carries_no_identifier_a_rule_stopped_reporting(): void
+    {
+        self::assertSame(
+            [],
+            array_values(array_diff(ReportedIssues::mappedIdentifiers(), $this->identifiersInRules())),
+            'a mapped identifier no rule produces is a suppression key that means nothing',
+        );
+    }
+
+    public function test_every_mapped_issue_is_a_psalm_plugin_issue(): void
+    {
+        foreach (ReportedIssues::mappedIdentifiers() as $identifier) {
+            $issueClass = ReportedIssues::issueFor($identifier);
+
+            self::assertNotNull($issueClass, $identifier . ' maps to nothing');
+            self::assertTrue(class_exists($issueClass), $issueClass . ' does not exist');
+            self::assertTrue(
+                is_subclass_of($issueClass, PluginIssue::class),
+                $issueClass . ' must extend PluginIssue to be suppressible by name',
+            );
+        }
+    }
+
+    public function test_an_identifier_no_rule_reports_maps_to_nothing(): void
+    {
+        self::assertNull(ReportedIssues::issueFor('gacela.notARule'));
+    }
+
+    /**
+     * Read out of the rules themselves rather than listed here, so adding a rule
+     * with a new identifier fails this test instead of passing a copy of it.
+     *
+     * @return list<string>
+     */
+    private function identifiersInRules(): array
+    {
+        $found = [];
+
+        /** @var SplFileInfo $file */
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator(self::RULES_DIR)) as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            preg_match_all("/'(gacela\\.[A-Za-z]+)'/", (string)file_get_contents($file->getPathname()), $matches);
+            foreach ($matches[1] as $identifier) {
+                $found[] = $identifier;
+            }
+        }
+
+        $found = array_values(array_unique($found));
+        sort($found);
+
+        return $found;
+    }
+}

--- a/tests/Unit/Psalm/StorageAnalysedClassTest.php
+++ b/tests/Unit/Psalm/StorageAnalysedClassTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Psalm\StorageAnalysedClass;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\Storage\ClassLikeStorage;
+use ReflectionClass;
+
+/**
+ * The seam between the shared rules and Psalm's own view of a class.
+ *
+ * `ArchitectureRulesTest` exercises it against a real analysis, but that is a
+ * subprocess and invisible to coverage; these drive it directly.
+ */
+final class StorageAnalysedClassTest extends TestCase
+{
+    private const FACADE = 'App\Checkout\CheckoutFacade';
+
+    public function test_it_reports_the_stored_name(): void
+    {
+        self::assertSame(self::FACADE, $this->analysedClass()->name());
+    }
+
+    /**
+     * Psalm keys the ancestry by lowercase name, so the lookup has to lower the
+     * name it is given -- `AbstractFacade` would otherwise never match.
+     */
+    public function test_it_finds_a_parent_class(): void
+    {
+        $class = $this->analysedClass(parents: [AbstractFacade::class]);
+
+        self::assertTrue($class->extendsClass(AbstractFacade::class));
+    }
+
+    public function test_it_reports_an_absent_parent(): void
+    {
+        self::assertFalse($this->analysedClass()->extendsClass(AbstractFacade::class));
+    }
+
+    /**
+     * `parent_classes` holds the whole ancestry, not the immediate parent, which
+     * is what lets the rules see a facade that extends an intermediate class.
+     */
+    public function test_it_finds_an_indirect_parent(): void
+    {
+        $class = $this->analysedClass(parents: ['App\Checkout\BaseFacade', AbstractFacade::class]);
+
+        self::assertTrue($class->extendsClass(AbstractFacade::class));
+    }
+
+    /**
+     * The values carry the original casing; the keys do not, and reporting a
+     * lowercased interface name would name a class that does not exist.
+     */
+    public function test_it_reports_interfaces_with_their_original_casing(): void
+    {
+        $class = $this->analysedClass(interfaces: ['App\Checkout\CheckoutFacadeInterface']);
+
+        self::assertSame(['App\Checkout\CheckoutFacadeInterface'], $class->interfaceNames());
+    }
+
+    public function test_a_class_implementing_nothing_has_no_interfaces(): void
+    {
+        self::assertSame([], $this->analysedClass()->interfaceNames());
+    }
+
+    /**
+     * @param list<string> $parents
+     * @param list<string> $interfaces
+     */
+    private function analysedClass(array $parents = [], array $interfaces = []): StorageAnalysedClass
+    {
+        $storage = new ClassLikeStorage(self::FACADE);
+
+        foreach ($parents as $parent) {
+            $storage->parent_classes[strtolower($parent)] = $parent;
+        }
+
+        foreach ($interfaces as $interface) {
+            $storage->class_implements[strtolower($interface)] = $interface;
+        }
+
+        // Codebase is final and wants a whole analysis context to build; only
+        // interfaceHasMethod() reaches for it, and that is covered end-to-end by
+        // ArchitectureRulesTest against a real run.
+        $codebase = (new ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+
+        return new StorageAnalysedClass($storage, $codebase);
+    }
+}

--- a/tests/Unit/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyserTest.php
@@ -68,7 +68,7 @@ final class FacadeInterfaceInSyncAnalyserTest extends TestCase
      */
     public function test_the_violation_points_at_the_method_not_the_class(): void
     {
-        self::assertSame(12, $this->analyse(['declared'])[0]->line);
+        self::assertSame(12, $this->analyse(['declared'])[0]->node?->getStartLine());
     }
 
     /**

--- a/tests/Unit/StaticAnalysis/Rules/SuffixExtendsAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/SuffixExtendsAnalyserTest.php
@@ -32,11 +32,11 @@ final class SuffixExtendsAnalyserTest extends TestCase
 
     /**
      * The finding belongs to the class, which is the node the host is already
-     * reporting on -- overriding the line would move it off the declaration.
+     * reporting on -- carrying one of its own would move it off the declaration.
      */
-    public function test_a_violation_carries_no_line_of_its_own(): void
+    public function test_a_violation_carries_no_node_of_its_own(): void
     {
-        self::assertNull($this->analyse('App\Checkout\CheckoutFacade')[0]->line);
+        self::assertNull($this->analyse('App\Checkout\CheckoutFacade')[0]->node);
     }
 
     public function test_a_class_without_the_suffix_is_not_checked(): void


### PR DESCRIPTION
## 📚 Description

`phpstan-gacela.neon` gives a consumer eight registrations. The Psalm plugin gave
them one pseudo-method — so a team standardised on Psalm had no mechanical way to
hold Gacela's own architectural claims, and `docs/static-analysis.md` presented
the two analysers under one heading as though they were peers.

This adds the five default-on rules to Psalm, over the analyser core from #639,
so each rule is decided in exactly one place. Two implementations of "what counts
as a delegation" would drift, which is the failure `FacadeInterfaceInSyncAnalyser`
exists to catch.

Closes #640

## 🔖 Changes

- Add `Gacela\Psalm\ClassRules`, an `AfterClassLikeAnalysis` handler running
  `SuffixExtends` (×4 pillars), `FactoryDoesNotCallFacade`,
  `FacadeInterfaceInSync` and `FacadeOnlyDelegates`
- Add `StorageAnalysedClass` — the Psalm half of `AnalysedClassInterface`,
  answered from `ClassLikeStorage` and the public `Codebase` API
- Add six `PluginIssue` subclasses and `ReportedIssues`, which maps a rule's
  error identifier onto one. PHPStan suppresses on an identifier, Psalm on an
  issue class name; this is where one becomes the other
- Register `ClassRules` from `Gacela\Psalm\Plugin`, which consumers already
  declare — no config change on their side
- Suppress `GacelaSuffixExtends` under `src/Framework` in `psalm.xml`, the same
  exemption `phpstan.neon` carries and for the same reason
- Document the rules and the `<PluginIssue name="...">` suppression form

### Two things Gacela found by analysing itself

Registering the plugin in Gacela's own `psalm.xml` was not ceremony:

- **Three of my issue classes tripped the rule they implement.**
  `GacelaFactoryInstantiatesFacade`, `GacelaFactoryCallsGetFacade` and
  `GacelaCrossModuleWithoutFacade` all end in `Facade`, which is exactly the
  confusion `SuffixExtends` exists to prevent. Renamed to
  `GacelaFacadeInstantiation`, `GacelaFactoryFacadeAccess` and
  `GacelaCrossModuleAccess` rather than suppressed
- **The existing ServiceMap fixture had inline logic in a facade method.**
  `ConsumerFacade::knownMethod()` returned a literal; it now delegates to a
  `ConsumerFactory`, which is also what a fixture should look like

### One design note

`FacadeOnlyDelegates` runs from the class handler rather than an
`AfterFunctionLikeAnalysis` handler of its own. Psalm hands a function-like over
without the class storage the rule needs, and every route back to it
(`Codebase::$classlike_storage_provider`) is `@internal` — Psalm said so itself
when analysing this branch. Walking the methods of a class already in hand costs
nothing and keeps the plugin off Psalm's internals entirely.

## 🧪 Testing

- `ArchitectureRulesTest` runs a real `vendor/bin/psalm` over seven deliberately
  broken modules, asserting each rule fires under its own issue name, that the
  interface-drift finding lands on the **method** rather than the class, and that
  the two clean fixtures are silent — a rule that fires on everything is not a
  rule
- `ReportedIssuesTest` holds the identifier map complete in **both** directions,
  reading the identifiers out of the rule sources rather than restating them: a
  rule with no issue class cannot be suppressed, and a mapped identifier no rule
  produces is a suppression key that silently stopped meaning anything
- `StorageAnalysedClassTest` drives the seam in-process, which is what puts it
  under the mutation gate — the subprocess test above is invisible to coverage
- Infection over `src/Psalm`: **100% MSI**, 75 mutations, 0 escaped
- `Violation` now carries the `Node` a finding belongs to instead of a line
  number: Psalm locates an issue by its exact source span, and a line cannot be
  widened back into one. PHPStan's mapper reads `getStartLine()` off it, so the
  reported lines are unchanged
