### PR TITLE
feat(config): declare what the configuration must contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Declare what the configuration must contain with `declareConfigSchema()`, read by `validate:config`, `doctor` and `debug:config`
+- Fill a declared default when no config source provides the key, without ever overriding one that does
+- Mark every key `declared`, `undeclared` or `missing` in `debug:config`
+- Check the declared schema on every bootstrap with `validateConfigSchemaOnBoot()`, for local development
+
+### Added
+
 - Declare which modules may depend on which, in one JSON file read by `debug:graph --check --rules` and by both analysers
 - Report a module rule that governs no module, so a rule cannot outlive what it was written about
 - Write the `--check` findings as JSON with `--format=json`, for a CI job that wants more than an exit code

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [CLI commands](cli.md) — every `vendor/bin/gacela` command, what it is for
 - [Getting a dependency](getting-a-dependency.md) — one primary path per intent, and when the other paths are right
 - [Container configuration](container-configuration.md) — factories, aliases, contextual bindings
+- [Config schema](config-schema.md) — declare what the configuration must contain, and fail before a request does
 - [Static analysis](static-analysis.md) — the architecture rules, for PHPStan and Psalm alike
 - [Module health checks](module-health-checks.md) — report module operational status
 - [Events](events.md) — listen to Gacela internals: dispatch model, event catalog, cookbook

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ root. `init` is the one that creates it.
 | `list:modules` | Renders every module found |
 | `debug:modules` | Dependency resolvability of every module pillar |
 | `debug:module App/Blog` | One module: resolved classes, container bindings, dependency tree |
-| `debug:config` | The effective merged configuration, after every source and override |
+| `debug:config` | The effective merged configuration, after every source and override, each key marked `declared`, `undeclared` or `missing` against the [schema](config-schema.md) |
 | `debug:container` | Container contents — user bindings and plugins only |
 | `debug:dependencies Foo::class` | A class's constructor parameters and whether the container can supply each. `--tree` walks the whole graph and marks every node `binding`, `instance`, `autowired` or `unresolvable` |
 | `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--allowed-cycles`, `--rules` to fail on dependencies your rules file forbids, `--compare-to` |
@@ -38,8 +38,8 @@ root. `init` is the one that creates it.
 
 | Command | What it does |
 |---|---|
-| `doctor` | Environmental and wiring health checks. Takes an optional namespace to restrict module-scoped checks, and `--strict` to exit non-zero on warnings too |
-| `validate:config` | Checks the configuration for errors and best-practice violations |
+| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md). Takes an optional namespace to restrict module-scoped checks, and `--strict` to exit non-zero on warnings too |
+| `validate:config` | Checks the configuration for errors and best-practice violations, and against the [declared schema](config-schema.md) |
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see
 [module health checks](module-health-checks.md).

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1,0 +1,75 @@
+# Config schema
+
+`validate:config` checks the *wiring* — bindings, dependency cycles. Nothing
+checked the configuration itself, so a missing or misspelled key surfaced as a
+runtime failure in whichever environment lacked it: usually production, usually
+far from the file that should have carried it.
+
+Every call site already knows what it expects — `getInt('retries')` says so — but
+that expectation was written nowhere a command could read before anything ran.
+
+## Declaring one
+
+```php
+// gacela.php
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Schema\ConfigType;
+
+return static function (GacelaConfig $config): void {
+    $config->declareConfigSchema([
+        'db.dsn'   => ConfigType::string()->required(),
+        'retries'  => ConfigType::int()->default(3),
+        'features' => ConfigType::array()->required()->describe('feature flags, keyed by name'),
+    ]);
+};
+```
+
+Types: `string()`, `int()`, `float()`, `bool()`, `array()`.
+
+- `required()` — the key must be present after every source is merged.
+- `default($value)` — used when no source provides the key, never over one that
+  does. A defaulted key is therefore never missing, and cannot also be required.
+- `describe($text)` — travels into the violation, where "wrong type" alone
+  leaves the reader guessing.
+
+A `float` accepts an `int`: `timeout: 5` in a config file is about the value, not
+about PHP's literal syntax. Nothing else is coerced — `'true'` is not a `bool`.
+
+Declarations merge per key, so `declareConfigSchema()` can be called more than
+once and an [extended config](container-configuration.md) can refine one key
+without repeating the rest. The later declaration of a key wins.
+
+## Where it is checked
+
+Nothing is checked while booting. The declaration is read by the commands you
+already run:
+
+```bash
+vendor/bin/gacela validate:config   # non-zero when a declared key is unsatisfied
+vendor/bin/gacela doctor            # the same, as one more check in the deploy gate
+vendor/bin/gacela debug:config      # marks every key declared / undeclared / missing
+```
+
+`debug:config` is the counterweight in the other direction: a schema can only
+report the keys it declares, so the table flags the ones it does *not*, and lists
+a declared key nothing provides even though it has no value to show.
+
+## Checking on boot, locally
+
+```php
+$config->validateConfigSchemaOnBoot();
+```
+
+Moves the report from a command you have to remember to run to the first thing
+that boots, and throws a `ConfigException` listing every violation. It is off by
+default so bootstrap does no work a project did not ask for — leave it off in
+production, where the deploy gate has already answered the question.
+
+Declared **defaults** are applied either way: a key with a default is not
+missing, it is provided by the declaration.
+
+## See also
+
+- [CLI commands](cli.md)
+- [Container configuration](container-configuration.md)
+- [Module health checks](module-health-checks.md)

--- a/src/Console/Application/Doctor/Check/ConfigSchemaCheck.php
+++ b/src/Console/Application/Doctor/Check/ConfigSchemaCheck.php
@@ -7,7 +7,6 @@ namespace Gacela\Console\Application\Doctor\Check;
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Framework\Config\Schema\ConfigSchema;
-use Gacela\Framework\Config\Schema\ConfigSchemaViolation;
 
 use function count;
 use function sprintf;
@@ -24,11 +23,15 @@ use function sprintf;
 final class ConfigSchemaCheck implements HealthCheck
 {
     /**
-     * @param list<ConfigSchemaViolation> $violations
+     * The values rather than the findings: a check handed both could be handed
+     * two that disagree, and then it reports whatever it was told.
+     *
+     * @param array<string, mixed> $values the merged configuration, as this
+     *                                     environment sees it
      */
     public function __construct(
         private readonly ConfigSchema $schema,
-        private readonly array $violations,
+        private readonly array $values,
     ) {
     }
 
@@ -43,7 +46,8 @@ final class ConfigSchemaCheck implements HealthCheck
             return CheckResult::ok($this->name(), 'no schema declared — nothing to check');
         }
 
-        if ($this->violations === []) {
+        $violations = $this->schema->violations($this->values);
+        if ($violations === []) {
             return CheckResult::ok($this->name(), sprintf(
                 '%d declared key(s), all satisfied',
                 count($this->schema->declaredKeys()),
@@ -51,7 +55,7 @@ final class ConfigSchemaCheck implements HealthCheck
         }
 
         $details = [];
-        foreach ($this->violations as $violation) {
+        foreach ($violations as $violation) {
             $details[] = $violation->message;
         }
 

--- a/src/Console/Application/Doctor/Check/ConfigSchemaCheck.php
+++ b/src/Console/Application/Doctor/Check/ConfigSchemaCheck.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Framework\Config\Schema\ConfigSchema;
+use Gacela\Framework\Config\Schema\ConfigSchemaViolation;
+
+use function count;
+use function sprintf;
+
+/**
+ * The declared configuration schema, read against the environment being
+ * checked.
+ *
+ * A missing key is an error rather than a warning: whatever reads it was going
+ * to fail anyway, and the only question is whether that happens here or in a
+ * request. Nothing declared means nothing to check, and the check says so
+ * rather than reporting a pass it never made.
+ */
+final class ConfigSchemaCheck implements HealthCheck
+{
+    /**
+     * @param list<ConfigSchemaViolation> $violations
+     */
+    public function __construct(
+        private readonly ConfigSchema $schema,
+        private readonly array $violations,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'config schema';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->schema->isEmpty()) {
+            return CheckResult::ok($this->name(), 'no schema declared — nothing to check');
+        }
+
+        if ($this->violations === []) {
+            return CheckResult::ok($this->name(), sprintf(
+                '%d declared key(s), all satisfied',
+                count($this->schema->declaredKeys()),
+            ));
+        }
+
+        $details = [];
+        foreach ($this->violations as $violation) {
+            $details[] = $violation->message;
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            $details,
+            'Provide the missing keys for this environment, or change what gacela.php declares.',
+        );
+    }
+}

--- a/src/Console/Infrastructure/Command/DebugConfigCommand.php
+++ b/src/Console/Infrastructure/Command/DebugConfigCommand.php
@@ -15,9 +15,11 @@ use Symfony\Component\Console\Input\InputInterface;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_key_exists;
 use function count;
 use function is_bool;
 use function is_scalar;
+
 use function ksort;
 
 use function sprintf;
@@ -47,7 +49,9 @@ final class DebugConfigCommand extends Command
     {
         $filter = ConsoleInput::argument($input, 'filter');
 
-        $values = Config::getInstance()->getAllValues();
+        $config = Config::getInstance();
+        $values = $config->getAllValues();
+        $schema = $config->configSchema();
         ksort($values);
 
         $rows = [];
@@ -57,7 +61,15 @@ final class DebugConfigCommand extends Command
                 continue;
             }
 
-            $rows[] = [$key, $this->renderValue($value)];
+            $rows[] = [$key, $this->renderValue($value), $schema->declares($key) ? 'declared' : 'undeclared'];
+        }
+
+        // A declared key nothing provides has no value to list, so it would
+        // otherwise be the one kind of drift this table cannot show.
+        foreach ($schema->declaredKeys() as $key) {
+            if (!array_key_exists($key, $values) && ($filter === '' || str_contains($key, $filter))) {
+                $rows[] = [$key, '<comment>—</comment>', '<error>missing</error>'];
+            }
         }
 
         if ($rows === []) {
@@ -69,7 +81,7 @@ final class DebugConfigCommand extends Command
         }
 
         $table = new Table($output);
-        $table->setHeaders(['Key', 'Value']);
+        $table->setHeaders(['Key', 'Value', 'Schema']);
         $table->setRows($rows);
         $table->render();
 

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -94,7 +94,7 @@ final class DoctorCommand extends Command
             ),
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules),
-            new ConfigSchemaCheck($config->configSchema(), $config->configSchemaViolations()),
+            new ConfigSchemaCheck($config->configSchema(), $config->getAllValues()),
         ];
 
         foreach (HealthCheckRegistry::createHealthChecker(Gacela::container())->checkAll()->getResults() as $moduleName => $status) {

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
+use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
 use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
@@ -93,6 +94,7 @@ final class DoctorCommand extends Command
             ),
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules),
+            new ConfigSchemaCheck($config->configSchema(), $config->configSchemaViolations()),
         ];
 
         foreach (HealthCheckRegistry::createHealthChecker(Gacela::container())->checkAll()->getResults() as $moduleName => $status) {

--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Container\ValidationProblem;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
 use Symfony\Component\Console\Command\Command;
@@ -54,6 +55,8 @@ final class ValidateConfigCommand extends Command
         $hasErrors = $hasErrors || $circularDepsValidation['errors'];
         $hasWarnings = $hasWarnings || $circularDepsValidation['warnings'];
 
+        $hasErrors = $this->validateConfigSchema($output) || $hasErrors;
+
         $output->writeln('');
         ConsoleSection::separator($output);
 
@@ -73,6 +76,43 @@ final class ValidateConfigCommand extends Command
         $output->writeln('');
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * The declared configuration schema against this environment's merged
+     * values.
+     *
+     * Reading values constructs nothing, which is what keeps this command
+     * side-effect free; a missing key is an error because whatever reads it was
+     * going to fail regardless, and the only question is where.
+     */
+    private function validateConfigSchema(OutputInterface $output): bool
+    {
+        $output->writeln('<comment>Checking configuration schema...</comment>');
+
+        $config = Config::getInstance();
+        if ($config->configSchema()->isEmpty()) {
+            $output->writeln('  <fg=cyan>No schema declared</fg=cyan>');
+            $output->writeln('');
+
+            return false;
+        }
+
+        $violations = $config->configSchemaViolations();
+        foreach ($violations as $violation) {
+            $output->writeln(sprintf('  <error>✗ %s</>', $violation->message));
+        }
+
+        if ($violations === []) {
+            $output->writeln(sprintf(
+                '  <fg=green>✓ %d declared key(s), all satisfied</>',
+                count($config->configSchema()->declaredKeys()),
+            ));
+        }
+
+        $output->writeln('');
+
+        return $violations !== [];
     }
 
     /**

--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -85,6 +85,10 @@ final class ValidateConfigCommand extends Command
      * Reading values constructs nothing, which is what keeps this command
      * side-effect free; a missing key is an error because whatever reads it was
      * going to fail regardless, and the only question is where.
+     *
+     * @return bool true when the configuration violates its own declaration.
+     *              Only errors, no warnings: a declared key is either satisfied
+     *              or it is not
      */
     private function validateConfigSchema(OutputInterface $output): bool
     {

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -8,6 +8,7 @@ use Gacela\Framework\ClassResolver\Cache\GacelaFileCache;
 use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
+use Gacela\Framework\Config\Schema\ConfigType;
 
 /**
  * @psalm-import-type ExternalServicesMap from BuilderConfigurationInterface
@@ -27,6 +28,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     public const string appModulePaths = 'appModulePaths';
 
     public const string configKeyValues = 'configKeyValues';
+
+    public const string configSchema = 'configSchema';
 
     public const string servicesToExtend = 'servicesToExtend';
 
@@ -65,6 +68,10 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_APP_MODULE_PATHS = [];
 
     protected const array DEFAULT_CONFIG_KEY_VALUES = [];
+
+    protected const array DEFAULT_CONFIG_SCHEMA = [];
+
+    protected const bool DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT = false;
 
     protected const array DEFAULT_GENERIC_LISTENERS = [];
 
@@ -126,5 +133,26 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     public function externalServices(): array
     {
         return [];
+    }
+
+    /**
+     * Declaring no schema is the default: nothing is checked until a project
+     * says what its configuration is supposed to contain.
+     *
+     * @return array<string, ConfigType>
+     */
+    public function getConfigSchema(): array
+    {
+        return self::DEFAULT_CONFIG_SCHEMA;
+    }
+
+    /**
+     * Off by default, so bootstrap does no work a project did not ask for. The
+     * schema is meant to be checked by `validate:config` and `doctor`; the boot
+     * check is a local-development convenience.
+     */
+    public function shouldValidateConfigSchemaOnBoot(): bool
+    {
+        return self::DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT;
     }
 }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -12,6 +12,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
@@ -57,6 +58,11 @@ final class GacelaConfig
 
     /** @var ConfigKeyValues */
     private ?array $configKeyValues = null;
+
+    /** @var ?array<string, ConfigType> */
+    private ?array $configSchema = null;
+
+    private ?bool $shouldValidateConfigSchemaOnBoot = null;
 
     private ?bool $areEventListenersEnabled = null;
 
@@ -315,6 +321,47 @@ final class GacelaConfig
     public function addAppConfigKeyValues(array $config): self
     {
         $this->configKeyValues = array_merge($this->configKeyValues ?? [], $config);
+
+        return $this;
+    }
+
+    /**
+     * Declare what the application's configuration is supposed to contain.
+     *
+     * ```php
+     * $config->declareConfigSchema([
+     *     'db.dsn'  => ConfigType::string()->required(),
+     *     'retries' => ConfigType::int()->default(3),
+     * ]);
+     * ```
+     *
+     * Nothing is checked while booting: the declaration is what
+     * `validate:config` and `doctor` read, so a missing key fails a command
+     * rather than a request in whichever environment lacked it. Declared
+     * defaults *are* applied, because a key with a default is not missing.
+     *
+     * Called twice, or reached again through `extendGacelaConfig()`, the
+     * declarations merge per key and the later one wins.
+     *
+     * @param array<string, ConfigType> $schema
+     */
+    public function declareConfigSchema(array $schema): self
+    {
+        $this->configSchema = array_merge($this->configSchema ?? [], $schema);
+
+        return $this;
+    }
+
+    /**
+     * Check the declared schema on every bootstrap, and fail there.
+     *
+     * For local development: it moves the report from a command you have to
+     * remember to run to the first thing that boots. Leave it off in
+     * production, where the deploy gate has already answered the question.
+     */
+    public function validateConfigSchemaOnBoot(bool $enabled = true): self
+    {
+        $this->shouldValidateConfigSchemaOnBoot = $enabled;
 
         return $this;
     }
@@ -686,6 +733,8 @@ final class GacelaConfig
             $this->tags,
             $this->afterResolvingCallbacks,
             $this->definitions,
+            $this->configSchema,
+            $this->shouldValidateConfigSchemaOnBoot,
         );
     }
 

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 
 /**
@@ -48,6 +49,7 @@ final class GacelaConfigTransfer
      * @param TagsMap $tags
      * @param AfterResolvingMap $afterResolvingCallbacks
      * @param DefinitionSources $definitions
+     * @param ?array<string, ConfigType> $configSchema
      */
     public function __construct(
         public readonly AppConfigBuilder $appConfigBuilder,
@@ -75,6 +77,8 @@ final class GacelaConfigTransfer
         public readonly array $tags = [],
         public readonly array $afterResolvingCallbacks = [],
         public readonly array $definitions = [],
+        public readonly ?array $configSchema = null,
+        public readonly ?bool $shouldValidateConfigSchemaOnBoot = null,
     ) {
     }
 }

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 
@@ -64,6 +65,11 @@ final class Properties
 
     /** @var ?ConfigKeyValues */
     public ?array $configKeyValues = null;
+
+    /** @var ?array<string, ConfigType> */
+    public ?array $configSchema = null;
+
+    public ?bool $shouldValidateConfigSchemaOnBoot = null;
 
     public ?bool $areEventListenersEnabled = null;
 

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Bootstrap\ContainerConfigurationInterface;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Config\Schema\ConfigType;
 
 use function array_merge;
 use function array_unique;
@@ -59,6 +60,18 @@ final class PropertyMerger
     {
         $current = $this->setup->getConfigKeyValues();
         $this->setup->setConfigKeyValues(array_merge($current, $list));
+    }
+
+    /**
+     * Per key, later wins: an extended config refining one key's declaration
+     * says nothing about the keys it did not mention.
+     *
+     * @param array<string, ConfigType> $schema
+     */
+    public function mergeConfigSchema(array $schema): void
+    {
+        $current = $this->setup->getConfigSchema();
+        $this->setup->setConfigSchema(array_merge($current, $schema));
     }
 
     /**

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -29,6 +29,8 @@ final class SetupInitializer
             ->setProjectNamespaces($dto->projectNamespaces)
             ->setAppModulePaths($dto->appModulePaths)
             ->setConfigKeyValues($dto->configKeyValues)
+            ->setConfigSchema($dto->configSchema)
+            ->setShouldValidateConfigSchemaOnBoot($dto->shouldValidateConfigSchemaOnBoot)
             ->setAreEventListenersEnabled($dto->areEventListenersEnabled)
             ->setGenericListeners($dto->genericListeners)
             ->setSpecificListeners($dto->specificListeners)

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -29,6 +29,7 @@ final class SetupMerger
         $this->whenChanged($other, SetupGacela::externalServices, fn () => $this->original->mergeExternalServices($other->externalServices()));
         $this->whenChanged($other, SetupGacela::projectNamespaces, fn () => $this->original->mergeProjectNamespaces($other->getProjectNamespaces()));
         $this->whenChanged($other, SetupGacela::configKeyValues, fn () => $this->original->mergeConfigKeyValues($other->getConfigKeyValues()));
+        $this->whenChanged($other, SetupGacela::configSchema, fn () => $this->original->mergeConfigSchema($other->getConfigSchema()));
         $this->mergeEventDispatcher($other);
         $this->mergeServicesToExtend($other);
         $this->whenChanged($other, SetupGacela::factories, fn () => $this->original->mergeFactories($other->getFactories()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -16,6 +16,7 @@ use Gacela\Framework\Config\GacelaConfigBuilder\AppConfigBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\BindingsBuilder;
 use Gacela\Framework\Config\GacelaConfigBuilder\SuffixTypesBuilder;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Override;
 
@@ -286,6 +287,51 @@ final class SetupGacela extends AbstractSetupGacela
     public function getConfigKeyValues(): array
     {
         return $this->properties->configKeyValues ?? self::DEFAULT_CONFIG_KEY_VALUES;
+    }
+
+    /**
+     * @return array<string, ConfigType>
+     */
+    #[Override]
+    public function getConfigSchema(): array
+    {
+        return $this->properties->configSchema ?? self::DEFAULT_CONFIG_SCHEMA;
+    }
+
+    #[Override]
+    public function shouldValidateConfigSchemaOnBoot(): bool
+    {
+        return $this->properties->shouldValidateConfigSchemaOnBoot ?? self::DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT;
+    }
+
+    /**
+     * @param ?array<string, ConfigType> $configSchema
+     */
+    public function setConfigSchema(?array $configSchema): self
+    {
+        $this->properties->configSchema = $this->setPropertyWithTracking(
+            self::configSchema,
+            $configSchema,
+            self::DEFAULT_CONFIG_SCHEMA,
+        );
+
+        return $this;
+    }
+
+    public function setShouldValidateConfigSchemaOnBoot(?bool $enabled): self
+    {
+        $this->properties->shouldValidateConfigSchemaOnBoot = $enabled
+            ?? self::DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, ConfigType> $schema
+     */
+    public function mergeConfigSchema(array $schema): void
+    {
+        $this->propertyMerger->mergeConfigSchema($schema);
     }
 
     public function getEventDispatcher(): EventDispatcherInterface

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Bootstrap;
 
+use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 
 /**
@@ -34,6 +35,15 @@ interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerC
      * @return ConfigKeyValues
      */
     public function getConfigKeyValues(): array;
+
+    /**
+     * What the application's configuration is declared to contain.
+     *
+     * @return array<string, ConfigType>
+     */
+    public function getConfigSchema(): array;
+
+    public function shouldValidateConfigSchemaOnBoot(): bool;
 
     public function getEventDispatcher(): EventDispatcherInterface;
 

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Config\Schema\ConfigSchema;
+use Gacela\Framework\Config\Schema\ConfigSchemaViolation;
 use Gacela\Framework\Event\Config\ConfigInitializedEvent;
 use Gacela\Framework\Event\Config\ConfigKeyNotFoundEvent;
 use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
@@ -40,6 +42,8 @@ final class Config implements ConfigInterface
     private bool $initialized = false;
 
     private ?string $cacheDir = null;
+
+    private ?ConfigSchema $configSchema = null;
 
     private function __construct(
         private readonly SetupGacelaInterface $setup,
@@ -265,17 +269,45 @@ final class Config implements ConfigInterface
     {
         $this->configFactory = null;
 
+        // Declared defaults come first: a key a source provides is that
+        // source's, and a key nobody provides is the declaration's.
         /** @psalm-suppress DuplicateArrayKey */
         $this->config = [
+            ...$this->configSchema()->defaults(),
             ...$this->loadMergedConfigValues(),
             ...$this->setup->getConfigKeyValues(),
         ];
 
         $this->initialized = true;
 
+        if ($this->setup->shouldValidateConfigSchemaOnBoot()) {
+            $this->assertConfigMatchesSchema();
+        }
+
         if (self::shouldDispatch(ConfigInitializedEvent::class)) {
             self::dispatchEvent(new ConfigInitializedEvent(count($this->config)));
         }
+    }
+
+    /**
+     * What the application declared its configuration should contain.
+     *
+     * Built once and kept: `validate:config`, `doctor` and `debug:config` all
+     * ask the same question of the same declaration.
+     */
+    public function configSchema(): ConfigSchema
+    {
+        return $this->configSchema ??= ConfigSchema::fromArray($this->setup->getConfigSchema());
+    }
+
+    /**
+     * Every declared key the merged configuration does not satisfy.
+     *
+     * @return list<ConfigSchemaViolation>
+     */
+    public function configSchemaViolations(): array
+    {
+        return $this->configSchema()->violations($this->getAllValues());
     }
 
     /**
@@ -358,6 +390,24 @@ final class Config implements ConfigInterface
     public function hasKey(string $key): bool
     {
         return array_key_exists($key, $this->config);
+    }
+
+    /**
+     * @throws ConfigException
+     */
+    private function assertConfigMatchesSchema(): void
+    {
+        $violations = $this->configSchema()->violations($this->config);
+        if ($violations === []) {
+            return;
+        }
+
+        $messages = [];
+        foreach ($violations as $violation) {
+            $messages[] = $violation->message;
+        }
+
+        throw ConfigException::schemaViolations($messages);
     }
 
     private function notifyKeyNotFound(string $key): void

--- a/src/Framework/Config/Schema/ConfigSchema.php
+++ b/src/Framework/Config/Schema/ConfigSchema.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\Schema;
+
+use function array_key_exists;
+use function array_keys;
+
+/**
+ * What the application's configuration is expected to contain.
+ *
+ * `validate:config` checks the wiring -- bindings, cycles -- and nothing checked
+ * the configuration itself, so a missing or misspelled key surfaced as a runtime
+ * failure in whichever environment lacked it: usually production, usually far
+ * from the file that should have carried it.
+ *
+ * Declaring it once turns that into something three existing commands can ask
+ * about before anything runs, and it is not on the hot path: bootstrap only
+ * takes the defaults, and the checking is opt-in.
+ */
+final class ConfigSchema
+{
+    /**
+     * @param array<string, ConfigType> $types
+     */
+    private function __construct(
+        private readonly array $types,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @param array<string, mixed> $schema key => ConfigType
+     *
+     * @throws MalformedConfigSchemaException
+     */
+    public static function fromArray(array $schema): self
+    {
+        $types = [];
+
+        /** @var mixed $type */
+        foreach ($schema as $key => $type) {
+            if (!$type instanceof ConfigType) {
+                throw MalformedConfigSchemaException::notAType($key);
+            }
+
+            self::assertDeclarationIsCoherent($key, $type);
+            $types[$key] = $type;
+        }
+
+        return new self($types);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->types === [];
+    }
+
+    public function declares(string $key): bool
+    {
+        return array_key_exists($key, $this->types);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function declaredKeys(): array
+    {
+        return array_keys($this->types);
+    }
+
+    /**
+     * Every key that does not match its declaration, in the order declared.
+     *
+     * @param array<string, mixed> $values the merged configuration, as an
+     *                                     environment would see it
+     *
+     * @return list<ConfigSchemaViolation>
+     */
+    public function violations(array $values): array
+    {
+        $violations = [];
+
+        foreach ($this->types as $key => $type) {
+            if (!array_key_exists($key, $values)) {
+                if ($type->isRequired) {
+                    $violations[] = ConfigSchemaViolation::missing($key, $type);
+                }
+
+                continue;
+            }
+
+            if (!$type->accepts($values[$key])) {
+                $violations[] = ConfigSchemaViolation::wrongType($key, $type, $values[$key]);
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * The declared defaults, for the keys that carry one.
+     *
+     * @return array<string, mixed>
+     */
+    public function defaults(): array
+    {
+        /** @var array<string, mixed> $defaults */
+        $defaults = [];
+
+        foreach ($this->types as $key => $type) {
+            if ($type->hasDefault) {
+                /** @psalm-suppress MixedAssignment a declared default is whatever the key is declared to be */
+                $defaults[$key] = $type->default;
+            }
+        }
+
+        return $defaults;
+    }
+
+    /**
+     * @throws MalformedConfigSchemaException
+     */
+    private static function assertDeclarationIsCoherent(string $key, ConfigType $type): void
+    {
+        if (!$type->hasDefault) {
+            return;
+        }
+
+        if ($type->isRequired) {
+            throw MalformedConfigSchemaException::requiredWithDefault($key);
+        }
+
+        if (!$type->accepts($type->default)) {
+            throw MalformedConfigSchemaException::defaultOfWrongType($key, $type, $type->default);
+        }
+    }
+}

--- a/src/Framework/Config/Schema/ConfigSchemaViolation.php
+++ b/src/Framework/Config/Schema/ConfigSchemaViolation.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\Schema;
+
+use function sprintf;
+
+/**
+ * One configuration key that does not match what was declared for it.
+ *
+ * The message is built where the declaration is known, so whoever reports it --
+ * `validate:config`, `doctor`, a boot-time check -- does not have to rebuild the
+ * same sentence three times.
+ */
+final class ConfigSchemaViolation
+{
+    private function __construct(
+        public readonly string $key,
+        public readonly string $message,
+    ) {
+    }
+
+    public static function missing(string $key, ConfigType $type): self
+    {
+        return new self($key, self::withDescription(
+            sprintf('"%s" is required but missing: no config source provides it (expected %s)', $key, $type->name),
+            $type,
+        ));
+    }
+
+    public static function wrongType(string $key, ConfigType $type, mixed $value): self
+    {
+        return new self($key, self::withDescription(
+            sprintf('"%s" is declared %s but is %s', $key, $type->name, $type->describeValue($value)),
+            $type,
+        ));
+    }
+
+    private static function withDescription(string $message, ConfigType $type): string
+    {
+        return $type->description === '' ? $message : $message . ' — ' . $type->description;
+    }
+}

--- a/src/Framework/Config/Schema/ConfigType.php
+++ b/src/Framework/Config/Schema/ConfigType.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\Schema;
+
+use function get_debug_type;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+
+/**
+ * What one configuration key is expected to be.
+ *
+ * Every call site already knows: `getInt('retries')` says so, and so does the
+ * code that reads it. What nothing knew until now is whether the environment
+ * about to boot actually carries that key, in that shape -- so the expectation
+ * is written down once, where a command can read it before anything runs.
+ *
+ * Immutable: each refinement returns a new type, so a declaration cannot be
+ * changed from a distance by whoever else holds it.
+ */
+final class ConfigType
+{
+    public const STRING = 'string';
+
+    public const INT = 'int';
+
+    public const FLOAT = 'float';
+
+    public const BOOL = 'bool';
+
+    public const ARRAY = 'array';
+
+    private function __construct(
+        public readonly string $name,
+        public readonly bool $isRequired = false,
+        public readonly bool $hasDefault = false,
+        public readonly mixed $default = null,
+        public readonly string $description = '',
+    ) {
+    }
+
+    public static function string(): self
+    {
+        return new self(self::STRING);
+    }
+
+    public static function int(): self
+    {
+        return new self(self::INT);
+    }
+
+    public static function float(): self
+    {
+        return new self(self::FLOAT);
+    }
+
+    public static function bool(): self
+    {
+        return new self(self::BOOL);
+    }
+
+    public static function array(): self
+    {
+        return new self(self::ARRAY);
+    }
+
+    public function required(): self
+    {
+        return new self($this->name, true, $this->hasDefault, $this->default, $this->description);
+    }
+
+    public function default(mixed $default): self
+    {
+        return new self($this->name, $this->isRequired, true, $default, $this->description);
+    }
+
+    /**
+     * What the key is for, in the words of whoever declared it -- it travels
+     * into the violation, where "wrong type" alone leaves the reader guessing.
+     */
+    public function describe(string $description): self
+    {
+        return new self($this->name, $this->isRequired, $this->hasDefault, $this->default, $description);
+    }
+
+    public function accepts(mixed $value): bool
+    {
+        return match ($this->name) {
+            self::STRING => is_string($value),
+            self::INT => is_int($value),
+            // An int is a legitimate float: `timeout: 5` in a config file is
+            // about the value, not about php's literal syntax.
+            self::FLOAT => is_float($value) || is_int($value),
+            self::BOOL => is_bool($value),
+            default => is_array($value),
+        };
+    }
+
+    public function describeValue(mixed $value): string
+    {
+        return get_debug_type($value);
+    }
+}

--- a/src/Framework/Config/Schema/MalformedConfigSchemaException.php
+++ b/src/Framework/Config/Schema/MalformedConfigSchemaException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config\Schema;
+
+use RuntimeException;
+
+use function get_debug_type;
+use function sprintf;
+
+final class MalformedConfigSchemaException extends RuntimeException
+{
+    public static function notAType(string $key): self
+    {
+        return new self(sprintf(
+            'The schema entry for "%s" must be a %s, declared with ConfigType::string(), int(), float(), bool() or array().',
+            $key,
+            ConfigType::class,
+        ));
+    }
+
+    public static function defaultOfWrongType(string $key, ConfigType $type, mixed $default): self
+    {
+        return new self(sprintf(
+            'The default for "%s" is %s, but the key is declared %s.',
+            $key,
+            get_debug_type($default),
+            $type->name,
+        ));
+    }
+
+    public static function requiredWithDefault(string $key): self
+    {
+        return new self(sprintf(
+            '"%s" is both required and defaulted. A default is what makes an absent key legitimate, so requiring it as well is two answers to one question.',
+            $key,
+        ));
+    }
+}

--- a/src/Framework/Exception/ConfigException.php
+++ b/src/Framework/Exception/ConfigException.php
@@ -6,6 +6,7 @@ namespace Gacela\Framework\Exception;
 
 use RuntimeException;
 
+use function implode;
 use function sprintf;
 
 final class ConfigException extends RuntimeException
@@ -20,6 +21,17 @@ final class ConfigException extends RuntimeException
         $message .= ErrorSuggestionHelper::addHelpfulTip('config_error');
 
         return new self($message);
+    }
+
+    /**
+     * @param list<string> $violations
+     */
+    public static function schemaViolations(array $violations): self
+    {
+        return new self(sprintf(
+            "The configuration does not match the declared schema:\n- %s",
+            implode("\n- ", $violations),
+        ));
     }
 
     public static function invalidType(string $key, string $expectedType, string $actualType): self

--- a/tests/Feature/Console/ConfigSchema/ConfigSchemaCommandsTest.php
+++ b/tests/Feature/Console/ConfigSchema/ConfigSchemaCommandsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\ConfigSchema;
+
+use Closure;
+use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
+use Gacela\Console\Infrastructure\Command\DoctorCommand;
+use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Schema\ConfigType;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The three commands that read the declared schema, against the same
+ * declarations. They answer for different audiences -- a CI gate, a deploy
+ * gate, a person looking at a table -- and a schema that failed one and passed
+ * another would be worse than no schema.
+ */
+final class ConfigSchemaCommandsTest extends TestCase
+{
+    public function test_validate_config_fails_on_a_required_key_no_source_provides(): void
+    {
+        $tester = $this->execute(new ValidateConfigCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+        });
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('db.dsn', $tester->getDisplay());
+        self::assertStringContainsString('is required but missing', $tester->getDisplay());
+    }
+
+    public function test_validate_config_fails_on_a_value_of_the_wrong_type(): void
+    {
+        $tester = $this->execute(new ValidateConfigCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['retries' => ConfigType::int()->required()]);
+            $config->addAppConfigKeyValue('retries', 'three');
+        });
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('declared int but is string', $tester->getDisplay());
+    }
+
+    public function test_validate_config_passes_when_the_declaration_is_satisfied(): void
+    {
+        $tester = $this->execute(new ValidateConfigCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+            $config->addAppConfigKeyValue('db.dsn', 'sqlite::memory:');
+        });
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('1 declared key(s), all satisfied', $tester->getDisplay());
+    }
+
+    /**
+     * A green line about a check that never ran is worse than no line.
+     */
+    public function test_validate_config_says_no_schema_is_declared_rather_than_passing_one(): void
+    {
+        $tester = $this->execute(new ValidateConfigCommand(), static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('anything', 'goes');
+        });
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('No schema declared', $tester->getDisplay());
+    }
+
+    public function test_doctor_reports_the_unsatisfied_declaration(): void
+    {
+        $tester = $this->execute(new DoctorCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+        });
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('config schema', $tester->getDisplay());
+        self::assertStringContainsString('db.dsn', $tester->getDisplay());
+    }
+
+    public function test_doctor_stays_quiet_when_nothing_is_declared(): void
+    {
+        $tester = $this->execute(new DoctorCommand(), static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('anything', 'goes');
+        });
+
+        self::assertStringContainsString('no schema declared', $tester->getDisplay());
+    }
+
+    public function test_debug_config_marks_declared_undeclared_and_missing_keys(): void
+    {
+        $tester = $this->execute(new DebugConfigCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema([
+                'declared.key' => ConfigType::string()->required(),
+                'absent.key' => ConfigType::string()->required(),
+            ]);
+            $config->addAppConfigKeyValue('declared.key', 'here');
+            $config->addAppConfigKeyValue('undeclared.key', 'also here');
+        });
+
+        $display = $tester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertMatchesRegularExpression('/declared\.key\s*\|\s*here\s*\|\s*declared/', $display);
+        self::assertMatchesRegularExpression('/undeclared\.key\s*\|\s*also here\s*\|\s*undeclared/', $display);
+        self::assertMatchesRegularExpression('/absent\.key\s*\|.*\|\s*missing/', $display);
+    }
+
+    /**
+     * A declared default is not a missing key: it is the value the declaration
+     * itself provides.
+     */
+    public function test_debug_config_shows_a_defaulted_key_as_a_value(): void
+    {
+        $tester = $this->execute(new DebugConfigCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['retries' => ConfigType::int()->default(3)]);
+        });
+
+        self::assertMatchesRegularExpression('/retries\s*\|\s*3\s*\|\s*declared/', $tester->getDisplay());
+    }
+
+    private function execute(Command $command, Closure $configFn): CommandTester
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
+            $config->resetInMemoryCache();
+            $configFn($config);
+        });
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        return $tester;
+    }
+}

--- a/tests/Feature/Console/ConfigSchema/ConfigSchemaCommandsTest.php
+++ b/tests/Feature/Console/ConfigSchema/ConfigSchemaCommandsTest.php
@@ -80,6 +80,17 @@ final class ConfigSchemaCommandsTest extends TestCase
         self::assertStringContainsString('db.dsn', $tester->getDisplay());
     }
 
+    public function test_doctor_counts_the_keys_it_checked(): void
+    {
+        $tester = $this->execute(new DoctorCommand(), static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+            $config->addAppConfigKeyValue('db.dsn', 'sqlite::memory:');
+        });
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('1 declared key(s), all satisfied', $tester->getDisplay());
+    }
+
     public function test_doctor_stays_quiet_when_nothing_is_declared(): void
     {
         $tester = $this->execute(new DoctorCommand(), static function (GacelaConfig $config): void {

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -70,6 +70,7 @@ final class DoctorCommandTest extends TestCase
             '✓ cache staleness',
             '✓ suffix configuration',
             '✓ pillar filenames',
+            '✓ config schema',
             '✓ All checks passed',
         ], $this->statusLinesOf($tester));
     }
@@ -81,7 +82,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
         // The registered check runs after the built-in ones, and its detail is shown.
-        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[3]);
+        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[4]);
         self::assertStringContainsString('FakeHealthCheck ran', $tester->getDisplay());
     }
 

--- a/tests/Integration/Framework/Config/ConfigSchemaBootstrapTest.php
+++ b/tests/Integration/Framework/Config/ConfigSchemaBootstrapTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Config;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Config\Schema\ConfigType;
+use Gacela\Framework\Exception\ConfigException;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigSchemaBootstrapTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+    }
+
+    public function test_a_declared_default_fills_a_key_no_source_provides(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['retries' => ConfigType::int()->default(3)]);
+        });
+
+        self::assertSame(3, Config::getInstance()->getInt('retries'));
+    }
+
+    public function test_a_provided_value_wins_over_the_declared_default(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['retries' => ConfigType::int()->default(3)]);
+            $config->addAppConfigKeyValue('retries', 7);
+        });
+
+        self::assertSame(7, Config::getInstance()->getInt('retries'));
+    }
+
+    public function test_nothing_is_checked_while_booting_by_default(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+        });
+
+        // The declaration is unsatisfied, and booting is not where that is
+        // reported: validate:config and doctor are.
+        self::assertCount(1, Config::getInstance()->configSchemaViolations());
+    }
+
+    public function test_the_boot_check_fails_loudly_when_it_is_asked_for(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('db.dsn');
+
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+            $config->validateConfigSchemaOnBoot();
+        });
+
+        Config::getInstance()->init();
+    }
+
+    public function test_the_boot_check_stays_quiet_when_the_declaration_is_satisfied(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['db.dsn' => ConfigType::string()->required()]);
+            $config->addAppConfigKeyValue('db.dsn', 'sqlite::memory:');
+            $config->validateConfigSchemaOnBoot();
+        });
+
+        Config::getInstance()->init();
+
+        self::assertSame('sqlite::memory:', Config::getInstance()->getString('db.dsn'));
+    }
+
+    public function test_declaring_twice_merges_per_key(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['a' => ConfigType::string()->required()]);
+            $config->declareConfigSchema(['b' => ConfigType::int()->default(1)]);
+        });
+
+        self::assertSame(['a', 'b'], Config::getInstance()->configSchema()->declaredKeys());
+    }
+
+    public function test_the_later_declaration_of_one_key_wins(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['retries' => ConfigType::string()->required()]);
+            $config->declareConfigSchema(['retries' => ConfigType::int()->default(3)]);
+        });
+
+        self::assertSame(3, Config::getInstance()->getInt('retries'));
+        self::assertSame([], Config::getInstance()->configSchemaViolations());
+    }
+
+    public function test_a_violation_names_the_key_and_both_types(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->declareConfigSchema(['retries' => ConfigType::int()->required()]);
+            $config->addAppConfigKeyValue('retries', 'three');
+        });
+
+        $violations = Config::getInstance()->configSchemaViolations();
+
+        self::assertCount(1, $violations);
+        self::assertSame('retries', $violations[0]->key);
+        self::assertStringContainsString('int', $violations[0]->message);
+        self::assertStringContainsString('string', $violations[0]->message);
+    }
+
+    public function test_a_project_that_declares_nothing_is_unaffected(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('anything', 'goes');
+        });
+
+        self::assertTrue(Config::getInstance()->configSchema()->isEmpty());
+        self::assertSame([], Config::getInstance()->configSchemaViolations());
+    }
+
+    private function bootstrap(callable $configFn): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
+            $config->resetInMemoryCache();
+            $configFn($config);
+        });
+    }
+}

--- a/tests/Unit/Framework/Config/Schema/ConfigSchemaTest.php
+++ b/tests/Unit/Framework/Config/Schema/ConfigSchemaTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\Schema;
+
+use Gacela\Framework\Config\Schema\ConfigSchema;
+use Gacela\Framework\Config\Schema\ConfigType;
+use Gacela\Framework\Config\Schema\MalformedConfigSchemaException;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigSchemaTest extends TestCase
+{
+    public function test_an_empty_schema_declares_nothing_and_finds_nothing(): void
+    {
+        $schema = ConfigSchema::empty();
+
+        self::assertTrue($schema->isEmpty());
+        self::assertSame([], $schema->violations(['anything' => 'goes']));
+        self::assertSame([], $schema->defaults());
+    }
+
+    public function test_a_required_key_that_no_source_provides_is_a_violation(): void
+    {
+        $violations = $this->schema(['db.dsn' => ConfigType::string()->required()])->violations([]);
+
+        self::assertCount(1, $violations);
+        self::assertSame('db.dsn', $violations[0]->key);
+        self::assertStringContainsString('missing', $violations[0]->message);
+    }
+
+    public function test_a_required_key_that_is_provided_is_not_a_violation(): void
+    {
+        self::assertSame(
+            [],
+            $this->schema(['db.dsn' => ConfigType::string()->required()])->violations(['db.dsn' => 'sqlite::memory:']),
+        );
+    }
+
+    public function test_a_value_of_the_wrong_type_is_a_violation_naming_both_types(): void
+    {
+        $violations = $this->schema(['retries' => ConfigType::int()->required()])->violations(['retries' => 'three']);
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('int', $violations[0]->message);
+        self::assertStringContainsString('string', $violations[0]->message);
+    }
+
+    public function test_an_optional_key_that_is_absent_is_not_a_violation(): void
+    {
+        self::assertSame([], $this->schema(['retries' => ConfigType::int()])->violations([]));
+    }
+
+    /**
+     * An optional key is optional about being *there*, not about what it is.
+     */
+    public function test_an_optional_key_that_is_present_is_still_type_checked(): void
+    {
+        self::assertCount(1, $this->schema(['retries' => ConfigType::int()])->violations(['retries' => 'three']));
+    }
+
+    public function test_every_declared_type_accepts_its_own_values(): void
+    {
+        $schema = $this->schema([
+            'a' => ConfigType::string(),
+            'b' => ConfigType::int(),
+            'c' => ConfigType::float(),
+            'd' => ConfigType::bool(),
+            'e' => ConfigType::array(),
+        ]);
+
+        self::assertSame([], $schema->violations([
+            'a' => 'text',
+            'b' => 1,
+            'c' => 1.5,
+            'd' => false,
+            'e' => ['x'],
+        ]));
+    }
+
+    /**
+     * `timeout: 5` in a config file is an int, and refusing it for a float would
+     * be a rule about php's literal syntax rather than about the value.
+     */
+    public function test_a_float_accepts_an_int(): void
+    {
+        self::assertSame([], $this->schema(['timeout' => ConfigType::float()])->violations(['timeout' => 5]));
+    }
+
+    public function test_an_int_does_not_accept_a_float(): void
+    {
+        self::assertCount(1, $this->schema(['retries' => ConfigType::int()])->violations(['retries' => 1.5]));
+    }
+
+    public function test_a_bool_does_not_accept_the_string_that_looks_like_one(): void
+    {
+        self::assertCount(1, $this->schema(['debug' => ConfigType::bool()])->violations(['debug' => 'true']));
+    }
+
+    public function test_every_violation_is_reported_not_only_the_first(): void
+    {
+        $violations = $this->schema([
+            'a' => ConfigType::string()->required(),
+            'b' => ConfigType::int()->required(),
+        ])->violations([]);
+
+        self::assertCount(2, $violations);
+    }
+
+    public function test_a_default_is_offered_for_a_key_no_source_provides(): void
+    {
+        self::assertSame(['retries' => 3], $this->schema(['retries' => ConfigType::int()->default(3)])->defaults());
+    }
+
+    public function test_a_key_without_a_default_offers_none(): void
+    {
+        self::assertSame([], $this->schema(['retries' => ConfigType::int()])->defaults());
+    }
+
+    /**
+     * A default is what makes an absent key legitimate; requiring it as well
+     * would be two answers to the same question.
+     */
+    public function test_a_defaulted_key_is_never_missing(): void
+    {
+        self::assertSame([], $this->schema(['retries' => ConfigType::int()->default(3)])->violations([]));
+    }
+
+    public function test_a_default_of_the_wrong_type_is_refused_when_the_schema_is_declared(): void
+    {
+        $this->expectException(MalformedConfigSchemaException::class);
+        $this->expectExceptionMessage('retries');
+
+        $this->schema(['retries' => ConfigType::int()->default('three')]);
+    }
+
+    public function test_a_required_key_cannot_also_carry_a_default(): void
+    {
+        $this->expectException(MalformedConfigSchemaException::class);
+
+        $this->schema(['retries' => ConfigType::int()->required()->default(3)]);
+    }
+
+    public function test_a_declaration_that_is_not_a_type_is_refused(): void
+    {
+        $this->expectException(MalformedConfigSchemaException::class);
+        $this->expectExceptionMessage('retries');
+
+        /** @psalm-suppress InvalidArgument */
+        ConfigSchema::fromArray(['retries' => 'int']);
+    }
+
+    public function test_it_knows_which_keys_it_declares(): void
+    {
+        $schema = $this->schema(['a' => ConfigType::string(), 'b' => ConfigType::int()]);
+
+        self::assertSame(['a', 'b'], $schema->declaredKeys());
+        self::assertTrue($schema->declares('a'));
+        self::assertFalse($schema->declares('c'));
+    }
+
+    /**
+     * The description is what a violation can say beyond "wrong type", so it
+     * has to survive into the message.
+     */
+    public function test_a_description_is_carried_into_the_violation(): void
+    {
+        $violations = $this->schema([
+            'features' => ConfigType::array()->required()->describe('feature flags, keyed by name'),
+        ])->violations([]);
+
+        self::assertStringContainsString('feature flags, keyed by name', $violations[0]->message);
+    }
+
+    /**
+     * @param array<string, ConfigType> $schema
+     */
+    private function schema(array $schema): ConfigSchema
+    {
+        return ConfigSchema::fromArray($schema);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`validate:config` checked the *wiring* — bindings, cycles. Nothing checked the
configuration itself, so a missing or misspelled key surfaced as a runtime
failure in whichever environment lacked it: usually production, usually far from
the file that should have carried it.

Every call site already knows what it expects (`getInt('retries')` says so). This
writes that expectation down once, where the commands you already run can read it
before anything boots.

## 🔖 Changes

- `GacelaConfig::declareConfigSchema()` with `ConfigType::string()|int()|float()|bool()|array()`, each `required()`, `default()` or `describe()`
- `validate:config` and `doctor` fail on an unsatisfied declaration; both say "no schema declared" rather than reporting a pass they never made
- `debug:config` marks every key `declared`, `undeclared` or `missing`
- Declared defaults are applied at boot and never override a provided value
- `validateConfigSchemaOnBoot()` for local development; off by default, so bootstrap does no work a project did not ask for

Closes #655