### PR TITLE
feat: enforce module boundaries under Psalm, opt-in through plugin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@
 - Type `getProvidedDependency(Foo::class)` under Psalm too, matching the PHPStan extension
 - Enforce the pillar rules under Psalm, each as its own suppressible issue type
 - Report cross-module method calls on injected dependencies, which name no class at the call site
-
-### Removed
-
-- Drop the `gacela-project/phpstan-extension` suggestion: its one rule is now built in, and it
-  cannot load against the PHPStan version Gacela requires
+- Enforce module boundaries under Psalm, opt-in through a `<crossModule>` plugin element
 
 ### Changed
 
@@ -19,8 +15,15 @@
 - Prune `vendor`, `node_modules` and hidden directories before descending in module discovery
 - Exit non-zero from `cache:warm` when a warmup fails, so a broken deploy is not reported green
 
+### Removed
+
+- Drop the `gacela-project/phpstan-extension` suggestion: its one rule is now built in, and it
+  cannot load against the PHPStan version Gacela requires
+
 ### Fixed
 
+- Match imported class names in the architecture rules however the host resolved them: under
+  Psalm a `use`d class read as its short name and belonged to no module
 - Strip only the matched psr-4 prefix in `make:module`/`make:file`, and accept list targets
 - Let `bin/gacela` run from any subdirectory, bootstrapping with the project root
 - Discover facades that extend `AbstractFacade` indirectly, not only direct children
@@ -297,6 +300,11 @@ silently.
   `use` statements, raises `E_USER_DEPRECATED`. Both are removed in 3.0. Declare
   it with `#[ServiceMap]`.
 
+### Fixed
+
+- Resolve imported class names in the graph rules whichever way the host resolved them: under
+  Psalm a `use`d class read as its short name and matched no module at all
+
 ### Removed (BREAKING)
 
 - `AbstractDependencyProvider`. Extend `AbstractProvider` instead.
@@ -471,6 +479,11 @@ before you migrate to 2.0.
 - `make:module` and `make:file` now throw when a generated file cannot be written. A read-only target or full disk previously printed success, exited `0`, and wrote nothing
 - An unresolvable health check now throws `HealthCheckNotResolvableException` instead of being skipped. A typo in `addHealthCheck(SomeCheck::class)` previously produced a report that looked healthy while the check never ran
 
+### Fixed
+
+- Resolve imported class names in the graph rules whichever way the host resolved them: under
+  Psalm a `use`d class read as its short name and matched no module at all
+
 ### Removed
 
 - `Gacela\Framework\Container\Locator::addSingleton()` — no production caller, and `Locator` is `@internal`. Seed through a `Container` plus `Locator::getInstance($container)`
@@ -576,6 +589,11 @@ before you migrate to 2.0.
 - `AbstractProvider::register()` is now `final`; overriding it silently disabled `#[Provides]` scanning — use `provideModuleDependencies()` instead
 - Class resolvers now share one `Container` built once from the global bindings, instead of rebuilding one per resolver type; reset with `Gacela::resetCache()`
 - `Gacela::bootstrap()` now batches file-cache writes into a single atomic write per cache file, instead of one full-file rewrite per newly discovered key
+
+### Fixed
+
+- Resolve imported class names in the graph rules whichever way the host resolved them: under
+  Psalm a `use`d class read as its short name and matched no module at all
 
 ### Removed
 

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -333,6 +333,31 @@ the plugin it ships, and suppresses `GacelaSuffixExtends` under `src/Framework`
 for the same reason `phpstan.neon` does — the framework internals reuse the
 pillar words for things that are not pillars.
 
+### Module boundaries
+
+The cross-module check is opt-in for the same reason it is under PHPStan: nothing
+in a class name says where a module boundary falls. Turn it on by giving the
+plugin your root namespace:
+
+```xml
+<plugins>
+    <pluginClass class="Gacela\Psalm\Plugin">
+        <crossModule rootNamespace="App\Modules" modulePathSegments="1">
+            <sharedNamespace>App\Modules\Shared</sharedNamespace>
+        </crossModule>
+    </pluginClass>
+</plugins>
+```
+
+Both halves go on together — `GacelaCrossModuleAccess` for the references a
+source names, `GacelaCrossModuleMethodCall` for the receivers it does not — and
+they behave exactly as `CrossModuleViaFacadeRule` and
+`CrossModuleMethodCallRule` do under PHPStan.
+
+A `<crossModule>` without a `rootNamespace` is a configuration error and stops
+the run. A rule that quietly does nothing is worse than no rule: it reads as a
+green check, and nothing would ever tell you the boundary went unchecked.
+
 
 ## Troubleshooting
 

--- a/src/Psalm/CrossModuleCallRules.php
+++ b/src/Psalm/CrossModuleCallRules.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\StaticAnalysis\Rules\CrossModuleMethodCallAnalyser;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * The half of the cross-module check that resolves a method call's receiver by
+ * type, for the boundary a call site never names.
+ *
+ * An expression handler rather than a class one: only the type known at the call
+ * site says what the receiver is.
+ *
+ * @see CrossModuleRules for the half that matches written names
+ */
+final class CrossModuleCallRules implements AfterExpressionAnalysisInterface
+{
+    private static ?CrossModuleMethodCallAnalyser $analyser = null;
+
+    /**
+     * Null turns the rule back off, so invoking the plugin twice leaves the
+     * state its latest config asked for rather than whatever a previous one set.
+     */
+    public static function configure(?CrossModuleSettings $settings): void
+    {
+        self::$analyser = $settings instanceof CrossModuleSettings
+            ? new CrossModuleMethodCallAnalyser(
+                $settings->rootNamespace,
+                $settings->modulePathSegments,
+                $settings->sharedNamespaces,
+            )
+            : null;
+    }
+
+    public static function isConfigured(): bool
+    {
+        return self::$analyser instanceof CrossModuleMethodCallAnalyser;
+    }
+
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        $analyser = self::$analyser;
+        if (!$analyser instanceof CrossModuleMethodCallAnalyser) {
+            return null;
+        }
+
+        $expr = $event->getExpr();
+        if (!$expr instanceof MethodCall && !$expr instanceof NullsafeMethodCall) {
+            return null;
+        }
+
+        $source = $event->getStatementsSource();
+        $callingClass = $source->getFQCLN();
+        if ($callingClass === null) {
+            return null;
+        }
+
+        ReportedIssues::report(
+            $analyser->analyse($callingClass, self::receiverClasses($event)),
+            $expr,
+            $source,
+        );
+
+        return null;
+    }
+
+    /**
+     * Empty when Psalm could not tell, which the analyser reads as "no evidence"
+     * rather than "no violation to find".
+     *
+     * @return list<string>
+     */
+    private static function receiverClasses(AfterExpressionAnalysisEvent $event): array
+    {
+        /** @var MethodCall|NullsafeMethodCall $expr */
+        $expr = $event->getExpr();
+
+        $type = $event->getStatementsSource()->getNodeTypeProvider()->getType($expr->var);
+        if (!$type instanceof Union) {
+            return [];
+        }
+
+        $classes = [];
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject) {
+                $classes[] = $atomic->value;
+            }
+        }
+
+        return $classes;
+    }
+}

--- a/src/Psalm/CrossModuleRules.php
+++ b/src/Psalm/CrossModuleRules.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\StaticAnalysis\Rules\CrossModuleViaFacadeAnalyser;
+use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
+
+/**
+ * The half of the cross-module check that matches names written in the source.
+ *
+ * Registered only when the consumer supplies a root namespace, so the analyser
+ * lives in a static: Psalm registers handlers by class-string and calls them
+ * statically, leaving nowhere else to put configuration.
+ *
+ * @see CrossModuleCallRules for the half that resolves receivers by type
+ */
+final class CrossModuleRules implements AfterClassLikeAnalysisInterface
+{
+    private static ?CrossModuleViaFacadeAnalyser $analyser = null;
+
+    /**
+     * Null turns the rule back off, so invoking the plugin twice leaves the
+     * state its latest config asked for rather than whatever a previous one set.
+     */
+    public static function configure(?CrossModuleSettings $settings): void
+    {
+        self::$analyser = $settings instanceof CrossModuleSettings
+            ? new CrossModuleViaFacadeAnalyser(
+                $settings->rootNamespace,
+                $settings->modulePathSegments,
+                $settings->sharedNamespaces,
+            )
+            : null;
+    }
+
+    public static function isConfigured(): bool
+    {
+        return self::$analyser instanceof CrossModuleViaFacadeAnalyser;
+    }
+
+    public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event): ?bool
+    {
+        $analyser = self::$analyser;
+        if (!$analyser instanceof CrossModuleViaFacadeAnalyser) {
+            return null;
+        }
+
+        $node = $event->getStmt();
+
+        ReportedIssues::report(
+            $analyser->analyse($node, new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase())),
+            $node,
+            $event->getStatementsSource(),
+        );
+
+        return null;
+    }
+}

--- a/src/Psalm/CrossModuleSettings.php
+++ b/src/Psalm/CrossModuleSettings.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Psalm\Exception\ConfigException;
+use SimpleXMLElement;
+
+use function count;
+use function trim;
+
+/**
+ * The cross-module check's configuration, read off the `<pluginClass>` element.
+ *
+ * Nothing in a class name says where a module boundary falls, so unlike the
+ * pillar rules this one cannot be on by default -- it needs the consumer's root
+ * namespace:
+ *
+ * ```xml
+ * <pluginClass class="Gacela\Psalm\Plugin">
+ *     <crossModule rootNamespace="App\Modules" modulePathSegments="1">
+ *         <sharedNamespace>App\Modules\Shared</sharedNamespace>
+ *     </crossModule>
+ * </pluginClass>
+ * ```
+ */
+final class CrossModuleSettings
+{
+    /**
+     * @param list<string> $sharedNamespaces
+     */
+    private function __construct(
+        public readonly string $rootNamespace,
+        public readonly int $modulePathSegments,
+        public readonly array $sharedNamespaces,
+    ) {
+    }
+
+    /**
+     * Null when no `<crossModule>` is present, which is the rule staying off --
+     * the same default as the commented-out block in `phpstan-gacela.neon`.
+     *
+     * A `<crossModule>` without a `rootNamespace` throws instead. A rule that
+     * quietly does nothing is worse than no rule: it reads as a green check, and
+     * nothing would ever tell you the boundary was never being checked.
+     *
+     * @throws ConfigException
+     */
+    public static function fromPluginConfig(?SimpleXMLElement $config): ?self
+    {
+        if (!$config instanceof SimpleXMLElement) {
+            return null;
+        }
+
+        // Reading an absent child yields an *empty* element rather than null,
+        // so the count is what says whether one was written. `instanceof` alone
+        // is true either way, and would turn "not configured" into "configured
+        // with nothing", which throws.
+        $crossModule = $config->crossModule;
+        if (count($crossModule) === 0) {
+            return null;
+        }
+
+        $rootNamespace = trim((string)($crossModule['rootNamespace'] ?? ''));
+
+        if ($rootNamespace === '') {
+            throw new ConfigException(
+                '<crossModule> needs a rootNamespace: without it there is no way to tell where a module begins.',
+            );
+        }
+
+        return new self(
+            $rootNamespace,
+            self::modulePathSegments($crossModule),
+            self::sharedNamespaces($crossModule),
+        );
+    }
+
+    private static function modulePathSegments(SimpleXMLElement $crossModule): int
+    {
+        $segments = trim((string)($crossModule['modulePathSegments'] ?? ''));
+
+        if ($segments === '') {
+            return 1;
+        }
+
+        if ((int)$segments < 1) {
+            throw new ConfigException(
+                'modulePathSegments must be a positive number of namespace segments, got: ' . $segments,
+            );
+        }
+
+        return (int)$segments;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function sharedNamespaces(SimpleXMLElement $crossModule): array
+    {
+        $namespaces = [];
+
+        foreach ($crossModule->sharedNamespace as $sharedNamespace) {
+            $name = trim((string)$sharedNamespace);
+            if ($name !== '') {
+                $namespaces[] = $name;
+            }
+        }
+
+        return $namespaces;
+    }
+}

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -16,6 +16,10 @@ use SimpleXMLElement;
  *     <pluginClass class="Gacela\Psalm\Plugin"/>
  * </plugins>
  * ```
+ *
+ * The cross-module check is opt-in, because nothing in a class name says where a
+ * module boundary falls -- add a `<crossModule>` child to turn it on. See
+ * {@see CrossModuleSettings}.
  */
 final class Plugin implements PluginEntryPointInterface
 {
@@ -26,9 +30,30 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/ServiceMapPseudoMethods.php';
         require_once __DIR__ . '/ProvidedDependencyReturnType.php';
         require_once __DIR__ . '/ClassRules.php';
+        require_once __DIR__ . '/CrossModuleRules.php';
+        require_once __DIR__ . '/CrossModuleCallRules.php';
 
         $registration->registerHooksFromClass(ServiceMapPseudoMethods::class);
         $registration->registerHooksFromClass(ProvidedDependencyReturnType::class);
         $registration->registerHooksFromClass(ClassRules::class);
+
+        $this->registerCrossModule($registration, CrossModuleSettings::fromPluginConfig($config));
+    }
+
+    private function registerCrossModule(PluginRegistrationSocket $registration, ?CrossModuleSettings $settings): void
+    {
+        // Two halves of one check, so they are turned on together: one matches
+        // the names a source writes, the other resolves the receivers it does
+        // not. Configured even when there is nothing to configure, so the state
+        // is what the current config says rather than what an earlier one left.
+        CrossModuleRules::configure($settings);
+        CrossModuleCallRules::configure($settings);
+
+        if (!$settings instanceof CrossModuleSettings) {
+            return;
+        }
+
+        $registration->registerHooksFromClass(CrossModuleRules::class);
+        $registration->registerHooksFromClass(CrossModuleCallRules::class);
     }
 }

--- a/src/StaticAnalysis/ResolvedName.php
+++ b/src/StaticAnalysis/ResolvedName.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis;
+
+use PhpParser\Node\Name;
+
+use function is_string;
+use function ltrim;
+
+/**
+ * The fully qualified name behind a name written in source.
+ *
+ * The hosts hand over differently resolved trees. PHPStan rewrites names in
+ * place, so `toString()` is already qualified. Psalm leaves the source text
+ * alone and puts the qualified form on the node as a `resolvedName` attribute,
+ * so `toString()` there is whatever was typed -- `ShopService` for an imported
+ * class.
+ *
+ * Reading only `toString()` therefore worked under PHPStan and silently matched
+ * nothing under Psalm: every module name carries a namespace, and a bare short
+ * name belongs to none.
+ *
+ * The attribute is a string as Psalm writes it and a {@see Name} as
+ * php-parser's own `NameResolver` writes it, so both are read.
+ */
+final class ResolvedName
+{
+    public static function of(Name $name): string
+    {
+        // A leading separator is legal and means the same class; module names
+        // carry none, so it has to go whichever form the name arrived in.
+        return ltrim(self::text($name->getAttribute('resolvedName')) ?? $name->toString(), '\\');
+    }
+
+    /**
+     * Taken as a parameter rather than assigned to a local: psalm reports every
+     * assignment of a mixed, and the `@var mixed` that answers it is a tag
+     * rector then strips as useless.
+     */
+    private static function text(mixed $resolved): ?string
+    {
+        if (is_string($resolved)) {
+            return $resolved;
+        }
+
+        return $resolved instanceof Name ? $resolved->toString() : null;
+    }
+}

--- a/src/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyser.php
+++ b/src/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyser.php
@@ -7,6 +7,7 @@ namespace Gacela\StaticAnalysis\Rules;
 use Gacela\StaticAnalysis\AnalysedClassInterface;
 use Gacela\StaticAnalysis\ClassAnalyserInterface;
 use Gacela\StaticAnalysis\ModuleBoundary;
+use Gacela\StaticAnalysis\ResolvedName;
 use Gacela\StaticAnalysis\ShortName;
 use Gacela\StaticAnalysis\Violation;
 use PhpParser\Node;
@@ -117,7 +118,7 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
             /** @var ClassConstFetch|New_|StaticCall|StaticPropertyFetch $ref */
             // `new $class` / `$class::CONST` name nothing to match on.
             if ($ref->class instanceof Name) {
-                $names[] = $ref->class->toString();
+                $names[] = ResolvedName::of($ref->class);
             }
         }
 

--- a/src/StaticAnalysis/Rules/FactoryDoesNotCallFacadeAnalyser.php
+++ b/src/StaticAnalysis/Rules/FactoryDoesNotCallFacadeAnalyser.php
@@ -7,6 +7,7 @@ namespace Gacela\StaticAnalysis\Rules;
 use Gacela\Framework\AbstractFactory;
 use Gacela\StaticAnalysis\AnalysedClassInterface;
 use Gacela\StaticAnalysis\ClassAnalyserInterface;
+use Gacela\StaticAnalysis\ResolvedName;
 use Gacela\StaticAnalysis\ShortName;
 use Gacela\StaticAnalysis\Violation;
 use PhpParser\Node\Expr\MethodCall;
@@ -59,7 +60,7 @@ final class FactoryDoesNotCallFacadeAnalyser implements ClassAnalyserInterface
                 continue;
             }
 
-            $className = $new->class->toString();
+            $className = ResolvedName::of($new->class);
             if (!str_ends_with(ShortName::of($className), 'Facade')) {
                 continue;
             }

--- a/tests/Integration/Psalm/CrossModuleFixture/Shared/Clock.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/Shared/Clock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\Shared;
+
+final class Clock
+{
+    public function now(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/SharedFoo/Thing.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/SharedFoo/Thing.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\SharedFoo;
+
+/**
+ * `Shared` is a raw-string prefix of `SharedFoo` but not a namespace boundary,
+ * so the exemption must not reach this one.
+ */
+final class Thing
+{
+    public function run(): string
+    {
+        return 'thing';
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/Shop/Domain/ShopService.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/Shop/Domain/ShopService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\Shop\Domain;
+
+final class ShopService
+{
+    public function run(): string
+    {
+        return 'shop';
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/Shop/ShopFacade.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/Shop/ShopFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\Shop;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<ShopFactory>
+ */
+final class ShopFacade extends AbstractFacade
+{
+    public function browse(): string
+    {
+        return $this->getFactory()->createBrowser();
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/Shop/ShopFactory.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/Shop/ShopFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\Shop;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * @extends AbstractFactory<\Gacela\Framework\AbstractConfig>
+ */
+final class ShopFactory extends AbstractFactory
+{
+    public function createBrowser(): string
+    {
+        return 'browsing';
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/User/CallsTheOtherModule.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/User/CallsTheOtherModule.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\User;
+
+use GacelaTest\Integration\Psalm\CrossModuleFixture\Shop\Domain\ShopService;
+
+/**
+ * The crossing the call site never names: ShopService appears once, in the
+ * constructor.
+ */
+final class CallsTheOtherModule
+{
+    public function __construct(
+        private readonly ShopService $shop,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->shop->run();
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/User/FacadeConsumer.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/User/FacadeConsumer.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\User;
+
+use GacelaTest\Integration\Psalm\CrossModuleFixture\Shop\ShopFacade;
+
+/**
+ * Named so it does not itself end in a pillar suffix -- the suffix rule runs
+ * over these fixtures too.
+ */
+final class FacadeConsumer
+{
+    public function __construct(
+        private readonly ShopFacade $shop,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->shop->browse();
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/User/NamesTheOtherModule.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/User/NamesTheOtherModule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\User;
+
+use GacelaTest\Integration\Psalm\CrossModuleFixture\Shop\Domain\ShopService;
+
+/**
+ * The crossing written at the call site.
+ */
+final class NamesTheOtherModule
+{
+    public function build(): ShopService
+    {
+        return new ShopService();
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/User/UsesANamespaceStartingWithShared.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/User/UsesANamespaceStartingWithShared.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\User;
+
+use GacelaTest\Integration\Psalm\CrossModuleFixture\SharedFoo\Thing;
+
+final class UsesANamespaceStartingWithShared
+{
+    public function __construct(
+        private readonly Thing $thing,
+    ) {
+    }
+
+    public function build(): string
+    {
+        return $this->thing->run();
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/User/UsesTheSharedKernel.php
+++ b/tests/Integration/Psalm/CrossModuleFixture/User/UsesTheSharedKernel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\CrossModuleFixture\User;
+
+use GacelaTest\Integration\Psalm\CrossModuleFixture\Shared\Clock;
+
+final class UsesTheSharedKernel
+{
+    public function __construct(
+        private readonly Clock $clock,
+    ) {
+    }
+
+    public function build(): int
+    {
+        return $this->clock->now();
+    }
+}

--- a/tests/Integration/Psalm/CrossModuleFixture/psalm-cross-module-fixture.xml
+++ b/tests/Integration/Psalm/CrossModuleFixture/psalm-cross-module-fixture.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+    The cross-module check turned on, which is the point: without a crossModule
+    element the rules are not registered at all.
+-->
+<psalm errorLevel="1" resolveFromConfigFile="true" findUnusedBaselineEntry="false" findUnusedCode="false">
+    <projectFiles>
+        <directory name="."/>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Gacela\Psalm\Plugin">
+            <crossModule rootNamespace="GacelaTest\Integration\Psalm\CrossModuleFixture" modulePathSegments="1">
+                <sharedNamespace>GacelaTest\Integration\Psalm\CrossModuleFixture\Shared</sharedNamespace>
+            </crossModule>
+        </pluginClass>
+    </plugins>
+
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>

--- a/tests/Integration/Psalm/CrossModuleRulesTest.php
+++ b/tests/Integration/Psalm/CrossModuleRulesTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm;
+
+/**
+ * Runs Psalm for real with the cross-module check turned on from plugin config.
+ *
+ * Both halves are on together, because they are halves of one thing: one matches
+ * the module names a source writes, the other resolves the receivers it does not.
+ */
+final class CrossModuleRulesTest extends PsalmFixtureTestCase
+{
+    public function test_a_reference_that_names_another_module_is_reported(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaCrossModuleAccess: Class ' . CrossModuleFixture\User\NamesTheOtherModule::class,
+            $this->errorsIn('NamesTheOtherModule.php'),
+        );
+    }
+
+    /**
+     * The headline case: `ShopService` appears once, in the constructor, so the
+     * name-matching half sees no crossing at the call site at all.
+     */
+    public function test_a_call_on_an_injected_dependency_is_reported(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaCrossModuleMethodCall: Class ' . CrossModuleFixture\User\CallsTheOtherModule::class,
+            $this->errorsIn('CallsTheOtherModule.php'),
+        );
+    }
+
+    public function test_going_through_the_facade_is_silent(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('GacelaCrossModule', $errors, 'precondition: the check ran at all');
+        self::assertSame('', $this->errorsIn('FacadeConsumer.php'));
+    }
+
+    public function test_an_allowlisted_shared_kernel_is_silent(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('GacelaCrossModule', $errors, 'precondition: the check ran at all');
+        self::assertSame('', $this->errorsIn('UsesTheSharedKernel.php'));
+    }
+
+    /**
+     * `Shared` is a raw-string prefix of `SharedFoo` but not a namespace
+     * boundary. Matching on the prefix would silently exempt every module whose
+     * name merely starts with an allowlisted one.
+     */
+    public function test_a_namespace_starting_with_a_shared_one_is_still_reported(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'GacelaCrossModuleMethodCall',
+            $this->errorsIn('UsesANamespaceStartingWithShared.php'),
+        );
+    }
+
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/CrossModuleFixture/psalm-cross-module-fixture.xml';
+    }
+}

--- a/tests/Unit/PHPStan/Rules/CrossModuleMethodCallRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/CrossModuleMethodCallRuleTest.php
@@ -35,6 +35,20 @@ final class CrossModuleMethodCallRuleTest extends RuleTestCase
         );
     }
 
+    /**
+     * `?->` crosses the boundary exactly as much as `->`. The rule is a
+     * `Rule<MethodCall>` and `NullsafeMethodCall` is a sibling node, not a
+     * subclass, so this is pinned rather than assumed: PHPStan reaches it, and
+     * the Psalm half handles the node explicitly.
+     */
+    public function test_a_nullsafe_call_on_an_injected_dependency_is_reported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/CrossModule/UserCalls/NullsafeCallFactory.php'],
+            [[$this->expectedError('NullsafeCallFactory', 'Shop\Domain\ShopService', 'Shop'), 21]],
+        );
+    }
+
     public function test_a_call_on_a_facade_is_allowed(): void
     {
         $this->analyse([__DIR__ . '/Fixture/CrossModule/UserCalls/ViaFacadeFactory.php'], []);

--- a/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/NullsafeCallFactory.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/CrossModule/UserCalls/NullsafeCallFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\UserCalls;
+
+use GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService;
+
+/**
+ * A nullsafe call crosses the boundary exactly as much as a plain one.
+ */
+final class NullsafeCallFactory
+{
+    public function __construct(
+        private readonly ?ShopService $shop = null,
+    ) {
+    }
+
+    public function build(): ?string
+    {
+        return $this->shop?->run();
+    }
+}

--- a/tests/Unit/Psalm/CrossModuleSettingsTest.php
+++ b/tests/Unit/Psalm/CrossModuleSettingsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Psalm\CrossModuleSettings;
+use PHPUnit\Framework\TestCase;
+use Psalm\Exception\ConfigException;
+use SimpleXMLElement;
+
+final class CrossModuleSettingsTest extends TestCase
+{
+    /**
+     * No `<crossModule>` is the rule staying off -- the same default as the
+     * commented-out block in `phpstan-gacela.neon`.
+     */
+    public function test_a_plugin_element_without_cross_module_configures_nothing(): void
+    {
+        self::assertNull(CrossModuleSettings::fromPluginConfig(new SimpleXMLElement('<pluginClass/>')));
+    }
+
+    public function test_no_plugin_element_at_all_configures_nothing(): void
+    {
+        self::assertNull(CrossModuleSettings::fromPluginConfig(null));
+    }
+
+    public function test_it_reads_the_root_namespace(): void
+    {
+        $settings = $this->settings('<crossModule rootNamespace="App\Modules"/>');
+
+        self::assertSame('App\Modules', $settings->rootNamespace);
+    }
+
+    public function test_the_module_depth_defaults_to_one_segment(): void
+    {
+        self::assertSame(1, $this->settings('<crossModule rootNamespace="App\Modules"/>')->modulePathSegments);
+    }
+
+    public function test_it_reads_the_module_depth(): void
+    {
+        $settings = $this->settings('<crossModule rootNamespace="App\Modules" modulePathSegments="2"/>');
+
+        self::assertSame(2, $settings->modulePathSegments);
+    }
+
+    public function test_a_class_with_no_shared_namespaces_has_none(): void
+    {
+        self::assertSame([], $this->settings('<crossModule rootNamespace="App\Modules"/>')->sharedNamespaces);
+    }
+
+    public function test_it_reads_every_shared_namespace(): void
+    {
+        $settings = $this->settings(
+            '<crossModule rootNamespace="App\Modules">'
+            . '<sharedNamespace>App\Modules\Shared</sharedNamespace>'
+            . '<sharedNamespace>App\Modules\Kernel</sharedNamespace>'
+            . '</crossModule>',
+        );
+
+        self::assertSame(['App\Modules\Shared', 'App\Modules\Kernel'], $settings->sharedNamespaces);
+    }
+
+    /**
+     * Whitespace around an xml value is formatting, not part of the namespace.
+     */
+    public function test_it_trims_what_it_reads(): void
+    {
+        $settings = $this->settings(
+            '<crossModule rootNamespace=" App\\Modules ">'
+            . "<sharedNamespace>\n    App\\Modules\\Shared\n</sharedNamespace>"
+            . '</crossModule>',
+        );
+
+        self::assertSame('App\Modules', $settings->rootNamespace);
+        self::assertSame(['App\Modules\Shared'], $settings->sharedNamespaces);
+    }
+
+    public function test_an_empty_shared_namespace_is_not_a_namespace(): void
+    {
+        $settings = $this->settings(
+            '<crossModule rootNamespace="App\Modules"><sharedNamespace>  </sharedNamespace></crossModule>',
+        );
+
+        self::assertSame([], $settings->sharedNamespaces);
+    }
+
+    /**
+     * The whole point of failing here: a rule that quietly does nothing is worse
+     * than no rule, because it reads as a green check and nothing would ever say
+     * the boundary went unchecked.
+     */
+    public function test_a_cross_module_without_a_root_namespace_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('<crossModule> needs a rootNamespace');
+
+        $this->settings('<crossModule/>');
+    }
+
+    public function test_a_blank_root_namespace_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        $this->settings('<crossModule rootNamespace="   "/>');
+    }
+
+    public function test_an_explicit_depth_of_one_is_accepted(): void
+    {
+        $settings = $this->settings('<crossModule rootNamespace="App\Modules" modulePathSegments="1"/>');
+
+        self::assertSame(1, $settings->modulePathSegments);
+    }
+
+    /**
+     * Whitespace is not a value, so it means the same as leaving the attribute
+     * out -- not a depth of zero, which would throw.
+     */
+    public function test_a_blank_module_depth_is_the_default(): void
+    {
+        $settings = $this->settings('<crossModule rootNamespace="App\Modules" modulePathSegments="  "/>');
+
+        self::assertSame(1, $settings->modulePathSegments);
+    }
+
+    public function test_a_module_depth_below_one_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('modulePathSegments must be a positive number of namespace segments, got: 0');
+
+        $this->settings('<crossModule rootNamespace="App\Modules" modulePathSegments="0"/>');
+    }
+
+    public function test_a_negative_module_depth_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('got: -1');
+
+        $this->settings('<crossModule rootNamespace="App\Modules" modulePathSegments="-1"/>');
+    }
+
+    /**
+     * `(int)` turns anything unparseable into 0, which is caught -- but only
+     * because the cast happens before the comparison.
+     */
+    public function test_a_module_depth_that_is_not_a_number_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('got: two');
+
+        $this->settings('<crossModule rootNamespace="App\Modules" modulePathSegments="two"/>');
+    }
+
+    private function settings(string $crossModuleXml): CrossModuleSettings
+    {
+        $settings = CrossModuleSettings::fromPluginConfig(
+            new SimpleXMLElement('<pluginClass>' . $crossModuleXml . '</pluginClass>'),
+        );
+
+        self::assertNotNull($settings);
+
+        return $settings;
+    }
+}

--- a/tests/Unit/Psalm/PluginTest.php
+++ b/tests/Unit/Psalm/PluginTest.php
@@ -6,10 +6,13 @@ namespace GacelaTest\Unit\Psalm;
 
 use Gacela\Framework\AbstractFactory;
 use Gacela\Psalm\ClassRules;
+use Gacela\Psalm\CrossModuleCallRules;
+use Gacela\Psalm\CrossModuleRules;
 use Gacela\Psalm\Plugin;
 use PHPUnit\Framework\TestCase;
 use Psalm\Codebase;
 use Psalm\Config;
+use Psalm\Exception\ConfigException;
 use Psalm\Internal\Codebase\Methods;
 use Psalm\Internal\EventDispatcher;
 use Psalm\Internal\Provider\MethodReturnTypeProvider;
@@ -62,6 +65,51 @@ final class PluginTest extends TestCase
         (new Plugin())($this->socket($dispatcher));
 
         self::assertContains(ClassRules::class, $dispatcher->after_classlike_checks);
+    }
+
+    /**
+     * Nothing in a class name says where a module boundary falls, so this one
+     * cannot be on by default -- and staying off has to be the behaviour, not an
+     * accident of nobody calling it.
+     */
+    public function test_it_leaves_the_cross_module_check_off_without_config(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        (new Plugin())($this->socket($dispatcher));
+
+        self::assertNotContains(CrossModuleRules::class, $dispatcher->after_classlike_checks);
+        self::assertNotContains(CrossModuleCallRules::class, $dispatcher->after_expression_checks);
+        self::assertFalse(CrossModuleRules::isConfigured());
+        self::assertFalse(CrossModuleCallRules::isConfigured());
+    }
+
+    /**
+     * Both halves go on together: one matches the module names a source writes,
+     * the other resolves the receivers it does not.
+     */
+    public function test_a_cross_module_element_turns_both_halves_on(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        (new Plugin())($this->socket($dispatcher), new SimpleXMLElement(
+            '<pluginClass><crossModule rootNamespace="App\Modules"/></pluginClass>',
+        ));
+
+        self::assertContains(CrossModuleRules::class, $dispatcher->after_classlike_checks);
+        self::assertContains(CrossModuleCallRules::class, $dispatcher->after_expression_checks);
+        self::assertTrue(CrossModuleRules::isConfigured());
+        self::assertTrue(CrossModuleCallRules::isConfigured());
+    }
+
+    public function test_a_cross_module_element_without_a_root_namespace_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        (new Plugin())(
+            $this->socket(new EventDispatcher()),
+            new SimpleXMLElement('<pluginClass><crossModule/></pluginClass>'),
+        );
     }
 
     public function test_it_ignores_the_optional_plugin_config(): void

--- a/tests/Unit/StaticAnalysis/Double/ParseSource.php
+++ b/tests/Unit/StaticAnalysis/Double/ParseSource.php
@@ -8,6 +8,8 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use RuntimeException;
 
@@ -24,13 +26,28 @@ final class ParseSource
 {
     public static function classIn(string $php): ClassLike
     {
-        $node = (new NodeFinder())->findFirstInstanceOf(self::parse($php), ClassLike::class);
+        return self::classInStatements(self::parse($php));
+    }
 
-        if (!$node instanceof ClassLike) {
-            throw new RuntimeException('The snippet declares no class');
-        }
+    /**
+     * Names rewritten in place, so `Name::toString()` is already qualified --
+     * the tree PHPStan hands a rule.
+     */
+    public static function classInAsPhpStanResolves(string $php): ClassLike
+    {
+        return self::classInStatements(self::resolveNames(self::parse($php), replaceNodes: true));
+    }
 
-        return $node;
+    /**
+     * Names left as the source wrote them, with the qualified form on a
+     * `resolvedName` attribute -- the shape Psalm hands a plugin.
+     *
+     * The difference is not cosmetic: reading `toString()` on this tree gives
+     * `InvoiceRepository` for an imported class, which belongs to no module.
+     */
+    public static function classInWithNameAttributes(string $php): ClassLike
+    {
+        return self::classInStatements(self::resolveNames(self::parse($php), replaceNodes: false));
     }
 
     public static function methodIn(string $php, string $methodName): ClassMethod
@@ -42,6 +59,35 @@ final class ParseSource
         }
 
         throw new RuntimeException(sprintf('The snippet declares no method %s()', $methodName));
+    }
+
+    /**
+     * @param list<Stmt> $statements
+     *
+     * @return list<Stmt>
+     */
+    private static function resolveNames(array $statements, bool $replaceNodes): array
+    {
+        $traverser = new NodeTraverser(new NameResolver(null, ['replaceNodes' => $replaceNodes]));
+
+        /** @var list<Stmt> $resolved */
+        $resolved = $traverser->traverse($statements);
+
+        return $resolved;
+    }
+
+    /**
+     * @param list<Stmt> $statements
+     */
+    private static function classInStatements(array $statements): ClassLike
+    {
+        $node = (new NodeFinder())->findFirstInstanceOf($statements, ClassLike::class);
+
+        if (!$node instanceof ClassLike) {
+            throw new RuntimeException('The snippet declares no class');
+        }
+
+        return $node;
     }
 
     /**

--- a/tests/Unit/StaticAnalysis/ResolvedNameTest.php
+++ b/tests/Unit/StaticAnalysis/ResolvedNameTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\StaticAnalysis;
+
+use Gacela\StaticAnalysis\ResolvedName;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Each case here is a shape some real resolver produces. Getting this wrong is
+ * silent: a short name simply belongs to no module, so the rule reports nothing
+ * and reads as a pass.
+ */
+final class ResolvedNameTest extends TestCase
+{
+    private const FQCN = 'App\Modules\Billing\Domain\InvoiceRepository';
+
+    /**
+     * PHPStan rewrites names in place, so there is nothing to look up.
+     */
+    public function test_a_name_rewritten_in_place_is_used_as_written(): void
+    {
+        self::assertSame(self::FQCN, ResolvedName::of(new FullyQualified(self::FQCN)));
+    }
+
+    /**
+     * Psalm writes the attribute as a string.
+     */
+    public function test_a_string_attribute_wins_over_the_source_text(): void
+    {
+        $name = new Name('InvoiceRepository');
+        $name->setAttribute('resolvedName', self::FQCN);
+
+        self::assertSame(self::FQCN, ResolvedName::of($name));
+    }
+
+    /**
+     * php-parser's own NameResolver writes it as a node.
+     */
+    public function test_a_name_attribute_wins_over_the_source_text(): void
+    {
+        $name = new Name('InvoiceRepository');
+        $name->setAttribute('resolvedName', new FullyQualified(self::FQCN));
+
+        self::assertSame(self::FQCN, ResolvedName::of($name));
+    }
+
+    public function test_an_unresolved_name_falls_back_to_the_source_text(): void
+    {
+        self::assertSame('InvoiceRepository', ResolvedName::of(new Name('InvoiceRepository')));
+    }
+
+    /**
+     * An attribute of some other type is not a name, and reading it as one would
+     * be worse than falling back.
+     */
+    public function test_an_attribute_that_is_neither_falls_back(): void
+    {
+        $name = new Name('InvoiceRepository');
+        $name->setAttribute('resolvedName', 42);
+
+        self::assertSame('InvoiceRepository', ResolvedName::of($name));
+    }
+
+    /**
+     * A leading separator is legal and means the same class. Module names carry
+     * none, so keeping it would make every such name miss its module.
+     */
+    public function test_a_leading_separator_is_dropped(): void
+    {
+        self::assertSame(self::FQCN, ResolvedName::of(new Name('\\' . self::FQCN)));
+    }
+
+    public function test_a_leading_separator_is_dropped_from_the_attribute_too(): void
+    {
+        $name = new Name('InvoiceRepository');
+        $name->setAttribute('resolvedName', '\\' . self::FQCN);
+
+        self::assertSame(self::FQCN, ResolvedName::of($name));
+    }
+}

--- a/tests/Unit/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyserTest.php
@@ -55,6 +55,37 @@ final class CrossModuleViaFacadeAnalyserTest extends TestCase
     }
 
     /**
+     * The two hosts resolve names differently: PHPStan rewrites them in place,
+     * Psalm leaves the source text and puts the qualified form on an attribute.
+     * Reading only `toString()` matched nothing under Psalm, because an imported
+     * class reads as a bare `InvoiceRepository`, which belongs to no module.
+     */
+    public function test_an_imported_class_is_matched_whichever_way_the_host_resolved_it(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            namespace App\Modules\Checkout;
+
+            use App\Modules\Billing\Domain\InvoiceRepository;
+
+            final class CheckoutFactory
+            {
+                public function create()
+                {
+                    return new InvoiceRepository();
+                }
+            }
+            PHP;
+
+        $analyser = new CrossModuleViaFacadeAnalyser(self::ROOT);
+        $class = new FakeAnalysedClass('App\Modules\Checkout\CheckoutFactory');
+
+        self::assertCount(1, $analyser->analyse(ParseSource::classInAsPhpStanResolves($source), $class));
+        self::assertCount(1, $analyser->analyse(ParseSource::classInWithNameAttributes($source), $class));
+    }
+
+    /**
      * `new $class` names nothing to resolve a module from.
      */
     public function test_a_dynamic_reference_is_not_reported(): void


### PR DESCRIPTION
## 📚 Description

The last rule PHPStan had and Psalm did not. It cannot be on by default, because nothing in a class name says where a module boundary falls — so it reads the root namespace from a `<crossModule>` element on `<pluginClass>`, the config Psalm hands the entry point and the plugin has ignored until now.

Closes #642

## 🔖 Changes

- Add `CrossModuleSettings`, `CrossModuleRules` and `CrossModuleCallRules`
- Both halves go on together, matching `phpstan-gacela.neon`: the one matching written names and the one resolving receivers by type
- A `<crossModule>` without a `rootNamespace` stops the run rather than silently turning the rule off
- `configure(null)` turns it back off, so invoking the plugin twice leaves the state its latest config asked for

## 🐛 A real defect the fixtures exposed

The analysers read `Name::toString()`, which is qualified **only because PHPStan rewrites names in place**. Psalm leaves the source text alone and puts the qualified form on a `resolvedName` attribute — so an imported class read as its bare short name, belonged to no module, and the syntactic half of the check reported *nothing at all* under Psalm.

`ResolvedName` reads both shapes (Psalm writes a string, php-parser's own `NameResolver` writes a `Name`). `ResolvedNameTest` pins each shape, and `ParseSource` can now produce either host's tree so the analyser test covers both.

## 🧪 Testing

- `CrossModuleRulesTest` runs real Psalm with the check on: both halves fire, the Facade route and an allowlisted shared kernel are silent, and `SharedFoo` is still reported — the exemption is namespace-boundary aware
- `CrossModuleSettingsTest` covers the config, including every way it fails loudly
- `PluginTest` asserts the check stays **off** without a `<crossModule>`
- Infection over all three analysis namespaces: **100% MSI**, 401 mutations, 0 escaped