### PR TITLE
test: pin the one place PHPStan and Psalm disagree

### DIFF
--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -285,6 +285,29 @@ green check, and nothing would ever tell you the boundary went unchecked.
 To see the actual module dependency graph of your app, run
 `vendor/bin/gacela debug:graph` (formats: `text`, `mermaid`, `graphviz`, `json`).
 
+### One place the two analysers differ
+
+A facade whose public method comes from a **trait** is judged by PHPStan and not
+by Psalm:
+
+```php
+final class CheckoutFacade extends AbstractFacade
+{
+    use LogicTrait;   // PHPStan reports logic in here, Psalm does not
+}
+```
+
+Both run the same rule; the difference is what each host hands a plugin. PHPStan
+analyses a trait's methods once **per class that uses it**, so the rule sees the
+method with the facade as its class. Psalm analyses them once, in the **trait's
+own** context — a trait extends nothing, and a trait-provided method does not
+appear in the using class's AST.
+
+There is no route to a trait method's body in a using class's context through
+Psalm's public plugin API, so this is a limitation to know about rather than
+something a future release quietly fixes. If your facades take methods from
+traits, PHPStan is the analyser that checks them.
+
 ## Failing on dependency cycles
 
 `debug:graph --check` exits non-zero when two modules depend on each other:

--- a/tests/Integration/Psalm/RulesFixture/LogicTrait.php
+++ b/tests/Integration/Psalm/RulesFixture/LogicTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+trait LogicTrait
+{
+    public function fromTheTrait(): int
+    {
+        return 1 + 1;
+    }
+}

--- a/tests/Integration/Psalm/RulesFixture/TraitUsingFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/TraitUsingFacade.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<CleanFactory>
+ */
+final class TraitUsingFacade extends AbstractFacade
+{
+    use LogicTrait;
+}

--- a/tests/Integration/Psalm/TraitFacadeDivergenceTest.php
+++ b/tests/Integration/Psalm/TraitFacadeDivergenceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm;
+
+/**
+ * The one place the two analysers do not agree, pinned so it cannot drift
+ * quietly in either direction.
+ *
+ * A facade whose public method comes from a trait is judged by PHPStan and not
+ * by Psalm. That is not a bug in the rule -- both run the same
+ * `FacadeOnlyDelegatesAnalyser` -- but in what each host hands a plugin:
+ *
+ * - PHPStan analyses a trait's methods **once per class that uses it**, so the
+ *   rule is handed `fromTheTrait()` with the facade as its class.
+ * - Psalm analyses them **once, in the trait's own context**. Its
+ *   `AfterFunctionLikeAnalysis` reports the enclosing class as the trait, which
+ *   extends nothing, and its `AfterClassLikeAnalysis` hands over the facade's
+ *   own AST, where a trait-provided method does not appear.
+ *
+ * There is no route to a trait method's *body* in a using class's context
+ * through Psalm's public plugin API, so this is a limitation to know about
+ * rather than a defect to fix. `FacadeOnlyDelegatesRuleTest` pins the PHPStan
+ * half.
+ */
+final class TraitFacadeDivergenceTest extends PsalmFixtureTestCase
+{
+    public function test_psalm_does_not_judge_a_facade_method_that_comes_from_a_trait(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString(
+            'GacelaFacadeOnlyDelegates',
+            $errors,
+            'precondition: the rule runs at all, so silence below is about the trait and not the rule',
+        );
+
+        self::assertSame('', $this->errorsIn('LogicTrait.php'));
+        self::assertSame('', $this->errorsIn('TraitUsingFacade.php'));
+    }
+
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/RulesFixture/psalm-rules-fixture.xml';
+    }
+}

--- a/tests/Unit/PHPStan/Rules/FacadeOnlyDelegatesRuleTest.php
+++ b/tests/Unit/PHPStan/Rules/FacadeOnlyDelegatesRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Unit\PHPStan\Rules;
 
 use Gacela\PHPStan\Rules\FacadeOnlyDelegatesRule;
+use GacelaTest\Unit\PHPStan\Rules\Fixture\FacadeDelegate\TraitUsingFacade;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -54,6 +55,28 @@ final class FacadeOnlyDelegatesRuleTest extends RuleTestCase
                 [$prefix . 'cachedOnNullsafeThis' . $suffix, 94, $tip],
                 [$prefix . 'cachedClosureWithLeadingDelegation' . $suffix, 99, $tip],
             ],
+        );
+    }
+
+    /**
+     * PHPStan analyses a trait's methods once per class that uses it, so the
+     * rule sees `fromTheTrait()` as a method of the facade and judges it there.
+     * Psalm does not -- see `TraitFacadeDivergenceTest`.
+     */
+    public function test_logic_reaching_a_facade_through_a_trait_is_reported(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/FacadeDelegate/TraitUsingFacade.php',
+                __DIR__ . '/Fixture/FacadeDelegate/LogicTrait.php',
+            ],
+            [[
+                'Facade method ' . TraitUsingFacade::class
+                . '::fromTheTrait() must only delegate to $this->getFactory()/getConfig()/getProvider();'
+                . ' no inline logic allowed.',
+                9,
+                'Move the logic into the Factory and have this method call it.',
+            ]],
         );
     }
 

--- a/tests/Unit/PHPStan/Rules/Fixture/FacadeDelegate/LogicTrait.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/FacadeDelegate/LogicTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\FacadeDelegate;
+
+trait LogicTrait
+{
+    public function fromTheTrait(): int
+    {
+        return 1 + 1;
+    }
+}

--- a/tests/Unit/PHPStan/Rules/Fixture/FacadeDelegate/TraitUsingFacade.php
+++ b/tests/Unit/PHPStan/Rules/Fixture/FacadeDelegate/TraitUsingFacade.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Rules\Fixture\FacadeDelegate;
+
+use Gacela\Framework\AbstractFacade;
+
+final class TraitUsingFacade extends AbstractFacade
+{
+    use LogicTrait;
+}


### PR DESCRIPTION
## 📚 Description

I claimed earlier that `FacadeOnlyDelegates` cannot see trait-provided methods. **That was half wrong**, and the truth is worth pinning.

Probed both hosts against the same fixture — a facade whose only public method comes from a trait:

| | Result |
|---|---|
| **PHPStan** | reports it: *"in context of class TraitUsingFacade … `TraitUsingFacade::fromTheTrait()` must only delegate"* |
| **Psalm** | silent |

Both run the *same* `FacadeOnlyDelegatesAnalyser`. The difference is entirely in what each host hands a plugin.

## 🔍 Why

- **PHPStan** analyses a trait's methods **once per class that uses it**, so the rule is handed the method with the facade as its class.
- **Psalm** analyses them **once, in the trait's own context**. I verified this directly with a throwaway handler: `AfterFunctionLikeAnalysis` reports `fqcln=LogicTrait`, which extends nothing. And `AfterClassLikeAnalysis` hands over the facade's own AST, where a trait-provided method does not appear.

A trait method's *body* is not reachable in a using class's context through Psalm's public plugin API. `ClassLikeStorage` carries `MethodStorage`, not the AST. The only routes to it are `@internal` to Psalm — and Psalm flags them when Gacela analyses itself.

So this is a **limitation to know about, not a defect to fix**. I'm not building something fragile on Psalm internals for it.

## 🔖 Changes

- `FacadeOnlyDelegatesRuleTest` pins that PHPStan **does** report it
- `TraitFacadeDivergenceTest` pins that Psalm does **not** — while asserting the rule still fires elsewhere in the same run, so the test cannot pass by the rule being off
- `docs/static-analysis.md` says so plainly: *"If your facades take methods from traits, PHPStan is the analyser that checks them"*

Silence is exactly how a thing like this goes unnoticed. Pinning both halves means a future Psalm release that starts reporting it fails a test rather than passing quietly.