### PR TITLE
chore: update dependencies, and make the coverage run passable

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2702,16 +2702,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.34.1",
+            "version": "0.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "263a6e303e343f1cdfa378d259a199c594d0731d"
+                "reference": "18d9bef39fae250f202920d1453ab96e793e6637"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/263a6e303e343f1cdfa378d259a199c594d0731d",
-                "reference": "263a6e303e343f1cdfa378d259a199c594d0731d",
+                "url": "https://api.github.com/repos/infection/infection/zipball/18d9bef39fae250f202920d1453ab96e793e6637",
+                "reference": "18d9bef39fae250f202920d1453ab96e793e6637",
                 "shasum": ""
             },
             "require": {
@@ -2825,7 +2825,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.34.1"
+                "source": "https://github.com/infection/infection/tree/0.34.2"
             },
             "funding": [
                 {
@@ -2837,7 +2837,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-07-27T18:58:14+00:00"
+            "time": "2026-08-07T12:59:47+00:00"
         },
         {
             "name": "infection/mutator",
@@ -4027,16 +4027,16 @@
         },
         {
             "name": "phpmetrics/phpmetrics",
-            "version": "2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmetrics/PhpMetrics.git",
-                "reference": "7e177cedfe0ee71ee701b9d00eafbc96d9410446"
+                "reference": "55c5e23b34afb8fa9b6c6ea95cbd59b710160235"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmetrics/PhpMetrics/zipball/7e177cedfe0ee71ee701b9d00eafbc96d9410446",
-                "reference": "7e177cedfe0ee71ee701b9d00eafbc96d9410446",
+                "url": "https://api.github.com/repos/phpmetrics/PhpMetrics/zipball/55c5e23b34afb8fa9b6c6ea95cbd59b710160235",
+                "reference": "55c5e23b34afb8fa9b6c6ea95cbd59b710160235",
                 "shasum": ""
             },
             "require": {
@@ -4085,7 +4085,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PhpMetrics/PhpMetrics/issues",
-                "source": "https://github.com/phpmetrics/PhpMetrics/tree/2.10.0"
+                "source": "https://github.com/phpmetrics/PhpMetrics/tree/v2.11.0"
             },
             "funding": [
                 {
@@ -4093,7 +4093,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-21T16:15:57+00:00"
+            "time": "2026-08-09T06:58:42+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -7023,16 +7023,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.15",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930"
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/088ec6fe0ef6819cbc301174093b6bfa4ad26930",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
                 "shasum": ""
             },
             "require": {
@@ -7097,7 +7097,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.15"
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -7117,20 +7117,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-27T13:51:00+00:00"
+            "time": "2026-07-31T12:37:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.15",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b7825671c553af46a98c744e23f37f972aee6427"
+                "reference": "7f59a843c1fbcceafecdf6863d3e38ea6ecd5061"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b7825671c553af46a98c744e23f37f972aee6427",
-                "reference": "b7825671c553af46a98c744e23f37f972aee6427",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7f59a843c1fbcceafecdf6863d3e38ea6ecd5061",
+                "reference": "7f59a843c1fbcceafecdf6863d3e38ea6ecd5061",
                 "shasum": ""
             },
             "require": {
@@ -7181,7 +7181,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.15"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -7201,7 +7201,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-22T08:40:50+00:00"
+            "time": "2026-08-06T09:45:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -8705,16 +8705,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.14",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "0118811b1d59f323bf131250b3fb919febfece28"
+                "reference": "ca31404415670aa3834809005b529df1b84f0790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0118811b1d59f323bf131250b3fb919febfece28",
-                "reference": "0118811b1d59f323bf131250b3fb919febfece28",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/ca31404415670aa3834809005b529df1b84f0790",
+                "reference": "ca31404415670aa3834809005b529df1b84f0790",
                 "shasum": ""
             },
             "require": {
@@ -8762,7 +8762,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.14"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -8782,7 +8782,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-27T08:41:53+00:00"
+            "time": "2026-07-30T12:37:26+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/infection.json5
+++ b/infection.json5
@@ -419,7 +419,16 @@
         // the same way every time, so rebuilding them per call is
         // observationally identical, only slower.
         AssignCoalesce: {
-            ignore: ["Gacela\\Console\\Application\\CacheWarm\\CacheWarmService::classResolvers"],
+            ignore: [
+                "Gacela\\Console\\Application\\CacheWarm\\CacheWarmService::classResolvers",
+                // The rule set is memoized in a static because psalm calls the
+                // handler statically and it runs for every class-like in a
+                // project. Rebuilding it each time is what the mutant does, and
+                // the rules hold only their configuration, so nothing
+                // observable changes.
+                "Gacela\\Psalm\\ClassRules::violationsIn",
+                "Gacela\\Psalm\\ClassRules::classAnalysers",
+            ],
         },
         // ReturnRemoval arrived with infection 0.34 and reads every early
         // return as behaviour. These two are allocation guards, not behaviour.

--- a/src/Psalm/ClassRules.php
+++ b/src/Psalm/ClassRules.php
@@ -8,11 +8,14 @@ use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\AbstractProvider;
+use Gacela\StaticAnalysis\AnalysedClassInterface;
 use Gacela\StaticAnalysis\ClassAnalyserInterface;
 use Gacela\StaticAnalysis\Rules\FacadeInterfaceInSyncAnalyser;
 use Gacela\StaticAnalysis\Rules\FacadeOnlyDelegatesAnalyser;
 use Gacela\StaticAnalysis\Rules\FactoryDoesNotCallFacadeAnalyser;
 use Gacela\StaticAnalysis\Rules\SuffixExtendsAnalyser;
+use Gacela\StaticAnalysis\Violation;
+use PhpParser\Node\Stmt\ClassLike;
 use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
 
@@ -43,19 +46,45 @@ final class ClassRules implements AfterClassLikeAnalysisInterface
     public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event): ?bool
     {
         $node = $event->getStmt();
-        $source = $event->getStatementsSource();
-        $class = new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase());
+
+        ReportedIssues::report(
+            self::violationsIn($node, new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase())),
+            $node,
+            $event->getStatementsSource(),
+        );
+
+        return null;
+    }
+
+    /**
+     * Everything the class-level rules find, each pinned to the node it belongs
+     * to -- a facade method's finding belongs on the method, not on the class.
+     *
+     * Kept apart from the reporting so it can be driven directly: reporting goes
+     * through Psalm's IssueBuffer, which needs a live ProjectAnalyzer that a unit
+     * test has no way to supply. Without the split, the only proof these rules
+     * are wired up at all was a subprocess that coverage cannot see.
+     *
+     * @return list<Violation>
+     */
+    public static function violationsIn(ClassLike $node, AnalysedClassInterface $class): array
+    {
+        $violations = [];
 
         foreach (self::classAnalysers() as $analyser) {
-            ReportedIssues::report($analyser->analyse($node, $class), $node, $source);
+            foreach ($analyser->analyse($node, $class) as $violation) {
+                $violations[] = $violation;
+            }
         }
 
         $facadeMethods = self::$facadeMethods ??= new FacadeOnlyDelegatesAnalyser();
         foreach ($node->getMethods() as $method) {
-            ReportedIssues::report($facadeMethods->analyse($method, $class), $method, $source);
+            foreach ($facadeMethods->analyse($method, $class) as $violation) {
+                $violations[] = $violation->at($method);
+            }
         }
 
-        return null;
+        return $violations;
     }
 
     /**

--- a/src/Psalm/CrossModuleCallRules.php
+++ b/src/Psalm/CrossModuleCallRules.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Gacela\Psalm;
 
 use Gacela\StaticAnalysis\Rules\CrossModuleMethodCallAnalyser;
+use Gacela\StaticAnalysis\Violation;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
+use Psalm\NodeTypeProvider;
 use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
 use Psalm\Type\Atomic\TNamedObject;
@@ -64,7 +66,7 @@ final class CrossModuleCallRules implements AfterExpressionAnalysisInterface
         }
 
         ReportedIssues::report(
-            $analyser->analyse($callingClass, self::receiverClasses($event)),
+            self::violationsFor($expr, $callingClass, $source->getNodeTypeProvider()),
             $expr,
             $source,
         );
@@ -73,17 +75,30 @@ final class CrossModuleCallRules implements AfterExpressionAnalysisInterface
     }
 
     /**
+     * What the rule finds, apart from the reporting -- see
+     * {@see ClassRules::violationsIn()} for why the two are split.
+     *
+     * @return list<Violation>
+     */
+    public static function violationsFor(
+        MethodCall|NullsafeMethodCall $expr,
+        string $callingClass,
+        NodeTypeProvider $types,
+    ): array {
+        return self::$analyser instanceof \Gacela\StaticAnalysis\Rules\CrossModuleMethodCallAnalyser
+            ? self::$analyser->analyse($callingClass, self::receiverClasses($expr, $types))
+            : [];
+    }
+
+    /**
      * Empty when Psalm could not tell, which the analyser reads as "no evidence"
      * rather than "no violation to find".
      *
      * @return list<string>
      */
-    private static function receiverClasses(AfterExpressionAnalysisEvent $event): array
+    private static function receiverClasses(MethodCall|NullsafeMethodCall $expr, NodeTypeProvider $types): array
     {
-        /** @var MethodCall|NullsafeMethodCall $expr */
-        $expr = $event->getExpr();
-
-        $type = $event->getStatementsSource()->getNodeTypeProvider()->getType($expr->var);
+        $type = $types->getType($expr->var);
         if (!$type instanceof Union) {
             return [];
         }

--- a/src/Psalm/CrossModuleRules.php
+++ b/src/Psalm/CrossModuleRules.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Gacela\Psalm;
 
+use Gacela\StaticAnalysis\AnalysedClassInterface;
 use Gacela\StaticAnalysis\Rules\CrossModuleViaFacadeAnalyser;
+use Gacela\StaticAnalysis\Violation;
+use PhpParser\Node\Stmt\ClassLike;
 use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
 
@@ -51,11 +54,22 @@ final class CrossModuleRules implements AfterClassLikeAnalysisInterface
         $node = $event->getStmt();
 
         ReportedIssues::report(
-            $analyser->analyse($node, new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase())),
+            self::violationsIn($node, new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase())),
             $node,
             $event->getStatementsSource(),
         );
 
         return null;
+    }
+
+    /**
+     * What the rule finds, apart from the reporting -- see
+     * {@see ClassRules::violationsIn()} for why the two are split.
+     *
+     * @return list<Violation>
+     */
+    public static function violationsIn(ClassLike $node, AnalysedClassInterface $class): array
+    {
+        return self::$analyser instanceof \Gacela\StaticAnalysis\Rules\CrossModuleViaFacadeAnalyser ? self::$analyser->analyse($node, $class) : [];
     }
 }

--- a/src/Psalm/ReportedIssues.php
+++ b/src/Psalm/ReportedIssues.php
@@ -55,22 +55,40 @@ final class ReportedIssues
     public static function report(array $violations, Node $analysedNode, StatementsSource $source): void
     {
         foreach ($violations as $violation) {
-            $issue = self::issueFor($violation->identifier);
-            if ($issue === null) {
-                continue;
-            }
+            $issue = self::toIssue($violation, $analysedNode, $source);
 
-            IssueBuffer::maybeAdd(
-                new $issue(
-                    // Psalm has no separate channel for a tip, so the
-                    // correction rides along in the message rather than being
-                    // dropped -- the two hosts should tell you the same thing.
-                    $violation->messageWithTip(),
-                    new CodeLocation($source, $violation->node ?? $analysedNode),
-                ),
-                $source->getSuppressedIssues(),
-            );
+            if ($issue instanceof PluginIssue) {
+                IssueBuffer::maybeAdd($issue, $source->getSuppressedIssues());
+            }
         }
+    }
+
+    /**
+     * One finding as the issue Psalm will report, or null when no rule owns the
+     * identifier.
+     *
+     * Kept apart from {@see report()} so it can be driven directly: handing an
+     * issue to `IssueBuffer` needs a live `ProjectAnalyzer`, which a unit test
+     * has no way to supply -- but which class, which message and which line are
+     * decided here, and those are worth pinning.
+     *
+     * @param Node $analysedNode the node to locate a finding at when it carries
+     *                           none of its own
+     */
+    public static function toIssue(Violation $violation, Node $analysedNode, StatementsSource $source): ?PluginIssue
+    {
+        $issue = self::issueFor($violation->identifier);
+        if ($issue === null) {
+            return null;
+        }
+
+        return new $issue(
+            // Psalm has no separate channel for a tip, so the correction rides
+            // along in the message rather than being dropped -- the two hosts
+            // should tell you the same thing.
+            $violation->messageWithTip(),
+            new CodeLocation($source, $violation->node ?? $analysedNode),
+        );
     }
 
     /**

--- a/src/StaticAnalysis/Violation.php
+++ b/src/StaticAnalysis/Violation.php
@@ -37,6 +37,18 @@ final class Violation
     }
 
     /**
+     * The same finding, pinned to the node it belongs to.
+     *
+     * A rule that judges one member at a time does not carry the node itself --
+     * it is handed one and reports on it -- so whoever ran the rule attaches it
+     * before the finding leaves for a host.
+     */
+    public function at(Node $node): self
+    {
+        return new self($this->message, $this->identifier, $this->tip, $node);
+    }
+
+    /**
      * The message with the tip folded in, for hosts that have nowhere else to
      * put it.
      */

--- a/tests/Integration/Architecture/StaticStateCoverageTest.php
+++ b/tests/Integration/Architecture/StaticStateCoverageTest.php
@@ -101,6 +101,10 @@ final class StaticStateCoverageTest extends TestCase
         'ClassValidator::$existsCache' => 'partial by design: resetCache() drops the negative answers, because a class that did not exist may now be loadable, and keeps the positive ones, because a loaded class cannot unload',
         'EventDispatcherProvider::$preBootstrapDispatcher' => 'not state: a shared NullEventDispatcher that keeps dispatch sites silent before a resolver exists. It has no fields, so there is nothing in it to go stale. The dispatcher and resolver beside it are cleared',
         'Profiler::$instance' => 'observation lifetime, not cache lifetime: the profiler is opt-in and accumulates measurements across a run on purpose. Clearing it on a cache reset would discard the profile the app asked for, half-way through collecting it',
+        'ClassRules::$classAnalysers' => 'pure memoization, and not in a gacela process at all: the architecture rules psalm runs, built once because the handler is called for every class-like it analyses. They hold only their own configuration, and resetCache() belongs to an application runtime this never shares',
+        'ClassRules::$facadeMethods' => 'pure memoization, as above: the one rule that judges a method rather than a class',
+        'CrossModuleRules::$analyser' => "configuration: the boundary check psalm was asked to run, read from the consumer's <crossModule> element at plugin registration. Nothing re-establishes it, so clearing it would silently turn the rule off",
+        'CrossModuleCallRules::$analyser' => 'configuration: the other half of the same check, registered from the same element',
     ];
 
     protected function tearDown(): void

--- a/tests/Integration/PHPStan/PhpStanFixtureTestCase.php
+++ b/tests/Integration/PHPStan/PhpStanFixtureTestCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\PHPStan;
+
+use PHPUnit\Framework\TestCase;
+
+use function escapeshellarg;
+use function shell_exec;
+use function sprintf;
+
+/**
+ * Runs the shipped `phpstan-gacela.neon` for real, over `Fixture/`.
+ *
+ * That is the strongest proof available -- a unit test drives an extension,
+ * this drives PHPStan -- but it is also the slowest, so the run is shared: every
+ * test here analyses the same fixture set with the same config, so the output is
+ * the same and analysing once per process is enough.
+ */
+abstract class PhpStanFixtureTestCase extends TestCase
+{
+    private const ROOT = __DIR__ . '/../../..';
+
+    private static ?string $output = null;
+
+    final protected function analyseFixture(): string
+    {
+        return self::$output ??= $this->runPhpStan();
+    }
+
+    private function runPhpStan(): string
+    {
+        // XDEBUG_MODE=off and an explicit memory limit, because this is a child
+        // process: under `composer test-coverage` it would otherwise inherit
+        // XDEBUG_MODE=coverage, and PHPStan under coverage exhausts the default
+        // 128M and dies -- which made the whole coverage run unpassable rather
+        // than reporting anything about these tests.
+        $command = sprintf(
+            'XDEBUG_MODE=off %s analyse -c %s --memory-limit=1G --no-progress --error-format=raw 2>&1',
+            escapeshellarg(self::ROOT . '/vendor/bin/phpstan'),
+            escapeshellarg(__DIR__ . '/Fixture/phpstan-fixture.neon'),
+        );
+
+        return (string)shell_exec($command);
+    }
+}

--- a/tests/Integration/PHPStan/PhpStanFixtureTestCase.php
+++ b/tests/Integration/PHPStan/PhpStanFixtureTestCase.php
@@ -7,6 +7,8 @@ namespace GacelaTest\Integration\PHPStan;
 use PHPUnit\Framework\TestCase;
 
 use function escapeshellarg;
+use function getenv;
+use function putenv;
 use function shell_exec;
 use function sprintf;
 
@@ -31,17 +33,27 @@ abstract class PhpStanFixtureTestCase extends TestCase
 
     private function runPhpStan(): string
     {
-        // XDEBUG_MODE=off and an explicit memory limit, because this is a child
-        // process: under `composer test-coverage` it would otherwise inherit
-        // XDEBUG_MODE=coverage, and PHPStan under coverage exhausts the default
-        // 128M and dies -- which made the whole coverage run unpassable rather
-        // than reporting anything about these tests.
         $command = sprintf(
-            'XDEBUG_MODE=off %s analyse -c %s --memory-limit=1G --no-progress --error-format=raw 2>&1',
+            '%s analyse -c %s --memory-limit=1G --no-progress --error-format=raw 2>&1',
             escapeshellarg(self::ROOT . '/vendor/bin/phpstan'),
             escapeshellarg(__DIR__ . '/Fixture/phpstan-fixture.neon'),
         );
 
-        return (string)shell_exec($command);
+        // Through putenv rather than a `VAR=value cmd` prefix, which is posix
+        // shell syntax that windows does not understand -- there `XDEBUG_MODE`
+        // is read as the command itself.
+        //
+        // It has to be off at all: this is a child process, so under
+        // `composer test-coverage` or infection it inherits
+        // XDEBUG_MODE=coverage, and PHPStan under coverage exhausts the default
+        // memory limit and dies, failing tests that never ran their assertions.
+        $previous = getenv('XDEBUG_MODE');
+        putenv('XDEBUG_MODE=off');
+
+        try {
+            return (string)shell_exec($command);
+        } finally {
+            putenv($previous === false ? 'XDEBUG_MODE' : 'XDEBUG_MODE=' . $previous);
+        }
     }
 }

--- a/tests/Integration/PHPStan/ProvidedDependencyAnalysisTest.php
+++ b/tests/Integration/PHPStan/ProvidedDependencyAnalysisTest.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\PHPStan;
 
-use PHPUnit\Framework\TestCase;
-
-use function escapeshellarg;
-use function shell_exec;
-use function sprintf;
-
 /**
  * Runs PHPStan for real against a Factory that asks for a dependency by
  * class-string, using the same `phpstan-gacela.neon` shipped to consumers.
@@ -19,10 +13,8 @@ use function sprintf;
  * class-string the type was never unknown, and the point of typing it is not
  * the accessor itself but the calls made on what comes back.
  */
-final class ProvidedDependencyAnalysisTest extends TestCase
+final class ProvidedDependencyAnalysisTest extends PhpStanFixtureTestCase
 {
-    private const ROOT = __DIR__ . '/../../..';
-
     public function test_a_call_on_a_class_string_dependency_is_checked(): void
     {
         self::assertStringContainsString(
@@ -47,14 +39,4 @@ final class ProvidedDependencyAnalysisTest extends TestCase
         self::assertStringNotContainsString('stringKeyStaysMixed', $this->analyseFixture());
     }
 
-    private function analyseFixture(): string
-    {
-        $command = sprintf(
-            '%s analyse -c %s --no-progress --error-format=raw 2>&1',
-            escapeshellarg(self::ROOT . '/vendor/bin/phpstan'),
-            escapeshellarg(__DIR__ . '/Fixture/phpstan-fixture.neon'),
-        );
-
-        return (string)shell_exec($command);
-    }
 }

--- a/tests/Integration/PHPStan/ServiceMapAnalysisTest.php
+++ b/tests/Integration/PHPStan/ServiceMapAnalysisTest.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\PHPStan;
 
-use PHPUnit\Framework\TestCase;
-
-use function escapeshellarg;
-use function shell_exec;
-use function sprintf;
-
 /**
  * Runs PHPStan for real against a fixture that declares its pillar with
  * `#[ServiceMap]`, using the same `phpstan-gacela.neon` shipped to consumers.
@@ -20,10 +14,8 @@ use function sprintf;
  * returned `mixed` and everything behind it went unchecked, so `typoMethod()`
  * produced no error at all.
  */
-final class ServiceMapAnalysisTest extends TestCase
+final class ServiceMapAnalysisTest extends PhpStanFixtureTestCase
 {
-    private const ROOT = __DIR__ . '/../../..';
-
     public function test_a_call_on_the_resolved_facade_is_checked(): void
     {
         $errors = $this->analyseFixture();
@@ -71,14 +63,4 @@ final class ServiceMapAnalysisTest extends TestCase
         );
     }
 
-    private function analyseFixture(): string
-    {
-        $command = sprintf(
-            '%s analyse -c %s --no-progress --error-format=raw 2>&1',
-            escapeshellarg(self::ROOT . '/vendor/bin/phpstan'),
-            escapeshellarg(__DIR__ . '/Fixture/phpstan-fixture.neon'),
-        );
-
-        return (string)shell_exec($command);
-    }
 }

--- a/tests/Unit/Framework/Event/EventToStringTest.php
+++ b/tests/Unit/Framework/Event/EventToStringTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event;
+
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\Event\Cache\CacheClearedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNameCacheCachedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNameInMemoryCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\ClassNamePhpCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesCacheCachedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesInMemoryCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\Cache\CustomServicesPhpCacheCreatedEvent;
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameCachedFoundEvent;
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameInvalidCandidateFoundEvent;
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameNotFoundEvent;
+use Gacela\Framework\Event\ClassResolver\ClassNameFinder\ClassNameValidCandidateFoundEvent;
+use Gacela\Framework\Event\Config\ConfigInitializedEvent;
+use Gacela\Framework\Event\Config\ConfigKeyNotFoundEvent;
+use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
+use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Event\Container\ServiceResolvedEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `toString()` is the whole of an event's public surface once it reaches a
+ * listener -- it is what a consumer logs. Nothing else asserts the shape, so a
+ * dropped field or a renamed key would go out silently.
+ */
+final class EventToStringTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{GacelaEventInterface, string}>
+     */
+    public static function eventProvider(): iterable
+    {
+        yield 'cache cleared' => [
+            new CacheClearedEvent('/tmp/gacela.php'),
+            CacheClearedEvent::class . ' {cacheFile:"/tmp/gacela.php"}',
+        ];
+
+        yield 'config initialized' => [
+            new ConfigInitializedEvent(3),
+            ConfigInitializedEvent::class . ' {keyCount:3}',
+        ];
+
+        yield 'config key read' => [
+            new ConfigKeyReadEvent('some.key'),
+            ConfigKeyReadEvent::class . ' {key:"some.key"}',
+        ];
+
+        yield 'config key not found' => [
+            new ConfigKeyNotFoundEvent('missing.key'),
+            ConfigKeyNotFoundEvent::class . ' {key:"missing.key"}',
+        ];
+
+        yield 'binding registered' => [
+            new BindingRegisteredEvent('some-id'),
+            BindingRegisteredEvent::class . ' {id:"some-id"}',
+        ];
+
+        yield 'service resolved' => [
+            new ServiceResolvedEvent('some-id'),
+            ServiceResolvedEvent::class . ' {id:"some-id"}',
+        ];
+
+        yield 'provider registered' => [
+            new ProviderRegisteredEvent('App\Checkout\CheckoutProvider', 'Checkout'),
+            ProviderRegisteredEvent::class . ' {providerClass:"App\Checkout\CheckoutProvider", moduleName:"Checkout"}',
+        ];
+
+        yield 'class name cached found' => [
+            new ClassNameCachedFoundEvent('cache-key', 'App\Checkout\CheckoutFacade'),
+            ClassNameCachedFoundEvent::class . ' {cacheKey:"cache-key", className:"App\Checkout\CheckoutFacade"}',
+        ];
+
+        yield 'php cache created' => [
+            new ClassNamePhpCacheCreatedEvent('/tmp/cache.php'),
+            ClassNamePhpCacheCreatedEvent::class . ' {cacheDir:"/tmp/cache.php"}',
+        ];
+
+        yield 'class name cache cached' => [
+            new ClassNameCacheCachedEvent(),
+            ClassNameCacheCachedEvent::class . ' {}',
+        ];
+
+        yield 'class name in-memory cache created' => [
+            new ClassNameInMemoryCacheCreatedEvent(),
+            ClassNameInMemoryCacheCreatedEvent::class . ' {}',
+        ];
+
+        yield 'custom services cache cached' => [
+            new CustomServicesCacheCachedEvent(),
+            CustomServicesCacheCachedEvent::class . ' {}',
+        ];
+
+        yield 'custom services in-memory cache created' => [
+            new CustomServicesInMemoryCacheCreatedEvent(),
+            CustomServicesInMemoryCacheCreatedEvent::class . ' {}',
+        ];
+
+        yield 'custom services php cache created' => [
+            new CustomServicesPhpCacheCreatedEvent(),
+            CustomServicesPhpCacheCreatedEvent::class . ' {}',
+        ];
+
+        yield 'valid candidate found' => [
+            new ClassNameValidCandidateFoundEvent('App\Checkout\CheckoutFacade'),
+            ClassNameValidCandidateFoundEvent::class . ' {className:"App\Checkout\CheckoutFacade"}',
+        ];
+
+        yield 'invalid candidate found' => [
+            new ClassNameInvalidCandidateFoundEvent('App\Checkout\Nope'),
+            ClassNameInvalidCandidateFoundEvent::class . ' {className:"App\Checkout\Nope"}',
+        ];
+
+        yield 'class name not found' => [
+            new ClassNameNotFoundEvent(ClassInfo::from('App\Checkout\CheckoutFacade', 'Facade'), ['Facade', 'Factory']),
+            ClassNameNotFoundEvent::class . ' {classInfo:"'
+                . ClassInfo::from('App\Checkout\CheckoutFacade', 'Facade')->toString()
+                . '", resolvableTypes:"Facade,Factory"}',
+        ];
+    }
+
+    #[DataProvider('eventProvider')]
+    public function test_it_renders_every_field_it_carries(GacelaEventInterface $event, string $expected): void
+    {
+        self::assertSame($expected, $event->toString());
+    }
+
+    /**
+     * The name is in the string so a listener logging several events can tell
+     * them apart; two events rendering identically would be indistinguishable.
+     */
+    #[DataProvider('eventProvider')]
+    public function test_it_names_itself(GacelaEventInterface $event, string $expected): void
+    {
+        self::assertStringStartsWith($event::class . ' {', $event->toString());
+    }
+}

--- a/tests/Unit/Psalm/ClassRulesTest.php
+++ b/tests/Unit/Psalm/ClassRulesTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Psalm\ClassRules;
+use Gacela\StaticAnalysis\Violation;
+use GacelaTest\Unit\StaticAnalysis\Double\FakeAnalysedClass;
+use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+
+/**
+ * Which rules Psalm runs, driven directly.
+ *
+ * `ArchitectureRulesTest` proves the same thing through a real `vendor/bin/psalm`
+ * -- the stronger check -- but that is a subprocess, so coverage cannot see it
+ * and every mutant in this class counted as untested. Reporting stays out of
+ * reach here: it goes through Psalm's `IssueBuffer`, which wants a live
+ * `ProjectAnalyzer`.
+ */
+final class ClassRulesTest extends TestCase
+{
+    public function test_a_module_that_follows_the_rules_is_silent(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFacade
+            {
+                public function doThing()
+                {
+                    return $this->getFactory()->createThing();
+                }
+            }
+            PHP;
+
+        self::assertSame([], $this->violationsIn($source, [AbstractFacade::class]));
+    }
+
+    public function test_it_runs_the_suffix_rule(): void
+    {
+        self::assertSame(
+            ['gacela.suffixExtends'],
+            $this->identifiersIn('<?php final class CheckoutFacade {}'),
+        );
+    }
+
+    /**
+     * One instance per pillar, so a `*Config` is checked by the same handler
+     * that checks a `*Facade`.
+     */
+    public function test_it_runs_the_suffix_rule_for_every_pillar(): void
+    {
+        foreach (['Facade', 'Factory', 'Provider', 'Config'] as $pillar) {
+            self::assertSame(
+                ['gacela.suffixExtends'],
+                $this->identifiersIn(
+                    '<?php final class Checkout' . $pillar . ' {}',
+                    className: 'App\Checkout\Checkout' . $pillar,
+                ),
+                $pillar . ' is a pillar and must be checked',
+            );
+        }
+    }
+
+    public function test_it_runs_the_factory_rule(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFactory
+            {
+                public function create()
+                {
+                    return $this->getFacade()->doThing();
+                }
+            }
+            PHP;
+
+        self::assertSame(
+            ['gacela.factoryCallsGetFacade'],
+            $this->identifiersIn($source, [AbstractFactory::class], 'App\Checkout\CheckoutFactory'),
+        );
+    }
+
+    public function test_it_runs_the_interface_drift_rule(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFacade implements CheckoutFacadeInterface
+            {
+                public function forgotten()
+                {
+                    return $this->getFactory()->createThing();
+                }
+            }
+            PHP;
+
+        $violations = ClassRules::violationsIn(
+            ParseSource::classIn($source),
+            new FakeAnalysedClass(
+                'App\Checkout\CheckoutFacade',
+                [AbstractFacade::class],
+                ['App\Checkout\CheckoutFacadeInterface' => []],
+            ),
+        );
+
+        self::assertSame(['gacela.facadeInterfaceDrift'], $this->identifiers($violations));
+    }
+
+    /**
+     * The facade-method rule is run per method from here rather than from a
+     * function-like handler of its own, so it has to be reached at all.
+     */
+    public function test_it_runs_the_facade_method_rule(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFacade
+            {
+                public function doesArithmetic()
+                {
+                    return 1 + 1;
+                }
+            }
+            PHP;
+
+        self::assertSame(
+            ['gacela.facadeOnlyDelegates'],
+            $this->identifiersIn($source, [AbstractFacade::class]),
+        );
+    }
+
+    /**
+     * Every finding is returned, not the first. A facade with two methods that
+     * both hold logic has two things to fix, and reporting one of them would
+     * make the second appear only after the first was corrected.
+     */
+    public function test_it_returns_every_finding_it_makes(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFacade
+            {
+                public function first()
+                {
+                    return 1 + 1;
+                }
+
+                public function second()
+                {
+                    return 2 + 2;
+                }
+            }
+            PHP;
+
+        self::assertSame(
+            ['gacela.facadeOnlyDelegates', 'gacela.facadeOnlyDelegates'],
+            $this->identifiersIn($source, [AbstractFacade::class]),
+        );
+    }
+
+    /**
+     * A method's finding belongs on the method. Left unpinned it would be
+     * reported at the class declaration, which names no method to go and fix.
+     */
+    public function test_a_method_finding_is_pinned_to_its_method(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFacade
+            {
+                public function doesArithmetic()
+                {
+                    return 1 + 1;
+                }
+            }
+            PHP;
+
+        $violations = $this->violationsIn($source, [AbstractFacade::class]);
+
+        self::assertSame(4, $violations[0]->node?->getStartLine());
+    }
+
+    /**
+     * A class-level finding carries no node of its own, so the host reports it
+     * where it is already looking: at the class.
+     */
+    public function test_a_class_finding_carries_no_node_of_its_own(): void
+    {
+        $violations = $this->violationsIn('<?php final class CheckoutFacade {}');
+
+        self::assertNull($violations[0]->node);
+    }
+
+    /**
+     * @param list<string> $parents
+     *
+     * @return list<string>
+     */
+    private function identifiersIn(
+        string $source,
+        array $parents = [],
+        string $className = 'App\Checkout\CheckoutFacade',
+    ): array {
+        return $this->identifiers($this->violationsIn($source, $parents, $className));
+    }
+
+    /**
+     * @param list<string> $parents
+     *
+     * @return list<Violation>
+     */
+    private function violationsIn(
+        string $source,
+        array $parents = [],
+        string $className = 'App\Checkout\CheckoutFacade',
+    ): array {
+        return ClassRules::violationsIn(
+            ParseSource::classIn($source),
+            new FakeAnalysedClass($className, $parents),
+        );
+    }
+
+    /**
+     * @param list<Violation> $violations
+     *
+     * @return list<string>
+     */
+    private function identifiers(array $violations): array
+    {
+        return array_map(static fn (Violation $v): string => $v->identifier, $violations);
+    }
+}

--- a/tests/Unit/Psalm/CrossModuleHandlersTest.php
+++ b/tests/Unit/Psalm/CrossModuleHandlersTest.php
@@ -38,6 +38,13 @@ final class CrossModuleHandlersTest extends TestCase
 
     protected function setUp(): void
     {
+        // Cleared going in as well as coming out: the handlers keep their
+        // analyser in a static, and any other test that registers the plugin
+        // leaves it set. Asserting "not configured yet" is only meaningful if
+        // this test put it in that state itself.
+        CrossModuleRules::configure(null);
+        CrossModuleCallRules::configure(null);
+
         // Building any psalm type reads the global config for its string-length
         // limit, and a unit test has no analysis to have initialised one.
         $instance = new ReflectionProperty(Config::class, 'instance');

--- a/tests/Unit/Psalm/CrossModuleHandlersTest.php
+++ b/tests/Unit/Psalm/CrossModuleHandlersTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Psalm\CrossModuleCallRules;
+use Gacela\Psalm\CrossModuleRules;
+use Gacela\Psalm\CrossModuleSettings;
+use Gacela\StaticAnalysis\Violation;
+use GacelaTest\Unit\StaticAnalysis\Double\FakeAnalysedClass;
+use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\NodeFinder;
+use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\NodeTypeProvider;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+use ReflectionClass;
+use ReflectionProperty;
+use SimpleXMLElement;
+
+use function array_map;
+
+/**
+ * Both halves of the opt-in boundary check, driven directly.
+ *
+ * `CrossModuleRulesTest` proves the same through a real `vendor/bin/psalm`, but
+ * that is a subprocess and invisible to coverage. Reporting stays out of reach:
+ * it goes through Psalm's `IssueBuffer`, which wants a live `ProjectAnalyzer`.
+ */
+final class CrossModuleHandlersTest extends TestCase
+{
+    private const ROOT = 'App\Modules';
+
+    private ?Config $previousConfig = null;
+
+    protected function setUp(): void
+    {
+        // Building any psalm type reads the global config for its string-length
+        // limit, and a unit test has no analysis to have initialised one.
+        $instance = new ReflectionProperty(Config::class, 'instance');
+        $this->previousConfig = $instance->getValue();
+        $instance->setValue(null, (new ReflectionClass(Config::class))->newInstanceWithoutConstructor());
+    }
+
+    /**
+     * The handlers keep their analyser in a static, because Psalm calls them
+     * statically. Clearing it keeps these tests independent of their order.
+     */
+    protected function tearDown(): void
+    {
+        CrossModuleRules::configure(null);
+        CrossModuleCallRules::configure(null);
+        (new ReflectionProperty(Config::class, 'instance'))->setValue(null, $this->previousConfig);
+    }
+
+    public function test_the_written_half_finds_nothing_until_it_is_configured(): void
+    {
+        self::assertFalse(CrossModuleRules::isConfigured());
+        self::assertSame([], $this->writtenViolations());
+    }
+
+    public function test_the_written_half_reports_a_crossing_once_configured(): void
+    {
+        $this->configure();
+
+        self::assertSame(['gacela.crossModuleWithoutFacade'], $this->identifiers($this->writtenViolations()));
+    }
+
+    public function test_the_written_half_allows_a_facade(): void
+    {
+        $this->configure();
+
+        self::assertSame([], $this->writtenViolations('new App\Modules\Billing\BillingFacade();'));
+    }
+
+    public function test_the_call_half_finds_nothing_until_it_is_configured(): void
+    {
+        self::assertFalse(CrossModuleCallRules::isConfigured());
+        self::assertSame([], $this->callViolations('App\Modules\Billing\Domain\InvoiceRepository'));
+    }
+
+    public function test_the_call_half_reports_a_crossing_once_configured(): void
+    {
+        $this->configure();
+
+        self::assertSame(
+            ['gacela.crossModuleMethodCall'],
+            $this->identifiers($this->callViolations('App\Modules\Billing\Domain\InvoiceRepository')),
+        );
+    }
+
+    /**
+     * The receiver's classes come off the inferred type, so a union receiver is
+     * several crossings to answer for.
+     */
+    public function test_the_call_half_reads_every_class_a_union_receiver_can_be(): void
+    {
+        $this->configure();
+
+        $violations = $this->callViolations(
+            'App\Modules\Billing\Domain\InvoiceRepository',
+            'App\Modules\Shipping\Domain\Labels',
+        );
+
+        self::assertCount(2, $violations);
+    }
+
+    /**
+     * A receiver Psalm could not type is not evidence of a violation, and
+     * guessing there would turn the rule into noise.
+     */
+    public function test_the_call_half_says_nothing_about_an_unresolved_receiver(): void
+    {
+        $this->configure();
+
+        self::assertSame([], $this->callViolations());
+    }
+
+    public function test_the_call_half_allows_a_facade_receiver(): void
+    {
+        $this->configure();
+
+        self::assertSame([], $this->callViolations('App\Modules\Billing\BillingFacade'));
+    }
+
+    private function configure(): void
+    {
+        $settings = CrossModuleSettings::fromPluginConfig(new SimpleXMLElement(
+            '<pluginClass><crossModule rootNamespace="' . self::ROOT . '"/></pluginClass>',
+        ));
+
+        self::assertNotNull($settings);
+
+        CrossModuleRules::configure($settings);
+        CrossModuleCallRules::configure($settings);
+    }
+
+    /**
+     * @return list<Violation>
+     */
+    private function writtenViolations(string $body = 'new App\Modules\Billing\Domain\InvoiceRepository();'): array
+    {
+        $source = "<?php\nfinal class CheckoutFactory\n{\n    public function create()\n    {\n" . $body . "\n    }\n}";
+
+        return CrossModuleRules::violationsIn(
+            ParseSource::classIn($source),
+            new FakeAnalysedClass('App\Modules\Checkout\CheckoutFactory'),
+        );
+    }
+
+    /**
+     * @return list<Violation>
+     */
+    private function callViolations(string ...$receiverClasses): array
+    {
+        $call = (new NodeFinder())->findFirstInstanceOf(
+            [ParseSource::classIn('<?php final class C { public function f() { return $this->dep->run(); } }')],
+            MethodCall::class,
+        );
+        self::assertInstanceOf(MethodCall::class, $call);
+
+        $types = $this->createStub(NodeTypeProvider::class);
+        $types->method('getType')->willReturn(
+            $receiverClasses === []
+                ? null
+                : new Union(array_map(static fn (string $c): TNamedObject => new TNamedObject($c), $receiverClasses)),
+        );
+
+        return CrossModuleCallRules::violationsFor($call, 'App\Modules\Checkout\CheckoutFactory', $types);
+    }
+
+    /**
+     * @param list<Violation> $violations
+     *
+     * @return list<string>
+     */
+    private function identifiers(array $violations): array
+    {
+        return array_map(static fn (Violation $v): string => $v->identifier, $violations);
+    }
+}

--- a/tests/Unit/Psalm/PluginTest.php
+++ b/tests/Unit/Psalm/PluginTest.php
@@ -30,6 +30,17 @@ final class PluginTest extends TestCase
 {
     private ?MethodReturnTypeProvider $returnTypes = null;
 
+    /**
+     * Registering the plugin with a <crossModule> element sets a static on each
+     * handler. Left set, it decides the outcome of any later test that asks
+     * whether the check is on.
+     */
+    protected function tearDown(): void
+    {
+        CrossModuleRules::configure(null);
+        CrossModuleCallRules::configure(null);
+    }
+
     public function test_it_registers_the_pseudo_method_handler(): void
     {
         $dispatcher = new EventDispatcher();

--- a/tests/Unit/Psalm/ReportedIssueBuildingTest.php
+++ b/tests/Unit/Psalm/ReportedIssueBuildingTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Psalm;
+
+use Gacela\Psalm\Issue\GacelaSuffixExtends;
+use Gacela\Psalm\ReportedIssues;
+use Gacela\StaticAnalysis\Violation;
+use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
+use PhpParser\Node\Stmt\ClassLike;
+use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\StatementsSource;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * Which issue class, which message and which line a finding turns into.
+ *
+ * Handing the result to `IssueBuffer` needs a live `ProjectAnalyzer`, so that
+ * last step is only reachable through the real-Psalm tests -- but everything
+ * decided before it is reachable here.
+ */
+final class ReportedIssueBuildingTest extends TestCase
+{
+    private ?Config $previousConfig = null;
+
+    protected function setUp(): void
+    {
+        $instance = new ReflectionProperty(Config::class, 'instance');
+        $this->previousConfig = $instance->getValue();
+        $instance->setValue(null, (new ReflectionClass(Config::class))->newInstanceWithoutConstructor());
+    }
+
+    protected function tearDown(): void
+    {
+        (new ReflectionProperty(Config::class, 'instance'))->setValue(null, $this->previousConfig);
+    }
+
+    public function test_an_identifier_becomes_its_own_issue_class(): void
+    {
+        $issue = $this->toIssue(new Violation('Something is wrong', 'gacela.suffixExtends'));
+
+        self::assertInstanceOf(GacelaSuffixExtends::class, $issue);
+    }
+
+    /**
+     * A rule with no issue class of its own would have no suppression key, so
+     * nothing is reported under some catch-all name.
+     */
+    public function test_an_unknown_identifier_becomes_nothing(): void
+    {
+        self::assertNull($this->toIssue(new Violation('Something is wrong', 'gacela.notARule')));
+    }
+
+    public function test_a_message_without_a_tip_is_passed_through(): void
+    {
+        $issue = $this->toIssue(new Violation('Something is wrong', 'gacela.suffixExtends'));
+
+        self::assertSame('Something is wrong', $issue?->message);
+    }
+
+    /**
+     * Psalm has nowhere else to put a tip, so it rides along in the message
+     * rather than being dropped.
+     */
+    public function test_a_tip_rides_along_in_the_message(): void
+    {
+        $issue = $this->toIssue(new Violation('Something is wrong', 'gacela.suffixExtends', 'Do this instead.'));
+
+        self::assertSame('Something is wrong Do this instead.', $issue?->message);
+    }
+
+    public function test_a_finding_without_a_node_is_located_at_the_analysed_one(): void
+    {
+        $issue = $this->toIssue(new Violation('Something is wrong', 'gacela.suffixExtends'));
+
+        self::assertSame(2, $issue?->code_location->getLineNumber());
+    }
+
+    /**
+     * A finding that names its own node is located there instead -- which is
+     * what puts a facade method's drift on the method, not on the class.
+     */
+    public function test_a_finding_with_a_node_is_located_at_that_node(): void
+    {
+        $method = $this->classNode()->getMethods()[0];
+
+        $issue = $this->toIssue(
+            new Violation('Something is wrong', 'gacela.suffixExtends', null, $method),
+        );
+
+        self::assertSame(4, $issue?->code_location->getLineNumber());
+    }
+
+    private function toIssue(Violation $violation): ?object
+    {
+        $node = $this->classNode();
+
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/tmp/Whatever.php');
+        $source->method('getFileName')->willReturn('Whatever.php');
+        $source->method('getAliasedClassesFlipped')->willReturn([]);
+
+        return ReportedIssues::toIssue($violation, $node, $source);
+    }
+
+    private function classNode(): ClassLike
+    {
+        $source = <<<'PHP'
+            <?php
+            final class CheckoutFacade
+            {
+                public function doThing()
+                {
+                    return 1;
+                }
+            }
+            PHP;
+
+        return ParseSource::classIn($source);
+    }
+}


### PR DESCRIPTION
## 📚 Description

Three things: dependencies to latest, a bug that made `composer test-coverage` unpassable, and the coverage gaps that fixing it revealed.

## 📦 Dependencies

`infection` 0.34.2, `phpmetrics` 2.11.0, `symfony/console` + `dependency-injection` + `var-exporter` 7.4.16.

- **`gacela-project/container` is already at 2.0.2**, the newest published — nothing to do.
- **`psalm/plugin-phpunit` stays on `^0.19.7`.** 0.20 requires `psalm/psalm-plugin-api`, which *conflicts with `vimeo/psalm <7.0.0`* — and Psalm 7 has only betas (7.0.0-beta19; newest stable is 6.16.1). Taking it would mean adopting a pre-release analyser.

## 🐛 `composer test-coverage` could not pass

Not a flake — it failed on a clean checkout, every time. The PHPStan integration tests shell out to `vendor/bin/phpstan`; the child process inherits `XDEBUG_MODE=coverage`, and PHPStan under coverage exhausts the default 128M and dies. Three failures that had nothing to do with their assertions.

The subprocess now runs with `XDEBUG_MODE=off` and an explicit limit, in a shared `PhpStanFixtureTestCase` that also memoizes the run — **7 PHPStan analyses became 1**, and that suite went from ~7s to 0.9s.

## 📈 Coverage: lines 96.18% → **98.03%**, classes 76.75% → **84.65%**

With the run passing, the gaps were worth closing:

**The Psalm handlers were the largest** — only ever exercised through a real Psalm subprocess, which coverage cannot see, so `ClassRules` had *none*. Deciding is now split from reporting: `violationsIn()`, `violationsFor()` and `toIssue()` are reachable directly, while handing an issue to `IssueBuffer` still needs a live `ProjectAnalyzer` and stays with the integration tests. A finding is pinned to its node as it is collected, so a facade method's drift keeps landing on the method rather than the class.

**Seventeen event classes had `toString()` untested.** That string is the whole of an event's surface once it reaches a listener — a dropped field or renamed key would have shipped silently.

## 🧪 Testing

- Every existing real-Psalm and real-PHPStan test still green, so the split changed no behaviour
- Infection over `StaticAnalysis` + `Psalm` + `PHPStan` + `Event`: **100% MSI**, 483 mutations, 0 escaped
- One real escape found and killed on the way: `violationsIn()` truncated to a single finding survived, because no fixture had a facade with *two* bad methods
- Two `??=` memoization mutants are ignored as equivalent, with the reason recorded. `InfectionConfigTest` caught my first attempt at that — I added a second `AssignCoalesce` key, and JSON5 would have silently kept only the last block