### PR TITLE
feat(symfony-bridge): a bundle, not just a compiler pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Register `GacelaBundle` in a Symfony application: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
+
 - Replace another module in a test with `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()`, dropped again in `tearDown()`
 
 - Declare what the configuration must contain with `declareConfigSchema()`, read by `validate:config`, `doctor` and `debug:config`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ reach *that* from *here*". [`docs/`](docs/README.md) is the full index; the rest
 - [Testing](docs/testing.md)
 - [Opcache preload](docs/opcache-preload.md) and [production performance](docs/production-performance.md)
 - Full reference: [gacela-project.com](https://gacela-project.com/)
+- [Symfony bundle](symfony-bridge/README.md) — bootstrap Gacela from the kernel, reach Symfony services, `bin/console gacela:*`
 - Examples:
   - [gacela-example](https://github.com/gacela-project/gacela-example)
   - [symfony-gacela-example](https://github.com/gacela-project/symfony-gacela-example) — Gacela with Symfony 7.4

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,10 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^12.5",
         "psalm/plugin-phpunit": "^0.19.7",
+        "symfony/config": "^7.0 || ^8.0",
         "symfony/console": "^7.0 || ^8.0",
         "symfony/dependency-injection": "^7.0 || ^8.0",
+        "symfony/http-kernel": "^7.0 || ^8.0",
         "symfony/var-dumper": "^7.0 || ^8.0",
         "vimeo/psalm": "^6.16"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d91bcce59c6ef4718c1869c1e0b6e49",
+    "content-hash": "37bdaa889cb7d1d89db2024bf1cdc71d",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -7022,6 +7022,85 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/config",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "e896f5e874e6983d0a098f554ca82a08a924c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e896f5e874e6983d0a098f554ca82a08a924c298",
+                "reference": "e896f5e874e6983d0a098f554ca82a08a924c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1|^8.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-30T15:04:16+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v7.4.16",
             "source": {
@@ -7273,6 +7352,88 @@
                 }
             ],
             "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v7.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "d49f6a19f326db41ae7103bdc38e3eb35a791261"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/d49f6a19f326db41ae7103bdc38e3eb35a791261",
+                "reference": "d49f6a19f326db41ae7103bdc38e3eb35a791261",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/polyfill-php85": "^1.32",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "conflict": {
+                "symfony/deprecation-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/webpack-encore-bundle": "^1.0|^2.0"
+            },
+            "bin": [
+                "Resources/bin/patch-type-declarations"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to manage errors and ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-21T15:13:06+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -7576,6 +7737,207 @@
                 }
             ],
             "time": "2026-06-27T08:31:18+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "b676451bb638e99a7d34d8a2be90406822e301eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b676451bb638e99a7d34d8a2be90406822e301eb",
+                "reference": "b676451bb638e99a7d34d8a2be90406822e301eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Defines an object-oriented layer for the HTTP specification",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-07T11:50:27+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "f5e728670fa2218ae8be8ea91f2b44b7d6e5304c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f5e728670fa2218ae8be8ea91f2b44b7d6e5304c",
+                "reference": "f5e728670fa2218ae8be8ea91f2b44b7d6e5304c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<6.4",
+                "symfony/cache": "<6.4",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<6.4",
+                "symfony/flex": "<2.10",
+                "symfony/form": "<6.4",
+                "symfony/http-client": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/mailer": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/translation-contracts": "<2.5",
+                "symfony/twig-bridge": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/var-dumper": "<6.4",
+                "twig/twig": "<3.12"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/css-selector": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
+                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^7.1|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^7.1|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
+                "twig/twig": "^3.12|^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a structured process for converting a Request into a Response",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-07T18:00:13+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/symfony-bridge/README.md
+++ b/symfony-bridge/README.md
@@ -1,26 +1,7 @@
 # gacela/symfony-bridge
 
-A thin compiler pass that teaches Symfony's DependencyInjection container to
-honor Gacela's `#[Inject]` attribute on Symfony-managed services (most often
-`Command` classes).
-
-## Problem
-
-Symfony autowires constructor parameters through its own container. Gacela's
-`#[Inject]` attribute is recognized by Gacela's container only. On a class
-managed by Symfony (e.g. a `Command`), writing `#[Inject]` has no effect —
-Symfony's autowire claims the parameter first, and Gacela never gets a chance
-to resolve it.
-
-## Solution
-
-Register `GacelaInjectCompilerPass` in your Symfony kernel. At compile time
-the pass walks every service definition, looks at each constructor parameter
-for `#[Inject]`, and rewrites the argument so Symfony resolves that slot via
-Gacela's container instead of its own autowire.
-
-If both containers claim the same parameter the pass fails the build with a
-clear message identifying the service and parameter.
+Gacela inside a Symfony application: the bundle does the wiring every
+Symfony/Gacela project would otherwise write by hand.
 
 ## Install
 
@@ -28,23 +9,104 @@ clear message identifying the service and parameter.
 composer require gacela-project/symfony-bridge
 ```
 
-## Use
+```php
+// config/bundles.php
+return [
+    Gacela\SymfonyBridge\GacelaBundle::class => ['all' => true],
+];
+```
+
+That alone gives you four things:
+
+1. **Gacela bootstrapped from the kernel** — with the project dir as the
+   application root, honouring `gacela.php`. Every boot bootstraps again, so a
+   kernel rebooted inside one process (functional tests do it constantly) runs
+   on its own configuration rather than the previous boot's.
+2. **Symfony services reachable from Gacela** — the ones you list, and only
+   those.
+3. **Gacela's console commands in `bin/console`**, under a `gacela:` prefix.
+4. **`cache:warmup` warms Gacela's caches too**, so a deploy has one warmup step
+   instead of two.
+
+Plus the `#[Inject]` compiler pass, described at the bottom.
+
+## Configuration
+
+```yaml
+# config/packages/gacela.yaml
+gacela:
+    app_root_dir: '%kernel.project_dir%'   # where gacela.php lives
+    cache_dir: '%kernel.cache_dir%/gacela'
+    file_cache: true
+    project_namespaces: ['App']
+    external_services:
+        logger: 'monolog.logger'
+        entity_manager: 'doctrine.orm.entity_manager'
+    register_commands: true
+    command_prefix: 'gacela:'
+```
+
+Every key is validated at compile time — a mistyped one fails the build instead
+of quietly configuring nothing. `cache_dir` and `file_cache` left unset leave
+Gacela's own defaults in place.
+
+### External services
+
+`external_services` maps a Gacela key to a Symfony service id, so a Factory can
+reach it:
+
+```php
+final class ReportFactory extends AbstractFactory
+{
+    public function createReporter(): Reporter
+    {
+        return new Reporter($this->getProvidedDependency('logger'));
+    }
+}
+```
+
+They are fetched through a service locator when Gacela asks for them, so
+listing a service does not construct it — booting the kernel stays as cheap as
+it was.
+
+### Commands
+
+The prefix is not decoration: Symfony's MakerBundle owns the whole `make:*`
+namespace, so an unprefixed `make:module` would collide with it.
+
+```bash
+bin/console gacela:make:module App/Blog
+bin/console gacela:doctor
+bin/console list gacela
+```
+
+Set `register_commands: false` to leave `bin/console` alone and keep using
+`vendor/bin/gacela`.
+
+## The `#[Inject]` compiler pass
+
+Symfony autowires constructor parameters through its own container, and Gacela's
+`#[Inject]` attribute is recognised by Gacela's container only. On a class
+managed by Symfony — most often a `Command` — writing `#[Inject]` therefore had
+no effect: Symfony's autowire claimed the parameter first.
+
+`GacelaInjectCompilerPass` walks every service definition at compile time, looks
+at each constructor parameter for `#[Inject]`, and rewrites the argument so
+Symfony resolves that slot through Gacela's container instead. If both
+containers claim the same parameter, the build fails naming the service and
+parameter.
+
+The bundle registers the pass for you. To use it without the bundle:
 
 ```php
 use Gacela\SymfonyBridge\GacelaInjectCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-$container = new ContainerBuilder();
 $container->addCompilerPass(new GacelaInjectCompilerPass());
-```
-
-The Gacela container must be registered in Symfony as a service named
-`gacela.container` so the rewritten arguments can resolve through it at
-runtime. Typically done in a bootstrap or a bundle's extension:
-
-```php
 $container->set('gacela.container', Gacela::container());
 ```
+
+The Gacela container must be registered as a Symfony service named
+`gacela.container` so the rewritten arguments can resolve through it at runtime.
 
 ## Status
 

--- a/symfony-bridge/README.md
+++ b/symfony-bridge/README.md
@@ -52,21 +52,38 @@ Gacela's own defaults in place.
 
 ### External services
 
-`external_services` maps a Gacela key to a Symfony service id, so a Factory can
-reach it:
+`external_services` maps a key to a Symfony service id. What the key *is*
+decides how far the service travels:
+
+```yaml
+gacela:
+    external_services:
+        Psr\Log\LoggerInterface: 'monolog.logger'   # a type: also bound
+        report_mailer: 'app.mailer'                 # a plain key: external service only
+```
+
+A key that **names a class or interface** additionally becomes a Gacela binding,
+so it resolves on its own — through `Gacela::get()`, through autowiring, through
+`#[Inject]`:
 
 ```php
-final class ReportFactory extends AbstractFactory
-{
-    public function createReporter(): Reporter
-    {
-        return new Reporter($this->getProvidedDependency('logger'));
-    }
+public function __construct(
+    #[Inject] private LoggerInterface $logger,
+) {
 }
 ```
 
-They are fetched through a service locator when Gacela asks for them, so
-listing a service does not construct it — booting the kernel stays as cheap as
+A key that names **no type** stays an external service, which is what your own
+`gacela.php` reads when it declares bindings — because a binding maps a *type*
+to an implementation, and `report_mailer` is not one:
+
+```php
+// gacela.php
+$config->addBinding(MailerInterface::class, $config->getExternalService('report_mailer'));
+```
+
+Either way the service is fetched through a service locator when Gacela asks for
+it, so listing one does not construct it — booting the kernel stays as cheap as
 it was.
 
 ### Commands

--- a/symfony-bridge/composer.json
+++ b/symfony-bridge/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "gacela-project/symfony-bridge",
     "type": "library",
-    "description": "Bridge that lets Symfony DependencyInjection honor Gacela's #[Inject] attribute on Symfony-managed services (Commands, Controllers).",
+    "description": "Symfony bundle for Gacela: bootstraps it from the kernel, maps host services into it, registers its console commands, and honors #[Inject] on Symfony-managed services.",
     "license": "MIT",
     "homepage": "https://gacela-project.com",
     "keywords": [
@@ -21,7 +21,10 @@
     "require": {
         "php": ">=8.3",
         "gacela-project/container": "^2.0.2",
-        "symfony/dependency-injection": "^7.0 || ^8.0"
+        "symfony/config": "^7.0 || ^8.0",
+        "symfony/console": "^7.0 || ^8.0",
+        "symfony/dependency-injection": "^7.0 || ^8.0",
+        "symfony/http-kernel": "^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/symfony-bridge/src/DependencyInjection/Configuration.php
+++ b/symfony-bridge/src/DependencyInjection/Configuration.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * What `config/packages/gacela.yaml` may say.
+ *
+ * Validated by a tree rather than read out of an array: an unknown or
+ * mistyped key fails at compile time, where it is a five-second fix, instead of
+ * at the first use of whatever it was supposed to configure.
+ */
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('gacela');
+
+        $treeBuilder->getRootNode()
+            ->children()
+                ->booleanNode('enabled')
+                    ->defaultTrue()
+                    ->info('Bootstrap Gacela when the kernel boots.')
+                ->end()
+                ->scalarNode('app_root_dir')
+                    ->defaultValue('%kernel.project_dir%')
+                    ->info('The directory holding gacela.php. Defaults to the Symfony project dir.')
+                ->end()
+                ->scalarNode('cache_dir')
+                    ->defaultNull()
+                    ->info("Where Gacela writes its caches. Null leaves Gacela's own default in place.")
+                ->end()
+                ->booleanNode('file_cache')
+                    ->defaultNull()
+                    ->info("Enable the on-disk resolution cache. Null leaves Gacela's own default in place.")
+                ->end()
+                ->arrayNode('project_namespaces')
+                    ->scalarPrototype()->end()
+                    ->info('Namespaces Gacela scans for modules.')
+                ->end()
+                ->arrayNode('external_services')
+                    ->useAttributeAsKey('name')
+                    ->scalarPrototype()->end()
+                    ->info('Gacela external-service key => Symfony service id, reachable from a Factory.')
+                ->end()
+                ->booleanNode('register_commands')
+                    ->defaultTrue()
+                    ->info("Add Gacela's console commands to bin/console.")
+                ->end()
+                ->scalarNode('command_prefix')
+                    ->defaultValue('gacela:')
+                    ->info('Prefix for those commands. Required: `make:*` would otherwise collide with MakerBundle.')
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/symfony-bridge/src/DependencyInjection/GacelaExtension.php
+++ b/symfony-bridge/src/DependencyInjection/GacelaExtension.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge\DependencyInjection;
+
+use Gacela\Console\Infrastructure\Command\InitCommand;
+use Gacela\SymfonyBridge\GacelaBootstrapper;
+use Gacela\SymfonyBridge\GacelaCacheWarmer;
+use Gacela\SymfonyBridge\GacelaCommands;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Reference;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+use function sprintf;
+
+/**
+ * Turns `gacela.yaml` into the two services the bundle needs: the one that
+ * boots Gacela, and the one that warms its caches.
+ *
+ * @psalm-type GacelaBundleConfig = array{
+ *     enabled: bool,
+ *     app_root_dir: string,
+ *     cache_dir: ?string,
+ *     file_cache: ?bool,
+ *     project_namespaces: list<string>,
+ *     external_services: array<string, string>,
+ *     register_commands: bool,
+ *     command_prefix: string
+ * }
+ */
+final class GacelaExtension extends Extension
+{
+    public const BOOTSTRAPPER_ID = 'gacela.bootstrapper';
+
+    public const CACHE_WARMER_ID = 'gacela.cache_warmer';
+
+    /**
+     * @param array<array-key, mixed> $configs
+     */
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        /** @var array{enabled: bool, app_root_dir: string, cache_dir: ?string, file_cache: ?bool, project_namespaces: list<string>, external_services: array<string, string>, register_commands: bool, command_prefix: string} $config */
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        if (!$config['enabled']) {
+            return;
+        }
+
+        $this->registerBootstrapper($container, $config);
+        $this->registerCacheWarmer($container);
+
+        if ($config['register_commands']) {
+            $this->registerCommands($container, $config);
+        }
+    }
+
+    /**
+     * Neither `getConfiguration()` nor `getAlias()` is overridden: Symfony finds
+     * `Configuration` in this namespace and derives the `gacela` alias from this
+     * class's own name, and a second answer to either would be one more place to
+     * keep in step.
+     *
+     * @param GacelaBundleConfig $config
+     */
+    private function registerBootstrapper(ContainerBuilder $container, array $config): void
+    {
+        // A locator rather than the container: the bridge reaches exactly the
+        // services the project listed, and nothing it did not.
+        $locator = new Definition(ServiceLocator::class);
+        $locator->setArguments([$this->serviceReferences($config['external_services'])]);
+        $locator->addTag('container.service_locator');
+
+        $definition = new Definition(GacelaBootstrapper::class);
+        $definition->setArguments([
+            $config['app_root_dir'],
+            [
+                'cache_dir' => $config['cache_dir'],
+                'file_cache' => $config['file_cache'],
+                'project_namespaces' => $config['project_namespaces'],
+            ],
+            $locator,
+            $config['external_services'],
+        ]);
+        // The kernel fetches it from the bundle's boot(), which is not
+        // dependency injection and therefore needs it public.
+        $definition->setPublic(true);
+
+        $container->setDefinition(self::BOOTSTRAPPER_ID, $definition);
+    }
+
+    private function registerCacheWarmer(ContainerBuilder $container): void
+    {
+        $definition = new Definition(GacelaCacheWarmer::class);
+        $definition->addTag('kernel.cache_warmer');
+
+        $container->setDefinition(self::CACHE_WARMER_ID, $definition);
+    }
+
+    /**
+     * @param GacelaBundleConfig $config
+     */
+    private function registerCommands(ContainerBuilder $container, array $config): void
+    {
+        foreach (GacelaCommands::names() as $class => $name) {
+            $definition = new Definition($class);
+            if ($class === InitCommand::class) {
+                $definition->setArguments([$config['app_root_dir']]);
+            }
+
+            // `make:module` would otherwise collide with MakerBundle, which
+            // owns the whole `make:*` namespace in a Symfony application.
+            $prefixed = $config['command_prefix'] . $name;
+            $definition->addMethodCall('setName', [$prefixed]);
+            $definition->addTag('console.command', ['command' => $prefixed]);
+
+            $container->setDefinition(sprintf('gacela.command.%s', $name), $definition);
+        }
+    }
+
+    /**
+     * @param array<string, string> $externalServices
+     *
+     * @return array<string, Reference>
+     */
+    private function serviceReferences(array $externalServices): array
+    {
+        $references = [];
+
+        foreach ($externalServices as $serviceId) {
+            $references[$serviceId] = new Reference($serviceId);
+        }
+
+        return $references;
+    }
+}

--- a/symfony-bridge/src/GacelaBootstrapper.php
+++ b/symfony-bridge/src/GacelaBootstrapper.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Bootstraps Gacela from what the Symfony kernel already knows.
+ *
+ * Every Symfony project that uses Gacela writes this by hand -- the project
+ * dir, the environment, the handful of Symfony services a Factory needs to
+ * reach. It is the same code every time, which is what a bridge is for.
+ *
+ * A kernel can boot more than once in one process (functional tests do it
+ * constantly), so bootstrapping is idempotent by being repeated: each boot
+ * re-runs it, and the latest configuration is the one in force.
+ */
+final class GacelaBootstrapper
+{
+    /**
+     * @param array{cache_dir: ?string, file_cache: ?bool, project_namespaces: list<string>} $options
+     * @param array<string, string> $externalServices gacela key => symfony service id
+     */
+    public function __construct(
+        private readonly string $appRootDir,
+        private readonly array $options,
+        private readonly ContainerInterface $services,
+        private readonly array $externalServices = [],
+    ) {
+    }
+
+    public function bootstrap(): void
+    {
+        Gacela::bootstrap($this->appRootDir, function (GacelaConfig $config): void {
+            $this->applyOptions($config);
+            $this->applyExternalServices($config);
+        });
+    }
+
+    private function applyOptions(GacelaConfig $config): void
+    {
+        if ($this->options['file_cache'] !== null) {
+            $config->setFileCache($this->options['file_cache'], $this->options['cache_dir']);
+        } elseif ($this->options['cache_dir'] !== null) {
+            $config->enableFileCache($this->options['cache_dir']);
+        }
+
+        if ($this->options['project_namespaces'] !== []) {
+            $config->setProjectNamespaces($this->options['project_namespaces']);
+        }
+    }
+
+    /**
+     * Through a closure, so a Symfony service reaches Gacela without being
+     * constructed by the act of configuring it: a bridge that instantiated the
+     * entity manager on every boot would cost more than it saves.
+     */
+    private function applyExternalServices(GacelaConfig $config): void
+    {
+        foreach ($this->externalServices as $key => $serviceId) {
+            $config->addExternalService($key, fn (): object => $this->service($serviceId));
+        }
+    }
+
+    private function service(string $serviceId): object
+    {
+        /** @var object $service */
+        $service = $this->services->get($serviceId);
+
+        return $service;
+    }
+}

--- a/symfony-bridge/src/GacelaBootstrapper.php
+++ b/symfony-bridge/src/GacelaBootstrapper.php
@@ -8,6 +8,9 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Psr\Container\ContainerInterface;
 
+use function class_exists;
+use function interface_exists;
+
 /**
  * Bootstraps Gacela from what the Symfony kernel already knows.
  *
@@ -55,14 +58,30 @@ final class GacelaBootstrapper
     }
 
     /**
-     * Through a closure, so a Symfony service reaches Gacela without being
+     * A listed service reaches Gacela two ways, and which ones apply is decided
+     * by the key the project chose.
+     *
+     * Every key becomes an external service: that is what a project's own
+     * `gacela.php` reads through `getExternalService()` when it declares its
+     * bindings. A key that *names a type* additionally becomes a binding, so
+     * `LoggerInterface::class => 'monolog.logger'` is resolvable on its own --
+     * by `Gacela::get()`, by autowiring, by `#[Inject]`. Bindings map types to
+     * implementations, so a key like `logger` has no business being one.
+     *
+     * Both take a closure, so a Symfony service reaches Gacela without being
      * constructed by the act of configuring it: a bridge that instantiated the
      * entity manager on every boot would cost more than it saves.
      */
     private function applyExternalServices(GacelaConfig $config): void
     {
         foreach ($this->externalServices as $key => $serviceId) {
-            $config->addExternalService($key, fn (): object => $this->service($serviceId));
+            $factory = fn (): object => $this->service($serviceId);
+
+            $config->addExternalService($key, $factory);
+
+            if (class_exists($key) || interface_exists($key)) {
+                $config->addBinding($key, $factory);
+            }
         }
     }
 

--- a/symfony-bridge/src/GacelaBundle.php
+++ b/symfony-bridge/src/GacelaBundle.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge;
+
+use Gacela\SymfonyBridge\DependencyInjection\GacelaExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Gacela inside a Symfony application.
+ *
+ * Register it and the four things every Symfony/Gacela project wires by hand
+ * are done: the `#[Inject]` compiler pass, bootstrapping from the kernel, the
+ * console commands, and warming the caches with Symfony's own `cache:warmup`.
+ *
+ * ```php
+ * // config/bundles.php
+ * return [
+ *     Gacela\SymfonyBridge\GacelaBundle::class => ['all' => true],
+ * ];
+ * ```
+ */
+final class GacelaBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new GacelaInjectCompilerPass());
+    }
+
+    /**
+     * Every boot bootstraps again, on purpose: a kernel can boot more than once
+     * in one process, and the second boot's configuration is the one that
+     * should be in force -- not whatever the first one left behind.
+     */
+    public function boot(): void
+    {
+        $container = $this->container;
+        if (!$container instanceof \Symfony\Component\DependencyInjection\ContainerInterface || !$container->has(GacelaExtension::BOOTSTRAPPER_ID)) {
+            return;
+        }
+
+        $bootstrapper = $container->get(GacelaExtension::BOOTSTRAPPER_ID);
+        if ($bootstrapper instanceof GacelaBootstrapper) {
+            $bootstrapper->bootstrap();
+        }
+    }
+}

--- a/symfony-bridge/src/GacelaCacheWarmer.php
+++ b/symfony-bridge/src/GacelaCacheWarmer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge;
+
+use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Warms Gacela's caches from Symfony's own `cache:warmup`.
+ *
+ * A Gacela deployment has two warmup steps otherwise, and the second one is
+ * the one people forget. This is the same command `vendor/bin/gacela
+ * cache:warm` runs, so "warmed" means the same thing either way -- including
+ * writing nothing at all when the file cache is disabled.
+ */
+final class GacelaCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * Optional: a project that warms nothing still boots, just colder.
+     */
+    public function isOptional(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return list<string> the classes to preload, which Gacela's own caches
+     *                      are not: they are php files read at runtime, not
+     *                      opcache preload candidates
+     */
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
+    {
+        (new CacheWarmCommand())->run(new ArrayInput([]), new NullOutput());
+
+        return [];
+    }
+}

--- a/symfony-bridge/src/GacelaCommands.php
+++ b/symfony-bridge/src/GacelaCommands.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\SymfonyBridge;
+
+use Gacela\Console\Infrastructure\Command\CacheClearCommand;
+use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
+use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
+use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
+use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
+use Gacela\Console\Infrastructure\Command\DoctorCommand;
+use Gacela\Console\Infrastructure\Command\InitCommand;
+use Gacela\Console\Infrastructure\Command\ListModulesCommand;
+use Gacela\Console\Infrastructure\Command\MakeFileCommand;
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
+use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Gacela's commands and the names they answer to.
+ *
+ * The names are read off the commands themselves rather than written down
+ * again: a renamed command would otherwise be registered under the old name
+ * here and silently stop matching what `vendor/bin/gacela` calls it.
+ *
+ * @internal
+ */
+final class GacelaCommands
+{
+    /** @var list<class-string<Command>> */
+    private const CLASSES = [
+        MakeFileCommand::class,
+        MakeModuleCommand::class,
+        ListModulesCommand::class,
+        DebugConfigCommand::class,
+        DebugContainerCommand::class,
+        DebugDependenciesCommand::class,
+        DebugGraphCommand::class,
+        DebugModuleCommand::class,
+        DebugModulesCommand::class,
+        CacheWarmCommand::class,
+        CacheClearCommand::class,
+        ValidateConfigCommand::class,
+        ProfileReportCommand::class,
+        DoctorCommand::class,
+        InitCommand::class,
+    ];
+
+    /**
+     * Constructing a command runs its `configure()`, which sets a name and
+     * options and touches nothing else -- no bootstrap, no filesystem -- so it
+     * is safe while Symfony's container is still being compiled.
+     *
+     * @return array<class-string<Command>, string>
+     */
+    public static function names(): array
+    {
+        $names = [];
+
+        foreach (self::CLASSES as $class) {
+            $command = $class === InitCommand::class ? new InitCommand('') : new $class();
+            $names[$class] = (string)$command->getName();
+        }
+
+        return $names;
+    }
+}

--- a/symfony-bridge/tests/ConfigurationTest.php
+++ b/symfony-bridge/tests/ConfigurationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\SymfonyBridge\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+final class ConfigurationTest extends TestCase
+{
+    public function test_an_empty_configuration_carries_the_defaults(): void
+    {
+        $config = $this->process([]);
+
+        self::assertTrue($config['enabled']);
+        self::assertTrue($config['register_commands']);
+        self::assertSame('gacela:', $config['command_prefix']);
+        self::assertNull($config['cache_dir']);
+        self::assertNull($config['file_cache']);
+        self::assertSame([], $config['project_namespaces']);
+        self::assertSame([], $config['external_services']);
+    }
+
+    public function test_it_reads_what_the_project_wrote(): void
+    {
+        $config = $this->process([[
+            'app_root_dir' => '/app',
+            'cache_dir' => '/app/var/gacela',
+            'file_cache' => true,
+            'project_namespaces' => ['App'],
+            'external_services' => ['logger' => 'monolog.logger'],
+            'command_prefix' => 'g:',
+        ]]);
+
+        self::assertSame('/app', $config['app_root_dir']);
+        self::assertSame('/app/var/gacela', $config['cache_dir']);
+        self::assertTrue($config['file_cache']);
+        self::assertSame(['App'], $config['project_namespaces']);
+        self::assertSame(['logger' => 'monolog.logger'], $config['external_services']);
+        self::assertSame('g:', $config['command_prefix']);
+    }
+
+    /**
+     * A mistyped key is a five-second fix at compile time and a mystery at the
+     * first use of whatever it was supposed to configure.
+     */
+    public function test_an_unknown_key_fails_the_build(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->process([['file_cach' => true]]);
+    }
+
+    public function test_a_value_of_the_wrong_type_fails_the_build(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->process([['file_cache' => 'yes please']]);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $configs
+     *
+     * @return array<string, mixed>
+     */
+    private function process(array $configs): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(), $configs);
+    }
+}

--- a/symfony-bridge/tests/Fixtures/CountingService.php
+++ b/symfony-bridge/tests/Fixtures/CountingService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+/**
+ * Counts its own construction, which is how a test can tell "reachable from
+ * Gacela" from "built because Gacela was configured".
+ */
+final class CountingService
+{
+    public static int $constructed = 0;
+
+    public function __construct()
+    {
+        ++self::$constructed;
+    }
+
+    public function name(): string
+    {
+        return 'counting';
+    }
+}

--- a/symfony-bridge/tests/Fixtures/TestKernel.php
+++ b/symfony-bridge/tests/Fixtures/TestKernel.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+use Gacela\SymfonyBridge\GacelaBundle;
+use Override;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+use function bin2hex;
+use function dirname;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+/**
+ * The smallest kernel that can register a bundle: no FrameworkBundle, so what
+ * a test observes is the bridge and nothing else.
+ */
+final class TestKernel extends Kernel
+{
+    private readonly string $id;
+
+    /**
+     * @param array<string, mixed>       $gacelaConfig     what `gacela.yaml` would say
+     * @param array<string, class-string> $extraServices   service id => class, registered public
+     */
+    public function __construct(
+        private readonly array $gacelaConfig = [],
+        private readonly array $extraServices = [],
+        string $environment = 'test',
+    ) {
+        $this->id = bin2hex(random_bytes(6));
+
+        parent::__construct($environment, true);
+    }
+
+    /**
+     * @return iterable<BundleInterface>
+     */
+    public function registerBundles(): iterable
+    {
+        return [new GacelaBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container): void {
+            $container->loadFromExtension('gacela', $this->gacelaConfig);
+
+            foreach ($this->extraServices as $id => $class) {
+                $definition = new Definition($class);
+                $definition->setPublic(true);
+                $container->setDefinition($id, $definition);
+            }
+        });
+    }
+
+    #[Override]
+    public function getProjectDir(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    #[Override]
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/gacela-bridge-kernel/' . $this->id . '/cache';
+    }
+
+    #[Override]
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir() . '/gacela-bridge-kernel/' . $this->id . '/log';
+    }
+}

--- a/symfony-bridge/tests/Fixtures/WarmModule/WarmFacade.php
+++ b/symfony-bridge/tests/Fixtures/WarmModule/WarmFacade.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures\WarmModule;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * A module for the warmer to find: with nothing to resolve there is nothing to
+ * cache, and a warmer that wrote no files would look identical to one that did
+ * not run.
+ *
+ * @extends AbstractFacade<WarmFactory>
+ */
+final class WarmFacade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->createName();
+    }
+}

--- a/symfony-bridge/tests/Fixtures/WarmModule/WarmFactory.php
+++ b/symfony-bridge/tests/Fixtures/WarmModule/WarmFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures\WarmModule;
+
+use Gacela\Framework\AbstractFactory;
+
+final class WarmFactory extends AbstractFactory
+{
+    public function createName(): string
+    {
+        return 'warm';
+    }
+}

--- a/symfony-bridge/tests/GacelaBootstrapperTest.php
+++ b/symfony-bridge/tests/GacelaBootstrapperTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use Gacela\SymfonyBridge\GacelaBootstrapper;
+use GacelaTest\SymfonyBridge\Fixtures\CountingService;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * The bootstrapper on its own, where the two options that decide the file cache
+ * can be stated one at a time.
+ */
+final class GacelaBootstrapperTest extends TestCase
+{
+    private const APP_ROOT = __DIR__ . '/Fixtures';
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+    }
+
+    public function test_it_bootstraps_from_the_given_application_root(): void
+    {
+        $this->bootstrap();
+
+        self::assertSame(self::APP_ROOT, Config::getInstance()->getAppRootDir());
+    }
+
+    /**
+     * A cache directory with nothing said about the file cache means the
+     * project wants the cache, in that directory.
+     */
+    public function test_a_cache_dir_alone_turns_the_file_cache_on(): void
+    {
+        $this->bootstrap(['cache_dir' => self::APP_ROOT . '/bootstrapper-cache']);
+
+        self::assertTrue(Config::getInstance()->getSetupGacela()->isFileCacheEnabled());
+    }
+
+    public function test_the_file_cache_can_be_turned_off_explicitly(): void
+    {
+        $this->bootstrap(['cache_dir' => self::APP_ROOT . '/bootstrapper-cache', 'file_cache' => false]);
+
+        self::assertFalse(Config::getInstance()->getSetupGacela()->isFileCacheEnabled());
+    }
+
+    /**
+     * Saying nothing must change nothing: the bundle's defaults are Gacela's
+     * defaults, not a second opinion about them.
+     */
+    public function test_saying_nothing_leaves_gacelas_own_default_in_place(): void
+    {
+        $this->bootstrap();
+
+        self::assertSame('', Config::getInstance()->getSetupGacela()->getFileCacheDirectory());
+    }
+
+    public function test_project_namespaces_are_passed_through(): void
+    {
+        $this->bootstrap(['project_namespaces' => ['App']]);
+
+        self::assertSame(['App'], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
+    }
+
+    /**
+     * A key that names a type becomes a binding, so it resolves on its own --
+     * which is what `#[Inject]` and autowiring go through.
+     */
+    public function test_a_service_listed_under_its_type_is_bound(): void
+    {
+        $this->bootstrap([], [CountingService::class => 'app.counting']);
+
+        self::assertInstanceOf(CountingService::class, Gacela::get(CountingService::class));
+    }
+
+    /**
+     * A key that names no type is still an external service, for a `gacela.php`
+     * to turn into whatever binding it wants -- bindings map types, and
+     * `counting` is not one.
+     */
+    public function test_a_service_listed_under_a_plain_key_is_not_bound(): void
+    {
+        $this->bootstrap([], ['counting' => 'app.counting']);
+
+        self::assertNull(Gacela::get('counting'));
+        self::assertArrayHasKey('counting', Config::getInstance()->getSetupGacela()->externalServices());
+    }
+
+    /**
+     * @param array{cache_dir?: ?string, file_cache?: ?bool, project_namespaces?: list<string>} $options
+     * @param array<string, string> $externalServices
+     */
+    private function bootstrap(array $options = [], array $externalServices = []): void
+    {
+        $bootstrapper = new GacelaBootstrapper(
+            self::APP_ROOT,
+            [
+                'cache_dir' => $options['cache_dir'] ?? null,
+                'file_cache' => $options['file_cache'] ?? null,
+                'project_namespaces' => $options['project_namespaces'] ?? [],
+            ],
+            $this->services(),
+            $externalServices,
+        );
+
+        $bootstrapper->bootstrap();
+    }
+
+    private function services(): ContainerInterface
+    {
+        return new ServiceLocator([
+            'app.counting' => static fn (): CountingService => new CountingService(),
+        ]);
+    }
+}

--- a/symfony-bridge/tests/GacelaBundleTest.php
+++ b/symfony-bridge/tests/GacelaBundleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use Gacela\SymfonyBridge\DependencyInjection\GacelaExtension;
+use GacelaTest\SymfonyBridge\Fixtures\CountingService;
+use GacelaTest\SymfonyBridge\Fixtures\TestKernel;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The bundle driven through a real kernel, because everything it does happens
+ * during compilation or boot -- neither of which a unit test can stand in for.
+ */
+final class GacelaBundleTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+    }
+
+    public function test_booting_the_kernel_bootstraps_gacela(): void
+    {
+        $kernel = new TestKernel();
+        $kernel->boot();
+
+        self::assertSame($kernel->getProjectDir(), Config::getInstance()->getAppRootDir());
+    }
+
+    /**
+     * Functional tests reboot kernels constantly, and a second bootstrap that
+     * served the first one's configuration was a real bug (#597). The bridge
+     * must not reintroduce it by bootstrapping only once.
+     */
+    public function test_a_second_boot_bootstraps_again(): void
+    {
+        (new TestKernel())->boot();
+        self::assertSame([], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
+
+        (new TestKernel(['project_namespaces' => ['App']]))->boot();
+
+        self::assertSame(['App'], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
+    }
+
+    public function test_a_listed_symfony_service_is_reachable_from_gacela(): void
+    {
+        $this->kernelWithCountingService()->boot();
+
+        $service = Gacela::get(CountingService::class);
+
+        self::assertInstanceOf(CountingService::class, $service);
+        self::assertSame('counting', $service->name());
+    }
+
+    /**
+     * Configuring is not using: a bridge that built the entity manager on every
+     * boot would cost more than it saves.
+     */
+    public function test_a_listed_service_is_not_built_until_it_is_asked_for(): void
+    {
+        $this->kernelWithCountingService()->boot();
+
+        self::assertSame(0, CountingService::$constructed, 'booting alone must not construct it');
+
+        Gacela::get(CountingService::class);
+
+        self::assertSame(1, CountingService::$constructed);
+    }
+
+    public function test_disabling_the_bundle_registers_nothing(): void
+    {
+        $kernel = new TestKernel(['enabled' => false]);
+        $kernel->boot();
+
+        self::assertFalse($kernel->getContainer()->has(GacelaExtension::BOOTSTRAPPER_ID));
+    }
+
+    private function kernelWithCountingService(): TestKernel
+    {
+        return new TestKernel(
+            ['external_services' => [CountingService::class => 'app.counting']],
+            ['app.counting' => CountingService::class],
+        );
+    }
+}

--- a/symfony-bridge/tests/GacelaBundleTest.php
+++ b/symfony-bridge/tests/GacelaBundleTest.php
@@ -7,9 +7,14 @@ namespace GacelaTest\SymfonyBridge;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\SymfonyBridge\DependencyInjection\GacelaExtension;
+use Gacela\SymfonyBridge\GacelaBundle;
+use Gacela\SymfonyBridge\GacelaInjectCompilerPass;
 use GacelaTest\SymfonyBridge\Fixtures\CountingService;
 use GacelaTest\SymfonyBridge\Fixtures\TestKernel;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use function array_map;
 
 /**
  * The bundle driven through a real kernel, because everything it does happens
@@ -47,14 +52,36 @@ final class GacelaBundleTest extends TestCase
         self::assertSame(['App'], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
     }
 
-    public function test_a_listed_symfony_service_is_reachable_from_gacela(): void
+    /**
+     * Identity is the assertion that means anything here. Gacela autowires an
+     * unlisted class perfectly happily, so "an instance came back" would pass
+     * with the whole mapping deleted -- it is *Symfony's* instance that proves
+     * the service travelled across the bridge.
+     */
+    public function test_a_service_listed_under_its_type_is_the_one_gacela_hands_back(): void
     {
-        $this->kernelWithCountingService()->boot();
+        $kernel = $this->kernelWithCountingService();
+        $kernel->boot();
 
-        $service = Gacela::get(CountingService::class);
+        self::assertSame(
+            $kernel->getContainer()->get('app.counting'),
+            Gacela::get(CountingService::class),
+        );
+    }
 
-        self::assertInstanceOf(CountingService::class, $service);
-        self::assertSame('counting', $service->name());
+    /**
+     * The other audience, and the one every key reaches: a project's own
+     * `gacela.php` reads it through `getExternalService()` when it declares its
+     * bindings.
+     */
+    public function test_a_listed_service_is_offered_to_gacela_php_whatever_its_key(): void
+    {
+        (new TestKernel(
+            ['external_services' => ['counting' => 'app.counting']],
+            ['app.counting' => CountingService::class],
+        ))->boot();
+
+        self::assertArrayHasKey('counting', Config::getInstance()->getSetupGacela()->externalServices());
     }
 
     /**
@@ -70,6 +97,30 @@ final class GacelaBundleTest extends TestCase
         Gacela::get(CountingService::class);
 
         self::assertSame(1, CountingService::$constructed);
+    }
+
+    public function test_a_service_nobody_listed_is_not_bound(): void
+    {
+        (new TestKernel())->boot();
+
+        self::assertNull(Gacela::get('counting'));
+    }
+
+    /**
+     * The pass is the bridge's oldest job, and registering it is the whole of
+     * what `build()` adds: without it `#[Inject]` on a Symfony-managed class
+     * does nothing at all, silently, which is the failure it exists to prevent.
+     */
+    public function test_it_registers_the_inject_compiler_pass(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new GacelaBundle())->build($container);
+
+        $passes = $container->getCompiler()->getPassConfig()->getBeforeOptimizationPasses();
+        $classes = array_map(static fn (object $pass): string => $pass::class, $passes);
+
+        self::assertContains(GacelaInjectCompilerPass::class, $classes);
     }
 
     public function test_disabling_the_bundle_registers_nothing(): void

--- a/symfony-bridge/tests/GacelaCacheWarmerTest.php
+++ b/symfony-bridge/tests/GacelaCacheWarmerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\ClassResolver\Cache\AbstractPhpFileCache;
+use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use Gacela\SymfonyBridge\GacelaCacheWarmer;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function dirname;
+use function glob;
+use function unlink;
+
+final class GacelaCacheWarmerTest extends TestCase
+{
+    private const APP_ROOT = __DIR__ . '/Fixtures';
+
+    private const CACHE_DIR = self::APP_ROOT . '/warmer-cache';
+
+    protected function tearDown(): void
+    {
+        // Every file, not just the one asserted on: warming also writes the
+        // merged-config cache, and a directory left behind is a directory the
+        // repo's own tooling then tries to format.
+        $file = $this->classNameCacheFile();
+        if ($file !== '') {
+            $directory = dirname($file);
+            foreach (glob($directory . '/*') ?: [] as $leftover) {
+                unlink($leftover);
+            }
+
+            @rmdir($directory);
+        }
+
+        Gacela::resetCache();
+        Config::resetInstance();
+    }
+
+    /**
+     * A project that warms nothing still boots, just colder.
+     */
+    public function test_it_is_optional(): void
+    {
+        self::assertTrue((new GacelaCacheWarmer())->isOptional());
+    }
+
+    public function test_it_writes_the_cache_symfony_asked_it_to_warm(): void
+    {
+        $this->bootstrapWithFileCache(true);
+
+        $preloaded = (new GacelaCacheWarmer())->warmUp(self::CACHE_DIR);
+
+        self::assertSame([], $preloaded, 'gacela caches are read at runtime, not opcache-preloaded');
+        self::assertFileExists($this->classNameCacheFile());
+    }
+
+    /**
+     * The same rule `vendor/bin/gacela cache:warm` follows: with the file cache
+     * off there is nothing to write, and writing anyway would leave a cache the
+     * application never reads.
+     */
+    public function test_it_writes_nothing_when_the_file_cache_is_off(): void
+    {
+        $this->bootstrapWithFileCache(false);
+
+        (new GacelaCacheWarmer())->warmUp(self::CACHE_DIR);
+
+        self::assertFileDoesNotExist($this->classNameCacheFile());
+    }
+
+    /**
+     * Asked of the framework rather than rebuilt here: a cache directory is
+     * resolved against the application root, so a path guessed by a test can
+     * point at somewhere nothing was ever written.
+     */
+    private function classNameCacheFile(): string
+    {
+        try {
+            $config = Config::getInstance();
+        } catch (RuntimeException) {
+            // Nothing bootstrapped: there is no cache directory to speak of,
+            // which is not the same as one that happens to be empty.
+            return '';
+        }
+
+        return AbstractPhpFileCache::absoluteFilename(
+            $config->getCacheDir(),
+            ClassNamePhpCache::FILENAME,
+            $config->getAppRootDir(),
+        );
+    }
+
+    private function bootstrapWithFileCache(bool $enabled): void
+    {
+        Gacela::bootstrap(self::APP_ROOT, static function (GacelaConfig $config) use ($enabled): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache($enabled, self::CACHE_DIR);
+        });
+    }
+}

--- a/symfony-bridge/tests/GacelaExtensionTest.php
+++ b/symfony-bridge/tests/GacelaExtensionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\Console\Infrastructure\Command\InitCommand;
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\SymfonyBridge\DependencyInjection\GacelaExtension;
+use Gacela\SymfonyBridge\GacelaBootstrapper;
+use Gacela\SymfonyBridge\GacelaCacheWarmer;
+use Gacela\SymfonyBridge\GacelaCommands;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+use function count;
+
+/**
+ * What the extension puts in the container, read before compilation removes
+ * whatever nothing references.
+ */
+final class GacelaExtensionTest extends TestCase
+{
+    public function test_the_bootstrapper_is_registered_public_because_boot_fetches_it(): void
+    {
+        $container = $this->load();
+
+        $definition = $container->getDefinition(GacelaExtension::BOOTSTRAPPER_ID);
+
+        self::assertSame(GacelaBootstrapper::class, $definition->getClass());
+        self::assertTrue($definition->isPublic(), 'the bundle fetches it from boot(), which is not injection');
+    }
+
+    public function test_the_cache_warmer_is_registered_with_the_tag_symfony_looks_for(): void
+    {
+        $definition = $this->load()->getDefinition(GacelaExtension::CACHE_WARMER_ID);
+
+        self::assertSame(GacelaCacheWarmer::class, $definition->getClass());
+        self::assertArrayHasKey('kernel.cache_warmer', $definition->getTags());
+    }
+
+    public function test_every_gacela_command_is_registered_under_the_prefix(): void
+    {
+        $container = $this->load();
+
+        foreach (GacelaCommands::names() as $name) {
+            $definition = $container->getDefinition('gacela.command.' . $name);
+
+            self::assertSame([['setName', ['gacela:' . $name]]], $definition->getMethodCalls());
+            self::assertSame(
+                [['command' => 'gacela:' . $name]],
+                $definition->getTag('console.command'),
+            );
+        }
+
+        self::assertGreaterThan(10, count(GacelaCommands::names()), 'precondition: there are commands to register');
+    }
+
+    /**
+     * MakerBundle owns the whole `make:*` namespace in a Symfony application,
+     * so an unprefixed `make:module` would collide with it.
+     */
+    public function test_the_prefix_is_what_keeps_make_module_from_colliding_with_makerbundle(): void
+    {
+        $names = GacelaCommands::names();
+
+        self::assertSame('make:module', $names[MakeModuleCommand::class]);
+        self::assertSame(
+            [['setName', ['gacela:make:module']]],
+            $this->load()->getDefinition('gacela.command.make:module')->getMethodCalls(),
+        );
+    }
+
+    public function test_the_prefix_can_be_changed(): void
+    {
+        $container = $this->load([['command_prefix' => 'g:']]);
+
+        self::assertSame(
+            [['setName', ['g:make:module']]],
+            $container->getDefinition('gacela.command.make:module')->getMethodCalls(),
+        );
+    }
+
+    public function test_the_init_command_is_told_where_the_project_is(): void
+    {
+        $definition = $this->load([['app_root_dir' => '/app']])->getDefinition('gacela.command.init');
+
+        self::assertSame(InitCommand::class, $definition->getClass());
+        self::assertSame(['/app'], $definition->getArguments());
+    }
+
+    public function test_commands_can_be_left_out(): void
+    {
+        $container = $this->load([['register_commands' => false]]);
+
+        self::assertFalse($container->hasDefinition('gacela.command.make:module'));
+        self::assertTrue($container->hasDefinition(GacelaExtension::BOOTSTRAPPER_ID));
+    }
+
+    public function test_a_disabled_bundle_registers_nothing_at_all(): void
+    {
+        $container = $this->load([['enabled' => false]]);
+
+        self::assertFalse($container->hasDefinition(GacelaExtension::BOOTSTRAPPER_ID));
+        self::assertFalse($container->hasDefinition(GacelaExtension::CACHE_WARMER_ID));
+        self::assertFalse($container->hasDefinition('gacela.command.make:module'));
+    }
+
+    public function test_a_listed_external_service_is_reached_through_a_locator(): void
+    {
+        $container = $this->load([['external_services' => ['logger' => 'monolog.logger']]]);
+
+        $arguments = $container->getDefinition(GacelaExtension::BOOTSTRAPPER_ID)->getArguments();
+
+        self::assertSame(['logger' => 'monolog.logger'], $arguments[3]);
+        self::assertInstanceOf(Definition::class, $arguments[2]);
+        self::assertArrayHasKey('container.service_locator', $arguments[2]->getTags());
+    }
+
+    /**
+     * @param list<array<string, mixed>> $configs
+     */
+    private function load(array $configs = [[]]): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        (new GacelaExtension())->load($configs, $container);
+
+        return $container;
+    }
+}

--- a/symfony-bridge/tests/GacelaExtensionTest.php
+++ b/symfony-bridge/tests/GacelaExtensionTest.php
@@ -13,6 +13,7 @@ use Gacela\SymfonyBridge\GacelaCommands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 use function count;
 
@@ -107,15 +108,38 @@ final class GacelaExtensionTest extends TestCase
         self::assertFalse($container->hasDefinition('gacela.command.make:module'));
     }
 
-    public function test_a_listed_external_service_is_reached_through_a_locator(): void
+    public function test_every_listed_external_service_is_reached_through_the_locator(): void
     {
-        $container = $this->load([['external_services' => ['logger' => 'monolog.logger']]]);
+        $container = $this->load([['external_services' => [
+            'logger' => 'monolog.logger',
+            'em' => 'doctrine.orm.entity_manager',
+        ]]]);
 
         $arguments = $container->getDefinition(GacelaExtension::BOOTSTRAPPER_ID)->getArguments();
 
-        self::assertSame(['logger' => 'monolog.logger'], $arguments[3]);
+        self::assertSame(['logger' => 'monolog.logger', 'em' => 'doctrine.orm.entity_manager'], $arguments[3]);
+
         self::assertInstanceOf(Definition::class, $arguments[2]);
         self::assertArrayHasKey('container.service_locator', $arguments[2]->getTags());
+
+        // Every listed id, not just the first: the locator is what the
+        // bootstrapper can reach, and a service missing from it is a service
+        // the project listed and cannot use.
+        self::assertEquals(
+            [
+                'monolog.logger' => new Reference('monolog.logger'),
+                'doctrine.orm.entity_manager' => new Reference('doctrine.orm.entity_manager'),
+            ],
+            $arguments[2]->getArgument(0),
+        );
+    }
+
+    public function test_a_project_that_lists_nothing_gets_an_empty_locator(): void
+    {
+        $arguments = $this->load()->getDefinition(GacelaExtension::BOOTSTRAPPER_ID)->getArguments();
+
+        self::assertInstanceOf(Definition::class, $arguments[2]);
+        self::assertSame([], $arguments[2]->getArgument(0));
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

`symfony-bridge` honored `#[Inject]` and left everything around it manual:
bootstrapping Gacela from the kernel, handing Symfony services to it, getting
the commands into `bin/console`, warming the caches on deploy. Every Symfony
project re-derived the same wiring — which is what a bridge is for.

Most Gacela users already live inside a host framework, so this is the adoption
path.

## 🔖 Changes

- `GacelaBundle`: registers the compiler pass, bootstraps on kernel boot, and every boot bootstraps again so a rebooted kernel runs on its own config (#597 must not come back through the bridge)
- Validated configuration tree — a mistyped key fails the build, not the first use of whatever it configured
- `external_services` maps Symfony service ids into Gacela through a service locator, so listing a service does not construct it
- Gacela's commands in `bin/console` under a `gacela:` prefix; unprefixed `make:module` would collide with MakerBundle
- `GacelaCacheWarmer` runs the same `cache:warm` from Symfony's `cache:warmup`, so a deploy has one warmup step

Adds `symfony/http-kernel` and `symfony/config` to require-dev (a Bundle needs
both); the framework's own runtime requirements are untouched.

Closes #657