### PR TITLE
feat(graph): declare which modules may depend on which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- Declare which modules may depend on which, in one JSON file read by `debug:graph --check --rules` and by both analysers
+- Report a module rule that governs no module, so a rule cannot outlive what it was written about
+- Write the `--check` findings as JSON with `--format=json`, for a CI job that wants more than an exit code
+
 ## [2.1.0](https://github.com/gacela-project/gacela/compare/2.0.0...2.1.0) - 2026-08-09
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,7 @@ root. `init` is the one that creates it.
 | `debug:config` | The effective merged configuration, after every source and override |
 | `debug:container` | Container contents — user bindings and plugins only |
 | `debug:dependencies Foo::class` | A class's constructor parameters and whether the container can supply each. `--tree` walks the whole graph and marks every node `binding`, `instance`, `autowired` or `unresolvable` |
-| `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--allowed-cycles`, `--compare-to` |
+| `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--allowed-cycles`, `--rules` to fail on dependencies your rules file forbids, `--compare-to` |
 
 `debug:graph --check` is the one built for CI; see
 [static analysis](static-analysis.md) for wiring it into a workflow.

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -77,6 +77,7 @@ are what you suppress on, so a rule can be turned off on its own.
 | A Facade's public methods are in its `*FacadeInterface` | `gacela.facadeInterfaceDrift` | `GacelaFacadeInterfaceDrift` | on |
 | A cross-module reference the source **names** | `gacela.crossModuleWithoutFacade` | `GacelaCrossModuleAccess` | opt-in |
 | A cross-module call the source does **not** name | `gacela.crossModuleMethodCall` | `GacelaCrossModuleMethodCall` | opt-in |
+| A dependency the project's rules file forbids | `gacela.declaredModuleDependency` | `GacelaDeclaredModuleDependency` | opt-in |
 
 On top of the rules, both analysers gain two **types** they otherwise lack: the
 pillar accessors, and `getProvidedDependency()` by class-string.
@@ -342,6 +343,90 @@ indistinguishable from a cycle nobody noticed.
 
 `debug:graph` with no `--check` stays exit-code-neutral, so adding the gate does
 not change what the command already did.
+
+## Declaring which modules may depend on which
+
+A cycle is the only thing the graph can refuse on its own. Everything else a team
+agrees on — billing must not reach back-office, reporting reads and nothing more
+— lives in prose, where no tool can see it and a violation arrives as one more
+import in a diff. Write it in a JSON file instead:
+
+```json
+{
+    "rules": [
+        {
+            "from": "App\\Payment",
+            "deny": ["App\\Admin"],
+            "reason": "reviewed 2026-08: billing must not reach back-office"
+        },
+        {
+            "from": "App\\Reporting",
+            "allow": ["App\\Shared"],
+            "reason": "read-only module: the shared kernel and nothing else"
+        }
+    ]
+}
+```
+
+- `deny` forbids the listed modules and leaves every other dependency alone.
+- `allow` is the opposite reading: those are the **only** modules reachable, and
+  anything else is a violation. An empty `allow` is meaningful — a leaf module
+  that may depend on nothing.
+- One entry cannot carry both, and a rule with no `reason` is refused.
+- A rule about `App\Payment` also governs `App\Payment\Refunds`, and matching is
+  namespace-boundary aware: `App\Pay` never governs `App\Payment`.
+
+The same file is read in two places. In CI, over the whole graph:
+
+```bash
+vendor/bin/gacela debug:graph --check --rules=module-rules.json
+```
+
+and in the editor, per class, by whichever analyser you run:
+
+```neon
+# phpstan.neon
+services:
+    -
+        class: Gacela\PHPStan\Rules\DeclaredModuleDependencyRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: App
+            rulesFile: %currentWorkingDirectory%/module-rules.json
+```
+
+```xml
+<!-- psalm.xml -->
+<pluginClass class="Gacela\Psalm\Plugin">
+    <moduleRules rootNamespace="App" file="module-rules.json"/>
+</pluginClass>
+```
+
+One file, two readers, on purpose: a boundary that holds in CI and not in the
+editor is a boundary nobody trusts.
+
+The rules are **self-invalidating**, like the cycle allow list. A `from`, `allow`
+or `deny` naming a namespace that matches no module fails the check — a rule
+about a module nobody has any more still reads as a boundary being watched. A
+`deny` that never fires is not an error; that is the rule doing its job.
+
+`--rules` cannot be combined with a filter argument: in a narrowed graph, a rule
+about a filtered-out module is indistinguishable from a rule about a module that
+no longer exists, and those two must not look alike.
+
+`--check --format=json` writes the findings as a report instead of lines, for a
+CI job that wants more than an exit code:
+
+```json
+{
+    "undeclaredCycles": [],
+    "staleAllowedCycles": [],
+    "forbiddenDependencies": [
+        {"from": "App\\Payment", "to": "App\\Admin", "reason": "reviewed 2026-08: billing must not reach back-office"}
+    ],
+    "unknownRuleNamespaces": []
+}
+```
 
 ## Reviewing graph changes in CI
 

--- a/phpstan-gacela.neon
+++ b/phpstan-gacela.neon
@@ -72,3 +72,17 @@ services:
     #         modulePathSegments: 1
     #         sharedNamespaces:
     #             - App\Modules\Shared
+
+    # Opt-in: the module dependencies your project decided against, read from
+    # the same JSON file `debug:graph --check --rules` reads. Nothing is checked
+    # until that file names a rule, and a missing or malformed file fails the
+    # run rather than quietly turning the check off.
+    # -
+    #     class: Gacela\PHPStan\Rules\DeclaredModuleDependencyRule
+    #     tags: [phpstan.rules.rule]
+    #     arguments:
+    #         rootNamespace: App\Modules
+    #         rulesFile: %currentWorkingDirectory%/module-rules.json
+    #         modulePathSegments: 1
+    #         sharedNamespaces:
+    #             - App\Modules\Shared

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -7,8 +7,10 @@ namespace Gacela\Console;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
 use Gacela\Console\Domain\ModuleGraph\GraphDiffResult;
+use Gacela\Console\Domain\ModuleGraph\ModuleRuleCheckResult;
 use Gacela\Container\ContainerStats;
 use Gacela\Framework\AbstractFacade;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
 
 /**
  * @extends AbstractFacade<ConsoleFactory>
@@ -100,6 +102,19 @@ final class ConsoleFacade extends AbstractFacade
         return $this->getFactory()
             ->createModuleCycleDetector()
             ->detect($graph);
+    }
+
+    /**
+     * Read the declared module rules against the graph the project has: the
+     * dependencies they forbid, and the rules that govern nothing any more.
+     *
+     * @param array<string, list<string>> $graph
+     */
+    public function checkModuleRules(array $graph, ModuleRuleSet $rules): ModuleRuleCheckResult
+    {
+        return $this->getFactory()
+            ->createModuleRuleChecker()
+            ->check($graph, $rules);
     }
 
     /**

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -24,6 +24,7 @@ use Gacela\Console\Domain\ModuleGraph\MermaidGraphFormatter;
 use Gacela\Console\Domain\ModuleGraph\ModuleCycleDetector;
 use Gacela\Console\Domain\ModuleGraph\ModuleGraphBuilder;
 use Gacela\Console\Domain\ModuleGraph\ModuleGraphDiffer;
+use Gacela\Console\Domain\ModuleGraph\ModuleRuleChecker;
 use Gacela\Console\Domain\ModuleGraph\TextGraphFormatter;
 use Gacela\Console\Infrastructure\FileContentIo;
 use Gacela\Container\ContainerStats;
@@ -119,6 +120,11 @@ final class ConsoleFactory extends AbstractFactory
     public function createModuleCycleDetector(): ModuleCycleDetector
     {
         return new ModuleCycleDetector();
+    }
+
+    public function createModuleRuleChecker(): ModuleRuleChecker
+    {
+        return new ModuleRuleChecker();
     }
 
     public function createGraphDiffMarkdownFormatter(): GraphDiffMarkdownFormatter

--- a/src/Console/Domain/ModuleGraph/ModuleRuleCheckResult.php
+++ b/src/Console/Domain/ModuleGraph/ModuleRuleCheckResult.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleViolation;
+
+final class ModuleRuleCheckResult
+{
+    /**
+     * @param list<ModuleRuleViolation> $violations        dependencies a rule forbids
+     * @param list<string>              $unknownNamespaces namespaces the rules name that no module answers to
+     */
+    public function __construct(
+        public readonly array $violations,
+        public readonly array $unknownNamespaces,
+    ) {
+    }
+
+    public function isClean(): bool
+    {
+        return $this->violations === [] && $this->unknownNamespaces === [];
+    }
+}

--- a/src/Console/Domain/ModuleGraph/ModuleRuleChecker.php
+++ b/src/Console/Domain/ModuleGraph/ModuleRuleChecker.php
@@ -26,10 +26,6 @@ final class ModuleRuleChecker
      */
     public function check(array $graph, ModuleRuleSet $rules): ModuleRuleCheckResult
     {
-        if ($rules->isEmpty()) {
-            return new ModuleRuleCheckResult([], []);
-        }
-
         $violations = [];
 
         foreach ($graph as $module => $dependencies) {

--- a/src/Console/Domain/ModuleGraph/ModuleRuleChecker.php
+++ b/src/Console/Domain/ModuleGraph/ModuleRuleChecker.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ModuleGraph;
+
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleViolation;
+use Gacela\StaticAnalysis\NamespaceMatch;
+
+use function array_keys;
+
+/**
+ * The declared module rules, read against the graph the project actually has.
+ *
+ * Two findings come out of one pass, and both matter. A forbidden dependency is
+ * the rule doing its job. A rule naming a module nobody has any more is the rule
+ * having quietly stopped doing it -- the same failure the cycle allow list
+ * guards against, for the same reason: a boundary that no longer matches
+ * anything still reads as a boundary being watched.
+ */
+final class ModuleRuleChecker
+{
+    /**
+     * @param array<string, list<string>> $graph module namespace => the modules it depends on
+     */
+    public function check(array $graph, ModuleRuleSet $rules): ModuleRuleCheckResult
+    {
+        if ($rules->isEmpty()) {
+            return new ModuleRuleCheckResult([], []);
+        }
+
+        $violations = [];
+
+        foreach ($graph as $module => $dependencies) {
+            foreach ($dependencies as $dependency) {
+                $violation = $rules->violationFor($module, $dependency);
+                if ($violation instanceof ModuleRuleViolation) {
+                    $violations[] = $violation;
+                }
+            }
+        }
+
+        return new ModuleRuleCheckResult($violations, $this->unknownNamespaces($rules, array_keys($graph)));
+    }
+
+    /**
+     * @param list<string> $modules
+     *
+     * @return list<string>
+     */
+    private function unknownNamespaces(ModuleRuleSet $rules, array $modules): array
+    {
+        $unknown = [];
+
+        foreach ($rules->declaredNamespaces() as $namespace) {
+            if (!$this->coversAnyModule($namespace, $modules)) {
+                $unknown[] = $namespace;
+            }
+        }
+
+        return $unknown;
+    }
+
+    /**
+     * A namespace that names no module of its own still governs something when
+     * modules live underneath it, which is how a rule about a whole area of the
+     * app is written.
+     *
+     * @param list<string> $modules
+     */
+    private function coversAnyModule(string $namespace, array $modules): bool
+    {
+        foreach ($modules as $module) {
+            if (NamespaceMatch::covers($namespace, $module)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -6,9 +6,13 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\ModuleGraph\CycleAllowList;
+use Gacela\Console\Domain\ModuleGraph\CycleCheckResult;
 use Gacela\Console\Domain\ModuleGraph\MalformedCycleAllowListException;
+use Gacela\Console\Domain\ModuleGraph\ModuleRuleCheckResult;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Gacela\StaticAnalysis\ModuleRules\MalformedModuleRulesException;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
 use JsonException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -45,7 +49,8 @@ final class DebugGraphCommand extends Command
             ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format: text, mermaid, graphviz, or json', 'text')
             ->addOption('compare-to', 'c', InputOption::VALUE_REQUIRED, 'Path to a JSON graph (from --format=json) to diff the current graph against')
             ->addOption('check', null, InputOption::VALUE_NONE, 'Exit non-zero when the graph contains a dependency cycle')
-            ->addOption('allowed-cycles', null, InputOption::VALUE_REQUIRED, 'Path to a JSON file of reviewed cycles, each with a "modules" list and a "reason"');
+            ->addOption('allowed-cycles', null, InputOption::VALUE_REQUIRED, 'Path to a JSON file of reviewed cycles, each with a "modules" list and a "reason"')
+            ->addOption('rules', null, InputOption::VALUE_REQUIRED, 'Path to a JSON file of declared module rules, each with a "from", either "allow" or "deny", and a "reason"');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -66,7 +71,7 @@ final class DebugGraphCommand extends Command
         }
 
         if ($input->getOption('check') === true) {
-            return $this->checkCycles($graph, ConsoleInput::option($input, 'allowed-cycles'), $output);
+            return $this->check($graph, $filter, $format, $input, $output);
         }
 
         if ($graph === []) {
@@ -108,39 +113,101 @@ final class DebugGraphCommand extends Command
     }
 
     /**
-     * Fails on an undeclared cycle, and equally on an allowance that no longer
-     * matches one.
+     * The gate: cycles nobody declared, allowances that outlived their cycle,
+     * and dependencies a declared rule forbids.
      *
-     * The second half is the point. A reviewed cycle recorded only in prose is a
-     * decision the tooling cannot see, which makes it indistinguishable from a
-     * cycle nobody noticed; but an allow-list that outlives what it allows is
-     * worse, because it looks like the check is still watching.
+     * Both halves are self-invalidating, which is the point. A reviewed cycle
+     * recorded only in prose is a decision the tooling cannot see, and an
+     * allow-list that outlives what it allows is worse, because it looks like
+     * the check is still watching. A module rule about a module nobody has any
+     * more reads exactly the same way.
      *
      * @param array<string, list<string>> $graph
      */
-    private function checkCycles(array $graph, string $allowListPath, OutputInterface $output): int
+    private function check(array $graph, string $filter, string $format, InputInterface $input, OutputInterface $output): int
     {
-        $allowList = CycleAllowList::empty();
+        $rulesPath = ConsoleInput::option($input, 'rules');
+        if ($rulesPath !== '' && $filter !== '') {
+            $output->writeln(
+                '<error>--rules cannot be combined with a filter: in a narrowed graph, a rule about a filtered-out module is indistinguishable from a rule about a module that no longer exists.</error>',
+            );
 
-        if ($allowListPath !== '') {
-            /** @var list<mixed>|null $decoded */
-            $decoded = $this->readJsonFile($allowListPath, 'allowed cycles', $output);
-            if ($decoded === null) {
-                return self::FAILURE;
-            }
+            return self::FAILURE;
+        }
 
-            try {
-                $allowList = CycleAllowList::fromDecodedJson($decoded);
-            } catch (MalformedCycleAllowListException $exception) {
-                $output->writeln(sprintf('<error>%s</error>', $exception->getMessage()));
+        $allowList = $this->readAllowList(ConsoleInput::option($input, 'allowed-cycles'), $output);
+        if (!$allowList instanceof CycleAllowList) {
+            return self::FAILURE;
+        }
 
-                return self::FAILURE;
-            }
+        $rules = $this->readRuleSet($rulesPath, $output);
+        if (!$rules instanceof ModuleRuleSet) {
+            return self::FAILURE;
         }
 
         $cycles = $this->getFacade()->detectModuleCycles($graph);
-        $result = $allowList->check($cycles);
+        $cycleResult = $allowList->check($cycles);
+        $ruleResult = $this->getFacade()->checkModuleRules($graph, $rules);
 
+        if ($format === 'json') {
+            $output->writeln($this->checkReportAsJson($cycleResult, $ruleResult));
+        } else {
+            $this->writeCycleReport($cycles, $allowList, $cycleResult, $output);
+            $this->writeRuleReport($ruleResult, $rules->isEmpty(), $output);
+        }
+
+        return $cycleResult->isClean() && $ruleResult->isClean() ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * Null after reporting why the allow list is unusable; an empty list when
+     * none was asked for.
+     */
+    private function readAllowList(string $path, OutputInterface $output): ?CycleAllowList
+    {
+        if ($path === '') {
+            return CycleAllowList::empty();
+        }
+
+        /** @var list<mixed>|null $decoded */
+        $decoded = $this->readJsonFile($path, 'allowed cycles', $output);
+        if ($decoded === null) {
+            return null;
+        }
+
+        try {
+            return CycleAllowList::fromDecodedJson($decoded);
+        } catch (MalformedCycleAllowListException $malformedCycleAllowListException) {
+            $output->writeln(sprintf('<error>%s</error>', $malformedCycleAllowListException->getMessage()));
+
+            return null;
+        }
+    }
+
+    /**
+     * Null after reporting why the rules file is unusable; an empty set when
+     * none was asked for.
+     */
+    private function readRuleSet(string $path, OutputInterface $output): ?ModuleRuleSet
+    {
+        if ($path === '') {
+            return ModuleRuleSet::empty();
+        }
+
+        try {
+            return ModuleRuleSet::fromFile($path);
+        } catch (MalformedModuleRulesException $malformedModuleRulesException) {
+            $output->writeln(sprintf('<error>%s</error>', $malformedModuleRulesException->getMessage()));
+
+            return null;
+        }
+    }
+
+    /**
+     * @param list<list<string>> $cycles
+     */
+    private function writeCycleReport(array $cycles, CycleAllowList $allowList, CycleCheckResult $result, OutputInterface $output): void
+    {
         foreach ($cycles as $cycle) {
             $reason = $allowList->reasonFor($cycle);
             if ($reason !== null) {
@@ -159,13 +226,63 @@ final class DebugGraphCommand extends Command
             ));
         }
 
-        if (!$result->isClean()) {
-            return self::FAILURE;
+        if ($result->isClean()) {
+            $output->writeln('<fg=green>✓ No undeclared module dependency cycles</>');
+        }
+    }
+
+    /**
+     * Silent when no rules were declared: a green line about a check that never
+     * ran is the thing this whole file is written against.
+     */
+    private function writeRuleReport(ModuleRuleCheckResult $result, bool $noRulesDeclared, OutputInterface $output): void
+    {
+        foreach ($result->violations as $violation) {
+            $output->writeln(sprintf(
+                '<error>✗ Forbidden dependency:</error> %s -> %s <fg=gray>(%s)</>',
+                $violation->from,
+                $violation->to,
+                $violation->reason,
+            ));
         }
 
-        $output->writeln('<fg=green>✓ No undeclared module dependency cycles</>');
+        foreach ($result->unknownNamespaces as $namespace) {
+            $output->writeln(sprintf(
+                '<error>✗ Module rule governs nothing:</error> %s matches no module. Remove the rule, or fix the namespace.',
+                $namespace,
+            ));
+        }
 
-        return self::SUCCESS;
+        if ($noRulesDeclared) {
+            return;
+        }
+
+        if ($result->isClean()) {
+            $output->writeln('<fg=green>✓ No forbidden module dependencies</>');
+        }
+    }
+
+    /**
+     * The same findings as a machine-readable report, for a CI job that wants to
+     * do more than test an exit code.
+     */
+    private function checkReportAsJson(CycleCheckResult $cycleResult, ModuleRuleCheckResult $ruleResult): string
+    {
+        $forbidden = [];
+        foreach ($ruleResult->violations as $violation) {
+            $forbidden[] = [
+                'from' => $violation->from,
+                'to' => $violation->to,
+                'reason' => $violation->reason,
+            ];
+        }
+
+        return json_encode([
+            'undeclaredCycles' => $cycleResult->undeclaredCycles,
+            'staleAllowedCycles' => $cycleResult->staleAllowances,
+            'forbiddenDependencies' => $forbidden,
+            'unknownRuleNamespaces' => $ruleResult->unknownNamespaces,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -153,7 +153,7 @@ final class DebugGraphCommand extends Command
             $output->writeln($this->checkReportAsJson($cycleResult, $ruleResult));
         } else {
             $this->writeCycleReport($cycles, $allowList, $cycleResult, $output);
-            $this->writeRuleReport($ruleResult, $rules->isEmpty(), $output);
+            $this->writeRuleReport($ruleResult, $rules, $output);
         }
 
         return $cycleResult->isClean() && $ruleResult->isClean() ? self::SUCCESS : self::FAILURE;
@@ -235,7 +235,7 @@ final class DebugGraphCommand extends Command
      * Silent when no rules were declared: a green line about a check that never
      * ran is the thing this whole file is written against.
      */
-    private function writeRuleReport(ModuleRuleCheckResult $result, bool $noRulesDeclared, OutputInterface $output): void
+    private function writeRuleReport(ModuleRuleCheckResult $result, ModuleRuleSet $rules, OutputInterface $output): void
     {
         foreach ($result->violations as $violation) {
             $output->writeln(sprintf(
@@ -253,7 +253,7 @@ final class DebugGraphCommand extends Command
             ));
         }
 
-        if ($noRulesDeclared) {
+        if ($rules->isEmpty()) {
             return;
         }
 

--- a/src/PHPStan/Rules/DeclaredModuleDependencyRule.php
+++ b/src/PHPStan/Rules/DeclaredModuleDependencyRule.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\PHPStan\Rules;
+
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use Gacela\StaticAnalysis\Rules\DeclaredModuleDependencyAnalyser;
+
+/**
+ * @see DeclaredModuleDependencyAnalyser for what is checked and why
+ */
+final class DeclaredModuleDependencyRule extends InClassAnalyserRule
+{
+    /**
+     * The rules file is read once, when PHPStan builds its container. An
+     * unreadable or malformed file throws there rather than being treated as
+     * "no rules": a boundary check that quietly turns itself off is the one
+     * failure this rule cannot have.
+     *
+     * @param string       $rulesFile        path to the same JSON file `debug:graph --check --rules` reads
+     * @param list<string> $sharedNamespaces namespaces exempt from the rules
+     *                                       (shared kernels): references into
+     *                                       them are always allowed, and classes
+     *                                       inside them are not checked
+     */
+    public function __construct(
+        string $rootNamespace,
+        string $rulesFile,
+        int $modulePathSegments = 1,
+        array $sharedNamespaces = [],
+    ) {
+        parent::__construct(new DeclaredModuleDependencyAnalyser(
+            $rootNamespace,
+            ModuleRuleSet::fromFile($rulesFile),
+            $modulePathSegments,
+            $sharedNamespaces,
+        ));
+    }
+}

--- a/src/Psalm/CrossModuleSettings.php
+++ b/src/Psalm/CrossModuleSettings.php
@@ -7,9 +7,6 @@ namespace Gacela\Psalm;
 use Psalm\Exception\ConfigException;
 use SimpleXMLElement;
 
-use function count;
-use function trim;
-
 /**
  * The cross-module check's configuration, read off the `<pluginClass>` element.
  *
@@ -49,65 +46,19 @@ final class CrossModuleSettings
      */
     public static function fromPluginConfig(?SimpleXMLElement $config): ?self
     {
-        if (!$config instanceof SimpleXMLElement) {
+        $crossModule = PluginXml::element($config?->crossModule);
+        if (!$crossModule instanceof SimpleXMLElement) {
             return null;
-        }
-
-        // Reading an absent child yields an *empty* element rather than null,
-        // so the count is what says whether one was written. `instanceof` alone
-        // is true either way, and would turn "not configured" into "configured
-        // with nothing", which throws.
-        $crossModule = $config->crossModule;
-        if (count($crossModule) === 0) {
-            return null;
-        }
-
-        $rootNamespace = trim((string)($crossModule['rootNamespace'] ?? ''));
-
-        if ($rootNamespace === '') {
-            throw new ConfigException(
-                '<crossModule> needs a rootNamespace: without it there is no way to tell where a module begins.',
-            );
         }
 
         return new self(
-            $rootNamespace,
-            self::modulePathSegments($crossModule),
-            self::sharedNamespaces($crossModule),
+            PluginXml::requiredAttribute(
+                $crossModule,
+                'rootNamespace',
+                'without it there is no way to tell where a module begins.',
+            ),
+            PluginXml::modulePathSegments($crossModule),
+            PluginXml::sharedNamespaces($crossModule),
         );
-    }
-
-    private static function modulePathSegments(SimpleXMLElement $crossModule): int
-    {
-        $segments = trim((string)($crossModule['modulePathSegments'] ?? ''));
-
-        if ($segments === '') {
-            return 1;
-        }
-
-        if ((int)$segments < 1) {
-            throw new ConfigException(
-                'modulePathSegments must be a positive number of namespace segments, got: ' . $segments,
-            );
-        }
-
-        return (int)$segments;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private static function sharedNamespaces(SimpleXMLElement $crossModule): array
-    {
-        $namespaces = [];
-
-        foreach ($crossModule->sharedNamespace as $sharedNamespace) {
-            $name = trim((string)$sharedNamespace);
-            if ($name !== '') {
-                $namespaces[] = $name;
-            }
-        }
-
-        return $namespaces;
     }
 }

--- a/src/Psalm/DeclaredModuleDependencyRules.php
+++ b/src/Psalm/DeclaredModuleDependencyRules.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Gacela\StaticAnalysis\AnalysedClassInterface;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use Gacela\StaticAnalysis\Rules\DeclaredModuleDependencyAnalyser;
+use Gacela\StaticAnalysis\Violation;
+use PhpParser\Node\Stmt\ClassLike;
+use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
+
+/**
+ * The dependencies a project declared it would not have, checked per class.
+ *
+ * Registered only when the consumer supplies a rules file, so the analyser lives
+ * in a static: Psalm registers handlers by class-string and calls them
+ * statically, leaving nowhere else to put configuration.
+ *
+ * @see DeclaredModuleDependencyAnalyser for what is checked and why
+ */
+final class DeclaredModuleDependencyRules implements AfterClassLikeAnalysisInterface
+{
+    private static ?DeclaredModuleDependencyAnalyser $analyser = null;
+
+    /**
+     * Null turns the rule back off, so invoking the plugin twice leaves the
+     * state its latest config asked for rather than whatever a previous one set.
+     */
+    public static function configure(?ModuleRulesSettings $settings): void
+    {
+        self::$analyser = $settings instanceof ModuleRulesSettings
+            ? new DeclaredModuleDependencyAnalyser(
+                $settings->rootNamespace,
+                ModuleRuleSet::fromFile($settings->file),
+                $settings->modulePathSegments,
+                $settings->sharedNamespaces,
+            )
+            : null;
+    }
+
+    public static function isConfigured(): bool
+    {
+        return self::$analyser instanceof DeclaredModuleDependencyAnalyser;
+    }
+
+    public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event): ?bool
+    {
+        if (!self::$analyser instanceof DeclaredModuleDependencyAnalyser) {
+            return null;
+        }
+
+        $node = $event->getStmt();
+
+        ReportedIssues::report(
+            self::violationsIn($node, new StorageAnalysedClass($event->getClasslikeStorage(), $event->getCodebase())),
+            $node,
+            $event->getStatementsSource(),
+        );
+
+        return null;
+    }
+
+    /**
+     * What the rule finds, apart from the reporting -- see
+     * {@see ClassRules::violationsIn()} for why the two are split.
+     *
+     * @return list<Violation>
+     */
+    public static function violationsIn(ClassLike $node, AnalysedClassInterface $class): array
+    {
+        return self::$analyser instanceof DeclaredModuleDependencyAnalyser
+            ? self::$analyser->analyse($node, $class)
+            : [];
+    }
+}

--- a/src/Psalm/Issue/GacelaDeclaredModuleDependency.php
+++ b/src/Psalm/Issue/GacelaDeclaredModuleDependency.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm\Issue;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * A dependency between modules that the project's own rules file forbids.
+ *
+ * One class per rule so a consumer can suppress this one on its own:
+ *
+ * ```xml
+ * <PluginIssue name="GacelaDeclaredModuleDependency" errorLevel="suppress"/>
+ * ```
+ */
+final class GacelaDeclaredModuleDependency extends PluginIssue
+{
+}

--- a/src/Psalm/ModuleRulesSettings.php
+++ b/src/Psalm/ModuleRulesSettings.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Psalm\Exception\ConfigException;
+use SimpleXMLElement;
+
+/**
+ * The declared-module-rules check's configuration, read off the
+ * `<pluginClass>` element.
+ *
+ * ```xml
+ * <pluginClass class="Gacela\Psalm\Plugin">
+ *     <moduleRules rootNamespace="App\Modules" file="module-rules.json" modulePathSegments="1">
+ *         <sharedNamespace>App\Modules\Shared</sharedNamespace>
+ *     </moduleRules>
+ * </pluginClass>
+ * ```
+ *
+ * `file` is the same JSON `debug:graph --check --rules` reads, resolved from
+ * Psalm's working directory. One file, two readers: a boundary that held in CI
+ * and not in the editor would be a boundary nobody trusts.
+ */
+final class ModuleRulesSettings
+{
+    /**
+     * @param list<string> $sharedNamespaces
+     */
+    private function __construct(
+        public readonly string $rootNamespace,
+        public readonly string $file,
+        public readonly int $modulePathSegments,
+        public readonly array $sharedNamespaces,
+    ) {
+    }
+
+    /**
+     * Null when no `<moduleRules>` is present, which is the check staying off.
+     * A `<moduleRules>` missing either of its two required attributes throws
+     * instead: a rule that quietly does nothing reads as a green check.
+     *
+     * @throws ConfigException
+     */
+    public static function fromPluginConfig(?SimpleXMLElement $config): ?self
+    {
+        $moduleRules = PluginXml::element($config?->moduleRules);
+        if (!$moduleRules instanceof SimpleXMLElement) {
+            return null;
+        }
+
+        return new self(
+            PluginXml::requiredAttribute(
+                $moduleRules,
+                'rootNamespace',
+                'without it there is no way to tell where a module begins.',
+            ),
+            PluginXml::requiredAttribute(
+                $moduleRules,
+                'file',
+                'the rules to check are the ones written in that file.',
+            ),
+            PluginXml::modulePathSegments($moduleRules),
+            PluginXml::sharedNamespaces($moduleRules),
+        );
+    }
+}

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -32,12 +32,29 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/ClassRules.php';
         require_once __DIR__ . '/CrossModuleRules.php';
         require_once __DIR__ . '/CrossModuleCallRules.php';
+        require_once __DIR__ . '/DeclaredModuleDependencyRules.php';
 
         $registration->registerHooksFromClass(ServiceMapPseudoMethods::class);
         $registration->registerHooksFromClass(ProvidedDependencyReturnType::class);
         $registration->registerHooksFromClass(ClassRules::class);
 
         $this->registerCrossModule($registration, CrossModuleSettings::fromPluginConfig($config));
+        $this->registerModuleRules($registration, ModuleRulesSettings::fromPluginConfig($config));
+    }
+
+    /**
+     * Configured even when there is nothing to configure, so the state is what
+     * the current config says rather than what an earlier one left.
+     */
+    private function registerModuleRules(PluginRegistrationSocket $registration, ?ModuleRulesSettings $settings): void
+    {
+        DeclaredModuleDependencyRules::configure($settings);
+
+        if (!$settings instanceof ModuleRulesSettings) {
+            return;
+        }
+
+        $registration->registerHooksFromClass(DeclaredModuleDependencyRules::class);
     }
 
     private function registerCrossModule(PluginRegistrationSocket $registration, ?CrossModuleSettings $settings): void

--- a/src/Psalm/PluginXml.php
+++ b/src/Psalm/PluginXml.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Psalm;
+
+use Psalm\Exception\ConfigException;
+use SimpleXMLElement;
+
+use function count;
+use function sprintf;
+use function trim;
+
+/**
+ * Reading the plugin's own configuration element, once.
+ *
+ * Both opt-in checks are configured the same way -- a root namespace, how many
+ * segments name a module, which namespaces are shared -- and both have to fail
+ * loudly on a half-written element rather than quietly not running.
+ *
+ * @internal
+ */
+final class PluginXml
+{
+    /**
+     * Null when the element was not written, which is a check staying off.
+     *
+     * Reading an absent child yields an *empty* element rather than null, so the
+     * count is what says whether one was written. `instanceof` alone is true
+     * either way, and would turn "not configured" into "configured with
+     * nothing", which throws.
+     */
+    public static function element(?SimpleXMLElement $child): ?SimpleXMLElement
+    {
+        if (!$child instanceof SimpleXMLElement) {
+            return null;
+        }
+
+        return count($child) === 0 ? null : $child;
+    }
+
+    /**
+     * @throws ConfigException
+     */
+    public static function requiredAttribute(SimpleXMLElement $element, string $attribute, string $why): string
+    {
+        $value = trim((string)($element[$attribute] ?? ''));
+
+        if ($value === '') {
+            throw new ConfigException(sprintf('<%s> needs a %s: %s', $element->getName(), $attribute, $why));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws ConfigException
+     */
+    public static function modulePathSegments(SimpleXMLElement $element): int
+    {
+        $segments = trim((string)($element['modulePathSegments'] ?? ''));
+
+        if ($segments === '') {
+            return 1;
+        }
+
+        if ((int)$segments < 1) {
+            throw new ConfigException(
+                'modulePathSegments must be a positive number of namespace segments, got: ' . $segments,
+            );
+        }
+
+        return (int)$segments;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function sharedNamespaces(SimpleXMLElement $element): array
+    {
+        $namespaces = [];
+
+        foreach ($element->sharedNamespace as $sharedNamespace) {
+            $name = trim((string)$sharedNamespace);
+            if ($name !== '') {
+                $namespaces[] = $name;
+            }
+        }
+
+        return $namespaces;
+    }
+}

--- a/src/Psalm/ReportedIssues.php
+++ b/src/Psalm/ReportedIssues.php
@@ -6,6 +6,7 @@ namespace Gacela\Psalm;
 
 use Gacela\Psalm\Issue\GacelaCrossModuleAccess;
 use Gacela\Psalm\Issue\GacelaCrossModuleMethodCall;
+use Gacela\Psalm\Issue\GacelaDeclaredModuleDependency;
 use Gacela\Psalm\Issue\GacelaFacadeInstantiation;
 use Gacela\Psalm\Issue\GacelaFacadeInterfaceDrift;
 use Gacela\Psalm\Issue\GacelaFacadeOnlyDelegates;
@@ -45,6 +46,7 @@ final class ReportedIssues
         'gacela.facadeInterfaceDrift' => GacelaFacadeInterfaceDrift::class,
         'gacela.crossModuleWithoutFacade' => GacelaCrossModuleAccess::class,
         'gacela.crossModuleMethodCall' => GacelaCrossModuleMethodCall::class,
+        'gacela.declaredModuleDependency' => GacelaDeclaredModuleDependency::class,
     ];
 
     /**

--- a/src/StaticAnalysis/ModuleBoundary.php
+++ b/src/StaticAnalysis/ModuleBoundary.php
@@ -66,7 +66,7 @@ final class ModuleBoundary
     public function isShared(string $class): bool
     {
         foreach ($this->sharedNamespaces as $sharedNamespace) {
-            if ($class === $sharedNamespace || str_starts_with($class, $sharedNamespace . '\\')) {
+            if (NamespaceMatch::covers($sharedNamespace, $class)) {
                 return true;
             }
         }

--- a/src/StaticAnalysis/ModuleBoundary.php
+++ b/src/StaticAnalysis/ModuleBoundary.php
@@ -65,13 +65,7 @@ final class ModuleBoundary
      */
     public function isShared(string $class): bool
     {
-        foreach ($this->sharedNamespaces as $sharedNamespace) {
-            if (NamespaceMatch::covers($sharedNamespace, $class)) {
-                return true;
-            }
-        }
-
-        return false;
+        return NamespaceMatch::anyCovers($this->sharedNamespaces, $class);
     }
 
     /**

--- a/src/StaticAnalysis/ModuleRules/MalformedModuleRulesException.php
+++ b/src/StaticAnalysis/ModuleRules/MalformedModuleRulesException.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis\ModuleRules;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class MalformedModuleRulesException extends RuntimeException
+{
+    public static function missingRulesList(): self
+    {
+        return new self('A module rules file must be an object with a "rules" list.');
+    }
+
+    public static function entryIsNotAnObject(int $position): self
+    {
+        return new self(sprintf(
+            'Module rule #%d must be an object with "from", either "allow" or "deny", and a "reason".',
+            $position,
+        ));
+    }
+
+    public static function missingFrom(int $position): self
+    {
+        return new self(sprintf('Module rule #%d needs a non-empty "from" namespace.', $position));
+    }
+
+    public static function missingDirection(int $position): self
+    {
+        return new self(sprintf(
+            'Module rule #%d needs either "allow" or "deny": a rule that forbids nothing is not a rule.',
+            $position,
+        ));
+    }
+
+    public static function bothDirections(int $position): self
+    {
+        return new self(sprintf(
+            'Module rule #%d has both "allow" and "deny". Pick one: "deny" forbids the listed modules, "allow" forbids every other.',
+            $position,
+        ));
+    }
+
+    public static function emptyDeny(int $position): self
+    {
+        return new self(sprintf('Module rule #%d denies nothing. Remove it, or list what it forbids.', $position));
+    }
+
+    public static function nonStringNamespace(int $position): self
+    {
+        return new self(sprintf('Module rule #%d lists a namespace that is not a string.', $position));
+    }
+
+    public static function missingReason(int $position): self
+    {
+        return new self(sprintf(
+            'Module rule #%d needs a non-empty "reason": a boundary nobody justified is one nobody can revisit.',
+            $position,
+        ));
+    }
+
+    public static function unreadableFile(string $path): self
+    {
+        return new self(sprintf('Cannot read the module rules file: "%s".', $path));
+    }
+
+    public static function invalidJson(string $path, string $error): self
+    {
+        return new self(sprintf('"%s" is not valid JSON: %s', $path, $error));
+    }
+}

--- a/src/StaticAnalysis/ModuleRules/ModuleRule.php
+++ b/src/StaticAnalysis/ModuleRules/ModuleRule.php
@@ -17,13 +17,13 @@ use Gacela\StaticAnalysis\NamespaceMatch;
 final class ModuleRule
 {
     /**
-     * @param list<string>|null $allow the only modules reachable, or null when this is a deny rule
-     * @param list<string>|null $deny  the modules that may not be reached, or null when this is an allow rule
+     * @param list<string> $namespaces  what the rule names -- forbidden, or exclusively permitted
+     * @param bool         $isAllowList which of the two the list means
      */
     private function __construct(
         public readonly string $from,
-        private readonly ?array $allow,
-        private readonly ?array $deny,
+        private readonly array $namespaces,
+        private readonly bool $isAllowList,
         public readonly string $reason,
     ) {
     }
@@ -33,7 +33,7 @@ final class ModuleRule
      */
     public static function deny(string $from, array $namespaces, string $reason): self
     {
-        return new self($from, null, $namespaces, $reason);
+        return new self($from, $namespaces, false, $reason);
     }
 
     /**
@@ -42,7 +42,7 @@ final class ModuleRule
      */
     public static function allow(string $from, array $namespaces, string $reason): self
     {
-        return new self($from, $namespaces, null, $reason);
+        return new self($from, $namespaces, true, $reason);
     }
 
     /**
@@ -56,8 +56,8 @@ final class ModuleRule
 
     public function forbids(string $module): bool
     {
-        if ($this->deny !== null) {
-            return $this->covers($this->deny, $module);
+        if (!$this->isAllowList) {
+            return NamespaceMatch::anyCovers($this->namespaces, $module);
         }
 
         // Reaching deeper into the declaring module's own tree is not a
@@ -66,7 +66,7 @@ final class ModuleRule
             return false;
         }
 
-        return !$this->covers($this->allow ?? [], $module);
+        return !NamespaceMatch::anyCovers($this->namespaces, $module);
     }
 
     /**
@@ -74,20 +74,6 @@ final class ModuleRule
      */
     public function namespaces(): array
     {
-        return [$this->from, ...($this->deny ?? $this->allow ?? [])];
-    }
-
-    /**
-     * @param list<string> $namespaces
-     */
-    private function covers(array $namespaces, string $module): bool
-    {
-        foreach ($namespaces as $namespace) {
-            if (NamespaceMatch::covers($namespace, $module)) {
-                return true;
-            }
-        }
-
-        return false;
+        return [$this->from, ...$this->namespaces];
     }
 }

--- a/src/StaticAnalysis/ModuleRules/ModuleRule.php
+++ b/src/StaticAnalysis/ModuleRules/ModuleRule.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis\ModuleRules;
+
+use Gacela\StaticAnalysis\NamespaceMatch;
+
+/**
+ * One declared boundary: what a module may reach, or what it may not.
+ *
+ * The two directions are the same rule read from opposite ends. `deny` names the
+ * edges that are forbidden and leaves everything else alone; `allow` names the
+ * only edges permitted and forbids the rest. A module cannot be governed by both
+ * at once, because the two would answer the same question separately.
+ */
+final class ModuleRule
+{
+    /**
+     * @param list<string>|null $allow the only modules reachable, or null when this is a deny rule
+     * @param list<string>|null $deny  the modules that may not be reached, or null when this is an allow rule
+     */
+    private function __construct(
+        public readonly string $from,
+        private readonly ?array $allow,
+        private readonly ?array $deny,
+        public readonly string $reason,
+    ) {
+    }
+
+    /**
+     * @param list<string> $namespaces
+     */
+    public static function deny(string $from, array $namespaces, string $reason): self
+    {
+        return new self($from, null, $namespaces, $reason);
+    }
+
+    /**
+     * @param list<string> $namespaces an empty list is meaningful: a module that
+     *                                 may reach nothing outside itself
+     */
+    public static function allow(string $from, array $namespaces, string $reason): self
+    {
+        return new self($from, $namespaces, null, $reason);
+    }
+
+    /**
+     * Submodules included: a rule about `App\Payment` governs
+     * `App\Payment\Refunds`, which is part of the same module tree.
+     */
+    public function governs(string $module): bool
+    {
+        return NamespaceMatch::covers($this->from, $module);
+    }
+
+    public function forbids(string $module): bool
+    {
+        if ($this->deny !== null) {
+            return $this->covers($this->deny, $module);
+        }
+
+        // Reaching deeper into the declaring module's own tree is not a
+        // dependency the rule is about; an allow list names what is *outside*.
+        if (NamespaceMatch::covers($this->from, $module)) {
+            return false;
+        }
+
+        return !$this->covers($this->allow ?? [], $module);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function namespaces(): array
+    {
+        return [$this->from, ...($this->deny ?? $this->allow ?? [])];
+    }
+
+    /**
+     * @param list<string> $namespaces
+     */
+    private function covers(array $namespaces, string $module): bool
+    {
+        foreach ($namespaces as $namespace) {
+            if (NamespaceMatch::covers($namespace, $module)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/StaticAnalysis/ModuleRules/ModuleRuleSet.php
+++ b/src/StaticAnalysis/ModuleRules/ModuleRuleSet.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis\ModuleRules;
+
+use JsonException;
+
+use function array_key_exists;
+use function array_values;
+use function file_get_contents;
+use function is_array;
+use function is_file;
+use function is_string;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * The dependencies between modules somebody decided on, in a form both the CLI
+ * and the analysers can read.
+ *
+ * A cycle is the only thing the module graph could refuse on its own. Everything
+ * else a team agrees on -- billing must not reach back-office, reporting reads
+ * and nothing more -- lived in prose, where the tooling cannot see it and a
+ * violation is one more import in a diff. This is that agreement, machine-read.
+ *
+ * The same file feeds `debug:graph --check`, which sees whole modules, and the
+ * PHPStan/Psalm rules, which see one class at a time. Two readers, one decision:
+ * a rule that held in CI and not in the editor would be a rule nobody trusts.
+ */
+final class ModuleRuleSet
+{
+    /**
+     * @param list<ModuleRule> $rules
+     */
+    private function __construct(
+        private readonly array $rules,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @throws MalformedModuleRulesException
+     */
+    public static function fromFile(string $path): self
+    {
+        $contents = is_file($path) ? file_get_contents($path) : false;
+        if ($contents === false) {
+            throw MalformedModuleRulesException::unreadableFile($path);
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw MalformedModuleRulesException::invalidJson($path, $jsonException->getMessage());
+        }
+
+        if (!is_array($decoded)) {
+            throw MalformedModuleRulesException::missingRulesList();
+        }
+
+        return self::fromDecodedJson($decoded);
+    }
+
+    /**
+     * @param array<mixed> $decoded
+     *
+     * @throws MalformedModuleRulesException
+     */
+    public static function fromDecodedJson(array $decoded): self
+    {
+        $entries = $decoded['rules'] ?? null;
+        if (!is_array($entries)) {
+            throw MalformedModuleRulesException::missingRulesList();
+        }
+
+        $rules = [];
+        $position = 0;
+
+        /** @var mixed $entry */
+        foreach ($entries as $entry) {
+            $rules[] = self::ruleFrom($entry, $position);
+            ++$position;
+        }
+
+        return new self($rules);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->rules === [];
+    }
+
+    /**
+     * The first rule that governs `$fromModule` and forbids `$toModule`, as the
+     * finding it justifies -- null when the dependency is one nobody ruled on.
+     */
+    public function violationFor(string $fromModule, string $toModule): ?ModuleRuleViolation
+    {
+        foreach ($this->rules as $rule) {
+            if ($rule->governs($fromModule) && $rule->forbids($toModule)) {
+                return new ModuleRuleViolation($fromModule, $toModule, $rule->reason);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Every namespace the file names, in the order it names them.
+     *
+     * This is what makes the rules self-invalidating: a namespace that matches
+     * no module is a rule that stopped governing anything, and whoever checks
+     * the rules against a real module list can say so.
+     *
+     * @return list<string>
+     */
+    public function declaredNamespaces(): array
+    {
+        $namespaces = [];
+
+        foreach ($this->rules as $rule) {
+            foreach ($rule->namespaces() as $namespace) {
+                $namespaces[$namespace] = $namespace;
+            }
+        }
+
+        return array_values($namespaces);
+    }
+
+    private static function ruleFrom(mixed $entry, int $position): ModuleRule
+    {
+        if (!is_array($entry)) {
+            throw MalformedModuleRulesException::entryIsNotAnObject($position);
+        }
+
+        $from = $entry['from'] ?? null;
+        if (!is_string($from) || $from === '') {
+            throw MalformedModuleRulesException::missingFrom($position);
+        }
+
+        $hasAllow = array_key_exists('allow', $entry);
+        $hasDeny = array_key_exists('deny', $entry);
+        if ($hasAllow && $hasDeny) {
+            throw MalformedModuleRulesException::bothDirections($position);
+        }
+
+        if (!$hasAllow && !$hasDeny) {
+            throw MalformedModuleRulesException::missingDirection($position);
+        }
+
+        $reason = $entry['reason'] ?? null;
+        if (!is_string($reason) || $reason === '') {
+            throw MalformedModuleRulesException::missingReason($position);
+        }
+
+        if ($hasDeny) {
+            $deny = self::namespaceList($entry['deny'], $position);
+            if ($deny === []) {
+                throw MalformedModuleRulesException::emptyDeny($position);
+            }
+
+            return ModuleRule::deny($from, $deny, $reason);
+        }
+
+        return ModuleRule::allow($from, self::namespaceList($entry['allow'], $position), $reason);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function namespaceList(mixed $value, int $position): array
+    {
+        if (!is_array($value)) {
+            throw MalformedModuleRulesException::missingDirection($position);
+        }
+
+        $namespaces = [];
+
+        /** @var mixed $item */
+        foreach ($value as $item) {
+            if (!is_string($item) || $item === '') {
+                throw MalformedModuleRulesException::nonStringNamespace($position);
+            }
+
+            $namespaces[] = $item;
+        }
+
+        return $namespaces;
+    }
+}

--- a/src/StaticAnalysis/ModuleRules/ModuleRuleViolation.php
+++ b/src/StaticAnalysis/ModuleRules/ModuleRuleViolation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis\ModuleRules;
+
+/**
+ * One dependency a rule forbids, and the reason somebody wrote down for it.
+ *
+ * The reason travels with the finding rather than being looked up again by
+ * whoever reports it: a violation that cannot say why it is one leaves the
+ * reader with a rule file to go read.
+ */
+final class ModuleRuleViolation
+{
+    public function __construct(
+        public readonly string $from,
+        public readonly string $to,
+        public readonly string $reason,
+    ) {
+    }
+}

--- a/src/StaticAnalysis/NamespaceMatch.php
+++ b/src/StaticAnalysis/NamespaceMatch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis;
+
+use function str_starts_with;
+
+/**
+ * Whether a namespace covers a name, on the namespace boundary.
+ *
+ * On the raw prefix, `App\Pay` would silently cover `App\Payment` -- a rule
+ * about one module governing another module that merely starts with the same
+ * letters. Every namespace comparison in the analysis code goes through here so
+ * there is one answer to that.
+ */
+final class NamespaceMatch
+{
+    public static function covers(string $namespace, string $candidate): bool
+    {
+        return $candidate === $namespace || str_starts_with($candidate, $namespace . '\\');
+    }
+}

--- a/src/StaticAnalysis/NamespaceMatch.php
+++ b/src/StaticAnalysis/NamespaceMatch.php
@@ -20,4 +20,18 @@ final class NamespaceMatch
     {
         return $candidate === $namespace || str_starts_with($candidate, $namespace . '\\');
     }
+
+    /**
+     * @param list<string> $namespaces
+     */
+    public static function anyCovers(array $namespaces, string $candidate): bool
+    {
+        foreach ($namespaces as $namespace) {
+            if (self::covers($namespace, $candidate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/StaticAnalysis/ReferencedClasses.php
+++ b/src/StaticAnalysis/ReferencedClasses.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis;
+
+use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\UnionType;
+use PhpParser\NodeFinder;
+
+use function array_values;
+
+/**
+ * Every class a class refers to, however the reference is written.
+ *
+ * A module reaches another module through more than the names written in
+ * expressions: a constructor type-hint, a return type, an attribute, a caught
+ * exception and an extended base class are all dependencies, and all of them
+ * cost the file an import. The module graph is built from imports, so a rule
+ * checked per class has to look at the same set or the CLI and the editor would
+ * disagree about what depends on what.
+ */
+final class ReferencedClasses
+{
+    /**
+     * @return list<string> fully qualified, de-duplicated, in the order first seen
+     */
+    public static function in(ClassLike $node): array
+    {
+        $names = [];
+
+        foreach (self::nameNodes($node) as $name) {
+            $resolved = ResolvedName::of($name);
+            $names[$resolved] = $resolved;
+        }
+
+        return array_values($names);
+    }
+
+    /**
+     * @return array<Name>
+     */
+    private static function nameNodes(ClassLike $node): array
+    {
+        $names = self::declarationNames($node);
+
+        foreach ((new NodeFinder())->find($node, static fn (Node $n): bool => self::carriesReferences($n)) as $found) {
+            foreach (self::referencesOf($found) as $name) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * What the class header itself names -- the one place the references are not
+     * found by walking the body.
+     *
+     * @return array<Name>
+     */
+    private static function declarationNames(ClassLike $node): array
+    {
+        if ($node instanceof Class_) {
+            return [...($node->extends instanceof Name ? [$node->extends] : []), ...$node->implements];
+        }
+
+        if ($node instanceof Interface_) {
+            return $node->extends;
+        }
+
+        return $node instanceof Enum_ ? $node->implements : [];
+    }
+
+    private static function carriesReferences(Node $node): bool
+    {
+        return $node instanceof Node\Expr\New_
+            || $node instanceof Node\Expr\StaticCall
+            || $node instanceof Node\Expr\StaticPropertyFetch
+            || $node instanceof Node\Expr\ClassConstFetch
+            || $node instanceof Node\Expr\Instanceof_
+            || $node instanceof Node\Stmt\TraitUse
+            || $node instanceof Node\Stmt\Catch_
+            || $node instanceof Node\Attribute
+            || $node instanceof Node\Param
+            || $node instanceof Node\Stmt\Property
+            || $node instanceof Node\FunctionLike;
+    }
+
+    /**
+     * @return array<Name>
+     */
+    private static function referencesOf(Node $node): array
+    {
+        if ($node instanceof Node\Stmt\TraitUse) {
+            return $node->traits;
+        }
+
+        if ($node instanceof Node\Stmt\Catch_) {
+            return $node->types;
+        }
+
+        if ($node instanceof Node\Attribute) {
+            return [$node->name];
+        }
+
+        if ($node instanceof Node\Expr\New_
+            || $node instanceof Node\Expr\StaticCall
+            || $node instanceof Node\Expr\StaticPropertyFetch
+            || $node instanceof Node\Expr\ClassConstFetch
+            || $node instanceof Node\Expr\Instanceof_
+        ) {
+            // `new $class` / `$class::CONST` name nothing to match on.
+            return $node->class instanceof Name ? [$node->class] : [];
+        }
+
+        if ($node instanceof Node\Param) {
+            return self::typeNames($node->type);
+        }
+
+        if ($node instanceof Node\Stmt\Property) {
+            return self::typeNames($node->type);
+        }
+
+        return $node instanceof Node\FunctionLike ? self::typeNames($node->getReturnType()) : [];
+    }
+
+    /**
+     * @return array<Name>
+     */
+    private static function typeNames(null|ComplexType|Identifier|Name $type): array
+    {
+        if ($type instanceof Name) {
+            return [$type];
+        }
+
+        if ($type instanceof NullableType) {
+            return self::typeNames($type->type);
+        }
+
+        if ($type instanceof UnionType || $type instanceof IntersectionType) {
+            $names = [];
+            foreach ($type->types as $inner) {
+                foreach (self::typeNames($inner) as $name) {
+                    $names[] = $name;
+                }
+            }
+
+            return $names;
+        }
+
+        // An Identifier is a builtin -- `string`, `int`, `never` -- and names no class.
+        return [];
+    }
+}

--- a/src/StaticAnalysis/ReferencedClasses.php
+++ b/src/StaticAnalysis/ReferencedClasses.php
@@ -53,7 +53,11 @@ final class ReferencedClasses
     {
         $names = self::declarationNames($node);
 
-        foreach ((new NodeFinder())->find($node, static fn (Node $n): bool => self::carriesReferences($n)) as $found) {
+        // The dispatch below is also the filter. Naming the interesting node
+        // kinds twice -- once to select them, once to read them -- is how the
+        // two lists drift apart, and a kind missing from either one is a
+        // dependency nothing reports.
+        foreach ((new NodeFinder())->find($node, static fn (Node $n): bool => self::referencesOf($n) !== []) as $found) {
             foreach (self::referencesOf($found) as $name) {
                 $names[] = $name;
             }
@@ -79,21 +83,6 @@ final class ReferencedClasses
         }
 
         return $node instanceof Enum_ ? $node->implements : [];
-    }
-
-    private static function carriesReferences(Node $node): bool
-    {
-        return $node instanceof Node\Expr\New_
-            || $node instanceof Node\Expr\StaticCall
-            || $node instanceof Node\Expr\StaticPropertyFetch
-            || $node instanceof Node\Expr\ClassConstFetch
-            || $node instanceof Node\Expr\Instanceof_
-            || $node instanceof Node\Stmt\TraitUse
-            || $node instanceof Node\Stmt\Catch_
-            || $node instanceof Node\Attribute
-            || $node instanceof Node\Param
-            || $node instanceof Node\Stmt\Property
-            || $node instanceof Node\FunctionLike;
     }
 
     /**

--- a/src/StaticAnalysis/Rules/DeclaredModuleDependencyAnalyser.php
+++ b/src/StaticAnalysis/Rules/DeclaredModuleDependencyAnalyser.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\StaticAnalysis\Rules;
+
+use Gacela\StaticAnalysis\AnalysedClassInterface;
+use Gacela\StaticAnalysis\ClassAnalyserInterface;
+use Gacela\StaticAnalysis\ModuleBoundary;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleViolation;
+use Gacela\StaticAnalysis\ReferencedClasses;
+use Gacela\StaticAnalysis\Violation;
+use PhpParser\Node\Stmt\ClassLike;
+
+use function sprintf;
+
+/**
+ * The dependencies a project declared it would not have, checked where they are
+ * written rather than after the fact.
+ *
+ * `debug:graph --check` reads the same rules over the whole graph, which is the
+ * CI gate; this is the same decision arriving in the editor, on the line that
+ * creates the edge. One rule file feeds both, because a boundary that holds in
+ * one place and not the other is a boundary nobody trusts.
+ *
+ * Cycles are the one thing the graph could refuse on its own. Everything else --
+ * billing must not reach back-office, reporting reads and nothing more -- is a
+ * decision that has to be written down before any tool can hold anyone to it.
+ */
+final class DeclaredModuleDependencyAnalyser implements ClassAnalyserInterface
+{
+    private readonly ModuleBoundary $boundary;
+
+    /**
+     * @param list<string> $sharedNamespaces namespaces exempt from the rules
+     *                                       (shared kernels): references into
+     *                                       them are always allowed, and classes
+     *                                       inside them are not checked
+     */
+    public function __construct(
+        string $rootNamespace,
+        private readonly ModuleRuleSet $rules,
+        int $modulePathSegments = 1,
+        array $sharedNamespaces = [],
+    ) {
+        $this->boundary = new ModuleBoundary($rootNamespace, $modulePathSegments, $sharedNamespaces);
+    }
+
+    /**
+     * @return list<Violation>
+     */
+    public function analyse(ClassLike $node, AnalysedClassInterface $class): array
+    {
+        if ($this->rules->isEmpty()) {
+            return [];
+        }
+
+        $currentClass = $class->name();
+        if ($this->boundary->isShared($currentClass)) {
+            return [];
+        }
+
+        $currentModule = $this->boundary->moduleOf($currentClass);
+        if ($currentModule === null) {
+            return [];
+        }
+
+        $violations = [];
+        $seen = [];
+
+        foreach (ReferencedClasses::in($node) as $referenced) {
+            $referencedModule = $this->boundary->crossedBy($currentModule, $referenced);
+            if ($referencedModule === null) {
+                continue;
+            }
+
+            // One forbidden module reached from twenty places is one boundary to
+            // fix, and the rule that forbids it is the same rule every time.
+            if (isset($seen[$referencedModule])) {
+                continue;
+            }
+
+            $violation = $this->rules->violationFor($currentModule, $referencedModule);
+            if (!$violation instanceof ModuleRuleViolation) {
+                continue;
+            }
+
+            $seen[$referencedModule] = true;
+            $violations[] = new Violation(
+                sprintf(
+                    '%s must not depend on %s: %s',
+                    $currentModule,
+                    $referencedModule,
+                    $violation->reason,
+                ),
+                'gacela.declaredModuleDependency',
+                sprintf('Drop the dependency on %s, or change the rule that forbids it.', $referencedModule),
+            );
+        }
+
+        return $violations;
+    }
+}

--- a/tests/Feature/Console/DebugGraphRules/Admin/Facade.php
+++ b/tests/Feature/Console/DebugGraphRules/Admin/Facade.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraphRules\Admin;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * The other half: reached by Payment, reaching nobody. See Payment\Facade.
+ *
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->createName();
+    }
+}

--- a/tests/Feature/Console/DebugGraphRules/Admin/Factory.php
+++ b/tests/Feature/Console/DebugGraphRules/Admin/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraphRules\Admin;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createName(): string
+    {
+        return 'admin';
+    }
+}

--- a/tests/Feature/Console/DebugGraphRules/DebugGraphRulesTest.php
+++ b/tests/Feature/Console/DebugGraphRules/DebugGraphRulesTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraphRules;
+
+use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function bin2hex;
+use function file_put_contents;
+use function is_file;
+use function json_decode;
+use function json_encode;
+use function random_bytes;
+use function sys_get_temp_dir;
+use function unlink;
+
+use const JSON_THROW_ON_ERROR;
+
+final class DebugGraphRulesTest extends TestCase
+{
+    private const PAYMENT = 'GacelaTest\Feature\Console\DebugGraphRules\Payment';
+
+    private const ADMIN = 'GacelaTest\Feature\Console\DebugGraphRules\Admin';
+
+    private CommandTester $command;
+
+    /** @var list<string> */
+    private array $files = [];
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $this->command = new CommandTester(new DebugGraphCommand());
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->files = [];
+    }
+
+    public function test_check_fails_on_a_dependency_a_rule_denies(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'deny' => [self::ADMIN], 'reason' => 'billing must not reach back-office'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules]);
+
+        $display = $this->command->getDisplay();
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Forbidden dependency:', $display);
+        self::assertStringContainsString(self::PAYMENT . ' -> ' . self::ADMIN, $display);
+        self::assertStringContainsString('billing must not reach back-office', $display);
+    }
+
+    public function test_check_passes_when_the_rules_permit_the_edges_that_exist(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'allow' => [self::ADMIN], 'reason' => 'reviewed: payment reads the admin facade'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('No forbidden module dependencies', $this->command->getDisplay());
+    }
+
+    public function test_an_allow_list_forbids_the_edge_it_does_not_name(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'allow' => [], 'reason' => 'payment is a leaf module'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Forbidden dependency:', $this->command->getDisplay());
+    }
+
+    /**
+     * The self-invalidating half. A rule about a module nobody has any more
+     * reads as a boundary still being watched, which is the failure the cycle
+     * allow list is already written against.
+     */
+    public function test_check_fails_on_a_rule_that_governs_no_module(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'deny' => ['App\\Gone'], 'reason' => 'this module was deleted long ago'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Module rule governs nothing:', $this->command->getDisplay());
+        self::assertStringContainsString('App\\Gone', $this->command->getDisplay());
+    }
+
+    /**
+     * A filtered graph cannot tell a stale rule from a module the filter
+     * removed, so the two are not allowed to look alike.
+     */
+    public function test_rules_cannot_be_combined_with_a_filter(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'deny' => [self::ADMIN], 'reason' => 'reviewed'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules, 'filter' => 'Payment']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('--rules cannot be combined with a filter', $this->command->getDisplay());
+    }
+
+    public function test_check_fails_when_the_rules_file_is_missing(): void
+    {
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => '/does/not/exist.json']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Cannot read the module rules file', $this->command->getDisplay());
+    }
+
+    public function test_check_fails_when_a_rule_names_no_direction(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'reason' => 'reviewed'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('needs either "allow" or "deny"', $this->command->getDisplay());
+    }
+
+    public function test_check_fails_when_a_rule_has_no_reason(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'deny' => [self::ADMIN]],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('needs a non-empty "reason"', $this->command->getDisplay());
+    }
+
+    public function test_the_json_report_carries_the_forbidden_dependencies(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'deny' => [self::ADMIN], 'reason' => 'billing must not reach back-office'],
+        ]);
+
+        $exitCode = $this->command->execute(['--check' => true, '--rules' => $rules, '--format' => 'json']);
+
+        /** @var array{forbiddenDependencies: list<array{from: string, to: string, reason: string}>, undeclaredCycles: list<mixed>} $report */
+        $report = json_decode($this->command->getDisplay(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(1, $exitCode);
+        self::assertSame([], $report['undeclaredCycles']);
+        self::assertSame([[
+            'from' => self::PAYMENT,
+            'to' => self::ADMIN,
+            'reason' => 'billing must not reach back-office',
+        ]], $report['forbiddenDependencies']);
+    }
+
+    /**
+     * Silence, not a green line: a check that never ran must not report itself
+     * as passing.
+     */
+    public function test_check_without_rules_says_nothing_about_module_rules(): void
+    {
+        $exitCode = $this->command->execute(['--check' => true]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringNotContainsString('forbidden module dependencies', $this->command->getDisplay());
+    }
+
+    /**
+     * @param list<mixed> $entries
+     */
+    private function writeRules(array $entries): string
+    {
+        $path = sys_get_temp_dir() . '/gacela-module-rules-' . bin2hex(random_bytes(4)) . '.json';
+        file_put_contents($path, json_encode(['rules' => $entries], JSON_THROW_ON_ERROR));
+        $this->files[] = $path;
+
+        return $path;
+    }
+}

--- a/tests/Feature/Console/DebugGraphRules/Payment/Facade.php
+++ b/tests/Feature/Console/DebugGraphRules/Payment/Facade.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraphRules\Payment;
+
+use Gacela\Framework\AbstractFacade;
+use GacelaTest\Feature\Console\DebugGraphRules\Admin\Facade as AdminFacade;
+
+/**
+ * One half of a one-way edge: Payment reaches Admin, and Admin reaches nobody.
+ * A rule saying that edge must not exist is what these fixtures are here for.
+ *
+ * @extends AbstractFacade<Factory>
+ */
+final class Facade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->createName();
+    }
+
+    public function reachesAdmin(): string
+    {
+        return AdminFacade::class;
+    }
+}

--- a/tests/Feature/Console/DebugGraphRules/Payment/Factory.php
+++ b/tests/Feature/Console/DebugGraphRules/Payment/Factory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugGraphRules\Payment;
+
+use Gacela\Framework\AbstractFactory;
+
+final class Factory extends AbstractFactory
+{
+    public function createName(): string
+    {
+        return 'payment';
+    }
+}

--- a/tests/Integration/ModuleRulesFixture/Admin/AdminFacade.php
+++ b/tests/Integration/ModuleRulesFixture/Admin/AdminFacade.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\ModuleRulesFixture\Admin;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * The module the rules file says Payment must not reach.
+ *
+ * Well-formed on purpose: the always-on pillar rules run over this fixture too,
+ * and a finding from one of those would say nothing about the rule under test.
+ *
+ * @extends AbstractFacade<AdminFactory>
+ */
+final class AdminFacade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->createName();
+    }
+}

--- a/tests/Integration/ModuleRulesFixture/Admin/AdminFactory.php
+++ b/tests/Integration/ModuleRulesFixture/Admin/AdminFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\ModuleRulesFixture\Admin;
+
+use Gacela\Framework\AbstractFactory;
+
+final class AdminFactory extends AbstractFactory
+{
+    public function createName(): string
+    {
+        return 'admin';
+    }
+}

--- a/tests/Integration/ModuleRulesFixture/Payment/PaymentFacade.php
+++ b/tests/Integration/ModuleRulesFixture/Payment/PaymentFacade.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\ModuleRulesFixture\Payment;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * Reaches nothing outside its own module: whatever both hosts report here, they
+ * report because of {@see PaymentFactory}.
+ *
+ * @extends AbstractFacade<PaymentFactory>
+ */
+final class PaymentFacade extends AbstractFacade
+{
+    public function adminName(): string
+    {
+        return $this->getFactory()->createAdminName();
+    }
+}

--- a/tests/Integration/ModuleRulesFixture/Payment/PaymentFactory.php
+++ b/tests/Integration/ModuleRulesFixture/Payment/PaymentFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\ModuleRulesFixture\Payment;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Integration\ModuleRulesFixture\Admin\AdminFacade;
+
+/**
+ * The forbidden edge, written the way a real one is: through the other module's
+ * Facade, which every other rule in this project considers correct. Only the
+ * declared rules say this particular pair must not happen.
+ */
+final class PaymentFactory extends AbstractFactory
+{
+    public function createAdminName(): string
+    {
+        return (new AdminFacade())->name();
+    }
+}

--- a/tests/Integration/ModuleRulesFixture/module-rules.json
+++ b/tests/Integration/ModuleRulesFixture/module-rules.json
@@ -1,0 +1,9 @@
+{
+    "rules": [
+        {
+            "from": "GacelaTest\\Integration\\ModuleRulesFixture\\Payment",
+            "deny": ["GacelaTest\\Integration\\ModuleRulesFixture\\Admin"],
+            "reason": "fixture: payment must not reach back-office"
+        }
+    ]
+}

--- a/tests/Integration/ModuleRulesFixture/phpstan-module-rules.neon
+++ b/tests/Integration/ModuleRulesFixture/phpstan-module-rules.neon
@@ -1,0 +1,15 @@
+services:
+    -
+        class: Gacela\PHPStan\Rules\DeclaredModuleDependencyRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: GacelaTest\Integration\ModuleRulesFixture
+            rulesFile: %currentWorkingDirectory%/tests/Integration/ModuleRulesFixture/module-rules.json
+            modulePathSegments: 1
+
+parameters:
+    level: max
+    paths:
+        - .
+    excludePaths:
+        - phpstan-module-rules.neon

--- a/tests/Integration/ModuleRulesFixture/psalm-module-rules.xml
+++ b/tests/Integration/ModuleRulesFixture/psalm-module-rules.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+    The declared-module-rules check turned on, which is the point: without a
+    moduleRules element the rule is not registered at all.
+-->
+<psalm errorLevel="1" resolveFromConfigFile="true" findUnusedBaselineEntry="false" findUnusedCode="false">
+    <projectFiles>
+        <directory name="."/>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Gacela\Psalm\Plugin">
+            <moduleRules
+                rootNamespace="GacelaTest\Integration\ModuleRulesFixture"
+                file="module-rules.json"
+                modulePathSegments="1"
+            />
+        </pluginClass>
+    </plugins>
+
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>

--- a/tests/Integration/PHPStan/DeclaredModuleDependencyTest.php
+++ b/tests/Integration/PHPStan/DeclaredModuleDependencyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\PHPStan;
+
+use Override;
+
+use function str_contains;
+
+/**
+ * Runs PHPStan for real over the same fixture and the same rules file that
+ * {@see \GacelaTest\Integration\Psalm\DeclaredModuleDependencyTest} hands Psalm.
+ *
+ * The pair is the test. One rules file feeds `debug:graph --check --rules` and
+ * both analysers, and a boundary that held in one host and not the other would
+ * be a boundary nobody trusts.
+ */
+final class DeclaredModuleDependencyTest extends PhpStanFixtureTestCase
+{
+    public function test_a_dependency_the_rules_file_denies_is_reported(): void
+    {
+        $errors = $this->analyseFixture();
+
+        self::assertTrue(
+            str_contains($errors, 'must not depend on')
+            && str_contains($errors, 'fixture: payment must not reach back-office'),
+            'PHPStan did not report the denied dependency. Output: ' . $errors,
+        );
+    }
+
+    public function test_the_finding_is_reported_on_the_class_that_creates_the_edge(): void
+    {
+        self::assertStringContainsString('PaymentFactory.php', $this->analyseFixture());
+        self::assertStringNotContainsString('AdminFacade.php', $this->analyseFixture());
+    }
+
+    /**
+     * The suppression key is public contract: a consumer writes it into
+     * `ignoreErrors` to turn this rule off.
+     */
+    public function test_the_finding_carries_its_identifier(): void
+    {
+        self::assertStringContainsString('gacela.declaredModuleDependency', $this->analyseFixture());
+    }
+
+    #[Override]
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/../ModuleRulesFixture/phpstan-module-rules.neon';
+    }
+}

--- a/tests/Integration/PHPStan/DeclaredModuleDependencyTest.php
+++ b/tests/Integration/PHPStan/DeclaredModuleDependencyTest.php
@@ -31,14 +31,12 @@ final class DeclaredModuleDependencyTest extends PhpStanFixtureTestCase
     }
 
     /**
-     * The suppression key is public contract: a consumer writes it into
-     * `ignoreErrors` to turn this rule off.
+     * The suppression key is public contract, but it is not asserted here: the
+     * `raw` error format prints `[identifier=...]` in some PHPStan builds and
+     * not others, so this test would be pinning the formatter rather than the
+     * rule. It is held instead by DeclaredModuleDependencyAnalyserTest, the
+     * ReportedIssues map, and the docs table.
      */
-    public function test_the_finding_carries_its_identifier(): void
-    {
-        self::assertStringContainsString('gacela.declaredModuleDependency', $this->analyseFixture());
-    }
-
     #[Override]
     protected static function configPath(): string
     {

--- a/tests/Integration/PHPStan/DeclaredModuleDependencyTest.php
+++ b/tests/Integration/PHPStan/DeclaredModuleDependencyTest.php
@@ -6,8 +6,6 @@ namespace GacelaTest\Integration\PHPStan;
 
 use Override;
 
-use function str_contains;
-
 /**
  * Runs PHPStan for real over the same fixture and the same rules file that
  * {@see \GacelaTest\Integration\Psalm\DeclaredModuleDependencyTest} hands Psalm.
@@ -22,11 +20,8 @@ final class DeclaredModuleDependencyTest extends PhpStanFixtureTestCase
     {
         $errors = $this->analyseFixture();
 
-        self::assertTrue(
-            str_contains($errors, 'must not depend on')
-            && str_contains($errors, 'fixture: payment must not reach back-office'),
-            'PHPStan did not report the denied dependency. Output: ' . $errors,
-        );
+        self::assertStringContainsString('must not depend on', $errors);
+        self::assertStringContainsString('fixture: payment must not reach back-office', $errors);
     }
 
     public function test_the_finding_is_reported_on_the_class_that_creates_the_edge(): void

--- a/tests/Integration/PHPStan/PhpStanFixtureTestCase.php
+++ b/tests/Integration/PHPStan/PhpStanFixtureTestCase.php
@@ -24,11 +24,21 @@ abstract class PhpStanFixtureTestCase extends TestCase
 {
     private const ROOT = __DIR__ . '/../../..';
 
-    private static ?string $output = null;
+    /** @var array<string, string> */
+    private static array $outputs = [];
 
     final protected function analyseFixture(): string
     {
-        return self::$output ??= $this->runPhpStan();
+        return self::$outputs[static::configPath()] ??= $this->runPhpStan();
+    }
+
+    /**
+     * The config to analyse. One per fixture set, so a set of deliberately
+     * broken classes cannot leak its findings into a test about something else.
+     */
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/Fixture/phpstan-fixture.neon';
     }
 
     private function runPhpStan(): string
@@ -36,7 +46,7 @@ abstract class PhpStanFixtureTestCase extends TestCase
         $command = sprintf(
             '%s analyse -c %s --memory-limit=1G --no-progress --error-format=raw 2>&1',
             escapeshellarg(self::ROOT . '/vendor/bin/phpstan'),
-            escapeshellarg(__DIR__ . '/Fixture/phpstan-fixture.neon'),
+            escapeshellarg(static::configPath()),
         );
 
         // Through putenv rather than a `VAR=value cmd` prefix, which is posix

--- a/tests/Integration/Psalm/DeclaredModuleDependencyTest.php
+++ b/tests/Integration/Psalm/DeclaredModuleDependencyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm;
+
+/**
+ * The other half of the parity pair: Psalm, over the same fixture and the same
+ * rules file {@see \GacelaTest\Integration\PHPStan\DeclaredModuleDependencyTest}
+ * hands PHPStan.
+ */
+final class DeclaredModuleDependencyTest extends PsalmFixtureTestCase
+{
+    public function test_a_dependency_the_rules_file_denies_is_reported(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('GacelaDeclaredModuleDependency', $errors);
+        self::assertStringContainsString('fixture: payment must not reach back-office', $errors);
+    }
+
+    public function test_the_finding_is_reported_on_the_class_that_creates_the_edge(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('GacelaDeclaredModuleDependency', $this->errorsIn('PaymentFactory.php'));
+        self::assertSame('', $this->errorsIn('AdminFacade.php'));
+    }
+
+    /**
+     * Psalm has no separate channel for a tip, so the correction has to ride
+     * along in the message -- both hosts should tell you the same thing.
+     */
+    public function test_the_finding_carries_the_correction(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('or change the rule that forbids it', $errors);
+    }
+
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/../ModuleRulesFixture/psalm-module-rules.xml';
+    }
+}

--- a/tests/Unit/Console/Domain/ModuleGraph/ModuleRuleCheckerTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/ModuleRuleCheckerTest.php
@@ -80,6 +80,16 @@ final class ModuleRuleCheckerTest extends TestCase
         self::assertSame([], $result->violations);
     }
 
+    public function test_every_rule_that_governs_nothing_is_reported_not_only_the_first(): void
+    {
+        $result = $this->check(
+            ['App\Payment' => []],
+            $this->rules([['from' => 'App\Gone', 'deny' => ['App\AlsoGone'], 'reason' => 'reviewed']]),
+        );
+
+        self::assertSame(['App\Gone', 'App\AlsoGone'], $result->unknownNamespaces);
+    }
+
     public function test_a_namespace_covering_only_submodules_is_known(): void
     {
         $result = $this->check(

--- a/tests/Unit/Console/Domain/ModuleGraph/ModuleRuleCheckerTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/ModuleRuleCheckerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ModuleGraph;
+
+use Gacela\Console\Domain\ModuleGraph\ModuleRuleChecker;
+use Gacela\Console\Domain\ModuleGraph\ModuleRuleCheckResult;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleRuleCheckerTest extends TestCase
+{
+    public function test_a_graph_without_rules_is_clean(): void
+    {
+        $result = $this->check(
+            ['App\Payment' => ['App\Admin']],
+            ModuleRuleSet::empty(),
+        );
+
+        self::assertTrue($result->isClean());
+    }
+
+    public function test_a_denied_edge_present_in_the_graph_is_reported(): void
+    {
+        $result = $this->check(
+            ['App\Payment' => ['App\Admin'], 'App\Admin' => []],
+            $this->rules([['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed']]),
+        );
+
+        self::assertFalse($result->isClean());
+        self::assertCount(1, $result->violations);
+        self::assertSame('App\Payment', $result->violations[0]->from);
+        self::assertSame('App\Admin', $result->violations[0]->to);
+        self::assertSame('reviewed', $result->violations[0]->reason);
+    }
+
+    public function test_a_denied_edge_absent_from_the_graph_is_not_reported(): void
+    {
+        $result = $this->check(
+            ['App\Payment' => [], 'App\Admin' => []],
+            $this->rules([['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed']]),
+        );
+
+        self::assertTrue($result->isClean());
+        self::assertSame([], $result->violations);
+    }
+
+    public function test_every_forbidden_edge_is_reported_not_only_the_first(): void
+    {
+        $result = $this->check(
+            [
+                'App\Payment' => ['App\Admin', 'App\Legacy'],
+                'App\Admin' => [],
+                'App\Legacy' => [],
+            ],
+            $this->rules([[
+                'from' => 'App\Payment',
+                'deny' => ['App\Admin', 'App\Legacy'],
+                'reason' => 'reviewed',
+            ]]),
+        );
+
+        self::assertCount(2, $result->violations);
+    }
+
+    /**
+     * The self-invalidating half: a rule about a module nobody has any more
+     * reads as a boundary still being watched.
+     */
+    public function test_a_rule_naming_a_module_that_does_not_exist_is_reported(): void
+    {
+        $result = $this->check(
+            ['App\Payment' => [], 'App\Admin' => []],
+            $this->rules([['from' => 'App\Payment', 'deny' => ['App\Gone'], 'reason' => 'reviewed']]),
+        );
+
+        self::assertFalse($result->isClean());
+        self::assertSame(['App\Gone'], $result->unknownNamespaces);
+        self::assertSame([], $result->violations);
+    }
+
+    public function test_a_namespace_covering_only_submodules_is_known(): void
+    {
+        $result = $this->check(
+            ['App\Payment\Refunds' => [], 'App\Admin' => []],
+            $this->rules([['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed']]),
+        );
+
+        self::assertSame([], $result->unknownNamespaces);
+    }
+
+    public function test_a_namespace_is_unknown_when_only_a_longer_module_name_starts_with_its_letters(): void
+    {
+        $result = $this->check(
+            ['App\Payments' => [], 'App\Admin' => []],
+            $this->rules([['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed']]),
+        );
+
+        self::assertSame(['App\Payment'], $result->unknownNamespaces);
+    }
+
+    public function test_an_allow_list_reports_the_dependencies_it_does_not_permit(): void
+    {
+        $result = $this->check(
+            [
+                'App\Reporting' => ['App\Shared', 'App\Payment'],
+                'App\Shared' => [],
+                'App\Payment' => [],
+            ],
+            $this->rules([[
+                'from' => 'App\Reporting',
+                'allow' => ['App\Shared'],
+                'reason' => 'read-only module',
+            ]]),
+        );
+
+        self::assertCount(1, $result->violations);
+        self::assertSame('App\Payment', $result->violations[0]->to);
+    }
+
+    /**
+     * @param array<string, list<string>> $graph
+     */
+    private function check(array $graph, ModuleRuleSet $rules): ModuleRuleCheckResult
+    {
+        return (new ModuleRuleChecker())->check($graph, $rules);
+    }
+
+    /**
+     * @param list<mixed> $entries
+     */
+    private function rules(array $entries): ModuleRuleSet
+    {
+        return ModuleRuleSet::fromDecodedJson(['rules' => $entries]);
+    }
+}

--- a/tests/Unit/Psalm/PluginTest.php
+++ b/tests/Unit/Psalm/PluginTest.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractFactory;
 use Gacela\Psalm\ClassRules;
 use Gacela\Psalm\CrossModuleCallRules;
 use Gacela\Psalm\CrossModuleRules;
+use Gacela\Psalm\DeclaredModuleDependencyRules;
 use Gacela\Psalm\Plugin;
 use PHPUnit\Framework\TestCase;
 use Psalm\Codebase;
@@ -20,6 +21,8 @@ use Psalm\PluginRegistrationSocket;
 use ReflectionClass;
 use SimpleXMLElement;
 
+use function sprintf;
+
 /**
  * `ServiceMapPluginTest` proves the plugin works by running a real
  * `vendor/bin/psalm`, but that is a subprocess and invisible to coverage. These
@@ -30,6 +33,9 @@ final class PluginTest extends TestCase
 {
     private ?MethodReturnTypeProvider $returnTypes = null;
 
+    /** @var list<string> */
+    private array $files = [];
+
     /**
      * Registering the plugin with a <crossModule> element sets a static on each
      * handler. Left set, it decides the outcome of any later test that asks
@@ -39,6 +45,15 @@ final class PluginTest extends TestCase
     {
         CrossModuleRules::configure(null);
         CrossModuleCallRules::configure(null);
+        DeclaredModuleDependencyRules::configure(null);
+
+        foreach ($this->files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->files = [];
     }
 
     public function test_it_registers_the_pseudo_method_handler(): void
@@ -113,6 +128,54 @@ final class PluginTest extends TestCase
         self::assertTrue(CrossModuleCallRules::isConfigured());
     }
 
+    /**
+     * The rules live in a file the consumer writes, so with no file named there
+     * is nothing to check -- and staying off has to be the behaviour, not an
+     * accident of nobody calling it.
+     */
+    public function test_it_leaves_the_module_rules_check_off_without_config(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        (new Plugin())($this->socket($dispatcher));
+
+        self::assertNotContains(DeclaredModuleDependencyRules::class, $dispatcher->after_classlike_checks);
+        self::assertFalse(DeclaredModuleDependencyRules::isConfigured());
+    }
+
+    public function test_a_module_rules_element_turns_the_check_on(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        (new Plugin())($this->socket($dispatcher), new SimpleXMLElement(sprintf(
+            '<pluginClass><moduleRules rootNamespace="App\Modules" file="%s"/></pluginClass>',
+            $this->writeRulesFile(),
+        )));
+
+        self::assertContains(DeclaredModuleDependencyRules::class, $dispatcher->after_classlike_checks);
+        self::assertTrue(DeclaredModuleDependencyRules::isConfigured());
+    }
+
+    public function test_a_module_rules_element_without_a_file_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        (new Plugin())(
+            $this->socket(new EventDispatcher()),
+            new SimpleXMLElement('<pluginClass><moduleRules rootNamespace="App\Modules"/></pluginClass>'),
+        );
+    }
+
+    public function test_a_module_rules_element_without_a_root_namespace_fails_loudly(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        (new Plugin())(
+            $this->socket(new EventDispatcher()),
+            new SimpleXMLElement('<pluginClass><moduleRules file="module-rules.json"/></pluginClass>'),
+        );
+    }
+
     public function test_a_cross_module_element_without_a_root_namespace_fails_loudly(): void
     {
         $this->expectException(ConfigException::class);
@@ -131,6 +194,21 @@ final class PluginTest extends TestCase
         (new Plugin())($this->socket($dispatcher), new SimpleXMLElement('<pluginClass/>'));
 
         self::assertTrue($dispatcher->hasAfterClassLikeVisitHandlers());
+    }
+
+    /**
+     * A real file, because the plugin reads the rules while registering: an
+     * unreadable one is a setup error and has to be one here too.
+     */
+    private function writeRulesFile(): string
+    {
+        $path = sys_get_temp_dir() . '/gacela-plugin-rules-' . bin2hex(random_bytes(4)) . '.json';
+        file_put_contents($path, json_encode([
+            'rules' => [['from' => 'App\Modules\Payment', 'deny' => ['App\Modules\Admin'], 'reason' => 'reviewed']],
+        ], JSON_THROW_ON_ERROR));
+        $this->files[] = $path;
+
+        return $path;
     }
 
     /**

--- a/tests/Unit/StaticAnalysis/ModuleRules/ModuleRuleSetTest.php
+++ b/tests/Unit/StaticAnalysis/ModuleRules/ModuleRuleSetTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\StaticAnalysis\ModuleRules;
+
+use Gacela\StaticAnalysis\ModuleRules\MalformedModuleRulesException;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleRuleSetTest extends TestCase
+{
+    public function test_an_empty_rule_set_forbids_nothing(): void
+    {
+        $rules = ModuleRuleSet::empty();
+
+        self::assertTrue($rules->isEmpty());
+        self::assertNull($rules->violationFor('App\Payment', 'App\Admin'));
+    }
+
+    public function test_a_denied_edge_is_a_violation_carrying_its_reason(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'billing must not reach back-office'],
+        ]);
+
+        $violation = $rules->violationFor('App\Payment', 'App\Admin');
+
+        self::assertNotNull($violation);
+        self::assertSame('App\Payment', $violation->from);
+        self::assertSame('App\Admin', $violation->to);
+        self::assertSame('billing must not reach back-office', $violation->reason);
+    }
+
+    public function test_an_edge_no_rule_denies_is_allowed(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed'],
+        ]);
+
+        self::assertNull($rules->violationFor('App\Payment', 'App\Shipping'));
+    }
+
+    public function test_a_rule_only_judges_edges_leaving_its_own_module(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed'],
+        ]);
+
+        self::assertNull($rules->violationFor('App\Shipping', 'App\Admin'));
+    }
+
+    public function test_an_allow_list_turns_every_unlisted_edge_into_a_violation(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Reporting', 'allow' => ['App\Shared'], 'reason' => 'read-only module'],
+        ]);
+
+        self::assertNull($rules->violationFor('App\Reporting', 'App\Shared'));
+
+        $violation = $rules->violationFor('App\Reporting', 'App\Payment');
+        self::assertNotNull($violation);
+        self::assertSame('read-only module', $violation->reason);
+    }
+
+    /**
+     * A leaf module: legitimate, and the one case where an empty list is not
+     * the same as an absent key.
+     */
+    public function test_an_empty_allow_list_forbids_every_dependency(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Reporting', 'allow' => [], 'reason' => 'leaf module, depends on nothing'],
+        ]);
+
+        self::assertNotNull($rules->violationFor('App\Reporting', 'App\Shared'));
+    }
+
+    public function test_a_submodule_of_the_declaring_module_is_reachable_under_an_allow_list(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Reporting', 'allow' => ['App\Shared'], 'reason' => 'read-only module'],
+        ]);
+
+        self::assertNull($rules->violationFor('App\Reporting', 'App\Reporting\Export'));
+    }
+
+    public function test_a_rule_applies_to_the_submodules_of_the_module_it_names(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed'],
+        ]);
+
+        self::assertNotNull($rules->violationFor('App\Payment\Refunds', 'App\Admin\Users'));
+    }
+
+    /**
+     * Prefix matching that ignores the namespace boundary would let `App\Pay`
+     * silently govern `App\Payment`.
+     */
+    public function test_matching_respects_the_namespace_boundary(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Pay', 'deny' => ['App\Adm'], 'reason' => 'reviewed'],
+        ]);
+
+        self::assertNull($rules->violationFor('App\Payment', 'App\Admin'));
+    }
+
+    public function test_matching_is_case_sensitive(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed'],
+        ]);
+
+        self::assertNull($rules->violationFor('app\payment', 'app\admin'));
+    }
+
+    public function test_every_namespace_a_rule_names_is_declared(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin', 'App\Legacy'], 'reason' => 'reviewed'],
+            ['from' => 'App\Reporting', 'allow' => ['App\Shared'], 'reason' => 'read-only'],
+        ]);
+
+        self::assertSame(
+            ['App\Payment', 'App\Admin', 'App\Legacy', 'App\Reporting', 'App\Shared'],
+            $rules->declaredNamespaces(),
+        );
+    }
+
+    public function test_the_first_matching_rule_decides(): void
+    {
+        $rules = $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'first'],
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'second'],
+        ]);
+
+        $violation = $rules->violationFor('App\Payment', 'App\Admin');
+
+        self::assertNotNull($violation);
+        self::assertSame('first', $violation->reason);
+    }
+
+    public function test_a_missing_rules_key_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        ModuleRuleSet::fromDecodedJson(['whatever' => []]);
+    }
+
+    public function test_an_entry_that_is_not_an_object_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        ModuleRuleSet::fromDecodedJson(['rules' => ['App\Payment']]);
+    }
+
+    public function test_an_entry_without_a_from_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        $this->rules([['deny' => ['App\Admin'], 'reason' => 'reviewed']]);
+    }
+
+    public function test_an_entry_with_neither_allow_nor_deny_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        $this->rules([['from' => 'App\Payment', 'reason' => 'reviewed']]);
+    }
+
+    public function test_an_entry_with_both_allow_and_deny_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        $this->rules([[
+            'from' => 'App\Payment',
+            'allow' => ['App\Shared'],
+            'deny' => ['App\Admin'],
+            'reason' => 'reviewed',
+        ]]);
+    }
+
+    public function test_an_empty_deny_list_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        $this->rules([['from' => 'App\Payment', 'deny' => [], 'reason' => 'reviewed']]);
+    }
+
+    public function test_an_entry_without_a_reason_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        $this->rules([['from' => 'App\Payment', 'deny' => ['App\Admin']]]);
+    }
+
+    public function test_the_message_names_the_offending_entry(): void
+    {
+        $this->expectExceptionMessageMatches('/#1/');
+
+        $this->rules([
+            ['from' => 'App\Payment', 'deny' => ['App\Admin'], 'reason' => 'reviewed'],
+            ['from' => 'App\Reporting', 'deny' => ['App\Admin']],
+        ]);
+    }
+
+    /**
+     * @param list<mixed> $entries
+     */
+    private function rules(array $entries): ModuleRuleSet
+    {
+        return ModuleRuleSet::fromDecodedJson(['rules' => $entries]);
+    }
+}

--- a/tests/Unit/StaticAnalysis/ModuleRules/ModuleRuleSetTest.php
+++ b/tests/Unit/StaticAnalysis/ModuleRules/ModuleRuleSetTest.php
@@ -152,6 +152,10 @@ final class ModuleRuleSetTest extends TestCase
     public function test_an_entry_that_is_not_an_object_is_malformed(): void
     {
         $this->expectException(MalformedModuleRulesException::class);
+        // The message matters: reading `['from']` off a string yields null
+        // through `??`, so the entry would otherwise be reported as one missing
+        // a "from" rather than as the wrong shape entirely.
+        $this->expectExceptionMessage('must be an object');
 
         ModuleRuleSet::fromDecodedJson(['rules' => ['App\Payment']]);
     }
@@ -180,6 +184,21 @@ final class ModuleRuleSetTest extends TestCase
             'deny' => ['App\Admin'],
             'reason' => 'reviewed',
         ]]);
+    }
+
+    public function test_a_deny_that_is_not_a_list_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+
+        $this->rules([['from' => 'App\Payment', 'deny' => 'App\Admin', 'reason' => 'reviewed']]);
+    }
+
+    public function test_a_namespace_that_is_not_a_string_is_malformed(): void
+    {
+        $this->expectException(MalformedModuleRulesException::class);
+        $this->expectExceptionMessage('not a string');
+
+        $this->rules([['from' => 'App\Payment', 'deny' => [42], 'reason' => 'reviewed']]);
     }
 
     public function test_an_empty_deny_list_is_malformed(): void

--- a/tests/Unit/StaticAnalysis/ReferencedClassesTest.php
+++ b/tests/Unit/StaticAnalysis/ReferencedClassesTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\StaticAnalysis;
+
+use Gacela\StaticAnalysis\ReferencedClasses;
+use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * One case per way a class can name another one.
+ *
+ * The module graph is built from `use` statements, and every one of these costs
+ * the file an import -- so a kind missing here is a dependency the CLI gate sees
+ * and the editor does not, which is exactly the disagreement the rules exist to
+ * avoid.
+ */
+final class ReferencedClassesTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function referenceProvider(): iterable
+    {
+        yield 'new' => ['new \App\Other\Thing();', 'App\Other\Thing'];
+        yield 'static call' => ['\App\Other\Thing::go();', 'App\Other\Thing'];
+        yield 'class constant' => ['$x = \App\Other\Thing::class;', 'App\Other\Thing'];
+        yield 'static property' => ['$x = \App\Other\Thing::$instances;', 'App\Other\Thing'];
+        yield 'instanceof' => ['$x = $y instanceof \App\Other\Thing;', 'App\Other\Thing'];
+        yield 'catch' => ['try { $x = 1; } catch (\App\Other\Thing $e) {}', 'App\Other\Thing'];
+    }
+
+    #[DataProvider('referenceProvider')]
+    public function test_it_finds_a_reference_written_in_a_method_body(string $body, string $expected): void
+    {
+        self::assertContains($expected, $this->referencesIn(
+            "<?php\nfinal class Subject\n{\n    public function run()\n    {\n" . $body . "\n    }\n}",
+        ));
+    }
+
+    public function test_it_finds_the_parent_class(): void
+    {
+        self::assertContains('App\Other\Base', $this->referencesIn(
+            '<?php final class Subject extends \App\Other\Base {}',
+        ));
+    }
+
+    public function test_it_finds_an_implemented_interface(): void
+    {
+        self::assertContains('App\Other\Contract', $this->referencesIn(
+            '<?php final class Subject implements \App\Other\Contract {}',
+        ));
+    }
+
+    public function test_it_finds_an_interface_a_declared_interface_extends(): void
+    {
+        self::assertContains('App\Other\Contract', $this->referencesIn(
+            '<?php interface Subject extends \App\Other\Contract {}',
+        ));
+    }
+
+    public function test_it_finds_an_interface_an_enum_implements(): void
+    {
+        self::assertContains('App\Other\Contract', $this->referencesIn(
+            '<?php enum Subject implements \App\Other\Contract { case One; }',
+        ));
+    }
+
+    public function test_it_finds_a_used_trait(): void
+    {
+        self::assertContains('App\Other\Helper', $this->referencesIn(
+            '<?php final class Subject { use \App\Other\Helper; }',
+        ));
+    }
+
+    public function test_it_finds_an_attribute(): void
+    {
+        self::assertContains('App\Other\Marker', $this->referencesIn(
+            '<?php #[\App\Other\Marker] final class Subject {}',
+        ));
+    }
+
+    public function test_it_finds_a_parameter_type(): void
+    {
+        self::assertContains('App\Other\Thing', $this->referencesIn(
+            '<?php final class Subject { public function run(\App\Other\Thing $t): void {} }',
+        ));
+    }
+
+    public function test_it_finds_a_return_type(): void
+    {
+        self::assertContains('App\Other\Thing', $this->referencesIn(
+            '<?php final class Subject { public function run(): \App\Other\Thing {} }',
+        ));
+    }
+
+    public function test_it_finds_a_property_type(): void
+    {
+        self::assertContains('App\Other\Thing', $this->referencesIn(
+            '<?php final class Subject { private \App\Other\Thing $thing; }',
+        ));
+    }
+
+    public function test_it_finds_a_nullable_type(): void
+    {
+        self::assertContains('App\Other\Thing', $this->referencesIn(
+            '<?php final class Subject { public function run(?\App\Other\Thing $t): void {} }',
+        ));
+    }
+
+    public function test_it_finds_every_arm_of_a_union_type(): void
+    {
+        $references = $this->referencesIn(
+            '<?php final class Subject { public function run(\App\Other\A|\App\Other\B $t): void {} }',
+        );
+
+        self::assertContains('App\Other\A', $references);
+        self::assertContains('App\Other\B', $references);
+    }
+
+    public function test_it_finds_every_arm_of_an_intersection_type(): void
+    {
+        $references = $this->referencesIn(
+            '<?php final class Subject { public function run(\App\Other\A&\App\Other\B $t): void {} }',
+        );
+
+        self::assertContains('App\Other\A', $references);
+        self::assertContains('App\Other\B', $references);
+    }
+
+    public function test_a_builtin_type_names_no_class(): void
+    {
+        self::assertSame([], $this->referencesIn(
+            '<?php final class Subject { public function run(string $s): int {} }',
+        ));
+    }
+
+    /**
+     * `new $class` and `$class::CONST` name nothing a rule could match.
+     */
+    public function test_a_dynamic_class_name_is_not_a_reference(): void
+    {
+        self::assertSame([], $this->referencesIn(
+            '<?php final class Subject { public function run($class) { new $class(); } }',
+        ));
+    }
+
+    public function test_one_class_named_many_times_is_listed_once(): void
+    {
+        self::assertSame(['App\Other\Thing'], $this->referencesIn(
+            '<?php final class Subject { public function run() { new \App\Other\Thing(); \App\Other\Thing::go(); } }',
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function referencesIn(string $php): array
+    {
+        return ReferencedClasses::in(ParseSource::classInAsPhpStanResolves($php));
+    }
+}

--- a/tests/Unit/StaticAnalysis/Rules/DeclaredModuleDependencyAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/DeclaredModuleDependencyAnalyserTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\StaticAnalysis\Rules;
+
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use Gacela\StaticAnalysis\Rules\DeclaredModuleDependencyAnalyser;
+use Gacela\StaticAnalysis\Violation;
+use GacelaTest\Unit\StaticAnalysis\Double\FakeAnalysedClass;
+use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+final class DeclaredModuleDependencyAnalyserTest extends TestCase
+{
+    private const ROOT = 'App\Modules';
+
+    public function test_a_dependency_a_rule_denies_is_reported_with_its_reason(): void
+    {
+        $violations = $this->analyse('new App\Modules\Admin\AdminFacade();');
+
+        self::assertCount(1, $violations);
+        self::assertSame(
+            'App\Modules\Payment must not depend on App\Modules\Admin: billing must not reach back-office',
+            $violations[0]->message,
+        );
+        self::assertSame('gacela.declaredModuleDependency', $violations[0]->identifier);
+        self::assertSame(
+            'Drop the dependency on App\Modules\Admin, or change the rule that forbids it.',
+            $violations[0]->tip,
+        );
+    }
+
+    /**
+     * The rules are about modules, not about how a boundary is spelled: going
+     * through the other module's Facade is still the dependency the rule
+     * forbids.
+     */
+    public function test_a_denied_dependency_is_reported_even_when_it_goes_through_a_facade(): void
+    {
+        self::assertCount(1, $this->analyse('App\Modules\Admin\AdminFacade::create();'));
+    }
+
+    public function test_a_dependency_no_rule_denies_is_left_alone(): void
+    {
+        self::assertSame([], $this->analyse('new App\Modules\Shipping\ShippingFacade();'));
+    }
+
+    public function test_staying_inside_the_module_is_left_alone(): void
+    {
+        self::assertSame([], $this->analyse('new App\Modules\Payment\Domain\Basket();'));
+    }
+
+    public function test_a_class_outside_the_root_namespace_is_not_a_module(): void
+    {
+        self::assertSame([], $this->analyse('new Vendor\Library\Thing();'));
+    }
+
+    public function test_a_module_no_rule_governs_is_left_alone(): void
+    {
+        self::assertSame(
+            [],
+            $this->analyse('new App\Modules\Admin\AdminFacade();', 'App\Modules\Shipping\ShippingFactory'),
+        );
+    }
+
+    public function test_an_empty_rule_set_reports_nothing(): void
+    {
+        $analyser = new DeclaredModuleDependencyAnalyser(self::ROOT, ModuleRuleSet::empty());
+
+        self::assertSame([], $analyser->analyse(
+            ParseSource::classIn($this->sourceWith('new App\Modules\Admin\AdminFacade();')),
+            new FakeAnalysedClass('App\Modules\Payment\PaymentFactory'),
+        ));
+    }
+
+    public function test_one_forbidden_module_reached_many_times_is_one_finding(): void
+    {
+        self::assertCount(1, $this->analyse(
+            'new App\Modules\Admin\AdminFacade(); App\Modules\Admin\Other::go(); $x = App\Modules\Admin\Third::class;',
+        ));
+    }
+
+    /**
+     * A type-hint costs the file the same import the module graph is built
+     * from, so the CLI gate and the editor have to agree it is a dependency.
+     */
+    public function test_a_dependency_written_only_as_a_type_hint_is_reported(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            namespace App\Modules\Payment;
+
+            final class PaymentFactory
+            {
+                public function create(\App\Modules\Admin\AdminFacade $admin): void
+                {
+                }
+            }
+            PHP;
+
+        $analyser = new DeclaredModuleDependencyAnalyser(self::ROOT, $this->rules());
+
+        self::assertCount(1, $analyser->analyse(
+            ParseSource::classInAsPhpStanResolves($source),
+            new FakeAnalysedClass('App\Modules\Payment\PaymentFactory'),
+        ));
+    }
+
+    /**
+     * PHPStan rewrites names in place; Psalm leaves the source text and puts the
+     * qualified form on an attribute. A rule reading only the written name would
+     * hold in one host and pass silently in the other.
+     */
+    public function test_an_imported_class_is_matched_whichever_way_the_host_resolved_it(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            namespace App\Modules\Payment;
+
+            use App\Modules\Admin\AdminFacade;
+
+            final class PaymentFactory
+            {
+                public function create(): void
+                {
+                    new AdminFacade();
+                }
+            }
+            PHP;
+
+        $analyser = new DeclaredModuleDependencyAnalyser(self::ROOT, $this->rules());
+        $class = new FakeAnalysedClass('App\Modules\Payment\PaymentFactory');
+
+        self::assertCount(1, $analyser->analyse(ParseSource::classInAsPhpStanResolves($source), $class));
+        self::assertCount(1, $analyser->analyse(ParseSource::classInWithNameAttributes($source), $class));
+    }
+
+    public function test_a_shared_namespace_is_never_checked(): void
+    {
+        self::assertSame([], $this->analyse(
+            'new App\Modules\Admin\AdminFacade();',
+            'App\Modules\Payment\PaymentFactory',
+            ['App\Modules\Payment'],
+        ));
+    }
+
+    public function test_an_allow_list_reports_the_dependency_it_does_not_permit(): void
+    {
+        $rules = ModuleRuleSet::fromDecodedJson(['rules' => [
+            ['from' => 'App\Modules\Payment', 'allow' => ['App\Modules\Shipping'], 'reason' => 'payment reads shipping only'],
+        ]]);
+
+        $analyser = new DeclaredModuleDependencyAnalyser(self::ROOT, $rules);
+
+        $violations = $analyser->analyse(
+            ParseSource::classIn($this->sourceWith('new App\Modules\Admin\AdminFacade();')),
+            new FakeAnalysedClass('App\Modules\Payment\PaymentFactory'),
+        );
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('payment reads shipping only', $violations[0]->message);
+    }
+
+    /**
+     * @param list<string> $sharedNamespaces
+     *
+     * @return list<Violation>
+     */
+    private function analyse(
+        string $body,
+        string $className = 'App\Modules\Payment\PaymentFactory',
+        array $sharedNamespaces = [],
+    ): array {
+        $analyser = new DeclaredModuleDependencyAnalyser(self::ROOT, $this->rules(), 1, $sharedNamespaces);
+
+        return $analyser->analyse(
+            ParseSource::classIn($this->sourceWith($body)),
+            new FakeAnalysedClass($className),
+        );
+    }
+
+    private function rules(): ModuleRuleSet
+    {
+        return ModuleRuleSet::fromDecodedJson(['rules' => [
+            [
+                'from' => 'App\Modules\Payment',
+                'deny' => ['App\Modules\Admin'],
+                'reason' => 'billing must not reach back-office',
+            ],
+        ]]);
+    }
+
+    private function sourceWith(string $body): string
+    {
+        return sprintf("<?php\nfinal class PaymentFactory\n{\n    public function create()\n    {\n%s\n    }\n}", $body);
+    }
+}

--- a/tests/Unit/StaticAnalysis/Rules/DeclaredModuleDependencyAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/DeclaredModuleDependencyAnalyserTest.php
@@ -84,6 +84,40 @@ final class DeclaredModuleDependencyAnalyserTest extends TestCase
     }
 
     /**
+     * The scan cannot stop at the first reference it has nothing to say about:
+     * a class reaches many others, and the forbidden one is rarely written
+     * first.
+     */
+    public function test_a_forbidden_dependency_after_an_innocent_one_is_still_reported(): void
+    {
+        self::assertCount(1, $this->analyse(
+            'new App\Modules\Payment\Domain\Basket(); new App\Modules\Shipping\ShippingFacade(); new App\Modules\Admin\AdminFacade();',
+        ));
+    }
+
+    public function test_a_second_forbidden_module_after_a_repeated_one_is_still_reported(): void
+    {
+        $rules = ModuleRuleSet::fromDecodedJson(['rules' => [
+            [
+                'from' => 'App\Modules\Payment',
+                'deny' => ['App\Modules\Admin', 'App\Modules\Legacy'],
+                'reason' => 'reviewed',
+            ],
+        ]]);
+
+        $analyser = new DeclaredModuleDependencyAnalyser(self::ROOT, $rules);
+
+        $violations = $analyser->analyse(
+            ParseSource::classIn($this->sourceWith(
+                'new App\Modules\Admin\AdminFacade(); App\Modules\Admin\Other::go(); new App\Modules\Legacy\LegacyFacade();',
+            )),
+            new FakeAnalysedClass('App\Modules\Payment\PaymentFactory'),
+        );
+
+        self::assertCount(2, $violations);
+    }
+
+    /**
      * A type-hint costs the file the same import the module graph is built
      * from, so the CLI gate and the editor have to agree it is a dependency.
      */


### PR DESCRIPTION
## 📚 Description

Cycles were the only thing the module graph could refuse on its own. Every other
boundary a team agrees on — billing must not reach back-office, reporting reads
and nothing more — lived in prose, where no tool can see it and a violation
arrives as one more import in a diff.

This adds one JSON file of module rules, read in two places: over the whole graph
by `debug:graph --check --rules`, and per class by the PHPStan and Psalm rules.
One file, two readers, because a boundary that holds in CI and not in the editor
is a boundary nobody trusts.

Like the cycle allow list, the rules are self-invalidating: a rule naming a
namespace that matches no module fails the check.

## 🔖 Changes

- `ModuleRuleSet` / `ModuleRule` in `StaticAnalysis`, shared by the CLI and both analysers
- `debug:graph --check --rules=<file>`, and `--format=json` for a machine-readable report
- `--rules` refuses a filter argument: a narrowed graph cannot tell a stale rule from a filtered-out module
- `DeclaredModuleDependencyRule` (PHPStan) and `GacelaDeclaredModuleDependency` (Psalm), proven on one shared fixture
- Docs: `static-analysis.md` section, `cli.md` row, both suppression keys in the rule table

Closes #654