### PR TITLE
feat: report cross-module method calls on injected dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Type `getProvidedDependency(Foo::class)` under Psalm too, matching the PHPStan extension
 - Enforce the pillar rules under Psalm, each as its own suppressible issue type
+- Report cross-module method calls on injected dependencies, which name no class at the call site
+
+### Removed
+
+- Drop the `gacela-project/phpstan-extension` suggestion: its one rule is now built in, and it
+  cannot load against the PHPStan version Gacela requires
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
     "suggest": {
         "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
         "gacela-project/gacela-yaml-config-reader": "Allows to read yml/yaml config files",
-        "gacela-project/phpstan-extension": "A set of phpstan rules for Gacela",
         "phpunit/phpunit": "Allows to extend Gacela\\Framework\\Testing\\GacelaTestCase in your tests",
         "symfony/console": "Allows to use vendor/bin/gacela script"
     },

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -155,10 +155,16 @@ services:
 
 - A call on a `*Facade` **or a `*FacadeInterface`** is allowed — consumers
   type-hint the interface, which is the same sanctioned crossing.
+  `CrossModuleViaFacadeRule` accepts only `*Facade`, because a written
+  `SomeFacadeInterface::class` reference is not a call through one.
 - A receiver PHPStan cannot resolve is not reported. An unknown type is not
   evidence of a violation, and guessing there would make the rule noise.
 - The finding has its own identifier, `gacela.crossModuleMethodCall`, so it can
   be suppressed separately while a codebase catches up.
+
+With both rules on, one line can produce two findings —
+`(new ShopService())->run()` both names the other module and calls into it. They
+are two crossings and each has its own correction, so both are reported.
 
 To see the actual module dependency graph of your app, run
 `vendor/bin/gacela debug:graph` (formats: `text`, `mermaid`, `graphviz`, `json`).

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -121,6 +121,45 @@ services:
   namespace-boundary aware (`App\Modules\Shared` does not exempt
   `App\Modules\SharedFoo`).
 
+That rule matches names **written at the call site**, which is not how a boundary
+is usually crossed once dependencies go through Providers and constructors:
+
+```php
+public function __construct(
+    private readonly InvoiceRepository $invoices,  // App\Billing — another module
+) {
+}
+
+public function createProcessor(): Processor
+{
+    return new Processor($this->invoices->findAll());  // names nothing here
+}
+```
+
+`CrossModuleMethodCallRule` is the other half. It resolves the receiver of a
+method call by **type**, so the call above is reported even though the class is
+named only once, in a type-hint. Register it alongside the first, with the same
+arguments:
+
+```neon
+services:
+    -
+        class: Gacela\PHPStan\Rules\CrossModuleMethodCallRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: App\Modules
+            modulePathSegments: 1
+            sharedNamespaces:
+                - App\Modules\Shared
+```
+
+- A call on a `*Facade` **or a `*FacadeInterface`** is allowed — consumers
+  type-hint the interface, which is the same sanctioned crossing.
+- A receiver PHPStan cannot resolve is not reported. An unknown type is not
+  evidence of a violation, and guessing there would make the rule noise.
+- The finding has its own identifier, `gacela.crossModuleMethodCall`, so it can
+  be suppressed separately while a codebase catches up.
+
 To see the actual module dependency graph of your app, run
 `vendor/bin/gacela debug:graph` (formats: `text`, `mermaid`, `graphviz`, `json`).
 

--- a/phpstan-gacela.neon
+++ b/phpstan-gacela.neon
@@ -49,8 +49,23 @@ services:
     # how many segments beneath that root identify a module). Namespaces in
     # sharedNamespaces are exempt shared kernels: references into them are
     # always allowed, and classes inside them are not checked.
+    #
+    # The two rules are halves of one check and are meant to be enabled together.
+    # CrossModuleViaFacadeRule matches names written at the call site -- `new`, a
+    # static call, a class constant. CrossModuleMethodCallRule resolves the
+    # receiver of a method call by type, which is how a boundary is crossed once
+    # dependencies go through Providers and constructors: the class is named once,
+    # in a type-hint, and never at the call site.
     # -
     #     class: Gacela\PHPStan\Rules\CrossModuleViaFacadeRule
+    #     tags: [phpstan.rules.rule]
+    #     arguments:
+    #         rootNamespace: App\Modules
+    #         modulePathSegments: 1
+    #         sharedNamespaces:
+    #             - App\Modules\Shared
+    # -
+    #     class: Gacela\PHPStan\Rules\CrossModuleMethodCallRule
     #     tags: [phpstan.rules.rule]
     #     arguments:
     #         rootNamespace: App\Modules

--- a/src/PHPStan/Rules/CrossModuleMethodCallRule.php
+++ b/src/PHPStan/Rules/CrossModuleMethodCallRule.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\PHPStan\Rules;
+
+use Gacela\StaticAnalysis\Rules\CrossModuleMethodCallAnalyser;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<MethodCall>
+ *
+ * @see CrossModuleMethodCallAnalyser for what is checked and why
+ */
+final class CrossModuleMethodCallRule implements Rule
+{
+    private readonly CrossModuleMethodCallAnalyser $analyser;
+
+    /**
+     * @param list<string> $sharedNamespaces namespaces exempt from the boundary
+     *                                       check (shared kernels)
+     */
+    public function __construct(
+        string $rootNamespace,
+        int $modulePathSegments = 1,
+        array $sharedNamespaces = [],
+    ) {
+        $this->analyser = new CrossModuleMethodCallAnalyser($rootNamespace, $modulePathSegments, $sharedNamespaces);
+    }
+
+    /**
+     * A method call rather than the class node, because only the scope at the
+     * call site knows what the receiver is. The class-level scope the sibling
+     * rule runs in resolves every local expression to `mixed`.
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        return RuleErrors::from($this->analyser->analyse(
+            $classReflection->getName(),
+            // Empty for an untyped or `mixed` receiver, which is not evidence of
+            // a violation -- guessing there would turn the rule into noise.
+            $scope->getType($node->var)->getObjectClassNames(),
+        ));
+    }
+}

--- a/src/Psalm/Issue/GacelaCrossModuleMethodCall.php
+++ b/src/Psalm/Issue/GacelaCrossModuleMethodCall.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A method call on a value whose type belongs to another module.
+ *
+ * The name is written once, in a type-hint, so this is the crossing
+ * `GacelaCrossModuleAccess` cannot see.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaCrossModuleMethodCall" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaCrossModuleMethodCall extends PluginIssue
+{
+}

--- a/src/Psalm/ReportedIssues.php
+++ b/src/Psalm/ReportedIssues.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Psalm;
 
 use Gacela\Psalm\Issue\GacelaCrossModuleAccess;
+use Gacela\Psalm\Issue\GacelaCrossModuleMethodCall;
 use Gacela\Psalm\Issue\GacelaFacadeInstantiation;
 use Gacela\Psalm\Issue\GacelaFacadeInterfaceDrift;
 use Gacela\Psalm\Issue\GacelaFacadeOnlyDelegates;
@@ -43,6 +44,7 @@ final class ReportedIssues
         'gacela.factoryCallsGetFacade' => GacelaFactoryFacadeAccess::class,
         'gacela.facadeInterfaceDrift' => GacelaFacadeInterfaceDrift::class,
         'gacela.crossModuleWithoutFacade' => GacelaCrossModuleAccess::class,
+        'gacela.crossModuleMethodCall' => GacelaCrossModuleMethodCall::class,
     ];
 
     /**

--- a/src/StaticAnalysis/ModuleBoundary.php
+++ b/src/StaticAnalysis/ModuleBoundary.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis;
+
+use function array_slice;
+use function count;
+use function explode;
+use function implode;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * Where a module begins and ends, in one place.
+ *
+ * Nothing in a class name says that on its own, which is why the root namespace
+ * has to be supplied -- and why the rules built on this are opt-in while the
+ * pillar rules are on by default.
+ */
+final class ModuleBoundary
+{
+    /**
+     * No defaults here on purpose: the rules built on this are the public API
+     * and carry them, so a default repeated here would be a second answer to the
+     * same question that nothing exercises.
+     *
+     * @param int          $modulePathSegments how many segments under the root identify a module
+     * @param list<string> $sharedNamespaces   exempt shared kernels: references into
+     *                                         them are always allowed, and classes
+     *                                         inside them are not checked
+     */
+    public function __construct(
+        private readonly string $rootNamespace,
+        private readonly int $modulePathSegments,
+        private readonly array $sharedNamespaces,
+    ) {
+    }
+
+    /**
+     * The module a class belongs to, or null when it belongs to none -- either
+     * outside the root namespace entirely, or sitting directly under it with no
+     * segment left to name a module.
+     */
+    public function moduleOf(string $class): ?string
+    {
+        $prefix = $this->rootNamespace . '\\';
+        if (!str_starts_with($class, $prefix)) {
+            return null;
+        }
+
+        $remainder = substr($class, strlen($prefix));
+        $segments = explode('\\', $remainder);
+        if (count($segments) <= $this->modulePathSegments) {
+            return null;
+        }
+
+        return $this->rootNamespace . '\\' . implode('\\', array_slice($segments, 0, $this->modulePathSegments));
+    }
+
+    /**
+     * Matching is namespace-boundary aware on purpose: on the raw prefix,
+     * `App\Shared` would silently exempt `App\SharedFoo` as well.
+     */
+    public function isShared(string $class): bool
+    {
+        foreach ($this->sharedNamespaces as $sharedNamespace) {
+            if ($class === $sharedNamespace || str_starts_with($class, $sharedNamespace . '\\')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The module `$referenced` belongs to, when reaching it from `$fromModule`
+     * crosses a boundary that has to be justified -- null when it does not.
+     */
+    public function crossedBy(string $fromModule, string $referenced): ?string
+    {
+        $module = $this->moduleOf($referenced);
+
+        if ($module === null || $module === $fromModule || $this->isShared($referenced)) {
+            return null;
+        }
+
+        return $module;
+    }
+}

--- a/src/StaticAnalysis/Rules/CrossModuleMethodCallAnalyser.php
+++ b/src/StaticAnalysis/Rules/CrossModuleMethodCallAnalyser.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis\Rules;
+
+use Gacela\StaticAnalysis\ModuleBoundary;
+use Gacela\StaticAnalysis\ShortName;
+use Gacela\StaticAnalysis\Violation;
+
+use function sprintf;
+use function str_ends_with;
+
+/**
+ * The boundary crossing {@see CrossModuleViaFacadeAnalyser} cannot see.
+ *
+ * That rule matches names written at the call site. In a codebase built the way
+ * Gacela asks -- dependencies pushed through Providers and constructors -- a
+ * call site names nothing:
+ *
+ * ```php
+ * public function __construct(private readonly InvoiceRepository $invoices) {}
+ *
+ * public function createProcessor(): Processor
+ * {
+ *     return new Processor($this->invoices->findAll());  // App\Billing, unnamed here
+ * }
+ * ```
+ *
+ * The class appears once, in a constructor type-hint. So the rule that catches
+ * the direct instantiation reports green on exactly the codebases most likely to
+ * be crossing boundaries.
+ *
+ * The receiver's classes are resolved by the host and handed in, because that is
+ * the one part neither php-parser nor this package can do: PHPStan reads them off
+ * `Scope::getType()`, Psalm off its `NodeTypeProvider`.
+ */
+final class CrossModuleMethodCallAnalyser
+{
+    private readonly ModuleBoundary $boundary;
+
+    /**
+     * @param list<string> $sharedNamespaces namespaces exempt from the boundary check
+     */
+    public function __construct(
+        string $rootNamespace,
+        int $modulePathSegments = 1,
+        array $sharedNamespaces = [],
+    ) {
+        $this->boundary = new ModuleBoundary($rootNamespace, $modulePathSegments, $sharedNamespaces);
+    }
+
+    /**
+     * @param string       $callingClass    the class the call is written in
+     * @param list<string> $receiverClasses the classes the receiver's type resolves
+     *                                      to; empty when the host could not tell
+     *
+     * @return list<Violation>
+     */
+    public function analyse(string $callingClass, array $receiverClasses): array
+    {
+        if ($this->boundary->isShared($callingClass)) {
+            return [];
+        }
+
+        $callingModule = $this->boundary->moduleOf($callingClass);
+        if ($callingModule === null) {
+            return [];
+        }
+
+        $violations = [];
+
+        foreach ($receiverClasses as $receiver) {
+            // A Facade is the sanctioned way across, and so is the interface a
+            // consumer holds instead of the Facade itself.
+            if ($this->isFacade($receiver)) {
+                continue;
+            }
+
+            $module = $this->boundary->crossedBy($callingModule, $receiver);
+            if ($module === null) {
+                continue;
+            }
+
+            $violations[] = new Violation(
+                sprintf(
+                    'Class %s calls a method on %s from another module (%s). Cross-module access must go through a Facade.',
+                    $callingClass,
+                    $receiver,
+                    $module,
+                ),
+                'gacela.crossModuleMethodCall',
+            );
+        }
+
+        return $violations;
+    }
+
+    private function isFacade(string $class): bool
+    {
+        $shortName = ShortName::of($class);
+
+        return str_ends_with($shortName, 'Facade') || str_ends_with($shortName, 'FacadeInterface');
+    }
+}

--- a/src/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyser.php
+++ b/src/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyser.php
@@ -6,6 +6,7 @@ namespace Gacela\StaticAnalysis\Rules;
 
 use Gacela\StaticAnalysis\AnalysedClassInterface;
 use Gacela\StaticAnalysis\ClassAnalyserInterface;
+use Gacela\StaticAnalysis\ModuleBoundary;
 use Gacela\StaticAnalysis\ShortName;
 use Gacela\StaticAnalysis\Violation;
 use PhpParser\Node;
@@ -17,26 +18,22 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\NodeFinder;
 
-use function array_slice;
-use function count;
-use function explode;
-use function implode;
 use function sprintf;
 use function str_ends_with;
-use function str_starts_with;
-use function strlen;
-use function substr;
 
 /**
  * Module A may only reach module B through B's Facade -- gacela's central
- * architectural claim, checked.
+ * architectural claim, checked wherever the source writes the other module's
+ * name: `new`, a static call, a class constant, a static property.
  *
- * Nothing in a class name says where a module boundary falls, so the root
- * namespace has to be supplied; that is what keeps this rule opt-in while the
- * pillar rules are on by default.
+ * A boundary crossed through an injected dependency writes no name at the call
+ * site, so it is invisible here; {@see CrossModuleMethodCallAnalyser} resolves
+ * those by type instead.
  */
 final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
 {
+    private readonly ModuleBoundary $boundary;
+
     /**
      * @param list<string> $sharedNamespaces namespaces exempt from the boundary
      *                                       check (shared kernels): references
@@ -44,10 +41,11 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
      *                                       classes inside them are not checked
      */
     public function __construct(
-        private readonly string $rootNamespace,
-        private readonly int $modulePathSegments = 1,
-        private readonly array $sharedNamespaces = [],
+        string $rootNamespace,
+        int $modulePathSegments = 1,
+        array $sharedNamespaces = [],
     ) {
+        $this->boundary = new ModuleBoundary($rootNamespace, $modulePathSegments, $sharedNamespaces);
     }
 
     /**
@@ -56,11 +54,11 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
     public function analyse(ClassLike $node, AnalysedClassInterface $class): array
     {
         $currentClass = $class->name();
-        if ($this->isShared($currentClass)) {
+        if ($this->boundary->isShared($currentClass)) {
             return [];
         }
 
-        $currentModule = $this->moduleOf($currentClass);
+        $currentModule = $this->boundary->moduleOf($currentClass);
         if ($currentModule === null) {
             return [];
         }
@@ -69,20 +67,12 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
         $seen = [];
 
         foreach ($this->referencedClasses($node) as $referenced) {
-            $refModule = $this->moduleOf($referenced);
+            $refModule = $this->boundary->crossedBy($currentModule, $referenced);
             if ($refModule === null) {
                 continue;
             }
 
-            if ($refModule === $currentModule) {
-                continue;
-            }
-
             if (str_ends_with(ShortName::of($referenced), 'Facade')) {
-                continue;
-            }
-
-            if ($this->isShared($referenced)) {
                 continue;
             }
 
@@ -124,7 +114,7 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
         $names = [];
 
         foreach ($refs as $ref) {
-            /** @var New_|StaticCall|ClassConstFetch|StaticPropertyFetch $ref */
+            /** @var ClassConstFetch|New_|StaticCall|StaticPropertyFetch $ref */
             // `new $class` / `$class::CONST` name nothing to match on.
             if ($ref->class instanceof Name) {
                 $names[] = $ref->class->toString();
@@ -132,32 +122,5 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
         }
 
         return $names;
-    }
-
-    private function isShared(string $class): bool
-    {
-        foreach ($this->sharedNamespaces as $sharedNamespace) {
-            if ($class === $sharedNamespace || str_starts_with($class, $sharedNamespace . '\\')) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function moduleOf(string $class): ?string
-    {
-        $prefix = $this->rootNamespace . '\\';
-        if (!str_starts_with($class, $prefix)) {
-            return null;
-        }
-
-        $remainder = substr($class, strlen($prefix));
-        $segments = explode('\\', $remainder);
-        if (count($segments) <= $this->modulePathSegments) {
-            return null;
-        }
-
-        return $this->rootNamespace . '\\' . implode('\\', array_slice($segments, 0, $this->modulePathSegments));
     }
 }

--- a/tests/Unit/PHPStan/Rules/CrossModuleMethodCallRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/CrossModuleMethodCallRuleTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules;
+
+use Gacela\PHPStan\Rules\CrossModuleMethodCallRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+use function sprintf;
+
+/**
+ * @extends RuleTestCase<CrossModuleMethodCallRule>
+ */
+final class CrossModuleMethodCallRuleTest extends RuleTestCase
+{
+    private const ROOT = 'GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule';
+
+    /** @var list<string> */
+    private array $sharedNamespaces = [];
+
+    private ?Rule $rule = null;
+
+    /**
+     * The headline case. `ShopService` is written once, in a constructor
+     * type-hint; the call site names nothing, so the name-matching rule sees
+     * no crossing at all.
+     */
+    public function test_a_call_on_an_injected_dependency_from_another_module_is_reported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/UserCalls/InjectedFactory.php'],
+            [[$this->expectedError('InjectedFactory', 'Shop\Domain\ShopService', 'Shop'), 22]],
+        );
+    }
+
+    public function test_a_call_on_a_facade_is_allowed(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/UserCalls/ViaFacadeFactory.php'], []);
+    }
+
+    /**
+     * Consumers hold the interface rather than the Facade, which is the same
+     * sanctioned crossing.
+     */
+    public function test_a_call_on_a_facade_interface_is_allowed(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/UserCalls/ViaFacadeInterfaceFactory.php'], []);
+    }
+
+    public function test_a_call_inside_the_same_module_is_allowed(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/UserCalls/SameModuleCallFactory.php'], []);
+    }
+
+    public function test_a_call_on_a_shared_kernel_type_is_allowed_when_allowlisted(): void
+    {
+        $this->sharedNamespaces = [self::ROOT . '\Shared'];
+
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/UserCalls/SharedCallFactory.php'], []);
+    }
+
+    /**
+     * The same call without the allowance: the exemption is what silences it,
+     * not the namespace being called `Shared`.
+     */
+    public function test_a_call_on_a_shared_kernel_type_is_reported_when_not_allowlisted(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/UserCalls/SharedCallFactory.php'],
+            [[$this->expectedError('SharedCallFactory', 'Shared\Clock', 'Shared'), 18]],
+        );
+    }
+
+    /**
+     * An unresolvable receiver is not evidence of a violation, and guessing
+     * would turn the rule into noise on every `mixed` left in a codebase.
+     */
+    public function test_a_call_on_an_untyped_receiver_is_not_reported(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CrossModule/UserCalls/UntypedReceiverFactory.php'], []);
+    }
+
+    /**
+     * Registered with nothing but the root namespace, the shape the docs show
+     * for a project that keeps its modules one segment down.
+     */
+    public function test_the_optional_arguments_may_be_left_out(): void
+    {
+        $this->rule = new CrossModuleMethodCallRule(self::ROOT);
+
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/UserCalls/InjectedFactory.php'],
+            [[$this->expectedError('InjectedFactory', 'Shop\Domain\ShopService', 'Shop'), 22]],
+        );
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->rule ??= new CrossModuleMethodCallRule(self::ROOT, 1, $this->sharedNamespaces);
+    }
+
+    private function expectedError(string $caller, string $receiver, string $module): string
+    {
+        return sprintf(
+            'Class %s calls a method on %s from another module (%s). Cross-module access must go through a Facade.',
+            self::ROOT . '\UserCalls\\' . $caller,
+            self::ROOT . '\\' . $receiver,
+            self::ROOT . '\\' . $module,
+        );
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shop/Domain/ShopService.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shop/Domain/ShopService.php
@@ -6,4 +6,8 @@ namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain;
 
 final class ShopService
 {
+    public function run(): string
+    {
+        return 'shop';
+    }
 }

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shop/ShopFacade.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shop/ShopFacade.php
@@ -6,6 +6,10 @@ namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop;
 
 use Gacela\Framework\AbstractFacade;
 
-final class ShopFacade extends AbstractFacade
+final class ShopFacade extends AbstractFacade implements ShopFacadeInterface
 {
+    public function browse(): string
+    {
+        return 'browsing';
+    }
 }

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shop/ShopFacadeInterface.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/Shop/ShopFacadeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop;
+
+interface ShopFacadeInterface
+{
+    public function browse(): string;
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/Domain/UserCallsService.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/Domain/UserCallsService.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\Domain;
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls\Domain;
 
-final class UserService
+final class UserCallsService
 {
     public function run(): string
     {

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/InjectedFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/InjectedFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService;
+
+/**
+ * The crossing the name-matching rule cannot see: ShopService is written once,
+ * in a constructor type-hint, and the call site names nothing.
+ */
+final class InjectedFactory
+{
+    public function __construct(
+        private readonly ShopService $shop,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->shop->run();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/SameModuleCallFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/SameModuleCallFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls\Domain\UserCallsService;
+
+final class SameModuleCallFactory
+{
+    public function __construct(
+        private readonly UserCallsService $user,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->user->run();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/SharedCallFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/SharedCallFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock;
+
+final class SharedCallFactory
+{
+    public function __construct(
+        private readonly Clock $clock,
+    ) {
+    }
+
+    public function build(): int
+    {
+        return $this->clock->now();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/UntypedReceiverFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/UntypedReceiverFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+/**
+ * An unresolvable receiver is not evidence of a violation. Reporting it would
+ * turn the rule into noise on every codebase that has any mixed left.
+ */
+final class UntypedReceiverFactory
+{
+    /**
+     * @param mixed $anything
+     */
+    public function build($anything): mixed
+    {
+        return $anything->run();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/ViaFacadeFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/ViaFacadeFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\ShopFacade;
+
+final class ViaFacadeFactory
+{
+    public function __construct(
+        private readonly ShopFacade $shop,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->shop->browse();
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/ViaFacadeInterfaceFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/ViaFacadeInterfaceFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\ShopFacadeInterface;
+
+/**
+ * Type-hinting the interface rather than the Facade is the same sanctioned
+ * crossing, and is what `FacadeInterfaceInSyncRule` assumes consumers do.
+ */
+final class ViaFacadeInterfaceFactory
+{
+    public function __construct(
+        private readonly ShopFacadeInterface $shop,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->shop->browse();
+    }
+}

--- a/tests/Unit/StaticAnalysis/Rules/CrossModuleMethodCallAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/CrossModuleMethodCallAnalyserTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\StaticAnalysis\Rules;
+
+use Gacela\StaticAnalysis\Rules\CrossModuleMethodCallAnalyser;
+use Gacela\StaticAnalysis\Violation;
+use PHPUnit\Framework\TestCase;
+
+final class CrossModuleMethodCallAnalyserTest extends TestCase
+{
+    private const ROOT = 'App\Modules';
+
+    private const CALLER = 'App\Modules\Checkout\CheckoutFactory';
+
+    public function test_a_call_on_another_modules_type_is_reported(): void
+    {
+        $violations = $this->analyse(['App\Modules\Billing\Domain\InvoiceRepository']);
+
+        self::assertCount(1, $violations);
+        self::assertSame(
+            'Class App\Modules\Checkout\CheckoutFactory calls a method on App\Modules\Billing\Domain\InvoiceRepository from another module (App\Modules\Billing). Cross-module access must go through a Facade.',
+            $violations[0]->message,
+        );
+        self::assertSame('gacela.crossModuleMethodCall', $violations[0]->identifier);
+    }
+
+    public function test_a_call_on_a_facade_is_allowed(): void
+    {
+        self::assertSame([], $this->analyse(['App\Modules\Billing\BillingFacade']));
+    }
+
+    /**
+     * Consumers hold the interface rather than the Facade, which is the same
+     * sanctioned crossing.
+     */
+    public function test_a_call_on_a_facade_interface_is_allowed(): void
+    {
+        self::assertSame([], $this->analyse(['App\Modules\Billing\BillingFacadeInterface']));
+    }
+
+    public function test_a_call_inside_the_same_module_is_allowed(): void
+    {
+        self::assertSame([], $this->analyse(['App\Modules\Checkout\Domain\Basket']));
+    }
+
+    public function test_a_call_on_a_type_outside_the_root_namespace_is_allowed(): void
+    {
+        self::assertSame([], $this->analyse(['Vendor\Library\Thing']));
+    }
+
+    /**
+     * The host could not resolve the receiver. That is not evidence of a
+     * violation, and guessing would turn the rule into noise.
+     */
+    public function test_an_unresolved_receiver_is_not_reported(): void
+    {
+        self::assertSame([], $this->analyse([]));
+    }
+
+    /**
+     * A union receiver is several possible classes, and each is its own
+     * crossing to justify.
+     */
+    public function test_every_class_a_union_receiver_can_be_is_checked(): void
+    {
+        $violations = $this->analyse([
+            'App\Modules\Billing\Domain\InvoiceRepository',
+            'App\Modules\Shipping\Domain\Labels',
+        ]);
+
+        self::assertCount(2, $violations);
+    }
+
+    public function test_a_union_reports_only_the_branches_that_cross(): void
+    {
+        $violations = $this->analyse([
+            'App\Modules\Billing\BillingFacade',
+            'App\Modules\Billing\Domain\InvoiceRepository',
+        ]);
+
+        self::assertCount(1, $violations);
+    }
+
+    /**
+     * The skipped branch comes first here, so ending the scan instead of
+     * continuing it would swallow the crossing behind it.
+     */
+    public function test_a_union_is_scanned_past_a_branch_in_no_module(): void
+    {
+        $violations = $this->analyse([
+            'Vendor\Library\Thing',
+            'App\Modules\Billing\Domain\InvoiceRepository',
+        ]);
+
+        self::assertCount(1, $violations);
+    }
+
+    public function test_a_call_on_a_shared_kernel_type_is_allowed(): void
+    {
+        self::assertSame(
+            [],
+            $this->analyse(['App\Modules\Shared\Clock'], sharedNamespaces: ['App\Modules\Shared']),
+        );
+    }
+
+    /**
+     * The exemption is namespace-boundary aware: on the raw prefix,
+     * `App\Modules\Shared` would silently exempt `App\Modules\SharedFoo` too.
+     */
+    public function test_a_shared_namespace_does_not_exempt_a_namespace_that_starts_with_it(): void
+    {
+        self::assertCount(
+            1,
+            $this->analyse(['App\Modules\SharedFoo\Thing'], sharedNamespaces: ['App\Modules\Shared']),
+        );
+    }
+
+    public function test_a_caller_inside_a_shared_namespace_is_not_checked(): void
+    {
+        self::assertSame(
+            [],
+            $this->analyse(
+                ['App\Modules\Billing\Domain\InvoiceRepository'],
+                caller: 'App\Modules\Shared\Clock',
+                sharedNamespaces: ['App\Modules\Shared'],
+            ),
+        );
+    }
+
+    /**
+     * A caller with no segment under the root belongs to no module, so there is
+     * no boundary for it to be on one side of.
+     */
+    public function test_a_caller_outside_any_module_is_not_checked(): void
+    {
+        self::assertSame(
+            [],
+            $this->analyse(['App\Modules\Billing\Domain\InvoiceRepository'], caller: 'App\Modules\Loose'),
+        );
+    }
+
+    /**
+     * Left out, the depth is one segment under the root.
+     */
+    public function test_the_module_depth_defaults_to_one_segment(): void
+    {
+        $analyser = new CrossModuleMethodCallAnalyser(self::ROOT);
+
+        self::assertCount(1, $analyser->analyse(self::CALLER, ['App\Modules\Billing\Domain\InvoiceRepository']));
+    }
+
+    /**
+     * With two segments naming a module, `Billing\Invoicing` and `Billing\Ledger`
+     * are different modules rather than one `Billing`.
+     */
+    public function test_the_module_depth_is_configurable(): void
+    {
+        $analyser = new CrossModuleMethodCallAnalyser(self::ROOT, 2);
+
+        self::assertCount(
+            1,
+            $analyser->analyse('App\Modules\Billing\Invoicing\InvoiceFactory', ['App\Modules\Billing\Ledger\Entry']),
+        );
+    }
+
+    /**
+     * @param list<string> $receiverClasses
+     * @param list<string> $sharedNamespaces
+     *
+     * @return list<Violation>
+     */
+    private function analyse(
+        array $receiverClasses,
+        string $caller = self::CALLER,
+        array $sharedNamespaces = [],
+    ): array {
+        $analyser = new CrossModuleMethodCallAnalyser(self::ROOT, 1, $sharedNamespaces);
+
+        return $analyser->analyse($caller, $receiverClasses);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`CrossModuleViaFacadeRule` reports four kinds of reference — `new`, static call,
class constant, static property. All four are *syntactic*: the other module's
class name is written at the call site. That is not how a boundary gets crossed
in a codebase built the way Gacela asks:

```php
public function __construct(
    private readonly InvoiceRepository $invoices,  // App\Billing — another module
) {
}

public function createProcessor(): Processor
{
    return new Processor($this->invoices->findAll());  // not reported
}
```

The class appears once, in a constructor type-hint. Gacela pushes dependencies
through Providers and constructors *precisely* so call sites do not name classes
— which is exactly what makes them invisible to a name-matching scan. The rule
that catches the direct instantiation reported green on the codebases most likely
to be violating it.

Closes #643

## 🔖 Changes

- Add `CrossModuleMethodCallRule` / `CrossModuleMethodCallAnalyser`, resolving a
  method call's receiver by **type**
- Extract `ModuleBoundary` — `moduleOf()`, `isShared()`, `crossedBy()` — so both
  halves answer "same module?" from one implementation
- New identifier `gacela.crossModuleMethodCall`, suppressible on its own while a
  codebase catches up, plus its Psalm issue class. Registering the rule under
  Psalm is #642; the class exists now because `ReportedIssuesTest` holds the map
  complete and would otherwise fail
- Register it in `phpstan-gacela.neon`, commented out beside its sibling — the
  two are halves of one check and are meant to be enabled together
- **Remove the `gacela-project/phpstan-extension` suggestion**

### Why it is a `Rule<MethodCall>`

Not a stylistic choice. `CrossModuleViaFacadeRule` is a `Rule<InClassNode>`, and
the class-level `Scope` does not know local variable or `$this` property types —
`$scope->getType()` there resolves every local expression to `mixed`. Only the
scope at the call site can answer what a receiver is. This is also why
`gacela-project/phpstan-extension` used a `MethodCall` rule.

### On that package

`gacela-project/phpstan-extension@0.4.0` ships exactly one rule,
`EnforceModuleBoundariesForMethodCallRule`, and it *is* this check. It also
cannot run here: last commit 2024-08-11, develops against `phpstan/phpstan ^1.11`,
and its `RuleErrorBuilder::message(...)->build()` carries no `->identifier()`.
PHPStan 2's `UPGRADING.md:147` — *"Identifiers are also required in custom
rules."* Gacela 2.0 requires `^2.0`. So the suggestion pointed users at a package
that will not load, to obtain a check Gacela's own rule should have been making.

## 🧪 Testing

- `CrossModuleMethodCallRuleTest` runs the real rule over fixtures: an injected
  dependency from another module is reported; a `*Facade`, a `*FacadeInterface`,
  a same-module type and an allowlisted shared kernel are not; an untyped
  receiver is not
- `CrossModuleMethodCallAnalyserTest` covers the decision host-free, including
  union receivers — each branch is its own crossing, and the scan continues past
  a branch that does not cross
- `CrossModuleViaFacadeRuleTest` passes unchanged: the extraction of
  `ModuleBoundary` changed no behaviour
- Infection over `src/StaticAnalysis` + `src/PHPStan` + `src/Psalm`:
  **100% MSI**, 343 mutations, 0 escaped. Five escapes on the first run were
  real: the `modulePathSegments = 1` default was never exercised on the new rule,
  `ModuleBoundary` carried a second copy of that default that nothing could
  reach (removed rather than tested), and a `continue` → `break` survived because
  no union put a non-crossing branch first

## ⚠️ One thing I did **not** change

The two rules disagree about `*FacadeInterface`: the new one accepts it, the
existing one does not. That is defensible — a call *through* the interface a
consumer holds is the sanctioned crossing, while a written
`SomeFacadeInterface::class` reference is not one — but it is a difference
between two halves of one check, on a rule that shipped in 2.0.0. Documented
rather than silently loosened; say the word if you want them aligned.
