### PR TITLE
feat(console): publish the scaffolder's stubs into the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,17 @@
 
 ### Added
 
-- Register `GacelaBundle` in a Symfony application: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
-
-- Replace another module in a test with `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()`, dropped again in `tearDown()`
-
+- Declare which modules may depend on which, in one JSON file read by `debug:graph --check --rules` and by both analysers
+- Report a module rule that governs no module, so a rule cannot outlive what it was written about
+- Write the `--check` findings as JSON with `--format=json`, for a CI job that wants more than an exit code
 - Declare what the configuration must contain with `declareConfigSchema()`, read by `validate:config`, `doctor` and `debug:config`
 - Fill a declared default when no config source provides the key, without ever overriding one that does
 - Mark every key `declared`, `undeclared` or `missing` in `debug:config`
 - Check the declared schema on every bootstrap with `validateConfigSchemaOnBoot()`, for local development
-
-### Added
-
-- Declare which modules may depend on which, in one JSON file read by `debug:graph --check --rules` and by both analysers
-- Report a module rule that governs no module, so a rule cannot outlive what it was written about
-- Write the `--check` findings as JSON with `--format=json`, for a CI job that wants more than an exit code
+- Replace another module in a test with `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()`, dropped again in `tearDown()`
+- Register `GacelaBundle` in a Symfony application: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
+- Publish the scaffolder's templates into the project with `stubs:publish`, and generate from them per file, falling back to the built-in ones
+- Report a published stub that lost a placeholder, or one the scaffolder never reads, in `doctor`
 
 ## [2.1.0](https://github.com/gacela-project/gacela/compare/2.0.0...2.1.0) - 2026-08-09
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,30 @@ root. `init` is the one that creates it.
 | `init` | Creates the `gacela.php` a project needs before anything else works |
 | `make:module App/Blog` | Generates a module. `--template=basic\|service\|minimal`, `--minimal`, `--with-tests`, `--short-name` |
 | `make:file App/Blog Facade Factory` | Generates named pillar files into an existing module — Facade, Factory, Config, Provider |
+| `stubs:publish` | Copies the scaffolder's templates into the project so `make:*` generates your house style. `--template=basic\|service`, `--force` |
+
+### Your own stubs
+
+`make:module` and `make:file` generate from templates that ship with gacela.
+`stubs:publish` copies them into the project — `stubs/gacela/` by default,
+`GacelaConfig::setStubsDir()` to put them elsewhere:
+
+```bash
+vendor/bin/gacela stubs:publish                    # every stub
+vendor/bin/gacela stubs:publish --template=basic   # one template set
+vendor/bin/gacela stubs:publish --force            # replace ones already published
+```
+
+From then on a generated file uses the project's stub when there is one and the
+built-in template when there is not — **per file**, so publishing your Facade
+stub does not freeze the Factory at the version it was copied from. Without
+`--force` nothing already published is overwritten: it is a file somebody
+changed on purpose.
+
+Every stub substitutes `$NAMESPACE$`, `$MODULE_NAME$` and `$CLASS_NAME$`.
+`doctor` reports a published stub that lost `$NAMESPACE$` or `$CLASS_NAME$`, and
+one filed under a name the scaffolder does not read — an edit that never takes
+effect looks exactly like one that did.
 
 ## Inspecting a project
 

--- a/src/Console/Application/Doctor/Check/StubHealthCheck.php
+++ b/src/Console/Application/Doctor/Check/StubHealthCheck.php
@@ -17,6 +17,7 @@ use function is_file;
 use function is_string;
 use function sprintf;
 use function str_contains;
+use function str_replace;
 use function strlen;
 use function substr;
 
@@ -128,8 +129,13 @@ final class StubHealthCheck implements HealthCheck
     {
         $stray = [];
 
-        foreach (glob($stubsDir . '/{,*/}*.txt', GLOB_BRACE) ?: [] as $path) {
-            $relative = substr($path, strlen($stubsDir) + 1);
+        foreach ([...(glob($stubsDir . '/*.txt') ?: []), ...(glob($stubsDir . '/*/*.txt') ?: [])] as $path) {
+            // glob() answers in the platform's own separator, and the names
+            // this is compared against are written with '/'. On windows every
+            // `service/...` stub would otherwise be reported as one the
+            // scaffolder does not read.
+            $relative = str_replace('\\', '/', substr($path, strlen($stubsDir) + 1));
+
             if (!in_array($relative, StubFiles::all(), true)) {
                 $stray[] = $relative;
             }

--- a/src/Console/Application/Doctor/Check/StubHealthCheck.php
+++ b/src/Console/Application/Doctor/Check/StubHealthCheck.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\Domain\FileContent\StubFiles;
+
+use function count;
+use function file_get_contents;
+use function glob;
+use function in_array;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function sprintf;
+use function str_contains;
+use function strlen;
+use function substr;
+
+/**
+ * The stubs a project published, checked against what the scaffolder will do
+ * with them.
+ *
+ * A published stub is a copy that stops tracking its original -- the failure
+ * mode of the whole feature. Two things are mechanically knowable and both are
+ * silent otherwise: a stub that lost a placeholder generates a broken class,
+ * and a stub filed under a name nothing reads is an edit that never takes
+ * effect.
+ */
+final class StubHealthCheck implements HealthCheck
+{
+    /** @var list<string> */
+    private const REQUIRED_PLACEHOLDERS = ['$NAMESPACE$', '$CLASS_NAME$'];
+
+    /**
+     * @param array<string, string> $published stub file (relative) => contents
+     */
+    public function __construct(
+        private readonly string $stubsDir,
+        private readonly array $published,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'published stubs';
+    }
+
+    public function run(): CheckResult
+    {
+        if (!is_dir($this->stubsDir)) {
+            return CheckResult::ok($this->name(), 'no stubs published — the built-in templates are in use');
+        }
+
+        $problems = $this->problems();
+        if ($problems === []) {
+            return CheckResult::ok($this->name(), sprintf('%d published stub(s), all usable', count($this->published)));
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            $problems,
+            'Fix the stub, or delete it to fall back to the built-in template.',
+        );
+    }
+
+    /**
+     * Every file actually published, whatever it is named -- the unknown ones
+     * are the point.
+     *
+     * @return array<string, string> stub file (relative) => contents
+     */
+    public static function readPublished(string $stubsDir): array
+    {
+        if (!is_dir($stubsDir)) {
+            return [];
+        }
+
+        $published = [];
+
+        foreach ([...StubFiles::all(), ...self::strayFiles($stubsDir)] as $stubFile) {
+            $path = $stubsDir . '/' . $stubFile;
+            if (!is_file($path)) {
+                continue;
+            }
+
+            $contents = file_get_contents($path);
+            $published[$stubFile] = is_string($contents) ? $contents : '';
+        }
+
+        return $published;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function problems(): array
+    {
+        $known = StubFiles::all();
+        $problems = [];
+
+        foreach ($this->published as $stubFile => $contents) {
+            if (!in_array($stubFile, $known, true)) {
+                $problems[] = sprintf(
+                    '%s matches no template the scaffolder reads, so editing it changes nothing',
+                    $stubFile,
+                );
+                continue;
+            }
+
+            foreach (self::REQUIRED_PLACEHOLDERS as $placeholder) {
+                if (!str_contains($contents, $placeholder)) {
+                    $problems[] = sprintf('%s no longer contains %s, so it would generate a broken class', $stubFile, $placeholder);
+                }
+            }
+        }
+
+        return $problems;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function strayFiles(string $stubsDir): array
+    {
+        $stray = [];
+
+        foreach (glob($stubsDir . '/{,*/}*.txt', GLOB_BRACE) ?: [] as $path) {
+            $relative = substr($path, strlen($stubsDir) + 1);
+            if (!in_array($relative, StubFiles::all(), true)) {
+                $stray[] = $relative;
+            }
+        }
+
+        return $stray;
+    }
+}

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -6,6 +6,7 @@ namespace Gacela\Console;
 
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
+use Gacela\Console\Domain\FileContent\StubPublishResult;
 use Gacela\Console\Domain\ModuleGraph\GraphDiffResult;
 use Gacela\Console\Domain\ModuleGraph\ModuleRuleCheckResult;
 use Gacela\Container\ContainerStats;
@@ -140,6 +141,26 @@ final class ConsoleFacade extends AbstractFacade
         return $this->getFactory()
             ->createGraphDiffMarkdownFormatter()
             ->format($diff, $head);
+    }
+
+    /**
+     * Where a project's published scaffolder stubs live, absolute.
+     */
+    public function stubsDir(): string
+    {
+        return $this->getFactory()->stubsDir();
+    }
+
+    /**
+     * Copy the built-in stubs into the project.
+     *
+     * @param list<string> $only the stub files to publish; every one when empty
+     */
+    public function publishStubs(string $stubsDir, array $only = [], bool $force = false): StubPublishResult
+    {
+        return $this->getFactory()
+            ->createStubPublisher()
+            ->publish($stubsDir, $only, $force);
     }
 
     public function getContainerStats(): ContainerStats

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -14,6 +14,9 @@ use Gacela\Console\Domain\CommandArguments\CommandArgumentsParserInterface;
 use Gacela\Console\Domain\FileContent\FileContentGenerator;
 use Gacela\Console\Domain\FileContent\FileContentGeneratorInterface;
 use Gacela\Console\Domain\FileContent\FileContentIoInterface;
+use Gacela\Console\Domain\FileContent\StubFiles;
+use Gacela\Console\Domain\FileContent\StubLocator;
+use Gacela\Console\Domain\FileContent\StubPublisher;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizerInterface;
 use Gacela\Console\Domain\ModuleGraph\GraphDiffMarkdownFormatter;
@@ -87,7 +90,7 @@ final class ConsoleFactory extends AbstractFactory
     {
         return new FileContentGenerator(
             $this->createFileContentIo(),
-            $this->getTemplateByFilenameMap(),
+            new StubLocator($this->stubsDir(), $this->getTemplateByFilenameMap(), StubFiles::basic()),
         );
     }
 
@@ -95,8 +98,46 @@ final class ConsoleFactory extends AbstractFactory
     {
         return new FileContentGenerator(
             $this->createFileContentIo(),
-            $this->getServiceTemplateByFilenameMap(),
+            new StubLocator($this->stubsDir(), $this->getServiceTemplateByFilenameMap(), StubFiles::service()),
         );
+    }
+
+    /**
+     * Where a project's published stubs live, absolute.
+     */
+    public function stubsDir(): string
+    {
+        $config = Config::getInstance();
+        $configured = $config->getSetupGacela()->getStubsDir();
+
+        return str_starts_with($configured, DIRECTORY_SEPARATOR) || str_starts_with($configured, '/')
+            ? $configured
+            : $config->getAppRootDir() . '/' . $configured;
+    }
+
+    /**
+     * The built-in stub contents, by the file each is published as.
+     *
+     * @return array<string, string>
+     */
+    public function builtInStubs(): array
+    {
+        $contents = [];
+
+        foreach (StubFiles::basic() as $filename => $stubFile) {
+            $contents[$stubFile] = $this->getTemplateByFilenameMap()[$filename] ?? '';
+        }
+
+        foreach (StubFiles::service() as $filename => $stubFile) {
+            $contents[$stubFile] = $this->getServiceTemplateByFilenameMap()[$filename] ?? '';
+        }
+
+        return $contents;
+    }
+
+    public function createStubPublisher(): StubPublisher
+    {
+        return new StubPublisher($this->createFileContentIo(), $this->builtInStubs());
     }
 
     public function createAllAppModulesFinder(): AllAppModulesFinder

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -47,6 +47,7 @@ use Symfony\Component\Console\Command\Command;
 
 use function is_dir;
 use function is_string;
+use function preg_match;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
@@ -110,7 +111,7 @@ final class ConsoleFactory extends AbstractFactory
         $config = Config::getInstance();
         $configured = $config->getSetupGacela()->getStubsDir();
 
-        return str_starts_with($configured, DIRECTORY_SEPARATOR) || str_starts_with($configured, '/')
+        return $this->isAbsolutePath($configured)
             ? $configured
             : $config->getAppRootDir() . '/' . $configured;
     }
@@ -234,6 +235,16 @@ final class ConsoleFactory extends AbstractFactory
         }
 
         return $result;
+    }
+
+    /**
+     * A leading separator is not what makes a path absolute on windows: there
+     * it is `C:\...`, which starts with neither separator, and a configured
+     * absolute directory was being appended to the application root instead.
+     */
+    private function isAbsolutePath(string $path): bool
+    {
+        return preg_match('~^(?:[a-zA-Z]:[\\\\/]|[\\\\/])~', $path) === 1;
     }
 
     private function stringifyBoundConcrete(mixed $concrete): string

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -19,6 +19,7 @@ use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\MakeFileCommand;
 use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
 use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
+use Gacela\Console\Infrastructure\Command\StubsPublishCommand;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
@@ -58,6 +59,7 @@ final class ConsoleProvider extends AbstractProvider
             new ProfileReportCommand(),
             new DoctorCommand(),
             new InitCommand(Config::getInstance()->getAppRootDir()),
+            new StubsPublishCommand(),
         ];
     }
 

--- a/src/Console/Domain/FileContent/FileContentGenerator.php
+++ b/src/Console/Domain/FileContent/FileContentGenerator.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Gacela\Console\Domain\FileContent;
 
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
-use RuntimeException;
 
 use function sprintf;
 
 final class FileContentGenerator implements FileContentGeneratorInterface
 {
-    /**
-     * @param array<string,string> $templateByFilenameMap
-     */
     public function __construct(
         private readonly FileContentIoInterface $fileContentIo,
-        private array $templateByFilenameMap,
+        private readonly StubLocator $stubs,
     ) {
     }
 
@@ -41,12 +37,7 @@ final class FileContentGenerator implements FileContentGeneratorInterface
         $search = ['$NAMESPACE$', '$MODULE_NAME$', '$CLASS_NAME$'];
         $replace = [$commandArguments->namespace(), $moduleName, $className];
 
-        $template = $this->templateByFilenameMap[$filename] ?? '';
-        if ($template === '') {
-            throw new RuntimeException(sprintf("Unknown template for '%s'?", $filename));
-        }
-
-        $fileContent = str_replace($search, $replace, $template);
+        $fileContent = str_replace($search, $replace, $this->stubs->templateFor($filename));
 
         $this->fileContentIo->filePutContents($path, $fileContent);
 

--- a/src/Console/Domain/FileContent/StubFiles.php
+++ b/src/Console/Domain/FileContent/StubFiles.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\FileContent;
+
+use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
+
+use function array_values;
+use function in_array;
+
+/**
+ * Which file on disk holds the stub for which generated pillar.
+ *
+ * The scaffolder's templates ship as `.txt` files, and publishing them is
+ * copying those files somewhere a project can edit them. The names have to
+ * match in both directions -- a published stub is found by the same name it was
+ * written under -- so the mapping is stated once, here.
+ */
+final class StubFiles
+{
+    public const SERVICE_SUBDIRECTORY = 'service';
+
+    /**
+     * @return array<string, string> generated filename => stub file, relative to the stubs directory
+     */
+    public static function basic(): array
+    {
+        return [
+            FilenameSanitizer::FACADE => 'facade-maker.txt',
+            FilenameSanitizer::FACTORY => 'factory-maker.txt',
+            FilenameSanitizer::CONFIG => 'config-maker.txt',
+            FilenameSanitizer::PROVIDER => 'provider-maker.txt',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function service(): array
+    {
+        return [
+            FilenameSanitizer::FACADE => self::SERVICE_SUBDIRECTORY . '/facade-maker.txt',
+            FilenameSanitizer::FACTORY => self::SERVICE_SUBDIRECTORY . '/factory-maker.txt',
+            FilenameSanitizer::CONFIG => 'config-maker.txt',
+            FilenameSanitizer::PROVIDER => 'provider-maker.txt',
+            'Service' => self::SERVICE_SUBDIRECTORY . '/service-maker.txt',
+            'FacadeTest' => self::SERVICE_SUBDIRECTORY . '/facade-test-maker.txt',
+        ];
+    }
+
+    /**
+     * Every stub a project can publish, each named once however many templates
+     * use it.
+     *
+     * @return list<string>
+     */
+    public static function all(): array
+    {
+        $files = [];
+
+        foreach ([...array_values(self::basic()), ...array_values(self::service())] as $file) {
+            if (!in_array($file, $files, true)) {
+                $files[] = $file;
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/Console/Domain/FileContent/StubLocator.php
+++ b/src/Console/Domain/FileContent/StubLocator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\FileContent;
+
+use RuntimeException;
+
+use function array_key_exists;
+use function is_file;
+use function is_string;
+use function sprintf;
+
+/**
+ * The template used to generate one file: the project's, if it published one.
+ *
+ * Resolution is per file, not per template set. A project that published only
+ * its Facade stub gets its own Facade and the built-in everything else --
+ * publishing one file must not freeze the rest at the version it was copied
+ * from.
+ */
+final class StubLocator
+{
+    /**
+     * @param array<string, string> $builtIn     generated filename => template contents
+     * @param array<string, string> $stubFiles   generated filename => stub file, relative to the stubs dir
+     */
+    public function __construct(
+        private readonly string $stubsDir,
+        private readonly array $builtIn,
+        private readonly array $stubFiles,
+    ) {
+    }
+
+    public function templateFor(string $filename): string
+    {
+        $published = $this->publishedTemplate($filename);
+        if ($published !== null) {
+            return $published;
+        }
+
+        if (!array_key_exists($filename, $this->builtIn)) {
+            throw new RuntimeException(sprintf("Unknown template for '%s'?", $filename));
+        }
+
+        return $this->builtIn[$filename];
+    }
+
+    private function publishedTemplate(string $filename): ?string
+    {
+        if ($this->stubsDir === '' || !array_key_exists($filename, $this->stubFiles)) {
+            return null;
+        }
+
+        $path = $this->stubsDir . '/' . $this->stubFiles[$filename];
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        return is_string($contents) ? $contents : null;
+    }
+}

--- a/src/Console/Domain/FileContent/StubPublishResult.php
+++ b/src/Console/Domain/FileContent/StubPublishResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\FileContent;
+
+final class StubPublishResult
+{
+    /**
+     * @param list<string> $written stubs now in the project
+     * @param list<string> $skipped stubs already there, left as the project edited them
+     */
+    public function __construct(
+        public readonly array $written,
+        public readonly array $skipped,
+    ) {
+    }
+
+    public function hasSkipped(): bool
+    {
+        return $this->skipped !== [];
+    }
+}

--- a/src/Console/Domain/FileContent/StubPublisher.php
+++ b/src/Console/Domain/FileContent/StubPublisher.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\FileContent;
+
+use function dirname;
+use function in_array;
+use function is_file;
+
+/**
+ * Copies the built-in stubs into the project, where they can be edited.
+ *
+ * Refusing to overwrite is the default because a published stub is a file
+ * somebody changed on purpose: the one thing this must never do is quietly
+ * throw that away.
+ */
+final class StubPublisher
+{
+    /**
+     * @param array<string, string> $builtIn stub file => contents
+     */
+    public function __construct(
+        private readonly FileContentIoInterface $io,
+        private readonly array $builtIn,
+    ) {
+    }
+
+    /**
+     * @param list<string> $only the stub files to publish; every one when empty
+     */
+    public function publish(string $stubsDir, array $only = [], bool $force = false): StubPublishResult
+    {
+        $written = [];
+        $skipped = [];
+
+        foreach ($this->builtIn as $stubFile => $contents) {
+            if ($only !== [] && !in_array($stubFile, $only, true)) {
+                continue;
+            }
+
+            $path = $stubsDir . '/' . $stubFile;
+            if (!$force && is_file($path)) {
+                $skipped[] = $path;
+                continue;
+            }
+
+            $this->io->mkdir(dirname($path));
+            $this->io->filePutContents($path, $contents);
+            $written[] = $path;
+        }
+
+        return new StubPublishResult($written, $skipped);
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -8,6 +8,7 @@ use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
+use Gacela\Console\Application\Doctor\Check\StubHealthCheck;
 use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\CheckStatus;
@@ -83,6 +84,7 @@ final class DoctorCommand extends Command
         $modules = $this->getFacade()->findAllAppModules($filter);
         $configFactory = $config->getFactory();
         $suffixTypes = $configFactory->createGacelaFileConfig()->getSuffixTypes();
+        $stubsDir = $this->getFacade()->stubsDir();
 
         $checks = [
             new CacheStalenessCheck(
@@ -95,6 +97,7 @@ final class DoctorCommand extends Command
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules),
             new ConfigSchemaCheck($config->configSchema(), $config->getAllValues()),
+            new StubHealthCheck($stubsDir, StubHealthCheck::readPublished($stubsDir)),
         ];
 
         foreach (HealthCheckRegistry::createHealthChecker(Gacela::container())->checkAll()->getResults() as $moduleName => $status) {

--- a/src/Console/Infrastructure/Command/StubsPublishCommand.php
+++ b/src/Console/Infrastructure/Command/StubsPublishCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\FileContent\StubFiles;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_values;
+use function count;
+use function implode;
+use function in_array;
+use function sprintf;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
+final class StubsPublishCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const TEMPLATES = ['basic', 'service'];
+
+    protected function configure(): void
+    {
+        $this->setName('stubs:publish')
+            ->setDescription("Copy the scaffolder's templates into the project, so make:module generates your house style")
+            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Publish only one template set: basic or service')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite stubs the project already published');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $template = ConsoleInput::option($input, 'template');
+        if ($template !== '' && !in_array($template, self::TEMPLATES, true)) {
+            $output->writeln(sprintf(
+                '<error>Unknown template "%s". Use one of: %s</error>',
+                $template,
+                implode(', ', self::TEMPLATES),
+            ));
+
+            return self::FAILURE;
+        }
+
+        $stubsDir = $this->getFacade()->stubsDir();
+        $result = $this->getFacade()->publishStubs(
+            $stubsDir,
+            $this->stubsOf($template),
+            $input->getOption('force') === true,
+        );
+
+        foreach ($result->written as $path) {
+            $output->writeln(sprintf('<fg=green>✓</> %s', $path));
+        }
+
+        if ($result->hasSkipped()) {
+            $output->writeln('');
+            foreach ($result->skipped as $path) {
+                $output->writeln(sprintf('<error>✗ Already published:</error> %s', $path));
+            }
+
+            $output->writeln('<comment>Nothing was overwritten. Pass --force to replace them.</comment>');
+
+            return self::FAILURE;
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf('<info>%d stub(s) published into %s</info>', count($result->written), $stubsDir));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string> the stub files to publish; empty means every one
+     */
+    private function stubsOf(string $template): array
+    {
+        return match ($template) {
+            'basic' => array_values(StubFiles::basic()),
+            'service' => array_values(StubFiles::service()),
+            default => [],
+        };
+    }
+}

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -31,6 +31,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string configSchema = 'configSchema';
 
+    public const string stubsDir = 'stubsDir';
+
     public const string servicesToExtend = 'servicesToExtend';
 
     public const string factories = 'factories';
@@ -70,6 +72,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_CONFIG_KEY_VALUES = [];
 
     protected const array DEFAULT_CONFIG_SCHEMA = [];
+
+    protected const string DEFAULT_STUBS_DIR = 'stubs/gacela';
 
     protected const bool DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT = false;
 
@@ -154,5 +158,14 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     public function shouldValidateConfigSchemaOnBoot(): bool
     {
         return self::DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT;
+    }
+
+    /**
+     * Where a project's published scaffolder stubs live, relative to the
+     * application root unless an absolute path is given.
+     */
+    public function getStubsDir(): string
+    {
+        return self::DEFAULT_STUBS_DIR;
     }
 }

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -64,6 +64,8 @@ final class GacelaConfig
 
     private ?bool $shouldValidateConfigSchemaOnBoot = null;
 
+    private ?string $stubsDir = null;
+
     private ?bool $areEventListenersEnabled = null;
 
     /** @var list<callable> */
@@ -362,6 +364,21 @@ final class GacelaConfig
     public function validateConfigSchemaOnBoot(bool $enabled = true): self
     {
         $this->shouldValidateConfigSchemaOnBoot = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Where `stubs:publish` writes the scaffolder's templates, and where
+     * `make:module`/`make:file` look for them before falling back to the
+     * built-in ones.
+     *
+     * Relative to the application root unless an absolute path is given.
+     * Defaults to `stubs/gacela`.
+     */
+    public function setStubsDir(string $dir): self
+    {
+        $this->stubsDir = $dir;
 
         return $this;
     }
@@ -735,6 +752,7 @@ final class GacelaConfig
             $this->definitions,
             $this->configSchema,
             $this->shouldValidateConfigSchemaOnBoot,
+            $this->stubsDir,
         );
     }
 

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -79,6 +79,7 @@ final class GacelaConfigTransfer
         public readonly array $definitions = [],
         public readonly ?array $configSchema = null,
         public readonly ?bool $shouldValidateConfigSchemaOnBoot = null,
+        public readonly ?string $stubsDir = null,
     ) {
     }
 }

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -71,6 +71,8 @@ final class Properties
 
     public ?bool $shouldValidateConfigSchemaOnBoot = null;
 
+    public ?string $stubsDir = null;
+
     public ?bool $areEventListenersEnabled = null;
 
     /** @var ?list<callable> */

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -31,6 +31,7 @@ final class SetupInitializer
             ->setConfigKeyValues($dto->configKeyValues)
             ->setConfigSchema($dto->configSchema)
             ->setShouldValidateConfigSchemaOnBoot($dto->shouldValidateConfigSchemaOnBoot)
+            ->setStubsDir($dto->stubsDir)
             ->setAreEventListenersEnabled($dto->areEventListenersEnabled)
             ->setGenericListeners($dto->genericListeners)
             ->setSpecificListeners($dto->specificListeners)

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -30,6 +30,7 @@ final class SetupMerger
         $this->whenChanged($other, SetupGacela::projectNamespaces, fn () => $this->original->mergeProjectNamespaces($other->getProjectNamespaces()));
         $this->whenChanged($other, SetupGacela::configKeyValues, fn () => $this->original->mergeConfigKeyValues($other->getConfigKeyValues()));
         $this->whenChanged($other, SetupGacela::configSchema, fn () => $this->original->mergeConfigSchema($other->getConfigSchema()));
+        $this->whenChanged($other, SetupGacela::stubsDir, fn (): SetupGacela => $this->original->setStubsDir($other->getStubsDir()));
         $this->mergeEventDispatcher($other);
         $this->mergeServicesToExtend($other);
         $this->whenChanged($other, SetupGacela::factories, fn () => $this->original->mergeFactories($other->getFactories()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -304,6 +304,23 @@ final class SetupGacela extends AbstractSetupGacela
         return $this->properties->shouldValidateConfigSchemaOnBoot ?? self::DEFAULT_VALIDATE_CONFIG_SCHEMA_ON_BOOT;
     }
 
+    #[Override]
+    public function getStubsDir(): string
+    {
+        return $this->properties->stubsDir ?? self::DEFAULT_STUBS_DIR;
+    }
+
+    public function setStubsDir(?string $dir): self
+    {
+        $this->properties->stubsDir = $this->setPropertyWithTracking(
+            self::stubsDir,
+            $dir,
+            self::DEFAULT_STUBS_DIR,
+        );
+
+        return $this;
+    }
+
     /**
      * @param ?array<string, ConfigType> $configSchema
      */

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -45,6 +45,8 @@ interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerC
 
     public function shouldValidateConfigSchemaOnBoot(): bool;
 
+    public function getStubsDir(): string;
+
     public function getEventDispatcher(): EventDispatcherInterface;
 
     public function merge(SetupGacela $other): self;

--- a/symfony-bridge/tests/Fixtures/CountingService.php
+++ b/symfony-bridge/tests/Fixtures/CountingService.php
@@ -7,18 +7,28 @@ namespace GacelaTest\SymfonyBridge\Fixtures;
 /**
  * Counts its own construction, which is how a test can tell "reachable from
  * Gacela" from "built because Gacela was configured".
+ *
+ * The name says who built it. Object identity would say the same thing only as
+ * long as every container in the matrix memoises a bound closure the same way,
+ * and they do not: a constructor argument only Symfony supplies is the fact
+ * itself rather than a consequence of it.
  */
 final class CountingService
 {
+    public const AUTOWIRED = 'autowired';
+
+    public const FROM_SYMFONY = 'symfony';
+
     public static int $constructed = 0;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly string $name = self::AUTOWIRED,
+    ) {
         ++self::$constructed;
     }
 
     public function name(): string
     {
-        return 'counting';
+        return $this->name;
     }
 }

--- a/symfony-bridge/tests/Fixtures/TestKernel.php
+++ b/symfony-bridge/tests/Fixtures/TestKernel.php
@@ -55,6 +55,7 @@ final class TestKernel extends Kernel
 
             foreach ($this->extraServices as $id => $class) {
                 $definition = new Definition($class);
+                $definition->setArguments([CountingService::FROM_SYMFONY]);
                 $definition->setPublic(true);
                 $container->setDefinition($id, $definition);
             }

--- a/symfony-bridge/tests/GacelaBundleTest.php
+++ b/symfony-bridge/tests/GacelaBundleTest.php
@@ -53,20 +53,20 @@ final class GacelaBundleTest extends TestCase
     }
 
     /**
-     * Identity is the assertion that means anything here. Gacela autowires an
-     * unlisted class perfectly happily, so "an instance came back" would pass
-     * with the whole mapping deleted -- it is *Symfony's* instance that proves
-     * the service travelled across the bridge.
+     * Gacela autowires an unlisted class perfectly happily, so "an instance
+     * came back" would pass with the whole mapping deleted. What cannot is a
+     * constructor argument only Symfony supplies: an autowired one would carry
+     * the default instead.
      */
     public function test_a_service_listed_under_its_type_is_the_one_gacela_hands_back(): void
     {
         $kernel = $this->kernelWithCountingService();
         $kernel->boot();
 
-        self::assertSame(
-            $kernel->getContainer()->get('app.counting'),
-            Gacela::get(CountingService::class),
-        );
+        $service = Gacela::get(CountingService::class);
+
+        self::assertInstanceOf(CountingService::class, $service);
+        self::assertSame(CountingService::FROM_SYMFONY, $service->name());
     }
 
     /**

--- a/symfony-bridge/tests/GacelaCacheWarmerTest.php
+++ b/symfony-bridge/tests/GacelaCacheWarmerTest.php
@@ -13,7 +13,6 @@ use Gacela\SymfonyBridge\GacelaCacheWarmer;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-use function dirname;
 use function glob;
 use function unlink;
 
@@ -23,20 +22,24 @@ final class GacelaCacheWarmerTest extends TestCase
 
     private const CACHE_DIR = self::APP_ROOT . '/warmer-cache';
 
+    /**
+     * Only ever this fixture's own directory.
+     *
+     * Deriving the directory to empty from `Config::getCacheDir()` looked
+     * tidier and was not: with the file cache off that answers the *system*
+     * temp directory, and this loop then walked it deleting other processes'
+     * files. A cleanup must name what it created.
+     */
     protected function tearDown(): void
     {
-        // Every file, not just the one asserted on: warming also writes the
-        // merged-config cache, and a directory left behind is a directory the
-        // repo's own tooling then tries to format.
-        $file = $this->classNameCacheFile();
-        if ($file !== '') {
-            $directory = dirname($file);
-            foreach (glob($directory . '/*') ?: [] as $leftover) {
-                unlink($leftover);
-            }
-
-            @rmdir($directory);
+        // Warming writes more than the file asserted on -- the merged-config
+        // cache too -- and a directory left behind is one the repo's own
+        // tooling then tries to format.
+        foreach (glob(self::CACHE_DIR . '/*') ?: [] as $leftover) {
+            unlink($leftover);
         }
+
+        @rmdir(self::CACHE_DIR);
 
         Gacela::resetCache();
         Config::resetInstance();

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -71,6 +71,7 @@ final class DoctorCommandTest extends TestCase
             '✓ suffix configuration',
             '✓ pillar filenames',
             '✓ config schema',
+            '✓ published stubs',
             '✓ All checks passed',
         ], $this->statusLinesOf($tester));
     }
@@ -82,7 +83,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
         // The registered check runs after the built-in ones, and its detail is shown.
-        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[4]);
+        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[5]);
         self::assertStringContainsString('FakeHealthCheck ran', $tester->getDisplay());
     }
 

--- a/tests/Feature/Console/Stubs/StubsPublishCommandTest.php
+++ b/tests/Feature/Console/Stubs/StubsPublishCommandTest.php
@@ -161,6 +161,29 @@ final class StubsPublishCommandTest extends TestCase
         self::assertStringContainsString('matches no template', $tester->getDisplay());
     }
 
+    /**
+     * The scan has to descend one level: the service set lives in a
+     * subdirectory, so a typo there is exactly as invisible as one at the top.
+     */
+    public function test_doctor_reports_a_stub_nothing_reads_in_a_subdirectory(): void
+    {
+        $this->publishStub('service/facade-makr.txt', '<?php // typo, one level down');
+
+        $tester = $this->execute(new DoctorCommand());
+
+        self::assertStringContainsString('service/facade-makr.txt', $tester->getDisplay());
+        self::assertStringContainsString('matches no template', $tester->getDisplay());
+    }
+
+    public function test_doctor_accepts_a_published_service_stub(): void
+    {
+        $this->publishStub('service/facade-maker.txt', '<?php namespace $NAMESPACE$; class $CLASS_NAME$ {}');
+
+        $tester = $this->execute(new DoctorCommand());
+
+        self::assertStringContainsString('1 published stub(s), all usable', $tester->getDisplay());
+    }
+
     public function test_doctor_is_quiet_when_nothing_is_published(): void
     {
         $tester = $this->execute(new DoctorCommand());

--- a/tests/Feature/Console/Stubs/StubsPublishCommandTest.php
+++ b/tests/Feature/Console/Stubs/StubsPublishCommandTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\Stubs;
+
+use Gacela\Console\Infrastructure\Command\DoctorCommand;
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Console\Infrastructure\Command\StubsPublishCommand;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function bin2hex;
+use function dirname;
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class StubsPublishCommandTest extends TestCase
+{
+    private const GENERATED_DIR = __DIR__ . '/../../../../data/StubbedModule';
+
+    private string $appRoot = '';
+
+    private string $stubsDir = '';
+
+    protected function setUp(): void
+    {
+        $this->appRoot = sys_get_temp_dir() . '/gacela-stubs-app-' . bin2hex(random_bytes(6));
+        $this->stubsDir = $this->appRoot . '/stubs/gacela';
+        mkdir($this->appRoot, 0777, true);
+
+        $this->bootstrap();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursively($this->appRoot);
+        $this->removeRecursively(self::GENERATED_DIR);
+        Gacela::resetCache();
+    }
+
+    public function test_it_publishes_every_stub(): void
+    {
+        $tester = $this->execute(new StubsPublishCommand());
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertFileExists($this->stubsDir . '/facade-maker.txt');
+        self::assertFileExists($this->stubsDir . '/factory-maker.txt');
+        self::assertFileExists($this->stubsDir . '/service/facade-maker.txt');
+    }
+
+    public function test_it_publishes_only_the_asked_template_set(): void
+    {
+        $tester = $this->execute(new StubsPublishCommand(), ['--template' => 'basic']);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertFileExists($this->stubsDir . '/facade-maker.txt');
+        self::assertFileDoesNotExist($this->stubsDir . '/service/facade-maker.txt');
+    }
+
+    public function test_an_unknown_template_set_is_refused(): void
+    {
+        $tester = $this->execute(new StubsPublishCommand(), ['--template' => 'nope']);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('Unknown template "nope"', $tester->getDisplay());
+    }
+
+    /**
+     * A published stub is a file somebody changed on purpose. Overwriting it
+     * silently is the one thing this must never do.
+     */
+    public function test_it_refuses_to_overwrite_what_the_project_already_published(): void
+    {
+        $this->publishStub('facade-maker.txt', 'house style');
+
+        $tester = $this->execute(new StubsPublishCommand());
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('Already published:', $tester->getDisplay());
+        self::assertSame('house style', (string)file_get_contents($this->stubsDir . '/facade-maker.txt'));
+    }
+
+    public function test_force_replaces_them(): void
+    {
+        $this->publishStub('facade-maker.txt', 'house style');
+
+        $tester = $this->execute(new StubsPublishCommand(), ['--force' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertNotSame('house style', (string)file_get_contents($this->stubsDir . '/facade-maker.txt'));
+    }
+
+    /**
+     * Generation happens where the scaffolder puts files -- relative to the
+     * working directory, into the `data/` psr-4 target this repository maps --
+     * so this half bootstraps the repository itself and points it at a stubs
+     * directory of its own.
+     */
+    public function test_a_published_stub_is_what_make_module_generates_from(): void
+    {
+        $this->bootstrapRepositoryWithStubsDir();
+        $this->publishStub('facade-maker.txt', "<?php\n\nnamespace \$NAMESPACE\$;\n\n// house style \$CLASS_NAME\$\n");
+
+        $this->execute(new MakeModuleCommand(), ['path' => 'Psr4StubsData/StubbedModule']);
+
+        $generated = (string)file_get_contents(self::GENERATED_DIR . '/StubbedModuleFacade.php');
+
+        self::assertStringContainsString('// house style StubbedModuleFacade', $generated);
+    }
+
+    /**
+     * Publishing one file must not freeze the rest at the version it was copied
+     * from.
+     */
+    public function test_the_unpublished_files_still_come_from_the_built_in_stubs(): void
+    {
+        $this->bootstrapRepositoryWithStubsDir();
+        $this->publishStub('facade-maker.txt', "<?php\n\nnamespace \$NAMESPACE\$;\n\n// house style \$CLASS_NAME\$\n");
+
+        $this->execute(new MakeModuleCommand(), ['path' => 'Psr4StubsData/StubbedModule']);
+
+        $factory = (string)file_get_contents(self::GENERATED_DIR . '/StubbedModuleFactory.php');
+
+        self::assertStringContainsString('extends AbstractFactory', $factory);
+    }
+
+    public function test_doctor_reports_a_stub_that_lost_a_placeholder(): void
+    {
+        $this->publishStub('facade-maker.txt', '<?php // nothing to substitute');
+
+        $tester = $this->execute(new DoctorCommand());
+
+        self::assertStringContainsString('published stubs', $tester->getDisplay());
+        self::assertStringContainsString('$NAMESPACE$', $tester->getDisplay());
+    }
+
+    /**
+     * An edit filed under a name nothing reads is an edit that never takes
+     * effect, and looks exactly like one that did.
+     */
+    public function test_doctor_reports_a_stub_nothing_reads(): void
+    {
+        $this->publishStub('facade-maker.txt', '<?php namespace $NAMESPACE$; class $CLASS_NAME$ {}');
+        $this->publishStub('facade-makr.txt', '<?php // typo in the filename');
+
+        $tester = $this->execute(new DoctorCommand());
+
+        self::assertStringContainsString('facade-makr.txt', $tester->getDisplay());
+        self::assertStringContainsString('matches no template', $tester->getDisplay());
+    }
+
+    public function test_doctor_is_quiet_when_nothing_is_published(): void
+    {
+        $tester = $this->execute(new DoctorCommand());
+
+        self::assertStringContainsString('no stubs published', $tester->getDisplay());
+    }
+
+    /**
+     * The repository is its own scaffolding target: `data/` is a psr-4 path
+     * here, and the generator writes relative to the working directory.
+     */
+    private function bootstrapRepositoryWithStubsDir(): void
+    {
+        $stubsDir = $this->stubsDir;
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($stubsDir): void {
+            $config->resetInMemoryCache();
+            $config->setStubsDir($stubsDir);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function execute(Command $command, array $input = []): CommandTester
+    {
+        $tester = new CommandTester($command);
+        $tester->execute($input);
+
+        return $tester;
+    }
+
+    private function publishStub(string $relativePath, string $contents): void
+    {
+        $path = $this->stubsDir . '/' . $relativePath;
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function bootstrap(): void
+    {
+        file_put_contents($this->appRoot . '/composer.json', '{"autoload":{"psr-4":{"App\\\\":"src/"}}}');
+
+        Gacela::bootstrap($this->appRoot, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+    }
+
+    private function removeRecursively(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (scandir($directory) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $path = $directory . '/' . $entry;
+            if (is_dir($path)) {
+                $this->removeRecursively($path);
+            } elseif (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Feature/Console/Stubs/composer.json
+++ b/tests/Feature/Console/Stubs/composer.json
@@ -1,0 +1,12 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Psr4Stubs\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Psr4StubsData\\": "data/"
+        }
+    }
+}

--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -7,6 +7,8 @@ namespace GacelaTest\Unit\Console\Domain\FileContent;
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
 use Gacela\Console\Domain\FileContent\FileContentGenerator;
 use Gacela\Console\Domain\FileContent\FileContentIoInterface;
+use Gacela\Console\Domain\FileContent\StubFiles;
+use Gacela\Console\Domain\FileContent\StubLocator;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +17,7 @@ final class FileContentGeneratorTest extends TestCase
     public function test_error_when_unknown_template(): void
     {
         $fileContentIo = $this->createStub(FileContentIoInterface::class);
-        $generator = new FileContentGenerator($fileContentIo, []);
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [], StubFiles::basic()));
 
         $this->expectExceptionMessage("Unknown template for 'unknown_template'?");
         $generator->generate(
@@ -35,9 +37,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/DirFacade.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Facade' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -58,9 +60,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/Facade.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Facade' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -82,9 +84,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/DirFactory.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Factory' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -105,9 +107,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/Factory.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Factory' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -129,9 +131,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/DirConfig.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Config' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -152,9 +154,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/Config.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Config' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -176,9 +178,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/DirProvider.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Provider' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -199,9 +201,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('Dir/Provider.php', 'template-result');
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             'Provider' => 'template-result',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace', 'Dir'),
@@ -225,9 +227,9 @@ final class FileContentGeneratorTest extends TestCase
             ->method('filePutContents')
             ->with('src/Module/ModuleFacade.php', $expectedContent);
 
-        $generator = new FileContentGenerator($fileContentIo, [
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [
             FilenameSanitizer::FACADE => 'namespace $NAMESPACE$; class $CLASS_NAME$ extends $MODULE_NAME$Base {}',
-        ]);
+        ], StubFiles::basic()));
 
         $actualPath = $generator->generate(
             new CommandArguments('Namespace\Module', 'src/Module'),

--- a/tests/Unit/Console/Domain/FileContent/StubFilesTest.php
+++ b/tests/Unit/Console/Domain/FileContent/StubFilesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\FileContent;
+
+use Gacela\Console\Domain\FileContent\StubFiles;
+use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+/**
+ * The names are the contract in both directions: a stub is published under one
+ * and looked up again by the same. Pinning them is what stops a rename from
+ * silently publishing a file nothing reads.
+ */
+final class StubFilesTest extends TestCase
+{
+    public function test_the_basic_set_names_a_file_for_every_pillar(): void
+    {
+        self::assertSame([
+            FilenameSanitizer::FACADE => 'facade-maker.txt',
+            FilenameSanitizer::FACTORY => 'factory-maker.txt',
+            FilenameSanitizer::CONFIG => 'config-maker.txt',
+            FilenameSanitizer::PROVIDER => 'provider-maker.txt',
+        ], StubFiles::basic());
+    }
+
+    public function test_the_service_set_has_its_own_facade_and_factory(): void
+    {
+        $service = StubFiles::service();
+
+        self::assertSame('service/facade-maker.txt', $service[FilenameSanitizer::FACADE]);
+        self::assertSame('service/factory-maker.txt', $service[FilenameSanitizer::FACTORY]);
+        self::assertSame('service/service-maker.txt', $service['Service']);
+        self::assertSame('service/facade-test-maker.txt', $service['FacadeTest']);
+    }
+
+    /**
+     * Config and Provider are generated the same way by both sets, so they are
+     * one file, not two copies that drift.
+     */
+    public function test_the_sets_share_the_files_they_generate_identically(): void
+    {
+        self::assertSame(
+            StubFiles::basic()[FilenameSanitizer::CONFIG],
+            StubFiles::service()[FilenameSanitizer::CONFIG],
+        );
+        self::assertSame(
+            StubFiles::basic()[FilenameSanitizer::PROVIDER],
+            StubFiles::service()[FilenameSanitizer::PROVIDER],
+        );
+    }
+
+    public function test_every_publishable_stub_is_listed_once(): void
+    {
+        self::assertSame([
+            'facade-maker.txt',
+            'factory-maker.txt',
+            'config-maker.txt',
+            'provider-maker.txt',
+            'service/facade-maker.txt',
+            'service/factory-maker.txt',
+            'service/service-maker.txt',
+            'service/facade-test-maker.txt',
+        ], StubFiles::all());
+    }
+
+    public function test_all_covers_both_sets(): void
+    {
+        $all = StubFiles::all();
+
+        foreach ([...StubFiles::basic(), ...StubFiles::service()] as $file) {
+            self::assertContains($file, $all);
+        }
+
+        self::assertCount(count($all), array_unique($all), 'a file listed twice would be published twice');
+    }
+}

--- a/tests/Unit/Console/Domain/FileContent/StubLocatorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/StubLocatorTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\FileContent;
+
+use Gacela\Console\Domain\FileContent\StubFiles;
+use Gacela\Console\Domain\FileContent\StubLocator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function bin2hex;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class StubLocatorTest extends TestCase
+{
+    private string $stubsDir = '';
+
+    /** @var list<string> */
+    private array $written = [];
+
+    protected function setUp(): void
+    {
+        $this->stubsDir = sys_get_temp_dir() . '/gacela-stubs-' . bin2hex(random_bytes(6));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->written as $file) {
+            if (is_file($file)) {
+                unlink($file);
+                @rmdir(dirname($file));
+            }
+        }
+
+        $this->written = [];
+
+        if (is_dir($this->stubsDir)) {
+            @rmdir($this->stubsDir);
+        }
+    }
+
+    public function test_the_built_in_template_is_used_when_nothing_is_published(): void
+    {
+        self::assertSame('built-in facade', $this->locator()->templateFor('Facade'));
+    }
+
+    public function test_a_published_stub_replaces_the_built_in_one(): void
+    {
+        $this->publish('facade-maker.txt', 'house style facade');
+
+        self::assertSame('house style facade', $this->locator()->templateFor('Facade'));
+    }
+
+    /**
+     * Publishing one file must not freeze the rest at the version it was copied
+     * from.
+     */
+    public function test_the_other_files_keep_falling_back_to_the_built_in_ones(): void
+    {
+        $this->publish('facade-maker.txt', 'house style facade');
+
+        $locator = $this->locator();
+
+        self::assertSame('house style facade', $locator->templateFor('Facade'));
+        self::assertSame('built-in factory', $locator->templateFor('Factory'));
+    }
+
+    public function test_a_stub_in_a_subdirectory_is_found(): void
+    {
+        $this->publish('service/facade-maker.txt', 'house style service facade');
+
+        $locator = new StubLocator(
+            $this->stubsDir,
+            ['Facade' => 'built-in service facade'],
+            StubFiles::service(),
+        );
+
+        self::assertSame('house style service facade', $locator->templateFor('Facade'));
+    }
+
+    /**
+     * The published Facade of the basic set is not the published Facade of the
+     * service set: they generate different files and live under different names.
+     */
+    public function test_the_two_template_sets_do_not_share_a_published_stub(): void
+    {
+        $this->publish('facade-maker.txt', 'basic');
+
+        $service = new StubLocator(
+            $this->stubsDir,
+            ['Facade' => 'built-in service facade'],
+            StubFiles::service(),
+        );
+
+        self::assertSame('built-in service facade', $service->templateFor('Facade'));
+    }
+
+    public function test_without_a_stubs_directory_nothing_is_published(): void
+    {
+        $locator = new StubLocator('', ['Facade' => 'built-in facade'], StubFiles::basic());
+
+        self::assertSame('built-in facade', $locator->templateFor('Facade'));
+    }
+
+    public function test_an_unknown_filename_is_refused(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Nope');
+
+        $this->locator()->templateFor('Nope');
+    }
+
+    private function locator(): StubLocator
+    {
+        return new StubLocator(
+            $this->stubsDir,
+            ['Facade' => 'built-in facade', 'Factory' => 'built-in factory'],
+            StubFiles::basic(),
+        );
+    }
+
+    private function publish(string $relativePath, string $contents): void
+    {
+        $path = $this->stubsDir . '/' . $relativePath;
+        $directory = dirname($path);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($path, $contents);
+        $this->written[] = $path;
+    }
+}

--- a/tests/Unit/Console/Domain/FileContent/StubPublisherTest.php
+++ b/tests/Unit/Console/Domain/FileContent/StubPublisherTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\FileContent;
+
+use Gacela\Console\Domain\FileContent\FileContentIoInterface;
+use Gacela\Console\Domain\FileContent\StubPublisher;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class StubPublisherTest extends TestCase
+{
+    private string $stubsDir = '';
+
+    /** @var array<string, string> */
+    private array $written = [];
+
+    /** @var list<string> */
+    private array $directories = [];
+
+    /** @var list<string> */
+    private array $onDisk = [];
+
+    protected function setUp(): void
+    {
+        $this->stubsDir = sys_get_temp_dir() . '/gacela-publisher-' . bin2hex(random_bytes(6));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->onDisk as $path) {
+            if (is_file($path)) {
+                unlink($path);
+                @rmdir(dirname($path));
+            }
+        }
+
+        foreach ($this->directories as $directory) {
+            @rmdir($directory);
+        }
+
+        @rmdir($this->stubsDir);
+    }
+
+    public function test_it_writes_every_built_in_stub(): void
+    {
+        $result = $this->publisher()->publish($this->stubsDir);
+
+        self::assertSame([
+            $this->stubsDir . '/facade-maker.txt' => 'facade',
+            $this->stubsDir . '/service/facade-maker.txt' => 'service facade',
+        ], $this->written);
+        self::assertCount(2, $result->written);
+        self::assertSame([], $result->skipped);
+        self::assertFalse($result->hasSkipped());
+    }
+
+    public function test_it_creates_the_directory_each_stub_needs(): void
+    {
+        $this->publisher()->publish($this->stubsDir);
+
+        self::assertContains($this->stubsDir, $this->directories);
+        self::assertContains($this->stubsDir . '/service', $this->directories);
+    }
+
+    public function test_it_writes_only_the_stubs_asked_for(): void
+    {
+        $result = $this->publisher()->publish($this->stubsDir, ['facade-maker.txt']);
+
+        self::assertSame([$this->stubsDir . '/facade-maker.txt' => 'facade'], $this->written);
+        self::assertCount(1, $result->written);
+    }
+
+    /**
+     * A published stub is a file somebody changed on purpose.
+     */
+    public function test_it_leaves_an_already_published_stub_alone(): void
+    {
+        $this->publishOnDisk('facade-maker.txt');
+
+        $result = $this->publisher()->publish($this->stubsDir);
+
+        self::assertSame([$this->stubsDir . '/facade-maker.txt'], $result->skipped);
+        self::assertTrue($result->hasSkipped());
+        self::assertArrayNotHasKey($this->stubsDir . '/facade-maker.txt', $this->written);
+        self::assertArrayHasKey($this->stubsDir . '/service/facade-maker.txt', $this->written);
+    }
+
+    public function test_force_writes_over_it(): void
+    {
+        $this->publishOnDisk('facade-maker.txt');
+
+        $result = $this->publisher()->publish($this->stubsDir, [], true);
+
+        self::assertSame([], $result->skipped);
+        self::assertArrayHasKey($this->stubsDir . '/facade-maker.txt', $this->written);
+    }
+
+    private function publisher(): StubPublisher
+    {
+        return new StubPublisher($this->io(), [
+            'facade-maker.txt' => 'facade',
+            'service/facade-maker.txt' => 'service facade',
+        ]);
+    }
+
+    private function io(): FileContentIoInterface
+    {
+        return new class($this->written, $this->directories) implements FileContentIoInterface {
+            /**
+             * @param array<string, string> $written
+             * @param list<string> $directories
+             */
+            public function __construct(
+                private array &$written,
+                private array &$directories,
+            ) {
+            }
+
+            public function mkdir(string $directory): void
+            {
+                $this->directories[] = $directory;
+            }
+
+            public function filePutContents(string $path, string $fileContent): void
+            {
+                $this->written[$path] = $fileContent;
+            }
+        };
+    }
+
+    /**
+     * Really on disk: whether a stub is already published is a question about
+     * the filesystem, not about what this test recorded.
+     */
+    private function publishOnDisk(string $relativePath): void
+    {
+        $path = $this->stubsDir . '/' . $relativePath;
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+
+        file_put_contents($path, 'house style');
+        // Deliberately not recorded as written: the point of the test is what
+        // the publisher wrote, and a helper that says it wrote this file makes
+        // the two indistinguishable.
+        $this->onDisk[] = $path;
+    }
+}


### PR DESCRIPTION
## 📚 Description

The scaffolder's templates were string constants a provider handed to the
generator. A team with house style — a licence header, a base class of its own,
a different test skeleton — could not change one character without forking the
command, and scaffolding that fights the house style gets abandoned after the
first module.

## 🔖 Changes

- `stubs:publish` copies the built-in templates into the project (`stubs/gacela`, or `GacelaConfig::setStubsDir()`), with `--template=basic|service` and `--force`
- `StubLocator` resolves **per file**: a project stub when there is one, the built-in otherwise — publishing the Facade stub does not freeze the Factory at the version it was copied from
- Nothing already published is overwritten without `--force`: it is a file somebody changed on purpose
- `doctor` reports the two failures a published copy makes silent — a stub that lost `$NAMESPACE$`/`$CLASS_NAME$`, and one filed under a name the scaffolder never reads

Closes #658