### PR TITLE
feat(testing): replace another module with a double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Replace another module in a test with `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()`, dropped again in `tearDown()`
+
 - Declare what the configuration must contain with `declareConfigSchema()`, read by `validate:config`, `doctor` and `debug:config`
 - Fill a declared default when no config source provides the key, without ever overriding one that does
 - Mark every key `declared`, `undeclared` or `missing` in `debug:config`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,42 @@ If you only need the reset helpers inside an existing test hierarchy, use the
 [`ContainerFixture`](../src/Framework/Testing/ContainerFixture.php) trait
 directly — `GacelaTestCase` builds on it.
 
+## Replacing another module
+
+Testing module A in isolation means replacing module B. A container binding only
+works when B's Facade arrives through a Provider, and a consumer that writes
+`new BlogFacade()` leaves nothing to bind — so the seam is the **Factory** every
+Facade resolves:
+
+```php
+$this->swapModuleFactory(BlogFacade::class, new class() extends BlogFactory {
+    public function createPostReader(): PostReader
+    {
+        return new InMemoryPostReader(['a post']);
+    }
+});
+
+(new CheckoutFacade())->summary();  // reaches the double, not the real Blog
+```
+
+- `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()` all take
+  the **Facade** class: that is the name a consumer already knows, and the one
+  the resolver derives a module's pillars from.
+- Any object of the right pillar type works — an anonymous subclass, or a PHPUnit
+  stub (`$this->createStub(BlogFactory::class)`).
+- The swap survives repeated resolutions, and applies to a module that was
+  already resolved earlier in the same test.
+- Swapping the same module twice keeps the last double.
+- Every swap is dropped in `tearDown()`, so the next test sees the real module
+  again whatever order the suite runs in.
+
+Naming a class that is not a Facade — the Factory itself, or a typo — throws a
+`ModuleDoubleException` rather than registering a double nothing would ever read.
+
+This replaces reaching into `AnonymousGlobal::overrideExistingResolvedClass()`,
+which needed the resolver's key format and left the Facade's memoised Factory in
+place.
+
 ## Scaffolding a testable module
 
 `make:module` can scaffold a module already wired for testing:

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Gacela\Framework\Testing;
 
 use FilesystemIterator;
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\Cache\InMemoryCache;
+use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use RecursiveDirectoryIterator;
@@ -16,9 +21,11 @@ use ReflectionProperty;
 use RuntimeException;
 use SplFileInfo;
 
+use function class_exists;
 use function is_array;
 use function is_dir;
 use function is_string;
+use function is_subclass_of;
 use function register_shutdown_function;
 use function sprintf;
 
@@ -81,6 +88,53 @@ trait ContainerFixture
     protected function resetGacelaSingletons(): void
     {
         $this->resetContainer();
+    }
+
+    /**
+     * Resolve another module's Factory to a double, for as long as this test
+     * runs.
+     *
+     * Testing module A in isolation means replacing module B, and until now
+     * that was either a container binding -- which only works when B arrives
+     * through a Provider -- or a reach into `AnonymousGlobal` with a key format
+     * the caller had to know. The Factory is the seam: a consumer constructs
+     * B's Facade itself, and every Facade asks the resolver for its Factory.
+     *
+     * ```php
+     * $this->swapModuleFactory(BlogFacade::class, new class() extends BlogFactory {
+     *     public function createPostReader(): PostReader { ... }
+     * });
+     * ```
+     *
+     * The swap is dropped by {@see resetContainer()}, which `GacelaTestCase`
+     * already runs in `tearDown()`.
+     *
+     * @param class-string<AbstractFacade> $facadeClass the module to replace, named
+     *                                                  by the class its consumers use
+     */
+    protected function swapModuleFactory(string $facadeClass, AbstractFactory $double): void
+    {
+        $this->swapModulePillar($facadeClass, 'Factory', $double);
+    }
+
+    /**
+     * @see swapModuleFactory() for how the swap works and when it is dropped
+     *
+     * @param class-string<AbstractFacade> $facadeClass
+     */
+    protected function swapModuleConfig(string $facadeClass, AbstractConfig $double): void
+    {
+        $this->swapModulePillar($facadeClass, 'Config', $double);
+    }
+
+    /**
+     * @see swapModuleFactory() for how the swap works and when it is dropped
+     *
+     * @param class-string<AbstractFacade> $facadeClass
+     */
+    protected function swapModuleProvider(string $facadeClass, AbstractProvider $double): void
+    {
+        $this->swapModulePillar($facadeClass, 'Provider', $double);
     }
 
     /**
@@ -219,6 +273,30 @@ trait ContainerFixture
         if ($cacheDir !== null) {
             self::writePrivateProperty($config, 'cacheDir', $cacheDir);
         }
+    }
+
+    /**
+     * The resolver keys a pillar by its module's namespace and the pillar type,
+     * so a double is registered under the same key the module's own class would
+     * have taken -- whatever that class is named, and whether or not the module
+     * has one at all.
+     *
+     * @param class-string<AbstractFacade> $facadeClass
+     */
+    private function swapModulePillar(string $facadeClass, string $resolvableType, object $double): void
+    {
+        if (!class_exists($facadeClass) || !is_subclass_of($facadeClass, AbstractFacade::class)) {
+            throw ModuleDoubleException::notAFacade($facadeClass);
+        }
+
+        $namespace = (new ReflectionClass($facadeClass))->getNamespaceName();
+        AnonymousGlobal::overrideExistingResolvedClass($namespace . '\\' . $resolvableType, $double);
+
+        // A Facade resolved before the swap holds its Factory in a static, and
+        // a Factory holds the container built from its Provider and Config. A
+        // swap nothing re-reads is a swap that silently did not happen.
+        AbstractFacade::resetCache();
+        AbstractFactory::resetCache();
     }
 
     private function registerContainerTempDirsCleanup(): void

--- a/src/Framework/Testing/ModuleDoubleException.php
+++ b/src/Framework/Testing/ModuleDoubleException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Testing;
+
+use Gacela\Framework\AbstractFacade;
+use RuntimeException;
+
+use function class_exists;
+use function sprintf;
+
+final class ModuleDoubleException extends RuntimeException
+{
+    public static function notAFacade(string $className): self
+    {
+        return new self(sprintf(
+            class_exists($className)
+                ? '"%s" is not a %s. Name the module by the Facade its consumers use: that is the class the resolver derives the module\'s pillars from.'
+                : 'There is no class "%s". Name the module by the Facade its consumers use, so the double replaces the pillar that Facade resolves. (%s)',
+            $className,
+            AbstractFacade::class,
+        ));
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/Domain/Greeter.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/Domain/Greeter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\Domain;
+
+final class Greeter
+{
+    public function __construct(
+        private readonly string $greeting,
+    ) {
+    }
+
+    public function greet(): string
+    {
+        return $this->greeting;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingConfig.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting;
+
+use Gacela\Framework\AbstractConfig;
+
+/**
+ * Not final: see {@see GreetingFactory}.
+ */
+class GreetingConfig extends AbstractConfig
+{
+    public function language(): string
+    {
+        return 'en';
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingFacade.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingFacade.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting;
+
+/**
+ * The module a test wants to replace, reached the way a consumer reaches one.
+ *
+ * @extends \Gacela\Framework\AbstractFacade<GreetingFactory>
+ */
+final class GreetingFacade extends \Gacela\Framework\AbstractFacade
+{
+    public function greet(): string
+    {
+        return $this->getFactory()->createGreeter()->greet();
+    }
+
+    public function language(): string
+    {
+        return $this->getFactory()->language();
+    }
+
+    public function providedGreeting(): string
+    {
+        return $this->getFactory()->providedGreeting();
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingFactory.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\Domain\Greeter;
+
+/**
+ * Not final on purpose: a fixture exists to be replaced, and one of the ways a
+ * test replaces it is with a PHPUnit mock, which cannot extend a final class.
+ *
+ * @extends AbstractFactory<GreetingConfig>
+ */
+class GreetingFactory extends AbstractFactory
+{
+    public function createGreeter(): Greeter
+    {
+        return new Greeter('hello');
+    }
+
+    public function language(): string
+    {
+        return $this->getConfig()->language();
+    }
+
+    public function providedGreeting(): string
+    {
+        return (string)$this->getProvidedDependency(GreetingProvider::GREETING);
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingProvider.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Greeting/GreetingProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Not final: see {@see GreetingFactory}.
+ */
+class GreetingProvider extends AbstractProvider
+{
+    public const GREETING = 'GREETING';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::GREETING, 'hello from the provider');
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoublesTest.php
+++ b/tests/Integration/Framework/Testing/ModuleDoublesTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing;
+
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Testing\GacelaTestCase;
+use Gacela\Framework\Testing\ModuleDoubleException;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\Domain\Greeter;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingConfig;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingFactory;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingProvider;
+
+/**
+ * Replacing another module is the most common thing a test of a modular
+ * application does, and the framework had no supported way to do it.
+ */
+final class ModuleDoublesTest extends GacelaTestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/ModuleDoubleFixture';
+
+    public function test_a_swapped_factory_is_what_the_facade_uses(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->swapModuleFactory(GreetingFacade::class, $this->factoryDouble('swapped'));
+
+        self::assertSame('swapped', (new GreetingFacade())->greet());
+    }
+
+    /**
+     * The Facade keeps its Factory in a static, so a module already touched
+     * would otherwise keep answering with the real one -- the failure mode that
+     * made the underlying `AnonymousGlobal` call so easy to get wrong.
+     */
+    public function test_a_module_resolved_before_the_swap_still_picks_the_double_up(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        self::assertSame('hello', (new GreetingFacade())->greet(), 'precondition: the real module answers');
+
+        $this->swapModuleFactory(GreetingFacade::class, $this->factoryDouble('swapped'));
+
+        self::assertSame('swapped', (new GreetingFacade())->greet());
+    }
+
+    public function test_the_swap_holds_across_repeated_resolutions(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->swapModuleFactory(GreetingFacade::class, $this->factoryDouble('swapped'));
+
+        self::assertSame('swapped', (new GreetingFacade())->greet());
+        self::assertSame('swapped', (new GreetingFacade())->greet());
+        self::assertSame('swapped', (new GreetingFacade())->greet());
+    }
+
+    public function test_the_last_swap_of_a_module_wins(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->swapModuleFactory(GreetingFacade::class, $this->factoryDouble('first'));
+        $this->swapModuleFactory(GreetingFacade::class, $this->factoryDouble('second'));
+
+        self::assertSame('second', (new GreetingFacade())->greet());
+    }
+
+    /**
+     * Half of the isolation claim, and it has to hold in either execution
+     * order: this suite runs with a random seed.
+     *
+     * @see test_a_swapped_factory_is_what_the_facade_uses for the test that swaps
+     */
+    public function test_another_test_in_this_process_still_sees_the_real_module(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        self::assertSame('hello', (new GreetingFacade())->greet());
+    }
+
+    public function test_a_phpunit_test_double_is_accepted(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $double = $this->createStub(GreetingFactory::class);
+        $double->method('createGreeter')->willReturn(new Greeter('mocked'));
+
+        $this->swapModuleFactory(GreetingFacade::class, $double);
+
+        self::assertSame('mocked', (new GreetingFacade())->greet());
+    }
+
+    public function test_a_swapped_config_is_what_the_factory_reads(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->swapModuleConfig(GreetingFacade::class, new class() extends GreetingConfig {
+            public function language(): string
+            {
+                return 'eo';
+            }
+        });
+
+        self::assertSame('eo', (new GreetingFacade())->language());
+    }
+
+    public function test_a_swapped_provider_is_what_wires_the_module(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->swapModuleProvider(GreetingFacade::class, new class() extends GreetingProvider {
+            public function provideModuleDependencies(Container $container): void
+            {
+                $container->set(self::GREETING, 'from the swapped provider');
+            }
+        });
+
+        self::assertSame('from the swapped provider', (new GreetingFacade())->providedGreeting());
+    }
+
+    public function test_swapping_a_class_that_is_not_a_facade_fails_loudly(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->expectException(ModuleDoubleException::class);
+        $this->expectExceptionMessage(GreetingFactory::class);
+
+        /** @psalm-suppress InvalidArgument the wrong pillar is exactly the mistake under test */
+        $this->swapModuleFactory(GreetingFactory::class, $this->factoryDouble('never used'));
+    }
+
+    public function test_swapping_a_class_that_does_not_exist_fails_loudly(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        $this->expectException(ModuleDoubleException::class);
+        $this->expectExceptionMessage('There is no class');
+
+        /** @psalm-suppress ArgumentTypeCoercion,UndefinedClass a typo is the mistake under test */
+        $this->swapModuleFactory('App\Nope\NopeFacade', $this->factoryDouble('never used'));
+    }
+
+    private function factoryDouble(string $greeting): GreetingFactory
+    {
+        return new class($greeting) extends GreetingFactory {
+            public function __construct(
+                private readonly string $greeting,
+            ) {
+            }
+
+            public function createGreeter(): Greeter
+            {
+                return new Greeter($this->greeting);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 📚 Description

Testing module A in isolation means replacing module B — the most common test in
a modular application, and the one the framework had no supported way to write.

A container binding only works when B's Facade arrives through a Provider, and a
consumer that writes `new BlogFacade()` leaves nothing to bind. The remaining
route was `AnonymousGlobal::overrideExistingResolvedClass()`: undocumented in
`docs/testing.md`, keyed by a format the caller had to know, and defeated by the
Factory the Facade memoises in a static — a swap that silently did not happen.

## 🔖 Changes

- `swapModuleFactory()`, `swapModuleConfig()`, `swapModuleProvider()` on `ContainerFixture`, so `GacelaTestCase` and any custom base class both get them
- Each takes the **Facade** class: the name a consumer already knows, and the one the resolver derives a module's pillars from
- The Facade's and Factory's memoised state is dropped on swap, so a module resolved earlier in the test still picks the double up
- Naming a non-Facade class or a typo throws `ModuleDoubleException` instead of registering a double nothing reads
- Swaps are dropped in `tearDown()`; isolation verified under four random seeds

Closes #656