### PR TITLE
ref: mark real overrides with #[Override]

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -47,6 +47,17 @@
         <LessSpecificReturnStatement errorLevel="suppress" />
         <UnsafeInstantiation errorLevel="suppress" />
         <RiskyTruthyFalsyComparison errorLevel="suppress" />
+        <!--
+            Real parent-class overrides do carry #[Override] now: rector applies
+            it, and rector.php enables that one rule out of the 8.3 set so it
+            stays applied.
+
+            What stays suppressed is psalm counting an interface implementation
+            as an override too. That is ~246 methods rector will not touch, for
+            something php already enforces: a class that fails to implement an
+            interface method does not compile. The attribute there would be
+            noise on every implementation in the codebase.
+        -->
         <MissingOverrideAttribute errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
@@ -94,6 +95,11 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/tests/Unit/Framework/Testing/ContainerFixtureTest.php',
         ],
     ]);
+
+    // One rule out of the 8.3 set, not the set. #[Override] is a compile-time
+    // check on the class that declares it, so it constrains no downstream code
+    // -- unlike ReadOnlyClassRector below, which is why the level set stays put.
+    $rectorConfig->rule(AddOverrideAttributeToOverriddenMethodsRector::class);
 
     $rectorConfig->sets([
         SetList::CODE_QUALITY,

--- a/src/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/Console/Infrastructure/ConsoleBootstrap.php
@@ -7,6 +7,7 @@ namespace Gacela\Console\Infrastructure;
 use Gacela\Console\ConsoleFactory;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Override;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 
@@ -21,6 +22,7 @@ final class ConsoleBootstrap extends Application
     /**
      * @return array<array-key,Command>
      */
+    #[Override]
     protected function getDefaultCommands(): array
     {
         $commands = parent::getDefaultCommands();

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -17,6 +17,8 @@ use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Override;
+
 use RuntimeException;
 
 use function is_callable;
@@ -134,6 +136,7 @@ final class SetupGacela extends AbstractSetupGacela
         return $this;
     }
 
+    #[Override]
     public function buildAppConfig(AppConfigBuilder $builder): AppConfigBuilder
     {
         $builder = parent::buildAppConfig($builder);
@@ -156,6 +159,7 @@ final class SetupGacela extends AbstractSetupGacela
      *
      * @param ExternalServicesMap $externalServices
      */
+    #[Override]
     public function buildBindings(
         BindingsBuilder $builder,
         array $externalServices,
@@ -178,6 +182,7 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * Allow overriding gacela resolvable types.
      */
+    #[Override]
     public function buildSuffixTypes(SuffixTypesBuilder $builder): SuffixTypesBuilder
     {
         $builder = parent::buildSuffixTypes($builder);
@@ -188,6 +193,7 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @return ExternalServicesMap
      */
+    #[Override]
     public function externalServices(): array
     {
         return $this->properties->externalServices ?? parent::externalServices();

--- a/tests/Feature/Framework/MissingFile/MissingFactoryFile/Facade.php
+++ b/tests/Feature/Framework/MissingFile/MissingFactoryFile/Facade.php
@@ -6,9 +6,11 @@ namespace GacelaTest\Feature\Framework\MissingFile\MissingFactoryFile;
 
 use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\AbstractFactory;
+use Override;
 
 final class Facade extends AbstractFacade
 {
+    #[Override]
     public function getFactory(): AbstractFactory
     {
         return parent::getFactory();

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/src/Main/ModuleA/Factory.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/src/Main/ModuleA/Factory.php
@@ -7,9 +7,11 @@ namespace GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\src\Mai
 use GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleA\Factory as ThirdPartyFactory;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
+use Override;
 
 final class Factory extends ThirdPartyFactory
 {
+    #[Override]
     public function createStringA1(): StringValueInterface
     {
         return new StringValue('Overridden, from src\CompanyA\ModuleA::StringA');

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/src/Secondary/ModuleB/Factory.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/src/Secondary/ModuleB/Factory.php
@@ -7,9 +7,11 @@ namespace GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\src\Sec
 use GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleB\Factory as ThirdPartyFactory;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
+use Override;
 
 final class Factory extends ThirdPartyFactory
 {
+    #[Override]
     public function createStringB1(): StringValueInterface
     {
         return new StringValue('Overridden, from src\CompanyB\ModuleB');

--- a/tests/Unit/PHPStan/Reflection/GetProvidedDependencyTypeInferenceTest.php
+++ b/tests/Unit/PHPStan/Reflection/GetProvidedDependencyTypeInferenceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit\PHPStan\Reflection;
 
+use Override;
 use PHPStan\Testing\TypeInferenceTestCase;
 
 final class GetProvidedDependencyTypeInferenceTest extends TypeInferenceTestCase
@@ -28,6 +29,7 @@ final class GetProvidedDependencyTypeInferenceTest extends TypeInferenceTestCase
     /**
      * @return list<string>
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/type-inference.neon'];

--- a/tests/Unit/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtensionTest.php
+++ b/tests/Unit/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtensionTest.php
@@ -14,6 +14,7 @@ use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithoutServiceMap;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithPositionalServiceMap;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithRepeatedServiceMap;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithServiceMap;
+use Override;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Testing\PHPStanTestCase;
 
@@ -21,6 +22,7 @@ final class ServiceMapMethodsClassReflectionExtensionTest extends PHPStanTestCas
 {
     private ServiceMapMethodsClassReflectionExtension $extension;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->extension = new ServiceMapMethodsClassReflectionExtension();


### PR DESCRIPTION
## 📚 Description

`MissingOverrideAttribute` was suppressed wholesale in `psalm.xml` — a genuine PHP 8.3 check turned off, on a codebase whose floor *is* 8.3. I measured it before deciding what to do.

**251 findings. Two very different halves.**

| | Count | Rector | Value |
|---|---|---|---|
| Real parent-class overrides | 5 | ✅ applies it | catches a renamed/removed parent method |
| Interface implementations | ~246 | ❌ won't touch | PHP already enforces it at compile time |

So I took the first half and left the second, rather than 246 hand-edits of an attribute PHP makes redundant — a class that fails to implement an interface method **does not compile**.

## 🔖 Changes

- `rector.php` enables `AddOverrideAttributeToOverriddenMethodsRector` — **one rule out of the 8.3 set, not the set**. The set stays at 8.1 for the reason already recorded there: `ReadOnlyClassRector` marks 103 classes readonly, which a non-readonly child may not extend, and that is every downstream `AbstractFacade`/`AbstractFactory`/`AbstractConfig`/`AbstractProvider`.

  `#[Override]` has no such problem: it is a compile-time check on the class that *declares* it and constrains nothing downstream.

- 7 files gain the attribute (`SetupGacela`, `ConsoleBootstrap`, and 5 in tests). Rename or remove one of those parent methods now and it fails to compile, instead of silently leaving an override behind that overrides nothing.

- The Psalm suppression stays, **now with its reason written down** instead of sitting there unexplained.

Because the rule is in `rector.php` rather than applied once by hand, it stays applied — a new override without the attribute is a `composer quality` failure, not something that drifts back.