### PR TITLE
ref: modernise the static analysis rules, and stop reporting what cannot be fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enforce the pillar rules under Psalm, each as its own suppressible issue type
 - Report cross-module method calls on injected dependencies, which name no class at the call site
 - Enforce module boundaries under Psalm, opt-in through a `<crossModule>` plugin element
+- Report the correction alongside every architecture rule: PHPStan's tip line, Psalm's message
 
 ### Changed
 
@@ -22,6 +23,7 @@
 
 ### Fixed
 
+- Stop telling an interface, trait or enum to extend a pillar base class, which php does not allow
 - Match imported class names in the architecture rules however the host resolved them: under
   Psalm a `use`d class read as its short name and belonged to no module
 - Strip only the matched psr-4 prefix in `make:module`/`make:file`, and accept list targets

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -81,6 +81,19 @@ are what you suppress on, so a rule can be turned off on its own.
 On top of the rules, both analysers gain two **types** they otherwise lack: the
 pillar accessors, and `getProvidedDependency()` by class-string.
 
+Every finding carries the correction as well as the complaint — PHPStan renders
+it on its own 💡 line, Psalm appends it to the message, because it has nowhere
+else to put it:
+
+```
+Class App\Checkout\CheckoutFacade should extend Gacela\Framework\AbstractFacade
+    💡 Extend Gacela\Framework\AbstractFacade, or rename it so it does not end in Facade.
+```
+
+The pillar rules apply to **classes**. An interface, trait or enum named after a
+pillar is left alone: none of them can extend a class, so there would be no way
+to act on the report.
+
 Suppressing one rule:
 
 ```neon

--- a/src/PHPStan/Rules/FacadeOnlyDelegatesRule.php
+++ b/src/PHPStan/Rules/FacadeOnlyDelegatesRule.php
@@ -6,13 +6,12 @@ namespace Gacela\PHPStan\Rules;
 
 use Gacela\StaticAnalysis\Rules\FacadeOnlyDelegatesAnalyser;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ClassReflection;
+use PHPStan\Node\InClassMethodNode;
 use PHPStan\Rules\Rule;
 
 /**
- * @implements Rule<ClassMethod>
+ * @implements Rule<InClassMethodNode>
  *
  * @see FacadeOnlyDelegatesAnalyser for what is checked and why
  */
@@ -25,21 +24,22 @@ final class FacadeOnlyDelegatesRule implements Rule
         $this->analyser = new FacadeOnlyDelegatesAnalyser();
     }
 
+    /**
+     * `InClassMethodNode` rather than the bare `ClassMethod`: it carries the
+     * class reflection with it, and non-nullably. A plain method node left the
+     * class to be fetched from the scope, behind a null check that a method
+     * inside a class can never fail.
+     */
     public function getNodeType(): string
     {
-        return ClassMethod::class;
+        return InClassMethodNode::class;
     }
 
     public function processNode(Node $node, Scope $scope): array
     {
-        $classReflection = $scope->getClassReflection();
-        if (!$classReflection instanceof ClassReflection) {
-            return [];
-        }
-
         return RuleErrors::from($this->analyser->analyse(
-            $node,
-            new ReflectionAnalysedClass($classReflection),
+            $node->getOriginalNode(),
+            new ReflectionAnalysedClass($node->getClassReflection()),
         ));
     }
 }

--- a/src/PHPStan/Rules/InClassAnalyserRule.php
+++ b/src/PHPStan/Rules/InClassAnalyserRule.php
@@ -8,12 +8,11 @@ use Gacela\StaticAnalysis\ClassAnalyserInterface;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 
 /**
- * Adapts a {@see ClassAnalyserInterface} to PHPStan: resolve the class from the
- * scope, hand the analyser the original AST node, map what comes back.
+ * Adapts a {@see ClassAnalyserInterface} to PHPStan: hand the analyser the
+ * original AST node and the class it belongs to, then map what comes back.
  *
  * Each rule stays a class of its own because that is how a consumer registers
  * and suppresses it -- only the adapting is shared.
@@ -36,14 +35,12 @@ abstract class InClassAnalyserRule implements Rule
 
     final public function processNode(Node $node, Scope $scope): array
     {
-        $classReflection = $scope->getClassReflection();
-        if (!$classReflection instanceof ClassReflection) {
-            return [];
-        }
-
+        // InClassNode carries the reflection itself, and non-nullably: there is
+        // no such thing as being inside a class without one. Reaching through
+        // the scope instead bought a null check that could never be true.
         return RuleErrors::from($this->analyser->analyse(
             $node->getOriginalNode(),
-            new ReflectionAnalysedClass($classReflection),
+            new ReflectionAnalysedClass($node->getClassReflection()),
         ));
     }
 }

--- a/src/PHPStan/Rules/RuleErrors.php
+++ b/src/PHPStan/Rules/RuleErrors.php
@@ -28,6 +28,12 @@ final class RuleErrors
             $builder = RuleErrorBuilder::message($violation->message)
                 ->identifier($violation->identifier);
 
+            // PHPStan renders a tip on its own line under the error, which is
+            // where the correction belongs -- the message says what is wrong.
+            if ($violation->tip !== null) {
+                $builder->tip($violation->tip);
+            }
+
             // Left unset, PHPStan reports the line of the analysed node, which
             // is what every rule but the interface-drift one wants.
             if ($violation->node !== null) {

--- a/src/Psalm/ReportedIssues.php
+++ b/src/Psalm/ReportedIssues.php
@@ -62,7 +62,10 @@ final class ReportedIssues
 
             IssueBuffer::maybeAdd(
                 new $issue(
-                    $violation->message,
+                    // Psalm has no separate channel for a tip, so the
+                    // correction rides along in the message rather than being
+                    // dropped -- the two hosts should tell you the same thing.
+                    $violation->messageWithTip(),
                     new CodeLocation($source, $violation->node ?? $analysedNode),
                 ),
                 $source->getSuppressedIssues(),

--- a/src/StaticAnalysis/Rules/CrossModuleMethodCallAnalyser.php
+++ b/src/StaticAnalysis/Rules/CrossModuleMethodCallAnalyser.php
@@ -90,6 +90,7 @@ final class CrossModuleMethodCallAnalyser
                     $module,
                 ),
                 'gacela.crossModuleMethodCall',
+                sprintf("Type-hint %s's Facade, or its interface, instead.", $module),
             );
         }
 

--- a/src/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyser.php
+++ b/src/StaticAnalysis/Rules/CrossModuleViaFacadeAnalyser.php
@@ -91,6 +91,7 @@ final class CrossModuleViaFacadeAnalyser implements ClassAnalyserInterface
                     $refModule,
                 ),
                 'gacela.crossModuleWithoutFacade',
+                sprintf('Reach %s through its Facade.', $refModule),
             );
         }
 

--- a/src/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyser.php
+++ b/src/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyser.php
@@ -69,6 +69,7 @@ final class FacadeInterfaceInSyncAnalyser implements ClassAnalyserInterface
                     $facadeInterface,
                 ),
                 'gacela.facadeInterfaceDrift',
+                sprintf('Declare it in %s, or make the method non-public.', $facadeInterface),
                 $method,
             );
         }

--- a/src/StaticAnalysis/Rules/FacadeOnlyDelegatesAnalyser.php
+++ b/src/StaticAnalysis/Rules/FacadeOnlyDelegatesAnalyser.php
@@ -83,6 +83,7 @@ final class FacadeOnlyDelegatesAnalyser
                     $method->name->toString(),
                 ),
                 'gacela.facadeOnlyDelegates',
+                'Move the logic into the Factory and have this method call it.',
             ),
         ];
     }

--- a/src/StaticAnalysis/Rules/FactoryDoesNotCallFacadeAnalyser.php
+++ b/src/StaticAnalysis/Rules/FactoryDoesNotCallFacadeAnalyser.php
@@ -72,6 +72,7 @@ final class FactoryDoesNotCallFacadeAnalyser implements ClassAnalyserInterface
                     $className,
                 ),
                 'gacela.factoryInstantiatesFacade',
+                'Declare that Facade in your Provider and read it with getProvidedDependency().',
             );
         }
 
@@ -98,6 +99,7 @@ final class FactoryDoesNotCallFacadeAnalyser implements ClassAnalyserInterface
                     $class->name(),
                 ),
                 'gacela.factoryCallsGetFacade',
+                'Same-module wiring belongs in this Factory; another module belongs in the Provider.',
             );
         }
 

--- a/src/StaticAnalysis/Rules/SuffixExtendsAnalyser.php
+++ b/src/StaticAnalysis/Rules/SuffixExtendsAnalyser.php
@@ -9,6 +9,7 @@ use Gacela\StaticAnalysis\ClassAnalyserInterface;
 use Gacela\StaticAnalysis\ShortName;
 use Gacela\StaticAnalysis\Violation;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 
 use function sprintf;
@@ -34,9 +35,7 @@ final class SuffixExtendsAnalyser implements ClassAnalyserInterface
      */
     public function analyse(ClassLike $node, AnalysedClassInterface $class): array
     {
-        // An anonymous class has no name to carry a suffix, and nothing a
-        // consumer could rename if it were reported.
-        if (!$node->name instanceof Identifier) {
+        if (!$this->couldExtendAPillar($node)) {
             return [];
         }
 
@@ -59,7 +58,23 @@ final class SuffixExtendsAnalyser implements ClassAnalyserInterface
             new Violation(
                 sprintf('Class %s should extend %s', $className, $this->expectedParent),
                 'gacela.suffixExtends',
+                sprintf(
+                    'Extend %s, or rename it so it does not end in %s.',
+                    $this->expectedParent,
+                    $this->suffix,
+                ),
             ),
         ];
+    }
+
+    /**
+     * Interfaces, traits and enums cannot extend a class at all, so telling one
+     * of them to is advice it is impossible to take -- the only way out would be
+     * a baseline entry. An anonymous class has no name to carry a suffix, and
+     * nothing a consumer could rename if it were reported.
+     */
+    private function couldExtendAPillar(ClassLike $node): bool
+    {
+        return $node instanceof Class_ && $node->name instanceof Identifier;
     }
 }

--- a/src/StaticAnalysis/Violation.php
+++ b/src/StaticAnalysis/Violation.php
@@ -16,18 +16,32 @@ use PhpParser\Node;
 final class Violation
 {
     /**
-     * @param string    $identifier stable, dot-separated, e.g. `gacela.suffixExtends`
-     * @param Node|null $node       the node the finding belongs to, when that is
-     *                              not the one being analysed -- as with a method
-     *                              reported from inside its class. A node rather
-     *                              than a line number because Psalm locates an
-     *                              issue by its exact source span, and a line
-     *                              cannot be widened back into one
+     * @param string      $identifier stable, dot-separated, e.g. `gacela.suffixExtends`
+     * @param string|null $tip        what to do about it. PHPStan renders this on its
+     *                                own line; Psalm has no such channel, so it is
+     *                                appended to the message there. A rule that can
+     *                                name the correction should
+     * @param Node|null   $node       the node the finding belongs to, when that is
+     *                                not the one being analysed -- as with a method
+     *                                reported from inside its class. A node rather
+     *                                than a line number because Psalm locates an
+     *                                issue by its exact source span, and a line
+     *                                cannot be widened back into one
      */
     public function __construct(
         public readonly string $message,
         public readonly string $identifier,
+        public readonly ?string $tip = null,
         public readonly ?Node $node = null,
     ) {
+    }
+
+    /**
+     * The message with the tip folded in, for hosts that have nowhere else to
+     * put it.
+     */
+    public function messageWithTip(): string
+    {
+        return $this->tip === null ? $this->message : $this->message . ' ' . $this->tip;
     }
 }

--- a/tests/Integration/Psalm/ArchitectureRulesTest.php
+++ b/tests/Integration/Psalm/ArchitectureRulesTest.php
@@ -94,6 +94,35 @@ final class ArchitectureRulesTest extends PsalmFixtureTestCase
         self::assertSame('', $this->errorsIn('CleanFactory.php'));
     }
 
+    /**
+     * An interface, a trait and an enum cannot extend a class, so the suffix
+     * rule has nothing fixable to say about them. Reporting one leaves a
+     * consumer with a baseline entry as the only way out.
+     */
+    public function test_something_that_cannot_extend_a_pillar_is_not_told_to(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('GacelaSuffixExtends', $errors, 'precondition: the rule ran at all');
+        self::assertSame('', $this->errorsIn('StatusConfig.php'));
+        self::assertSame('', $this->errorsIn('PaymentFacade.php'));
+    }
+
+    /**
+     * Psalm has no separate channel for a tip, so the correction rides along in
+     * the message rather than being dropped.
+     */
+    public function test_a_finding_carries_the_correction(): void
+    {
+        $this->skipIfPsalmCannotRun($this->analyseFixture());
+
+        self::assertStringContainsString(
+            'Extend Gacela\Framework\AbstractFacade, or rename it so it does not end in Facade.',
+            $this->errorsIn('BadFacade.php'),
+        );
+    }
+
     protected static function configPath(): string
     {
         return __DIR__ . '/RulesFixture/psalm-rules-fixture.xml';

--- a/tests/Integration/Psalm/RulesFixture/PaymentFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/PaymentFacade.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+/**
+ * Same, as an interface.
+ */
+interface PaymentFacade
+{
+    public function pay(): void;
+}

--- a/tests/Integration/Psalm/RulesFixture/StatusConfig.php
+++ b/tests/Integration/Psalm/RulesFixture/StatusConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+/**
+ * Named after a pillar but unable to extend one -- an enum cannot extend a class
+ * at all. Reporting it would be advice nobody can take.
+ */
+enum StatusConfig: string
+{
+    case Open = 'open';
+}

--- a/tests/Unit/PHPStan/Rules/CrossModuleMethodCallRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/CrossModuleMethodCallRuleTest.php
@@ -31,7 +31,7 @@ final class CrossModuleMethodCallRuleTest extends RuleTestCase
     {
         $this->analyse(
             [__DIR__ . '/Fixture/CrossModule/UserCalls/InjectedFactory.php'],
-            [[$this->expectedError('InjectedFactory', 'Shop\Domain\ShopService', 'Shop'), 22]],
+            [[$this->expectedError('InjectedFactory', 'Shop\Domain\ShopService', 'Shop'), 22, $this->expectedTip('Shop')]],
         );
     }
 
@@ -45,7 +45,7 @@ final class CrossModuleMethodCallRuleTest extends RuleTestCase
     {
         $this->analyse(
             [__DIR__ . '/Fixture/CrossModule/UserCalls/NullsafeCallFactory.php'],
-            [[$this->expectedError('NullsafeCallFactory', 'Shop\Domain\ShopService', 'Shop'), 21]],
+            [[$this->expectedError('NullsafeCallFactory', 'Shop\Domain\ShopService', 'Shop'), 21, $this->expectedTip('Shop')]],
         );
     }
 
@@ -83,7 +83,7 @@ final class CrossModuleMethodCallRuleTest extends RuleTestCase
     {
         $this->analyse(
             [__DIR__ . '/Fixture/CrossModule/UserCalls/SharedCallFactory.php'],
-            [[$this->expectedError('SharedCallFactory', 'Shared\Clock', 'Shared'), 18]],
+            [[$this->expectedError('SharedCallFactory', 'Shared\Clock', 'Shared'), 18, $this->expectedTip('Shared')]],
         );
     }
 
@@ -106,13 +106,18 @@ final class CrossModuleMethodCallRuleTest extends RuleTestCase
 
         $this->analyse(
             [__DIR__ . '/Fixture/CrossModule/UserCalls/InjectedFactory.php'],
-            [[$this->expectedError('InjectedFactory', 'Shop\Domain\ShopService', 'Shop'), 22]],
+            [[$this->expectedError('InjectedFactory', 'Shop\Domain\ShopService', 'Shop'), 22, $this->expectedTip('Shop')]],
         );
     }
 
     protected function getRule(): Rule
     {
         return $this->rule ??= new CrossModuleMethodCallRule(self::ROOT, 1, $this->sharedNamespaces);
+    }
+
+    private function expectedTip(string $module): string
+    {
+        return sprintf("Type-hint %s's Facade, or its interface, instead.", self::ROOT . '\\' . $module);
     }
 
     private function expectedError(string $caller, string $receiver, string $module): string

--- a/tests/Unit/PHPStan/Rules/CrossModuleViaFacadeRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/CrossModuleViaFacadeRuleTest.php
@@ -8,6 +8,8 @@ use Gacela\PHPStan\Rules\CrossModuleViaFacadeRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
+use function sprintf;
+
 /**
  * @extends RuleTestCase<CrossModuleViaFacadeRule>
  */
@@ -32,6 +34,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\BadNewFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -65,6 +68,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\StaticCallFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -78,6 +82,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\ClassConstFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -91,6 +96,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\DuplicateFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -106,6 +112,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Admin\User\AdminUserFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Admin\Shop\AdminShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Admin\Shop). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Admin\Shop'),
                 ],
             ],
         );
@@ -129,14 +136,17 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\MixedOrderFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopRepository from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     15,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\MixedOrderFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     15,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\MixedOrderFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopWriter from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     15,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -150,6 +160,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\SharedKernelFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared'),
                 ],
             ],
         );
@@ -174,6 +185,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\SharedKernelFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared\Clock from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shared'),
                 ],
             ],
         );
@@ -189,6 +201,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\SharedThenBadFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     10,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -215,6 +228,7 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\User\BadNewFactory references GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop\Domain\ShopService from another module (GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop). Cross-module access must go through a Facade.',
                     9,
+                    $this->expectedTip('GacelaTest\Unit\PHPStan\Rules\Fixture\CrossModule\Shop'),
                 ],
             ],
         );
@@ -227,5 +241,10 @@ final class CrossModuleViaFacadeRuleTest extends RuleTestCase
             $this->modulePathSegments,
             $this->sharedNamespaces,
         );
+    }
+
+    private function expectedTip(string $module): string
+    {
+        return sprintf('Reach %s through its Facade.', $module);
     }
 }

--- a/tests/Unit/PHPStan/Rules/FacadeInterfaceInSyncRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/FacadeInterfaceInSyncRuleTest.php
@@ -29,8 +29,8 @@ final class FacadeInterfaceInSyncRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/Fixture/FacadeInterface/DriftedFacade.php'],
             [
-                [$this->expectedError('addedLaterAndForgotten'), 25],
-                [$this->expectedError('alsoForgotten'), 30],
+                [$this->expectedError('addedLaterAndForgotten'), 25, $this->expectedTip(DriftedFacadeInterface::class)],
+                [$this->expectedError('alsoForgotten'), 30, $this->expectedTip(DriftedFacadeInterface::class)],
             ],
         );
     }
@@ -62,6 +62,7 @@ final class FacadeInterfaceInSyncRuleTest extends RuleTestCase
                         SecondPositionFacadeInterface::class,
                     ),
                     27,
+                    $this->expectedTip(SecondPositionFacadeInterface::class),
                 ],
             ],
         );
@@ -70,6 +71,11 @@ final class FacadeInterfaceInSyncRuleTest extends RuleTestCase
     protected function getRule(): Rule
     {
         return new FacadeInterfaceInSyncRule();
+    }
+
+    private function expectedTip(string $interface): string
+    {
+        return sprintf('Declare it in %s, or make the method non-public.', $interface);
     }
 
     private function expectedError(string $method): string

--- a/tests/Unit/PHPStan/Rules/FacadeOnlyDelegatesRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/FacadeOnlyDelegatesRuleTest.php
@@ -33,24 +33,26 @@ final class FacadeOnlyDelegatesRuleTest extends RuleTestCase
         $prefix = 'Facade method ' . \GacelaTest\Unit\PHPStan\Rules\Fixture\FacadeDelegate\BadFacade::class . '::';
         $suffix = '() must only delegate to $this->getFactory()/getConfig()/getProvider(); no inline logic allowed.';
 
+        $tip = 'Move the logic into the Factory and have this method call it.';
+
         $this->analyse(
             [__DIR__ . '/Fixture/FacadeDelegate/BadFacade.php'],
             [
-                [$prefix . 'multipleStatements' . $suffix, 12],
-                [$prefix . 'localLogic' . $suffix, 19],
-                [$prefix . 'controlFlow' . $suffix, 24],
-                [$prefix . 'notAllowedRoot' . $suffix, 33],
-                [$prefix . 'cachedNonDelegation' . $suffix, 38],
-                [$prefix . 'cachedMultiStmt' . $suffix, 43],
-                [$prefix . 'somethingElse' . $suffix, 52],
-                [$prefix . 'singleIfStatement' . $suffix, 57],
-                [$prefix . 'delegatesOnLocalVariable' . $suffix, 69],
-                [$prefix . 'dynamicMethodName' . $suffix, 74],
-                [$prefix . 'notCachedWrapper' . $suffix, 79],
-                [$prefix . 'cachedWithoutArgs' . $suffix, 84],
-                [$prefix . 'cachedWithNonClosure' . $suffix, 89],
-                [$prefix . 'cachedOnNullsafeThis' . $suffix, 94],
-                [$prefix . 'cachedClosureWithLeadingDelegation' . $suffix, 99],
+                [$prefix . 'multipleStatements' . $suffix, 12, $tip],
+                [$prefix . 'localLogic' . $suffix, 19, $tip],
+                [$prefix . 'controlFlow' . $suffix, 24, $tip],
+                [$prefix . 'notAllowedRoot' . $suffix, 33, $tip],
+                [$prefix . 'cachedNonDelegation' . $suffix, 38, $tip],
+                [$prefix . 'cachedMultiStmt' . $suffix, 43, $tip],
+                [$prefix . 'somethingElse' . $suffix, 52, $tip],
+                [$prefix . 'singleIfStatement' . $suffix, 57, $tip],
+                [$prefix . 'delegatesOnLocalVariable' . $suffix, 69, $tip],
+                [$prefix . 'dynamicMethodName' . $suffix, 74, $tip],
+                [$prefix . 'notCachedWrapper' . $suffix, 79, $tip],
+                [$prefix . 'cachedWithoutArgs' . $suffix, 84, $tip],
+                [$prefix . 'cachedWithNonClosure' . $suffix, 89, $tip],
+                [$prefix . 'cachedOnNullsafeThis' . $suffix, 94, $tip],
+                [$prefix . 'cachedClosureWithLeadingDelegation' . $suffix, 99, $tip],
             ],
         );
     }

--- a/tests/Unit/PHPStan/Rules/FactoryDoesNotCallFacadeRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/FactoryDoesNotCallFacadeRuleTest.php
@@ -13,6 +13,10 @@ use PHPStan\Testing\RuleTestCase;
  */
 final class FactoryDoesNotCallFacadeRuleTest extends RuleTestCase
 {
+    private const NEW_TIP = 'Declare that Facade in your Provider and read it with getProvidedDependency().';
+
+    private const CALL_TIP = 'Same-module wiring belongs in this Factory; another module belongs in the Provider.';
+
     public function test_reports_new_facade_instantiation(): void
     {
         $this->analyse(
@@ -21,6 +25,7 @@ final class FactoryDoesNotCallFacadeRuleTest extends RuleTestCase
                 [
                     'Factory GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\BadFactoryNewFacade must not instantiate a Facade (found: new GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\ShopFacade). Depend on other modules through their Facade via the Provider.',
                     9,
+                    self::NEW_TIP,
                 ],
             ],
         );
@@ -34,6 +39,7 @@ final class FactoryDoesNotCallFacadeRuleTest extends RuleTestCase
                 [
                     'Factory GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\BadFactoryGetFacade must not call $this->getFacade(); same-module access goes through the Factory itself, cross-module access goes through the Provider.',
                     9,
+                    self::CALL_TIP,
                 ],
             ],
         );
@@ -57,10 +63,12 @@ final class FactoryDoesNotCallFacadeRuleTest extends RuleTestCase
                 [
                     'Factory GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\MultiViolationFactory must not instantiate a Facade (found: new GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\ShopFacade). Depend on other modules through their Facade via the Provider.',
                     9,
+                    self::NEW_TIP,
                 ],
                 [
                     'Factory GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\MultiViolationFactory must not call $this->getFacade(); same-module access goes through the Factory itself, cross-module access goes through the Provider.',
                     9,
+                    self::CALL_TIP,
                 ],
             ],
         );
@@ -74,10 +82,10 @@ final class FactoryDoesNotCallFacadeRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/Fixture/FactoryCallsFacade/MixedOrderBadFactory.php'],
             [
-                [$factory . ' must not instantiate a Facade (found: new GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\ShopFacade)' . $newSuffix, 10],
-                [$factory . ' must not instantiate a Facade (found: new Facade)' . $newSuffix, 10],
-                [$factory . ' must not instantiate a Facade (found: new GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\Sub\Facade)' . $newSuffix, 10],
-                [$factory . ' must not call $this->getFacade(); same-module access goes through the Factory itself, cross-module access goes through the Provider.', 10],
+                [$factory . ' must not instantiate a Facade (found: new GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\ShopFacade)' . $newSuffix, 10, self::NEW_TIP],
+                [$factory . ' must not instantiate a Facade (found: new Facade)' . $newSuffix, 10, self::NEW_TIP],
+                [$factory . ' must not instantiate a Facade (found: new GacelaTest\Unit\PHPStan\Rules\Fixture\FactoryCallsFacade\Sub\Facade)' . $newSuffix, 10, self::NEW_TIP],
+                [$factory . ' must not call $this->getFacade(); same-module access goes through the Factory itself, cross-module access goes through the Provider.', 10, self::CALL_TIP],
             ],
         );
     }

--- a/tests/Unit/PHPStan/Rules/SuffixExtendsRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/SuffixExtendsRuleTest.php
@@ -12,6 +12,8 @@ use Gacela\PHPStan\Rules\SuffixExtendsRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
+use function sprintf;
+
 /**
  * @extends RuleTestCase<SuffixExtendsRule>
  */
@@ -29,6 +31,7 @@ final class SuffixExtendsRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\SuffixFacade\BadFacade should extend ' . AbstractFacade::class,
                     7,
+                    $this->expectedTip(),
                 ],
             ],
         );
@@ -55,6 +58,7 @@ final class SuffixExtendsRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\SuffixFactory\InvalidFactory should extend ' . AbstractFactory::class,
                     7,
+                    $this->expectedTip(),
                 ],
             ],
         );
@@ -79,6 +83,7 @@ final class SuffixExtendsRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\SuffixProvider\InvalidProvider should extend ' . AbstractProvider::class,
                     7,
+                    $this->expectedTip(),
                 ],
             ],
         );
@@ -103,6 +108,7 @@ final class SuffixExtendsRuleTest extends RuleTestCase
                 [
                     'Class GacelaTest\Unit\PHPStan\Rules\Fixture\SuffixConfig\InvalidConfig should extend ' . AbstractConfig::class,
                     7,
+                    $this->expectedTip(),
                 ],
             ],
         );
@@ -119,5 +125,14 @@ final class SuffixExtendsRuleTest extends RuleTestCase
     protected function getRule(): Rule
     {
         return new SuffixExtendsRule($this->suffix, $this->expectedParent);
+    }
+
+    private function expectedTip(): string
+    {
+        return sprintf(
+            'Extend %s, or rename it so it does not end in %s.',
+            $this->expectedParent,
+            $this->suffix,
+        );
     }
 }

--- a/tests/Unit/StaticAnalysis/Rules/SuffixExtendsAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/SuffixExtendsAnalyserTest.php
@@ -63,6 +63,52 @@ final class SuffixExtendsAnalyserTest extends TestCase
     }
 
     /**
+     * Interfaces, traits and enums cannot extend a class at all, so telling one
+     * of them to would be advice it is impossible to take -- the only way out
+     * would be a baseline entry. `PaymentFacade` as an interface is a perfectly
+     * ordinary thing for a consumer to write.
+     */
+    public function test_only_a_class_can_be_told_to_extend_a_pillar(): void
+    {
+        $analyser = new SuffixExtendsAnalyser('Facade', AbstractFacade::class);
+        $class = new FakeAnalysedClass('App\Checkout\CheckoutFacade');
+
+        foreach (['interface', 'trait', 'enum'] as $kind) {
+            self::assertSame(
+                [],
+                $analyser->analyse(ParseSource::classIn('<?php ' . $kind . ' CheckoutFacade {}'), $class),
+                $kind . ' cannot extend a class, so reporting it would be unfixable',
+            );
+        }
+    }
+
+    /**
+     * An abstract class still can extend, so it is still held to the rule.
+     */
+    public function test_an_abstract_class_is_still_checked(): void
+    {
+        $analyser = new SuffixExtendsAnalyser('Facade', AbstractFacade::class);
+        $class = new FakeAnalysedClass('App\Checkout\CheckoutFacade');
+
+        self::assertCount(
+            1,
+            $analyser->analyse(ParseSource::classIn('<?php abstract class CheckoutFacade {}'), $class),
+        );
+    }
+
+    /**
+     * The message says what is wrong; the tip says what to do about it, and
+     * PHPStan renders it on its own line.
+     */
+    public function test_the_violation_carries_the_correction(): void
+    {
+        self::assertSame(
+            'Extend Gacela\Framework\AbstractFacade, or rename it so it does not end in Facade.',
+            $this->analyse('App\Checkout\CheckoutFacade')[0]->tip,
+        );
+    }
+
+    /**
      * An anonymous class has no name to carry a suffix, and nothing a consumer
      * could rename if it were reported.
      */


### PR DESCRIPTION
## 📚 Description

A pass over `src/StaticAnalysis`, `src/PHPStan` and `src/Psalm` for the current best APIs of both analysers. It turned up one real bug.

## 🐛 The bug

`SuffixExtendsAnalyser` matched on the **class name alone**, so all of these were reported and told to `extend` a base class:

```php
interface PaymentFacade {}   // reported
trait CacheConfig {}         // reported
enum StatusConfig {}         // reported
```

PHP allows **none** of the three to extend a class. The advice was impossible to take, so a baseline entry was the only way out — and `interface PaymentFacade` is an ordinary thing for a consumer to write. Now the pillar rules apply to classes; abstract classes are still held to them, since they *can* extend.

Not reachable in Gacela's own source (its interfaces all end in `Interface`), which is why nothing caught it here. Found by probing each `ClassLike` node kind through the analyser.

## ✨ Every finding now carries its correction

`RuleErrorBuilder::tip()` renders on its own line under a PHPStan error — the message says what is *wrong*, the tip says what to *do*:

```
Class App\Checkout\CheckoutFacade should extend Gacela\Framework\AbstractFacade
    💡 Extend Gacela\Framework\AbstractFacade, or rename it so it does not end in Facade.
```

All seven rules have one. Psalm has no tip channel, so `Violation::messageWithTip()` folds it into the message rather than dropping it — both hosts tell you the same thing.

## 🔧 Modern node types (separate `ref:` commit)

Both adapters reached through the `Scope` for the class they were already inside, behind a null check **that cannot be true** — there is no analysing a class member without a class. `InClassNode` and `InClassMethodNode` are `@api` and expose `getClassReflection()` non-nullably:

- `InClassAnalyserRule` — drops the scope lookup and the dead guard
- `FacadeOnlyDelegatesRule` — `Rule<ClassMethod>` → `Rule<InClassMethodNode>`, same methods visited

## 🧪 Testing

- The bug is pinned at the analyser (all three node kinds) **and** under a real Psalm run: `StatusConfig.php` and `PaymentFacade.php` fixtures must stay silent while `GacelaSuffixExtends` still fires elsewhere — so the test cannot pass by the rule simply being off
- Tips are asserted through `RuleTestCase`'s third expectation element, so the *rendered* output is pinned, not just the string
- `ArchitectureRulesTest` asserts the correction survives into Psalm's message
- Infection over all three namespaces: **100% MSI**, 406 mutations, 0 escaped