### PR TITLE
feat(laravel-bridge): a service provider — the bundle's four things in Laravel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 /tests                   export-ignore
 /tools                   export-ignore
 /symfony-bridge          export-ignore
+/laravel-bridge          export-ignore
 /.editorconfig           export-ignore
 /.gitattributes          export-ignore
 /.gitignore              export-ignore

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,6 +13,8 @@ $finder = Finder::create()
     // the same style and analysis as src/ and tests/.
     ->in(__DIR__ . '/symfony-bridge/src')
     ->in(__DIR__ . '/symfony-bridge/tests')
+    ->in(__DIR__ . '/laravel-bridge/src')
+    ->in(__DIR__ . '/laravel-bridge/tests')
     ->ignoreVCSIgnored(true);
 
 return (new Config())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Check the declared schema on every bootstrap with `validateConfigSchemaOnBoot()`, for local development
 - Replace another module in a test with `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()`, dropped again in `tearDown()`
 - Register `GacelaBundle` in a Symfony application: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
+- Register `GacelaServiceProvider` in a Laravel application: it bootstraps Gacela when the application boots, maps listed Laravel bindings into it, adds the artisan commands under a `gacela:` prefix, and warms Gacela's caches from `artisan optimize`
+- Honor `#[Inject]` on Laravel-resolved services: on constructor parameters through Laravel's contextual attributes, on properties and setters through `afterResolving`
 - Publish the scaffolder's templates into the project with `stubs:publish`, and generate from them per file, falling back to the built-in ones
 - Report a published stub that lost a placeholder, or one the scaffolder never reads, in `doctor`
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ reach *that* from *here*". [`docs/`](docs/README.md) is the full index; the rest
 - [Opcache preload](docs/opcache-preload.md) and [production performance](docs/production-performance.md)
 - Full reference: [gacela-project.com](https://gacela-project.com/)
 - [Symfony bundle](symfony-bridge/README.md) — bootstrap Gacela from the kernel, reach Symfony services, `bin/console gacela:*`
+- [Laravel provider](laravel-bridge/README.md) — bootstrap Gacela when the app boots, reach Laravel services, `artisan gacela:*`
 - Examples:
   - [gacela-example](https://github.com/gacela-project/gacela-example)
   - [symfony-gacela-example](https://github.com/gacela-project/symfony-gacela-example) — Gacela with Symfony 7.4

--- a/composer.json
+++ b/composer.json
@@ -71,10 +71,10 @@
         "psr-4": {
             "GacelaData\\": "data/",
             "GacelaTest\\": "tests/",
-            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/",
             "GacelaTest\\LaravelBridge\\": "laravel-bridge/tests/",
-            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/",
-            "Gacela\\LaravelBridge\\": "laravel-bridge/src/"
+            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/",
+            "Gacela\\LaravelBridge\\": "laravel-bridge/src/",
+            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/"
         }
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,12 @@
         "bamarni/composer-bin-plugin": "^1.8",
         "ergebnis/composer-normalize": "^2.50",
         "friendsofphp/php-cs-fixer": "^3.95",
+        "illuminate/config": "^11.28 || ^12.0",
+        "illuminate/console": "^11.28 || ^12.0",
+        "illuminate/container": "^11.28 || ^12.0",
+        "illuminate/contracts": "^11.28 || ^12.0",
+        "illuminate/events": "^11.28 || ^12.0",
+        "illuminate/support": "^11.28 || ^12.0",
         "infection/infection": "^0.34",
         "nikic/php-parser": "^5.4",
         "phpbench/phpbench": "^1.4",
@@ -66,7 +72,9 @@
             "GacelaData\\": "data/",
             "GacelaTest\\": "tests/",
             "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/",
-            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/"
+            "GacelaTest\\LaravelBridge\\": "laravel-bridge/tests/",
+            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/",
+            "Gacela\\LaravelBridge\\": "laravel-bridge/src/"
         }
     },
     "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37bdaa889cb7d1d89db2024bf1cdc71d",
+    "content-hash": "59a65b4ab6f6c3130f498ddf13f229c1",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -1012,6 +1012,75 @@
             "time": "2026-02-04T10:18:12+00:00"
         },
         {
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<4.0.0 || >=5.0.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^4.0.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
             "source": {
@@ -1639,6 +1708,96 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0 || ^13.0",
+                "phpstan/phpstan": "^1.12 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^12.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T19:31:58+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -2522,6 +2681,794 @@
             "time": "2026-07-30T15:46:02+00:00"
         },
         {
+            "name": "illuminate/bus",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/bus.git",
+                "reference": "9e70f409c744e0ba6b301fa608bb5b3c8c38669a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/bus/zipball/9e70f409c744e0ba6b301fa608bb5b3c8c38669a",
+                "reference": "9e70f409c744e0ba6b301fa608bb5b3c8c38669a",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/pipeline": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "illuminate/queue": "Required to use closures when chaining jobs (^12.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Bus\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Bus package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-09T13:55:34+00:00"
+        },
+        {
+            "name": "illuminate/collections",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/collections.git",
+                "reference": "83313b009c4afb6f02dbc090bdb67809756eefa2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/83313b009c4afb6f02dbc090bdb67809756eefa2",
+                "reference": "83313b009c4afb6f02dbc090bdb67809756eefa2",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "suggest": {
+                "illuminate/http": "Required to convert collections to API resources (^12.0).",
+                "symfony/var-dumper": "Required to use the dump method (^7.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php",
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Collections package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-11T14:13:25+00:00"
+        },
+        {
+            "name": "illuminate/conditionable",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/conditionable.git",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Conditionable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2025-05-13T15:08:45+00:00"
+        },
+        {
+            "name": "illuminate/config",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/config.git",
+                "reference": "7adbf5cc27081d4613e1fa2f4f53e2a4fc91ad53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/config/zipball/7adbf5cc27081d4613e1fa2f4f53e2a4fc91ad53",
+                "reference": "7adbf5cc27081d4613e1fa2f4f53e2a4fc91ad53",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Config package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2025-10-26T17:11:19+00:00"
+        },
+        {
+            "name": "illuminate/console",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/console.git",
+                "reference": "ce37b63fb90f036dbd34263d84725f79c6d6f221"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/console/zipball/ce37b63fb90f036dbd34263d84725f79c6d6f221",
+                "reference": "ce37b63fb90f036dbd34263d84725f79c6d6f221",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "illuminate/view": "^12.0",
+                "laravel/prompts": "^0.3.0",
+                "nunomaduro/termwind": "^2.0",
+                "php": "^8.2",
+                "symfony/console": "^7.2.0",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/process": "^7.2.0"
+            },
+            "suggest": {
+                "dragonmantank/cron-expression": "Required to use scheduler (^3.3.2).",
+                "ext-pcntl": "Required to use signal trapping.",
+                "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^7.8).",
+                "illuminate/bus": "Required to use the scheduled job dispatcher (^12.0).",
+                "illuminate/container": "Required to use the scheduler (^12.0).",
+                "illuminate/filesystem": "Required to use the generator command (^12.0).",
+                "illuminate/queue": "Required to use closures for scheduled jobs (^12.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Console package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-07-29T14:35:23+00:00"
+        },
+        {
+            "name": "illuminate/container",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/container.git",
+                "reference": "9abe9dba6b3f5220205ce143069c975a601e4294"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/container/zipball/9abe9dba6b3f5220205ce143069c975a601e4294",
+                "reference": "9abe9dba6b3f5220205ce143069c975a601e4294",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^12.0",
+                "illuminate/reflection": "^12.0",
+                "php": "^8.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0"
+            },
+            "suggest": {
+                "illuminate/auth": "Required to use the Auth attribute",
+                "illuminate/cache": "Required to use the Cache attribute",
+                "illuminate/config": "Required to use the Config attribute",
+                "illuminate/database": "Required to use the DB attribute",
+                "illuminate/filesystem": "Required to use the Storage attribute",
+                "illuminate/log": "Required to use the Log or Context attributes"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Container\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Container package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-16T14:05:01+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "c16fd7ba7d8e6b8f336639ceb6b7e1ff6ed0efb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/c16fd7ba7d8e6b8f336639ceb6b7e1ff6ed0efb5",
+                "reference": "c16fd7ba7d8e6b8f336639ceb6b7e1ff6ed0efb5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "psr/simple-cache": "^1.0|^2.0|^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-06-09T13:20:54+00:00"
+        },
+        {
+            "name": "illuminate/events",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/events.git",
+                "reference": "ff22aa6017bdbd90ace660f50638ed9c580ba555"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/ff22aa6017bdbd90ace660f50638ed9c580ba555",
+                "reference": "ff22aa6017bdbd90ace660f50638ed9c580ba555",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "^12.0",
+                "illuminate/collections": "^12.0",
+                "illuminate/container": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Events\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Events package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-05T16:20:14+00:00"
+        },
+        {
+            "name": "illuminate/filesystem",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/filesystem.git",
+                "reference": "3b5ad9b385595d735689ebc2bfe701567cc4f1c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/3b5ad9b385595d735689ebc2bfe701567cc4f1c3",
+                "reference": "3b5ad9b385595d735689ebc2bfe701567cc4f1c3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/finder": "^7.2.0"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required to use the Filesystem class.",
+                "ext-ftp": "Required to use the Flysystem FTP driver.",
+                "ext-hash": "Required to use the Filesystem class.",
+                "illuminate/http": "Required for handling uploaded files (^12.0).",
+                "league/flysystem": "Required to use the Flysystem local driver (^3.25.1).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
+                "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.25.1).",
+                "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
+                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
+                "symfony/mime": "Required to enable support for guessing extensions (^7.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Filesystem package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-06-02T13:54:37+00:00"
+        },
+        {
+            "name": "illuminate/macroable",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/macroable.git",
+                "reference": "e295d62d89dcdb87e2b1bd70dd14d074a0ed73cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/e295d62d89dcdb87e2b1bd70dd14d074a0ed73cc",
+                "reference": "e295d62d89dcdb87e2b1bd70dd14d074a0ed73cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Macroable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-30T19:05:19+00:00"
+        },
+        {
+            "name": "illuminate/pipeline",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/pipeline.git",
+                "reference": "b6a14c20d69a44bf0a6fba664a00d23ca71770ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/pipeline/zipball/b6a14c20d69a44bf0a6fba664a00d23ca71770ee",
+                "reference": "b6a14c20d69a44bf0a6fba664a00d23ca71770ee",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "illuminate/database": "Required to use database transactions (^12.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Pipeline\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Pipeline package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2025-08-20T13:36:50+00:00"
+        },
+        {
+            "name": "illuminate/reflection",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/reflection.git",
+                "reference": "348cf5da9de89b596d7723be6425fb048e2bf4bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/reflection/zipball/348cf5da9de89b596d7723be6425fb048e2bf4bb",
+                "reference": "348cf5da9de89b596d7723be6425fb048e2bf4bb",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Reflection package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-25T15:25:18+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "bc7bc2db3e635697f81ea123511ae25b014a63fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/bc7bc2db3e635697f81ea123511ae25b014a63fb",
+                "reference": "bc7bc2db3e635697f81ea123511ae25b014a63fb",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^2.0",
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-mbstring": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/reflection": "^12.0",
+                "nesbot/carbon": "^3.8.4",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php85": "^1.33",
+                "voku/portable-ascii": "^2.0.2"
+            },
+            "conflict": {
+                "tightenco/collect": "<5.5.33"
+            },
+            "replace": {
+                "spatie/once": "*"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the Composer class (^12.0).",
+                "laravel/serializable-closure": "Required to use the once function (^1.3|^2.0).",
+                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
+                "league/uri": "Required to use the Uri class (^7.5.1).",
+                "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
+                "symfony/process": "Required to use the Composer class (^7.2).",
+                "symfony/uid": "Required to use Str::ulid() (^7.2).",
+                "symfony/var-dumper": "Required to use the dd function (^7.2).",
+                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.6.1)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php",
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-07-13T16:08:36+00:00"
+        },
+        {
+            "name": "illuminate/view",
+            "version": "v12.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/view.git",
+                "reference": "83bf8a22bb61145bcc1b8912103f6fb85078e35c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/83bf8a22bb61145bcc1b8912103f6fb85078e35c",
+                "reference": "83bf8a22bb61145bcc1b8912103f6fb85078e35c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/container": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/events": "^12.0",
+                "illuminate/filesystem": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\View\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate View package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-07-04T20:38:24+00:00"
+        },
+        {
             "name": "infection/abstract-testframework-adapter",
             "version": "0.5.1",
             "source": {
@@ -3026,6 +3973,65 @@
             "time": "2023-02-03T21:26:53+00:00"
         },
         {
+            "name": "laravel/prompts",
+            "version": "v0.3.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/prompts.git",
+                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/02b89b39e8972a998db4d5d4ad4719239dd4aee4",
+                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "ext-mbstring": "*",
+                "php": "^8.1",
+                "symfony/console": "^6.2|^7.0|^8.0"
+            },
+            "conflict": {
+                "illuminate/console": ">=10.17.0 <10.25.0",
+                "laravel/framework": ">=10.17.0 <10.25.0"
+            },
+            "require-dev": {
+                "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.5",
+                "pestphp/pest": "^2.3|^3.4|^4.0",
+                "phpstan/phpstan": "^1.12.28",
+                "phpstan/phpstan-mockery": "^1.1.3"
+            },
+            "suggest": {
+                "ext-pcntl": "Required for the spinner to be animated."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Prompts\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Add beautiful and user-friendly forms to your command-line applications.",
+            "support": {
+                "issues": "https://github.com/laravel/prompts/issues",
+                "source": "https://github.com/laravel/prompts/tree/v0.3.22"
+            },
+            "time": "2026-08-04T14:50:50+00:00"
+        },
+        {
             "name": "league/uri",
             "version": "7.8.1",
             "source": {
@@ -3396,6 +4402,111 @@
             "time": "2025-08-01T08:46:24+00:00"
         },
         {
+            "name": "nesbot/carbon",
+            "version": "3.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon.git",
+                "reference": "a1c54919f5fff9800cd03c32bd01defd5a4061cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/a1c54919f5fff9800cd03c32bd01defd5a4061cb",
+                "reference": "a1c54919f5fff9800cd03c32bd01defd5a4061cb",
+                "shasum": ""
+            },
+            "require": {
+                "carbonphp/carbon-doctrine-types": "<100.0",
+                "ext-json": "*",
+                "php": "^8.1",
+                "psr/clock": "^1.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6.3 || ^4.0",
+                "doctrine/orm": "^2.15.2 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^v3.87.1",
+                "kylekatarnls/multi-tester": "^2.5.3",
+                "phpmd/phpmd": "^2.15.0",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.22",
+                "phpunit/phpunit": "^10.5.53",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev",
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "https://markido.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "https://carbonphp.github.io/carbon/",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
+                "issues": "https://github.com/CarbonPHP/carbon/issues",
+                "source": "https://github.com/CarbonPHP/carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-08T11:40:35+00:00"
+        },
+        {
             "name": "netresearch/jsonmapper",
             "version": "v5.0.1",
             "source": {
@@ -3502,6 +4613,93 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
             "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.2",
+                "symfony/console": "^7.4.4 || ^8.0.4"
+            },
+            "require-dev": {
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
+                "mockery/mockery": "^1.6.12",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
+                "phpstan/phpstan": "^1.12.32",
+                "phpstan/phpstan-strict-rules": "^1.6.2",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "It's like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -5055,6 +6253,57 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "react/cache",
@@ -7022,6 +8271,84 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/clock",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v7.4.16",
             "source": {
@@ -8510,6 +9837,86 @@
             "time": "2026-05-26T12:45:58+00:00"
         },
         {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-01T12:47:55+00:00"
+        },
+        {
             "name": "symfony/polyfill-php84",
             "version": "v1.38.1",
             "source": {
@@ -8977,6 +10384,188 @@
                 }
             ],
             "time": "2026-07-28T07:33:02+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "501e0ff4553c744209ca1a68790d8a4541563710"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/501e0ff4553c744209ca1a68790d8a4541563710",
+                "reference": "501e0ff4553c744209ca1a68790d8a4541563710",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5.3|^3.3"
+            },
+            "conflict": {
+                "nikic/php-parser": "<5.0",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-30T12:37:26+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -9456,6 +11045,80 @@
                 "source": "https://github.com/vimeo/psalm"
             },
             "time": "2026-03-19T10:56:09+00:00"
+        },
+        {
+            "name": "voku/portable-ascii",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "https://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/portable-ascii/issues",
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-ascii",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T05:33:54+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/infection.json5
+++ b/infection.json5
@@ -247,6 +247,10 @@
                 // The cast is already annotated @psalm-suppress RedundantCast:
                 // reset() on a non-empty string list returns a string either way.
                 "Gacela\\Console\\Domain\\FilenameSanitizer\\FilenameSanitizer::sanitize",
+                // getName() is ?string by signature only: every command sets a
+                // name in configure(), so the cast defends a null that cannot
+                // occur. Same line, same reason, in the Symfony twin.
+                "Gacela\\LaravelBridge\\GacelaCommands::names",
             ],
         },
         UnwrapArrayMap: {

--- a/infection.json5
+++ b/infection.json5
@@ -17,7 +17,8 @@
             // Ships from this repo as its own package. phpunit.xml's <source>
             // covers it too, so it is both measured and gated rather than
             // measured only.
-            'symfony-bridge/src'
+            'symfony-bridge/src',
+            'laravel-bridge/src'
         ]
     },
     // 90, not 100: at 100 one equivalent mutant anywhere turns main red, and

--- a/laravel-bridge/README.md
+++ b/laravel-bridge/README.md
@@ -21,8 +21,10 @@ That alone gives you four things:
 1. **Gacela bootstrapped when the application boots** — with `base_path()` as
    the application root, honouring `gacela.php`. Every boot bootstraps again,
    so an application rebooted inside one process (package tests do it
-   constantly, Octane workers do it for a living) runs on its own configuration
-   rather than the previous boot's.
+   constantly) runs on its own configuration rather than the previous boot's.
+   Note that Octane boots each worker once and reuses it: a request-scoped
+   Laravel service listed in `external_services` stays whatever the worker's
+   first boot captured.
 2. **Laravel services reachable from Gacela** — the ones you list, and only
    those.
 3. **Gacela's console commands in `artisan`**, under a `gacela:` prefix.

--- a/laravel-bridge/README.md
+++ b/laravel-bridge/README.md
@@ -1,0 +1,153 @@
+# gacela/laravel-bridge
+
+Gacela inside a Laravel application: the service provider does the wiring every
+Laravel/Gacela project would otherwise write by hand.
+
+## Install
+
+```
+composer require gacela-project/laravel-bridge
+```
+
+```php
+// bootstrap/providers.php
+return [
+    Gacela\LaravelBridge\GacelaServiceProvider::class,
+];
+```
+
+That alone gives you four things:
+
+1. **Gacela bootstrapped when the application boots** — with `base_path()` as
+   the application root, honouring `gacela.php`. Every boot bootstraps again,
+   so an application rebooted inside one process (package tests do it
+   constantly, Octane workers do it for a living) runs on its own configuration
+   rather than the previous boot's.
+2. **Laravel services reachable from Gacela** — the ones you list, and only
+   those.
+3. **Gacela's console commands in `artisan`**, under a `gacela:` prefix.
+4. **`artisan optimize` warms Gacela's caches too**, so a deploy has one
+   optimize step instead of two. `optimize:clear` clears them again.
+
+Plus `#[Inject]` on Laravel-resolved services, described at the bottom.
+
+## Configuration
+
+```bash
+php artisan vendor:publish --tag=gacela-config
+```
+
+```php
+// config/gacela.php
+return [
+    'enabled' => true,
+    'app_root_dir' => null,          // where gacela.php lives; null means base_path()
+    'cache_dir' => null,             // null leaves Gacela's own default in place
+    'file_cache' => null,            // null leaves Gacela's own default in place
+    'project_namespaces' => ['App'],
+    'external_services' => [
+        'logger' => 'log',
+        Psr\Log\LoggerInterface::class => 'log',
+    ],
+    'register_commands' => true,
+    'command_prefix' => 'gacela:',
+];
+```
+
+Every key is validated when the provider boots — a mistyped one fails there,
+naming the key, instead of quietly configuring nothing. Laravel has no compile
+step, so boot is the earliest the check can run.
+
+### External services
+
+`external_services` maps a key to a Laravel binding id. What the key *is*
+decides how far the service travels:
+
+```php
+'external_services' => [
+    Psr\Log\LoggerInterface::class => 'log',   // a type: also bound
+    'report_mailer' => 'mailer',               // a plain key: external service only
+],
+```
+
+A key that **names a class or interface** additionally becomes a Gacela
+binding, so it resolves on its own — through `Gacela::get()`, through
+autowiring, through `#[Inject]`.
+
+A key that names **no type** stays an external service, which is what your own
+`gacela.php` reads when it declares bindings — because a binding maps a *type*
+to an implementation, and `report_mailer` is not one:
+
+```php
+// gacela.php
+$config->addBinding(MailerInterface::class, $config->getExternalService('report_mailer'));
+```
+
+Either way the service is fetched from Laravel's container when Gacela asks for
+it, so listing one does not construct it — booting the application stays as
+cheap as it was.
+
+### Commands
+
+The prefix is not decoration: artisan owns the whole `make:*` namespace, so an
+unprefixed `make:module` would collide with it.
+
+```bash
+php artisan gacela:make:module App/Blog
+php artisan gacela:doctor
+php artisan list gacela
+```
+
+Set `'register_commands' => false` to leave artisan alone and keep using
+`vendor/bin/gacela`.
+
+## `#[Inject]` on Laravel-resolved services
+
+Laravel autowires constructor parameters through its own container, and
+Gacela's `#[Inject]` attribute is recognised by Gacela's container only. On a
+class managed by Laravel — a controller, a job, a command — writing
+`#[Inject]` therefore had no effect: Laravel's autowire claimed the parameter
+first.
+
+The bridge closes that gap twice over.
+
+**On a constructor parameter**, use the bridge's attribute with an explicit
+class. It implements Laravel's `ContextualAttribute` contract, so Laravel
+itself resolves the parameter through Gacela — and because it extends the
+Gacela attribute, Gacela honours it too on the classes *it* builds. One
+attribute, both containers:
+
+```php
+use Gacela\LaravelBridge\Attribute\Inject;
+
+public function __construct(
+    #[Inject(ProductFacade::class)] private ProductFacade $facade,
+) {
+}
+```
+
+The class is required there: Laravel hands a contextual attribute no parameter
+to read a type from. Leaving it off fails with directions, not with a silently
+autowired substitute.
+
+**On a property or a setter**, the bare form works — the type is on the member.
+The provider listens to `afterResolving` and injects into every instance
+Laravel builds, honouring the attribute under either namespace:
+
+```php
+use Gacela\Container\Attribute\Inject;
+
+final class SyncStock implements ShouldQueue
+{
+    #[Inject]
+    private ProductFacade $facade;
+}
+```
+
+A `readonly` property is refused by name — it cannot be written after
+construction — and so is a static or non-public setter.
+
+## Status
+
+Experimental. API may change until it graduates out of `gacela/gacela`'s
+`laravel-bridge/` subfolder.

--- a/laravel-bridge/composer.json
+++ b/laravel-bridge/composer.json
@@ -42,5 +42,12 @@
         "psr-4": {
             "GacelaTest\\LaravelBridge\\": "tests/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Gacela\\LaravelBridge\\GacelaServiceProvider"
+            ]
+        }
     }
 }

--- a/laravel-bridge/composer.json
+++ b/laravel-bridge/composer.json
@@ -1,0 +1,46 @@
+{
+    "name": "gacela-project/laravel-bridge",
+    "type": "library",
+    "description": "Laravel service provider for Gacela: bootstraps it when the application boots, maps host services into it, registers its artisan commands, and honors #[Inject] on Laravel-managed services.",
+    "license": "MIT",
+    "homepage": "https://gacela-project.com",
+    "keywords": [
+        "php",
+        "gacela",
+        "laravel",
+        "dependency-injection",
+        "bridge"
+    ],
+    "authors": [
+        {
+            "name": "Jose Maria Valera Reales",
+            "email": "chemaclass@outlook.es",
+            "homepage": "https://chemaclass.com"
+        }
+    ],
+    "require": {
+        "php": ">=8.3",
+        "gacela-project/container": "^2.0.2",
+        "illuminate/config": "^11.28 || ^12.0",
+        "illuminate/console": "^11.28 || ^12.0",
+        "illuminate/container": "^11.28 || ^12.0",
+        "illuminate/contracts": "^11.28 || ^12.0",
+        "illuminate/events": "^11.28 || ^12.0",
+        "illuminate/support": "^11.28 || ^12.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Gacela\\LaravelBridge\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GacelaTest\\LaravelBridge\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/laravel-bridge/composer.json
+++ b/laravel-bridge/composer.json
@@ -1,9 +1,8 @@
 {
     "name": "gacela-project/laravel-bridge",
-    "type": "library",
     "description": "Laravel service provider for Gacela: bootstraps it when the application boots, maps host services into it, registers its artisan commands, and honors #[Inject] on Laravel-managed services.",
     "license": "MIT",
-    "homepage": "https://gacela-project.com",
+    "type": "library",
     "keywords": [
         "php",
         "gacela",
@@ -18,6 +17,7 @@
             "homepage": "https://chemaclass.com"
         }
     ],
+    "homepage": "https://gacela-project.com",
     "require": {
         "php": ">=8.3",
         "gacela-project/container": "^2.0.2",
@@ -31,6 +31,8 @@
     "require-dev": {
         "phpunit/phpunit": "^10.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Gacela\\LaravelBridge\\": "src/"
@@ -40,7 +42,5 @@
         "psr-4": {
             "GacelaTest\\LaravelBridge\\": "tests/"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/laravel-bridge/config/gacela.php
+++ b/laravel-bridge/config/gacela.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * What `config/gacela.php` may say. These are the defaults; publish the file
+ * with `artisan vendor:publish --tag=gacela-config` and edit what differs.
+ *
+ * An unknown key fails boot naming the key -- Laravel has no compile step
+ * where a validated tree could catch it, so the provider checks here, where it
+ * is a five-second fix, instead of at the first use of whatever the key was
+ * supposed to configure.
+ */
+return [
+    // Bootstrap Gacela when the application boots.
+    'enabled' => true,
+
+    // The directory holding gacela.php. Null defaults to base_path().
+    'app_root_dir' => null,
+
+    // Where Gacela writes its caches. Null leaves Gacela's own default in place.
+    'cache_dir' => null,
+
+    // Enable the on-disk resolution cache. Null leaves Gacela's own default in place.
+    'file_cache' => null,
+
+    // Namespaces Gacela scans for modules.
+    'project_namespaces' => [],
+
+    // Gacela external-service key => Laravel binding id, reachable from a Factory.
+    'external_services' => [],
+
+    // Add Gacela's console commands to artisan.
+    'register_commands' => true,
+
+    // Prefix for those commands. Required: `make:*` would otherwise collide with artisan's own.
+    'command_prefix' => 'gacela:',
+];

--- a/laravel-bridge/src/Attribute/Inject.php
+++ b/laravel-bridge/src/Attribute/Inject.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\LaravelBridge\Attribute;
+
+use Attribute;
+use Gacela\Container\Attribute\Inject as ContainerInject;
+use Gacela\Framework\Gacela;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+/**
+ * `#[Inject]` that Laravel's container honors natively.
+ *
+ * Extends the Gacela attribute -- non-`final` for exactly this, and every
+ * attribute read in Gacela passes `IS_INSTANCEOF`, so the subclass is honored
+ * there too. One attribute serves both containers: Gacela resolves it on the
+ * classes it builds, Laravel resolves it on the classes *it* builds, through
+ * the `ContextualAttribute` contract.
+ *
+ * On a constructor parameter the implementation is required: Laravel hands a
+ * contextual attribute no parameter to read a type from. On a property or a
+ * setter the type is on the member, so the bare form works -- that path is
+ * {@see \Gacela\LaravelBridge\GacelaInjectListener}'s.
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+final class Inject extends ContainerInject implements ContextualAttribute
+{
+    /**
+     * @throws BindingResolutionException
+     */
+    public static function resolve(self $attribute, Container $container): object
+    {
+        $target = $attribute->implementation
+            ?? throw new BindingResolutionException(
+                '#[Inject] on a constructor parameter resolved by Laravel needs an explicit class,'
+                . ' e.g. #[Inject(ProductFacade::class)]: Laravel hands a contextual attribute no'
+                . ' parameter to infer a type from. On a property or a setter the bare form works.',
+            );
+
+        return Gacela::getRequired($target);
+    }
+}

--- a/laravel-bridge/src/Configuration.php
+++ b/laravel-bridge/src/Configuration.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\LaravelBridge;
+
+use InvalidArgumentException;
+
+use function array_diff_key;
+use function array_is_list;
+use function array_keys;
+use function gettype;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_string;
+use function sprintf;
+
+/**
+ * What `config/gacela.php` may say.
+ *
+ * The bundle validates with a TreeBuilder at compile time; Laravel has no
+ * compile step, so the same philosophy runs at boot: an unknown or mistyped
+ * key fails there, where it is a five-second fix, instead of at the first use
+ * of whatever it was supposed to configure.
+ *
+ * @psalm-type GacelaBridgeConfig = array{
+ *     enabled: bool,
+ *     app_root_dir: ?string,
+ *     cache_dir: ?string,
+ *     file_cache: ?bool,
+ *     project_namespaces: list<string>,
+ *     external_services: array<string, string>,
+ *     register_commands: bool,
+ *     command_prefix: string
+ * }
+ */
+final class Configuration
+{
+    public const DEFAULTS_FILE = __DIR__ . '/../config/gacela.php';
+
+    /**
+     * @param array<array-key, mixed> $config
+     *
+     * @return GacelaBridgeConfig
+     */
+    public static function validate(array $config): array
+    {
+        // The literal path, not DEFAULTS_FILE: an include behind a constant is
+        // one psalm cannot resolve to a file.
+        /** @var GacelaBridgeConfig $defaults */
+        $defaults = require __DIR__ . '/../config/gacela.php';
+
+        $unknown = array_diff_key($config, $defaults);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown gacela config key(s): "%s". Allowed keys: "%s".',
+                implode('", "', array_keys($unknown)),
+                implode('", "', array_keys($defaults)),
+            ));
+        }
+
+        $config += $defaults;
+
+        self::assertBool($config, 'enabled');
+        self::assertBool($config, 'register_commands');
+        self::assertNullableBool($config, 'file_cache');
+        self::assertNullableString($config, 'app_root_dir');
+        self::assertNullableString($config, 'cache_dir');
+        self::assertString($config, 'command_prefix');
+        self::assertListOfStrings($config, 'project_namespaces');
+        self::assertMapOfStrings($config, 'external_services');
+
+        /** @var GacelaBridgeConfig $config */
+        return $config;
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private static function assertBool(array $config, string $key): void
+    {
+        if (!is_bool($config[$key])) {
+            throw self::mistyped($key, 'a boolean', $config[$key]);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private static function assertNullableBool(array $config, string $key): void
+    {
+        if ($config[$key] !== null && !is_bool($config[$key])) {
+            throw self::mistyped($key, 'a boolean or null', $config[$key]);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private static function assertString(array $config, string $key): void
+    {
+        if (!is_string($config[$key])) {
+            throw self::mistyped($key, 'a string', $config[$key]);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private static function assertNullableString(array $config, string $key): void
+    {
+        if ($config[$key] !== null && !is_string($config[$key])) {
+            throw self::mistyped($key, 'a string or null', $config[$key]);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private static function assertListOfStrings(array $config, string $key): void
+    {
+        $value = $config[$key];
+        if (!is_array($value) || !array_is_list($value)) {
+            throw self::mistyped($key, 'a list of strings', $value);
+        }
+
+        foreach ($value as $item) {
+            if (!is_string($item)) {
+                throw self::mistyped($key, 'a list of strings', $item);
+            }
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private static function assertMapOfStrings(array $config, string $key): void
+    {
+        $value = $config[$key];
+        if (!is_array($value)) {
+            throw self::mistyped($key, 'a map of string keys to string values', $value);
+        }
+
+        foreach ($value as $mapKey => $item) {
+            if (!is_string($mapKey) || !is_string($item)) {
+                throw self::mistyped($key, 'a map of string keys to string values', $item);
+            }
+        }
+    }
+
+    private static function mistyped(string $key, string $expected, mixed $actual): InvalidArgumentException
+    {
+        return new InvalidArgumentException(sprintf(
+            'The gacela config key "%s" must be %s, got %s.',
+            $key,
+            $expected,
+            gettype($actual),
+        ));
+    }
+}

--- a/laravel-bridge/src/GacelaBootstrapper.php
+++ b/laravel-bridge/src/GacelaBootstrapper.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\LaravelBridge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Psr\Container\ContainerInterface;
+
+use function class_exists;
+use function interface_exists;
+
+/**
+ * Bootstraps Gacela from what the Laravel application already knows.
+ *
+ * Every Laravel project that uses Gacela writes this by hand -- the base path,
+ * the handful of Laravel services a Factory needs to reach. It is the same
+ * code every time, which is what a bridge is for.
+ *
+ * Package tests build fresh applications constantly, so bootstrapping is
+ * idempotent by being repeated: each boot re-runs it, and the latest
+ * configuration is the one in force.
+ */
+final class GacelaBootstrapper
+{
+    /**
+     * @param array{cache_dir: ?string, file_cache: ?bool, project_namespaces: list<string>} $options
+     * @param array<string, string> $externalServices gacela key => laravel binding id
+     */
+    public function __construct(
+        private readonly string $appRootDir,
+        private readonly array $options,
+        private readonly ContainerInterface $services,
+        private readonly array $externalServices = [],
+    ) {
+    }
+
+    public function bootstrap(): void
+    {
+        Gacela::bootstrap($this->appRootDir, function (GacelaConfig $config): void {
+            // Without this, a re-bootstrap keeps the previous boot's locator,
+            // which keeps serving the previous boot's container -- the #597
+            // class of bug, one layer down. A first boot resets nothing but
+            // empty caches, so it only costs where it is needed.
+            $config->resetInMemoryCache();
+
+            $this->applyOptions($config);
+            $this->applyExternalServices($config);
+        });
+    }
+
+    private function applyOptions(GacelaConfig $config): void
+    {
+        if ($this->options['file_cache'] !== null) {
+            $config->setFileCache($this->options['file_cache'], $this->options['cache_dir']);
+        } elseif ($this->options['cache_dir'] !== null) {
+            $config->enableFileCache($this->options['cache_dir']);
+        }
+
+        if ($this->options['project_namespaces'] !== []) {
+            $config->setProjectNamespaces($this->options['project_namespaces']);
+        }
+    }
+
+    /**
+     * A listed service reaches Gacela two ways, and which ones apply is decided
+     * by the key the project chose.
+     *
+     * Every key becomes an external service: that is what a project's own
+     * `gacela.php` reads through `getExternalService()` when it declares its
+     * bindings. A key that *names a type* additionally becomes a binding, so
+     * `LoggerInterface::class => 'log'` is resolvable on its own -- by
+     * `Gacela::get()`, by autowiring, by `#[Inject]`. Bindings map types to
+     * implementations, so a key like `logger` has no business being one.
+     *
+     * Both take a closure, so a Laravel binding reaches Gacela without being
+     * constructed by the act of configuring it: a bridge that instantiated the
+     * database connection on every boot would cost more than it saves.
+     */
+    private function applyExternalServices(GacelaConfig $config): void
+    {
+        foreach ($this->externalServices as $key => $serviceId) {
+            $factory = fn (): object => $this->service($serviceId);
+
+            $config->addExternalService($key, $factory);
+
+            if (class_exists($key) || interface_exists($key)) {
+                $config->addBinding($key, $factory);
+            }
+        }
+    }
+
+    private function service(string $serviceId): object
+    {
+        /** @var object $service */
+        $service = $this->services->get($serviceId);
+
+        return $service;
+    }
+}

--- a/laravel-bridge/src/GacelaCommands.php
+++ b/laravel-bridge/src/GacelaCommands.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\LaravelBridge;
+
+use Gacela\Console\Infrastructure\Command\CacheClearCommand;
+use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
+use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
+use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
+use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
+use Gacela\Console\Infrastructure\Command\DoctorCommand;
+use Gacela\Console\Infrastructure\Command\InitCommand;
+use Gacela\Console\Infrastructure\Command\ListModulesCommand;
+use Gacela\Console\Infrastructure\Command\MakeFileCommand;
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
+use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
+use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Gacela's commands and the names they answer to.
+ *
+ * The names are read off the commands themselves rather than written down
+ * again: a renamed command would otherwise be registered under the old name
+ * here and silently stop matching what `vendor/bin/gacela` calls it.
+ *
+ * @internal
+ */
+final class GacelaCommands
+{
+    /** @var list<class-string<Command>> */
+    private const CLASSES = [
+        MakeFileCommand::class,
+        MakeModuleCommand::class,
+        ListModulesCommand::class,
+        DebugConfigCommand::class,
+        DebugContainerCommand::class,
+        DebugDependenciesCommand::class,
+        DebugGraphCommand::class,
+        DebugModuleCommand::class,
+        DebugModulesCommand::class,
+        CacheWarmCommand::class,
+        CacheClearCommand::class,
+        ValidateConfigCommand::class,
+        ProfileReportCommand::class,
+        DoctorCommand::class,
+        InitCommand::class,
+    ];
+
+    /**
+     * Constructing a command runs its `configure()`, which sets a name and
+     * options and touches nothing else -- no bootstrap, no filesystem -- so it
+     * is safe while the provider is still registering.
+     *
+     * @return array<class-string<Command>, string>
+     */
+    public static function names(): array
+    {
+        $names = [];
+
+        foreach (self::CLASSES as $class) {
+            $command = $class === InitCommand::class ? new InitCommand('') : new $class();
+            $names[$class] = (string)$command->getName();
+        }
+
+        return $names;
+    }
+}

--- a/laravel-bridge/src/GacelaInjectListener.php
+++ b/laravel-bridge/src/GacelaInjectListener.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\LaravelBridge;
+
+use Gacela\Container\Attribute\Inject;
+use Gacela\Framework\Gacela;
+use Illuminate\Contracts\Container\Container;
+use LogicException;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+use ReflectionType;
+
+use function is_object;
+use function sprintf;
+
+/**
+ * Honors `#[Inject]` on properties and setters of Laravel-resolved services.
+ *
+ * The compiler pass covers Symfony because Symfony has definitions to rewrite;
+ * Laravel builds classes it has never been told about, so the bridge listens
+ * to `afterResolving` instead and injects into the instance Laravel just
+ * built. Constructor parameters are {@see Attribute\Inject}'s job -- an
+ * `afterResolving` listener arrives too late for a constructor.
+ *
+ * Either namespace of the attribute is honored (`IS_INSTANCEOF`, the same
+ * contract Gacela's own resolver keeps), so a class annotated for Gacela
+ * behaves the same when Laravel is the one building it.
+ */
+final class GacelaInjectListener
+{
+    /**
+     * Class definitions cannot change within a process, so the plan survives
+     * across applications on purpose -- most classes have no `#[Inject]`
+     * member, and being told "none" once is enough.
+     *
+     * @var array<class-string, array{props: list<ReflectionProperty>, methods: list<ReflectionMethod>}|null>
+     */
+    private static array $plans = [];
+
+    public static function register(Container $app): void
+    {
+        $app->afterResolving(static function (mixed $object): void {
+            if (is_object($object)) {
+                self::injectInto($object);
+            }
+        });
+    }
+
+    private static function injectInto(object $object): void
+    {
+        $plan = self::$plans[$object::class] ??= self::plan($object::class);
+        if ($plan === null) {
+            return;
+        }
+
+        foreach ($plan['props'] as $property) {
+            self::injectProperty($object, $property);
+        }
+
+        foreach ($plan['methods'] as $method) {
+            self::injectMethod($object, $method);
+        }
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return array{props: list<ReflectionProperty>, methods: list<ReflectionMethod>}|null
+     */
+    private static function plan(string $class): ?array
+    {
+        $reflection = new ReflectionClass($class);
+
+        $props = [];
+        foreach (self::allProperties($reflection) as $property) {
+            if ($property->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF) !== []) {
+                $props[] = $property;
+            }
+        }
+
+        $methods = [];
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF) !== []) {
+                $methods[] = $method;
+            }
+        }
+
+        if ($props === [] && $methods === []) {
+            return null;
+        }
+
+        return ['props' => $props, 'methods' => $methods];
+    }
+
+    /**
+     * A parent's private properties are invisible to the child's reflection,
+     * and `#[Inject]` on one is no less a request for being inherited.
+     *
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return list<ReflectionProperty>
+     */
+    private static function allProperties(ReflectionClass $reflection): array
+    {
+        $properties = $reflection->getProperties();
+
+        for ($parent = $reflection->getParentClass(); $parent !== false; $parent = $parent->getParentClass()) {
+            foreach ($parent->getProperties(ReflectionProperty::IS_PRIVATE) as $property) {
+                $properties[] = $property;
+            }
+        }
+
+        return $properties;
+    }
+
+    private static function injectProperty(object $object, ReflectionProperty $property): void
+    {
+        if ($property->isStatic()) {
+            throw new LogicException(sprintf(
+                'Cannot #[Inject] the static property %s::$%s: injection targets an instance.',
+                $property->getDeclaringClass()->getName(),
+                $property->getName(),
+            ));
+        }
+
+        if ($property->isReadOnly()) {
+            throw new LogicException(sprintf(
+                'Cannot #[Inject] the readonly property %s::$%s after construction: inject it through the constructor instead.',
+                $property->getDeclaringClass()->getName(),
+                $property->getName(),
+            ));
+        }
+
+        // The target is computed before the initialized-check on purpose: an
+        // untyped property is always initialized (implicitly, to null), so
+        // checking value-state first would turn "this can never work" into
+        // silence -- the failure the attribute exists to prevent.
+        $target = self::propertyTarget($property);
+
+        if ($property->isInitialized($object)) {
+            return;
+        }
+
+        $property->setValue($object, Gacela::getRequired($target));
+    }
+
+    private static function injectMethod(object $object, ReflectionMethod $method): void
+    {
+        if ($method->isStatic() || !$method->isPublic()) {
+            throw new LogicException(sprintf(
+                'Cannot #[Inject] through %s::%s(): an injected method must be public and non-static.',
+                $method->getDeclaringClass()->getName(),
+                $method->getName(),
+            ));
+        }
+
+        $attribute = $method->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF)[0]->newInstance();
+
+        $arguments = [];
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            $target = $attribute->implementation !== null && $method->getNumberOfParameters() === 1
+                ? $attribute->implementation
+                : self::assertClassType($type, $method);
+
+            $arguments[] = Gacela::getRequired($target);
+        }
+
+        $method->invokeArgs($object, $arguments);
+    }
+
+    /**
+     * @return class-string
+     */
+    private static function propertyTarget(ReflectionProperty $property): string
+    {
+        $attribute = $property->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF)[0]->newInstance();
+        if ($attribute->implementation !== null) {
+            return $attribute->implementation;
+        }
+
+        $type = $property->getType();
+        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            throw new LogicException(sprintf(
+                'Cannot #[Inject] the property %s::$%s: it needs a class type or an explicit #[Inject(SomeClass::class)].',
+                $property->getDeclaringClass()->getName(),
+                $property->getName(),
+            ));
+        }
+
+        /** @var class-string */
+        return $type->getName();
+    }
+
+    /**
+     * @return class-string
+     */
+    private static function assertClassType(?ReflectionType $type, ReflectionMethod $method): string
+    {
+        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            throw new LogicException(sprintf(
+                'Cannot #[Inject] through %s::%s(): every parameter needs a class type.',
+                $method->getDeclaringClass()->getName(),
+                $method->getName(),
+            ));
+        }
+
+        /** @var class-string */
+        return $type->getName();
+    }
+}

--- a/laravel-bridge/src/GacelaInjectListener.php
+++ b/laravel-bridge/src/GacelaInjectListener.php
@@ -16,6 +16,7 @@ use ReflectionProperty;
 
 use ReflectionType;
 
+use function array_key_exists;
 use function is_object;
 use function sprintf;
 
@@ -54,7 +55,13 @@ final class GacelaInjectListener
 
     private static function injectInto(object $object): void
     {
-        $plan = self::$plans[$object::class] ??= self::plan($object::class);
+        // array_key_exists, not `??=`: most classes plan to null, and a
+        // null-coalescing memo recomputes exactly those on every resolution.
+        if (!array_key_exists($object::class, self::$plans)) {
+            self::$plans[$object::class] = self::plan($object::class);
+        }
+
+        $plan = self::$plans[$object::class];
         if ($plan === null) {
             return;
         }
@@ -162,12 +169,22 @@ final class GacelaInjectListener
 
         $attribute = $method->getAttributes(Inject::class, ReflectionAttribute::IS_INSTANCEOF)[0]->newInstance();
 
+        // Refused rather than guessed at: with two parameters there is no
+        // saying which one the override was meant for, and every other misuse
+        // in this class fails loudly too.
+        if ($attribute->implementation !== null && $method->getNumberOfParameters() !== 1) {
+            throw new LogicException(sprintf(
+                'Cannot #[Inject(%s)] through %s::%s(): an explicit implementation needs exactly one parameter to receive it.',
+                $attribute->implementation,
+                $method->getDeclaringClass()->getName(),
+                $method->getName(),
+            ));
+        }
+
         $arguments = [];
         foreach ($method->getParameters() as $parameter) {
-            $type = $parameter->getType();
-            $target = $attribute->implementation !== null && $method->getNumberOfParameters() === 1
-                ? $attribute->implementation
-                : self::assertClassType($type, $method);
+            $target = $attribute->implementation
+                ?? self::assertClassType($parameter->getType(), $method);
 
             $arguments[] = Gacela::getRequired($target);
         }

--- a/laravel-bridge/src/GacelaServiceProvider.php
+++ b/laravel-bridge/src/GacelaServiceProvider.php
@@ -27,8 +27,6 @@ use Symfony\Component\Console\Command\Command;
  *     Gacela\LaravelBridge\GacelaServiceProvider::class,
  * ];
  * ```
- *
- * @psalm-import-type GacelaBridgeConfig from Configuration
  */
 final class GacelaServiceProvider extends ServiceProvider
 {
@@ -73,7 +71,9 @@ final class GacelaServiceProvider extends ServiceProvider
 
         GacelaInjectListener::register($this->app);
 
-        if ($config['register_commands']) {
+        // Also gated on the console: names() constructs all fifteen commands
+        // to read their names, a price no web request should pay.
+        if ($config['register_commands'] && $this->app->runningInConsole()) {
             $this->registerGacelaCommands($config['command_prefix'], $appRootDir);
         }
     }

--- a/laravel-bridge/src/GacelaServiceProvider.php
+++ b/laravel-bridge/src/GacelaServiceProvider.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\LaravelBridge;
+
+use Gacela\Console\Infrastructure\Command\CacheClearCommand;
+use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Gacela\Console\Infrastructure\Command\InitCommand;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\ServiceProvider;
+use Override;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Gacela inside a Laravel application.
+ *
+ * Register it and the four things every Laravel/Gacela project wires by hand
+ * are done: bootstrapping when the application boots, mapping Laravel services
+ * into Gacela, the artisan commands, and warming the caches with Laravel's own
+ * `artisan optimize`. `#[Inject]` on Laravel-resolved services is honored
+ * through {@see GacelaInjectListener} and {@see Attribute\Inject}.
+ *
+ * ```php
+ * // bootstrap/providers.php
+ * return [
+ *     Gacela\LaravelBridge\GacelaServiceProvider::class,
+ * ];
+ * ```
+ *
+ * @psalm-import-type GacelaBridgeConfig from Configuration
+ */
+final class GacelaServiceProvider extends ServiceProvider
+{
+    #[Override]
+    public function register(): void
+    {
+        $this->mergeConfigFrom(Configuration::DEFAULTS_FILE, 'gacela');
+    }
+
+    /**
+     * Every boot bootstraps again, on purpose: package tests build fresh
+     * applications constantly, and the latest application's configuration is
+     * the one that should be in force -- not whatever an earlier one left
+     * behind.
+     */
+    public function boot(): void
+    {
+        $config = Configuration::validate($this->gacelaConfig());
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                Configuration::DEFAULTS_FILE => $this->app->configPath('gacela.php'),
+            ], 'gacela-config');
+        }
+
+        if (!$config['enabled']) {
+            return;
+        }
+
+        $appRootDir = $config['app_root_dir'] ?? $this->app->basePath();
+
+        (new GacelaBootstrapper(
+            $appRootDir,
+            [
+                'cache_dir' => $config['cache_dir'],
+                'file_cache' => $config['file_cache'],
+                'project_namespaces' => $config['project_namespaces'],
+            ],
+            $this->app,
+            $config['external_services'],
+        ))->bootstrap();
+
+        GacelaInjectListener::register($this->app);
+
+        if ($config['register_commands']) {
+            $this->registerGacelaCommands($config['command_prefix'], $appRootDir);
+        }
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function gacelaConfig(): array
+    {
+        /** @var Repository $repository */
+        $repository = $this->app->make('config');
+
+        return (array)$repository->get('gacela', []);
+    }
+
+    /**
+     * The names carry a prefix, because artisan owns `make:*` -- the same
+     * collision MakerBundle forces on the Symfony bundle. Each class is bound
+     * as a singleton building the renamed command, so artisan's own
+     * resolution hands back the prefixed one.
+     *
+     * `optimize` is hooked inside this guard: hooking it while the commands
+     * are not registered would point `artisan optimize` at a command that
+     * does not exist.
+     */
+    private function registerGacelaCommands(string $prefix, string $appRootDir): void
+    {
+        $names = GacelaCommands::names();
+
+        foreach ($names as $class => $name) {
+            $prefixed = $prefix . $name;
+            $this->app->singleton($class, static function () use ($class, $prefixed, $appRootDir): Command {
+                $command = $class === InitCommand::class ? new InitCommand($appRootDir) : new $class();
+                $command->setName($prefixed);
+
+                return $command;
+            });
+        }
+
+        $this->commands(array_keys($names));
+
+        $this->optimizes(
+            optimize: $prefix . $names[CacheWarmCommand::class],
+            clear: $prefix . $names[CacheClearCommand::class],
+            key: 'gacela',
+        );
+    }
+}

--- a/laravel-bridge/tests/ConfigurationTest.php
+++ b/laravel-bridge/tests/ConfigurationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge;
+
+use Gacela\LaravelBridge\Configuration;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+final class ConfigurationTest extends TestCase
+{
+    public function test_an_empty_config_is_the_defaults(): void
+    {
+        $config = Configuration::validate([]);
+
+        self::assertSame([
+            'enabled' => true,
+            'app_root_dir' => null,
+            'cache_dir' => null,
+            'file_cache' => null,
+            'project_namespaces' => [],
+            'external_services' => [],
+            'register_commands' => true,
+            'command_prefix' => 'gacela:',
+        ], $config);
+    }
+
+    public function test_a_full_config_passes_through(): void
+    {
+        $config = Configuration::validate([
+            'enabled' => false,
+            'app_root_dir' => '/srv/app',
+            'cache_dir' => '/tmp/gacela',
+            'file_cache' => true,
+            'project_namespaces' => ['App'],
+            'external_services' => ['logger' => 'log'],
+            'register_commands' => false,
+            'command_prefix' => 'g:',
+        ]);
+
+        self::assertFalse($config['enabled']);
+        self::assertSame('/srv/app', $config['app_root_dir']);
+        self::assertSame('/tmp/gacela', $config['cache_dir']);
+        self::assertTrue($config['file_cache']);
+        self::assertSame(['App'], $config['project_namespaces']);
+        self::assertSame(['logger' => 'log'], $config['external_services']);
+        self::assertFalse($config['register_commands']);
+        self::assertSame('g:', $config['command_prefix']);
+    }
+
+    public function test_an_unknown_key_fails_naming_the_key(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cache_dri');
+
+        Configuration::validate(['cache_dri' => '/tmp/gacela']);
+    }
+
+    public function test_an_unknown_key_fails_naming_the_allowed_keys(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cache_dir');
+
+        Configuration::validate(['cache_dri' => '/tmp/gacela']);
+    }
+
+    #[DataProvider('mistypedProvider')]
+    public function test_a_mistyped_key_fails_naming_the_key(string $key, mixed $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('"%s"', $key));
+
+        Configuration::validate([$key => $value]);
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed}>
+     */
+    public static function mistypedProvider(): iterable
+    {
+        yield 'enabled not bool' => ['enabled', 'yes'];
+        yield 'register_commands not bool' => ['register_commands', 1];
+        yield 'file_cache not bool nor null' => ['file_cache', 'on'];
+        yield 'app_root_dir not string nor null' => ['app_root_dir', 42];
+        yield 'cache_dir not string nor null' => ['cache_dir', false];
+        yield 'command_prefix not string' => ['command_prefix', null];
+        yield 'project_namespaces not a list' => ['project_namespaces', 'App'];
+        yield 'project_namespaces with non-string' => ['project_namespaces', [42]];
+        yield 'project_namespaces a map' => ['project_namespaces', ['a' => 'App']];
+        yield 'external_services not a map' => ['external_services', 'log'];
+        yield 'external_services with non-string key' => ['external_services', ['log']];
+        yield 'external_services with non-string value' => ['external_services', ['logger' => 42]];
+    }
+}

--- a/laravel-bridge/tests/Fixtures/BareConstructorConsumer.php
+++ b/laravel-bridge/tests/Fixtures/BareConstructorConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+final class BareConstructorConsumer
+{
+    public function __construct(
+        #[Inject]
+        public CountingService $service,
+    ) {
+    }
+}

--- a/laravel-bridge/tests/Fixtures/BaseWithPrivateProperty.php
+++ b/laravel-bridge/tests/Fixtures/BaseWithPrivateProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+abstract class BaseWithPrivateProperty
+{
+    #[Inject]
+    private CountingService $baseService;
+
+    public function baseService(): CountingService
+    {
+        return $this->baseService;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/ConstructorConsumer.php
+++ b/laravel-bridge/tests/Fixtures/ConstructorConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+final class ConstructorConsumer
+{
+    public function __construct(
+        #[Inject(CountingService::class)]
+        public CountingService $service,
+    ) {
+    }
+}

--- a/laravel-bridge/tests/Fixtures/ContractPropertyConsumer.php
+++ b/laravel-bridge/tests/Fixtures/ContractPropertyConsumer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+/**
+ * The property names the contract; the attribute names the implementation.
+ * Only the implementation is bound, so resolving the property type instead
+ * would fail loudly -- which is what makes the override observable.
+ */
+final class ContractPropertyConsumer
+{
+    #[Inject(CountingService::class)]
+    private ServiceContract $service;
+
+    public function service(): ServiceContract
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/ContractSetterConsumer.php
+++ b/laravel-bridge/tests/Fixtures/ContractSetterConsumer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+/**
+ * The parameter names the contract; the attribute names the implementation.
+ * Only the implementation is bound, so resolving the parameter type instead
+ * would fail loudly -- which is what makes the override observable.
+ */
+final class ContractSetterConsumer
+{
+    private ?ServiceContract $service = null;
+
+    public function service(): ?ServiceContract
+    {
+        return $this->service;
+    }
+
+    #[Inject(CountingService::class)]
+    public function setService(ServiceContract $service): void
+    {
+        $this->service = $service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/CountingService.php
+++ b/laravel-bridge/tests/Fixtures/CountingService.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+/**
+ * Counts its constructions, so a test can tell "configured" apart from
+ * "built" -- and carries a name only Laravel supplies, so a test can tell
+ * Laravel's instance apart from an autowired one.
+ */
+final class CountingService implements ServiceContract
+{
+    public const FROM_LARAVEL = 'from-laravel';
+
+    public static int $constructed = 0;
+
+    public function __construct(
+        private readonly string $name = 'autowired',
+    ) {
+        ++self::$constructed;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/InheritedPropertiesConsumer.php
+++ b/laravel-bridge/tests/Fixtures/InheritedPropertiesConsumer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+/**
+ * Two `#[Inject]` properties, one of them private on the parent: the child's
+ * reflection cannot see it, and the listener must walk up for it anyway.
+ */
+final class InheritedPropertiesConsumer extends BaseWithPrivateProperty
+{
+    #[Inject]
+    private CountingService $ownService;
+
+    public function ownService(): CountingService
+    {
+        return $this->ownService;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/InitializedPropertyConsumer.php
+++ b/laravel-bridge/tests/Fixtures/InitializedPropertyConsumer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+/**
+ * The property already holds a value -- null, on purpose. Injection fills what
+ * construction left unset; it does not overrule what construction decided.
+ */
+final class InitializedPropertyConsumer
+{
+    #[Inject]
+    private ?CountingService $service = null;
+
+    public function service(): ?CountingService
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/PrivateSetterConsumer.php
+++ b/laravel-bridge/tests/Fixtures/PrivateSetterConsumer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+final class PrivateSetterConsumer
+{
+    private ?CountingService $service = null;
+
+    public function service(): ?CountingService
+    {
+        return $this->service;
+    }
+
+    #[Inject]
+    private function setService(CountingService $service): void
+    {
+        $this->service = $service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/PropertyConsumer.php
+++ b/laravel-bridge/tests/Fixtures/PropertyConsumer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+/**
+ * Annotated with the *Gacela* attribute, not the bridge's: the listener must
+ * honor either namespace, the way Gacela's own resolver does.
+ */
+final class PropertyConsumer
+{
+    #[Inject]
+    private CountingService $service;
+
+    public function service(): CountingService
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/ReadonlyPropertyConsumer.php
+++ b/laravel-bridge/tests/Fixtures/ReadonlyPropertyConsumer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+final class ReadonlyPropertyConsumer
+{
+    #[Inject]
+    private readonly CountingService $service;
+
+    public function service(): CountingService
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/ServiceContract.php
+++ b/laravel-bridge/tests/Fixtures/ServiceContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+interface ServiceContract
+{
+    public function name(): string;
+}

--- a/laravel-bridge/tests/Fixtures/SetterConsumer.php
+++ b/laravel-bridge/tests/Fixtures/SetterConsumer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+final class SetterConsumer
+{
+    private ?CountingService $service = null;
+
+    #[Inject]
+    public function setService(CountingService $service): void
+    {
+        $this->service = $service;
+    }
+
+    public function service(): ?CountingService
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/TestApplication.php
+++ b/laravel-bridge/tests/Fixtures/TestApplication.php
@@ -25,8 +25,10 @@ final class TestApplication extends Container
     /**
      * @param array<string, mixed> $gacelaConfig what `config/gacela.php` would say
      */
-    public function __construct(array $gacelaConfig = [])
-    {
+    public function __construct(
+        array $gacelaConfig = [],
+        private readonly bool $runningInConsole = true,
+    ) {
         $this->id = bin2hex(random_bytes(6));
 
         $this->instance('config', new Repository(['gacela' => $gacelaConfig]));
@@ -52,6 +54,6 @@ final class TestApplication extends Container
 
     public function runningInConsole(): bool
     {
-        return true;
+        return $this->runningInConsole;
     }
 }

--- a/laravel-bridge/tests/Fixtures/TestApplication.php
+++ b/laravel-bridge/tests/Fixtures/TestApplication.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\GacelaServiceProvider;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+
+use function bin2hex;
+use function dirname;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+/**
+ * The smallest container that can run a provider: no laravel/framework, so
+ * what a test observes is the bridge and nothing else. The three methods the
+ * provider reaches on a real Application are answered here.
+ */
+final class TestApplication extends Container
+{
+    private readonly string $id;
+
+    /**
+     * @param array<string, mixed> $gacelaConfig what `config/gacela.php` would say
+     */
+    public function __construct(array $gacelaConfig = [])
+    {
+        $this->id = bin2hex(random_bytes(6));
+
+        $this->instance('config', new Repository(['gacela' => $gacelaConfig]));
+    }
+
+    public function boot(): void
+    {
+        $provider = new GacelaServiceProvider($this);
+        $provider->register();
+        $provider->boot();
+    }
+
+    public function basePath(string $path = ''): string
+    {
+        return dirname(__DIR__) . ($path === '' ? '' : DIRECTORY_SEPARATOR . $path);
+    }
+
+    public function configPath(string $path = ''): string
+    {
+        return sys_get_temp_dir() . '/gacela-bridge-app/' . $this->id . '/config'
+            . ($path === '' ? '' : DIRECTORY_SEPARATOR . $path);
+    }
+
+    public function runningInConsole(): bool
+    {
+        return true;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/TwoParameterSetterConsumer.php
+++ b/laravel-bridge/tests/Fixtures/TwoParameterSetterConsumer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+/**
+ * An explicit implementation over two parameters: there is no saying which
+ * one it was meant for, so the listener must refuse rather than guess.
+ */
+final class TwoParameterSetterConsumer
+{
+    /** @var list<ServiceContract> */
+    public array $received = [];
+
+    #[Inject(CountingService::class)]
+    public function setServices(ServiceContract $first, CountingService $second): void
+    {
+        $this->received = [$first, $second];
+    }
+}

--- a/laravel-bridge/tests/Fixtures/UntypedPropertyConsumer.php
+++ b/laravel-bridge/tests/Fixtures/UntypedPropertyConsumer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+final class UntypedPropertyConsumer
+{
+    #[Inject]
+    private $service;
+
+    public function service(): mixed
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/Fixtures/UntypedSetterConsumer.php
+++ b/laravel-bridge/tests/Fixtures/UntypedSetterConsumer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\Container\Attribute\Inject;
+
+final class UntypedSetterConsumer
+{
+    private mixed $service = null;
+
+    public function service(): mixed
+    {
+        return $this->service;
+    }
+
+    #[Inject]
+    public function setService(mixed $service): void
+    {
+        $this->service = $service;
+    }
+}

--- a/laravel-bridge/tests/GacelaBootstrapperTest.php
+++ b/laravel-bridge/tests/GacelaBootstrapperTest.php
@@ -54,6 +54,20 @@ final class GacelaBootstrapperTest extends TestCase
     }
 
     /**
+     * The explicit-on path is its own branch, and "off is the default anyway"
+     * would let it rot unnoticed: turning it on must both enable the cache and
+     * carry the directory along.
+     */
+    public function test_the_file_cache_can_be_turned_on_explicitly(): void
+    {
+        $cacheDir = self::APP_ROOT . '/bootstrapper-cache';
+        $this->bootstrap(['cache_dir' => $cacheDir, 'file_cache' => true]);
+
+        self::assertTrue(Config::getInstance()->getSetupGacela()->isFileCacheEnabled());
+        self::assertSame($cacheDir, Config::getInstance()->getSetupGacela()->getFileCacheDirectory());
+    }
+
+    /**
      * Saying nothing must change nothing: the provider's defaults are Gacela's
      * defaults, not a second opinion about them.
      */

--- a/laravel-bridge/tests/GacelaBootstrapperTest.php
+++ b/laravel-bridge/tests/GacelaBootstrapperTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use Gacela\LaravelBridge\GacelaBootstrapper;
+use GacelaTest\LaravelBridge\Fixtures\CountingService;
+use GacelaTest\LaravelBridge\Fixtures\ServiceContract;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * The bootstrapper on its own, where the two options that decide the file
+ * cache can be stated one at a time.
+ */
+final class GacelaBootstrapperTest extends TestCase
+{
+    private const APP_ROOT = __DIR__ . '/Fixtures';
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+    }
+
+    public function test_it_bootstraps_from_the_given_application_root(): void
+    {
+        $this->bootstrap();
+
+        self::assertSame(self::APP_ROOT, Config::getInstance()->getAppRootDir());
+    }
+
+    /**
+     * A cache directory with nothing said about the file cache means the
+     * project wants the cache, in that directory.
+     */
+    public function test_a_cache_dir_alone_turns_the_file_cache_on(): void
+    {
+        $this->bootstrap(['cache_dir' => self::APP_ROOT . '/bootstrapper-cache']);
+
+        self::assertTrue(Config::getInstance()->getSetupGacela()->isFileCacheEnabled());
+    }
+
+    public function test_the_file_cache_can_be_turned_off_explicitly(): void
+    {
+        $this->bootstrap(['cache_dir' => self::APP_ROOT . '/bootstrapper-cache', 'file_cache' => false]);
+
+        self::assertFalse(Config::getInstance()->getSetupGacela()->isFileCacheEnabled());
+    }
+
+    /**
+     * Saying nothing must change nothing: the provider's defaults are Gacela's
+     * defaults, not a second opinion about them.
+     */
+    public function test_saying_nothing_leaves_gacelas_own_default_in_place(): void
+    {
+        $this->bootstrap();
+
+        self::assertSame('', Config::getInstance()->getSetupGacela()->getFileCacheDirectory());
+    }
+
+    public function test_project_namespaces_are_passed_through(): void
+    {
+        $this->bootstrap(['project_namespaces' => ['App']]);
+
+        self::assertSame(['App'], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
+    }
+
+    /**
+     * A key that names a type becomes a binding, so it resolves on its own --
+     * which is what `#[Inject]` and autowiring go through.
+     */
+    public function test_a_service_listed_under_its_class_is_bound(): void
+    {
+        $this->bootstrap([], [CountingService::class => 'app.counting']);
+
+        self::assertInstanceOf(CountingService::class, Gacela::get(CountingService::class));
+    }
+
+    /**
+     * An interface names a type as much as a class does.
+     */
+    public function test_a_service_listed_under_an_interface_is_bound(): void
+    {
+        $this->bootstrap([], [ServiceContract::class => 'app.counting']);
+
+        self::assertInstanceOf(CountingService::class, Gacela::get(ServiceContract::class));
+    }
+
+    /**
+     * A key that names no type is still an external service, for a
+     * `gacela.php` to turn into whatever binding it wants -- bindings map
+     * types, and `counting` is not one.
+     */
+    public function test_a_service_listed_under_a_plain_key_is_not_bound(): void
+    {
+        $this->bootstrap([], ['counting' => 'app.counting']);
+
+        self::assertNull(Gacela::get('counting'));
+        self::assertArrayHasKey('counting', Config::getInstance()->getSetupGacela()->externalServices());
+    }
+
+    /**
+     * @param array{cache_dir?: ?string, file_cache?: ?bool, project_namespaces?: list<string>} $options
+     * @param array<string, string> $externalServices
+     */
+    private function bootstrap(array $options = [], array $externalServices = []): void
+    {
+        $bootstrapper = new GacelaBootstrapper(
+            self::APP_ROOT,
+            [
+                'cache_dir' => $options['cache_dir'] ?? null,
+                'file_cache' => $options['file_cache'] ?? null,
+                'project_namespaces' => $options['project_namespaces'] ?? [],
+            ],
+            $this->services(),
+            $externalServices,
+        );
+
+        $bootstrapper->bootstrap();
+    }
+
+    private function services(): ContainerInterface
+    {
+        $container = new Container();
+        $container->singleton('app.counting', static fn (): CountingService => new CountingService());
+
+        return $container;
+    }
+}

--- a/laravel-bridge/tests/GacelaBootstrapperTest.php
+++ b/laravel-bridge/tests/GacelaBootstrapperTest.php
@@ -10,23 +10,15 @@ use Gacela\LaravelBridge\GacelaBootstrapper;
 use GacelaTest\LaravelBridge\Fixtures\CountingService;
 use GacelaTest\LaravelBridge\Fixtures\ServiceContract;
 use Illuminate\Container\Container;
-use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * The bootstrapper on its own, where the two options that decide the file
  * cache can be stated one at a time.
  */
-final class GacelaBootstrapperTest extends TestCase
+final class GacelaBootstrapperTest extends LaravelBridgeTestCase
 {
     private const APP_ROOT = __DIR__ . '/Fixtures';
-
-    protected function tearDown(): void
-    {
-        Gacela::resetCache();
-        Config::resetInstance();
-        CountingService::$constructed = 0;
-    }
 
     public function test_it_bootstraps_from_the_given_application_root(): void
     {

--- a/laravel-bridge/tests/GacelaInjectTest.php
+++ b/laravel-bridge/tests/GacelaInjectTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GacelaTest\LaravelBridge;
 
-use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\LaravelBridge\GacelaInjectListener;
 use GacelaTest\LaravelBridge\Fixtures\BareConstructorConsumer;
@@ -24,7 +23,6 @@ use GacelaTest\LaravelBridge\Fixtures\UntypedPropertyConsumer;
 use GacelaTest\LaravelBridge\Fixtures\UntypedSetterConsumer;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use LogicException;
-use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 /**
@@ -33,7 +31,7 @@ use ReflectionProperty;
  * and the listener rides `afterResolving`, and neither exists outside a real
  * resolution.
  */
-final class GacelaInjectTest extends TestCase
+final class GacelaInjectTest extends LaravelBridgeTestCase
 {
     private TestApplication $app;
 
@@ -44,13 +42,6 @@ final class GacelaInjectTest extends TestCase
         ]);
         $this->app->singleton('app.counting', static fn (): CountingService => new CountingService(CountingService::FROM_LARAVEL));
         $this->app->boot();
-    }
-
-    protected function tearDown(): void
-    {
-        Gacela::resetCache();
-        Config::resetInstance();
-        CountingService::$constructed = 0;
     }
 
     public function test_a_constructor_parameter_resolves_through_gacela(): void

--- a/laravel-bridge/tests/GacelaInjectTest.php
+++ b/laravel-bridge/tests/GacelaInjectTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\LaravelBridge\Fixtures\BareConstructorConsumer;
+use GacelaTest\LaravelBridge\Fixtures\ConstructorConsumer;
+use GacelaTest\LaravelBridge\Fixtures\ContractPropertyConsumer;
+use GacelaTest\LaravelBridge\Fixtures\ContractSetterConsumer;
+use GacelaTest\LaravelBridge\Fixtures\CountingService;
+use GacelaTest\LaravelBridge\Fixtures\InheritedPropertiesConsumer;
+use GacelaTest\LaravelBridge\Fixtures\InitializedPropertyConsumer;
+use GacelaTest\LaravelBridge\Fixtures\PrivateSetterConsumer;
+use GacelaTest\LaravelBridge\Fixtures\PropertyConsumer;
+use GacelaTest\LaravelBridge\Fixtures\ReadonlyPropertyConsumer;
+use GacelaTest\LaravelBridge\Fixtures\SetterConsumer;
+use GacelaTest\LaravelBridge\Fixtures\TestApplication;
+use GacelaTest\LaravelBridge\Fixtures\UntypedPropertyConsumer;
+use GacelaTest\LaravelBridge\Fixtures\UntypedSetterConsumer;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `#[Inject]` on classes *Laravel* builds, driven through a real Illuminate
+ * container: the attribute rides Laravel's own contextual-attribute mechanism
+ * and the listener rides `afterResolving`, and neither exists outside a real
+ * resolution.
+ */
+final class GacelaInjectTest extends TestCase
+{
+    private TestApplication $app;
+
+    protected function setUp(): void
+    {
+        $this->app = new TestApplication([
+            'external_services' => [CountingService::class => 'app.counting'],
+        ]);
+        $this->app->singleton('app.counting', static fn (): CountingService => new CountingService(CountingService::FROM_LARAVEL));
+        $this->app->boot();
+    }
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+    }
+
+    public function test_a_constructor_parameter_resolves_through_gacela(): void
+    {
+        $consumer = $this->app->make(ConstructorConsumer::class);
+
+        self::assertSame(CountingService::FROM_LARAVEL, $consumer->service->name());
+        self::assertSame($this->app->make('app.counting'), $consumer->service);
+    }
+
+    /**
+     * Laravel hands a contextual attribute no parameter to read a type from,
+     * so the bare form cannot work on a constructor -- and it must say so,
+     * not silently autowire something else.
+     */
+    public function test_a_bare_constructor_parameter_is_refused_with_directions(): void
+    {
+        $this->expectException(BindingResolutionException::class);
+        // The whole message in order: the refusal, the example, the way out.
+        $this->expectExceptionMessageMatches('/explicit class.*ProductFacade::class.*bare form works/s');
+
+        $this->app->make(BareConstructorConsumer::class);
+    }
+
+    /**
+     * The Gacela-namespace attribute, on a private property: the listener must
+     * honor either namespace, and the type is on the member, so the bare form
+     * works here.
+     */
+    public function test_a_property_is_injected_after_laravel_builds_the_instance(): void
+    {
+        $consumer = $this->app->make(PropertyConsumer::class);
+
+        self::assertSame(CountingService::FROM_LARAVEL, $consumer->service()->name());
+    }
+
+    public function test_a_setter_is_called_with_what_gacela_resolves(): void
+    {
+        $consumer = $this->app->make(SetterConsumer::class);
+
+        self::assertSame(CountingService::FROM_LARAVEL, $consumer->service()?->name());
+    }
+
+    /**
+     * A readonly property cannot be written after construction; pretending
+     * otherwise would fail deep in reflection. Refusing it by name is the
+     * kindness.
+     */
+    public function test_a_readonly_property_is_refused_by_name(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('readonly');
+
+        $this->app->make(ReadonlyPropertyConsumer::class);
+    }
+
+    /**
+     * Injection fills what construction left unset; a property that already
+     * holds a value -- even null -- keeps it.
+     */
+    public function test_an_initialized_property_keeps_its_value(): void
+    {
+        $consumer = $this->app->make(InitializedPropertyConsumer::class);
+
+        self::assertNull($consumer->service());
+    }
+
+    public function test_a_private_setter_is_refused_by_name(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('public and non-static');
+
+        $this->app->make(PrivateSetterConsumer::class);
+    }
+
+    public function test_an_untyped_property_without_an_explicit_class_is_refused(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('class type');
+
+        $this->app->make(UntypedPropertyConsumer::class);
+    }
+
+    public function test_an_untyped_setter_parameter_is_refused(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('class type');
+
+        $this->app->make(UntypedSetterConsumer::class);
+    }
+
+    /**
+     * The parameter names the contract, the attribute names the
+     * implementation, and only the implementation is bound: resolving the
+     * parameter type instead would fail loudly.
+     */
+    public function test_a_setter_honors_an_explicit_implementation_over_the_parameter_type(): void
+    {
+        $consumer = $this->app->make(ContractSetterConsumer::class);
+
+        self::assertInstanceOf(CountingService::class, $consumer->service());
+    }
+
+    public function test_a_property_honors_an_explicit_implementation_over_its_type(): void
+    {
+        $consumer = $this->app->make(ContractPropertyConsumer::class);
+
+        self::assertInstanceOf(CountingService::class, $consumer->service());
+    }
+
+    /**
+     * Two `#[Inject]` properties, one private on the parent, invisible to the
+     * child's reflection: both must arrive.
+     */
+    public function test_a_parents_private_property_is_injected_alongside_the_childs(): void
+    {
+        $consumer = $this->app->make(InheritedPropertiesConsumer::class);
+
+        self::assertSame(CountingService::FROM_LARAVEL, $consumer->baseService()->name());
+        self::assertSame(CountingService::FROM_LARAVEL, $consumer->ownService()->name());
+    }
+}

--- a/laravel-bridge/tests/GacelaInjectTest.php
+++ b/laravel-bridge/tests/GacelaInjectTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\LaravelBridge;
 
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
+use Gacela\LaravelBridge\GacelaInjectListener;
 use GacelaTest\LaravelBridge\Fixtures\BareConstructorConsumer;
 use GacelaTest\LaravelBridge\Fixtures\ConstructorConsumer;
 use GacelaTest\LaravelBridge\Fixtures\ContractPropertyConsumer;
@@ -18,11 +19,13 @@ use GacelaTest\LaravelBridge\Fixtures\PropertyConsumer;
 use GacelaTest\LaravelBridge\Fixtures\ReadonlyPropertyConsumer;
 use GacelaTest\LaravelBridge\Fixtures\SetterConsumer;
 use GacelaTest\LaravelBridge\Fixtures\TestApplication;
+use GacelaTest\LaravelBridge\Fixtures\TwoParameterSetterConsumer;
 use GacelaTest\LaravelBridge\Fixtures\UntypedPropertyConsumer;
 use GacelaTest\LaravelBridge\Fixtures\UntypedSetterConsumer;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * `#[Inject]` on classes *Laravel* builds, driven through a real Illuminate
@@ -151,6 +154,19 @@ final class GacelaInjectTest extends TestCase
         self::assertInstanceOf(CountingService::class, $consumer->service());
     }
 
+    /**
+     * With two parameters there is no saying which one the override was meant
+     * for: refused, not guessed at -- silently resolving both by type would be
+     * the one quiet path in a class that otherwise fails loudly.
+     */
+    public function test_an_explicit_implementation_over_two_parameters_is_refused(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('exactly one parameter');
+
+        $this->app->make(TwoParameterSetterConsumer::class);
+    }
+
     public function test_a_property_honors_an_explicit_implementation_over_its_type(): void
     {
         $consumer = $this->app->make(ContractPropertyConsumer::class);
@@ -168,5 +184,31 @@ final class GacelaInjectTest extends TestCase
 
         self::assertSame(CountingService::FROM_LARAVEL, $consumer->baseService()->name());
         self::assertSame(CountingService::FROM_LARAVEL, $consumer->ownService()->name());
+    }
+
+    /**
+     * White-box on purpose: a class with no `#[Inject]` member must be
+     * remembered as `null`, the fast path every later resolution of it takes.
+     * An empty plan would behave the same today and quietly cost the loop
+     * set-up on every resolution forever.
+     */
+    public function test_a_class_with_nothing_to_inject_is_remembered_as_null(): void
+    {
+        // Evict the memo first: under random order another test may have
+        // planned this class already, and a memoized answer would let this
+        // test pass without ever exercising the planning itself.
+        $property = new ReflectionProperty(GacelaInjectListener::class, 'plans');
+        /** @var array<class-string, mixed> $plans */
+        $plans = $property->getValue();
+        unset($plans[CountingService::class]);
+        $property->setValue(null, $plans);
+
+        $this->app->make(CountingService::class);
+
+        /** @var array<class-string, mixed> $plans */
+        $plans = $property->getValue();
+
+        self::assertArrayHasKey(CountingService::class, $plans);
+        self::assertNull($plans[CountingService::class]);
     }
 }

--- a/laravel-bridge/tests/GacelaServiceProviderTest.php
+++ b/laravel-bridge/tests/GacelaServiceProviderTest.php
@@ -15,25 +15,14 @@ use Illuminate\Console\Application as Artisan;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
 
 /**
  * The provider driven through a real container, because everything it does
  * happens during registration or boot -- neither of which a unit test can
  * stand in for.
  */
-final class GacelaServiceProviderTest extends TestCase
+final class GacelaServiceProviderTest extends LaravelBridgeTestCase
 {
-    protected function tearDown(): void
-    {
-        Gacela::resetCache();
-        Config::resetInstance();
-        CountingService::$constructed = 0;
-        Artisan::forgetBootstrappers();
-        ServiceProvider::$optimizeCommands = [];
-        ServiceProvider::$optimizeClearCommands = [];
-    }
-
     public function test_booting_the_application_bootstraps_gacela(): void
     {
         $app = new TestApplication();

--- a/laravel-bridge/tests/GacelaServiceProviderTest.php
+++ b/laravel-bridge/tests/GacelaServiceProviderTest.php
@@ -201,6 +201,19 @@ final class GacelaServiceProviderTest extends TestCase
         self::assertSame('gacela:cache:clear', ServiceProvider::$optimizeClearCommands['gacela'] ?? null);
     }
 
+    /**
+     * names() constructs all fifteen commands to read their names -- a price
+     * no web request should pay for artisan commands it can never run.
+     */
+    public function test_a_web_request_registers_no_commands(): void
+    {
+        $app = new TestApplication([], runningInConsole: false);
+        $app->boot();
+
+        self::assertFalse($this->artisan($app)->has('gacela:make:module'));
+        self::assertArrayNotHasKey('gacela', ServiceProvider::$optimizeCommands);
+    }
+
     public function test_registering_no_commands_registers_no_optimize_hooks_either(): void
     {
         $app = new TestApplication(['register_commands' => false]);

--- a/laravel-bridge/tests/GacelaServiceProviderTest.php
+++ b/laravel-bridge/tests/GacelaServiceProviderTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use Gacela\LaravelBridge\Configuration;
+use Gacela\LaravelBridge\GacelaCommands;
+use Gacela\LaravelBridge\GacelaServiceProvider;
+use GacelaTest\LaravelBridge\Fixtures\CountingService;
+use GacelaTest\LaravelBridge\Fixtures\TestApplication;
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The provider driven through a real container, because everything it does
+ * happens during registration or boot -- neither of which a unit test can
+ * stand in for.
+ */
+final class GacelaServiceProviderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+        Artisan::forgetBootstrappers();
+        ServiceProvider::$optimizeCommands = [];
+        ServiceProvider::$optimizeClearCommands = [];
+    }
+
+    public function test_booting_the_application_bootstraps_gacela(): void
+    {
+        $app = new TestApplication();
+        $app->boot();
+
+        self::assertSame($app->basePath(), Config::getInstance()->getAppRootDir());
+    }
+
+    /**
+     * Package tests build fresh applications constantly, and a second
+     * bootstrap that served the first one's configuration was a real bug
+     * (#597). The bridge must not reintroduce it by bootstrapping only once.
+     */
+    public function test_a_second_boot_bootstraps_again(): void
+    {
+        (new TestApplication())->boot();
+        self::assertSame([], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
+
+        (new TestApplication(['project_namespaces' => ['App']]))->boot();
+
+        self::assertSame(['App'], Config::getInstance()->getSetupGacela()->getProjectNamespaces());
+    }
+
+    /**
+     * The sharper variant of the same lesson: the locator memoizes instances,
+     * and a re-bootstrap that kept it would keep serving the first
+     * application's services no matter what the second one listed.
+     */
+    public function test_a_second_boot_serves_the_second_applications_services(): void
+    {
+        $this->appWithCountingService()->boot();
+        self::assertSame(CountingService::FROM_LARAVEL, Gacela::get(CountingService::class)?->name());
+
+        $rebooted = new TestApplication([
+            'external_services' => [CountingService::class => 'app.counting'],
+        ]);
+        $rebooted->singleton('app.counting', static fn (): CountingService => new CountingService('rebooted'));
+        $rebooted->boot();
+
+        self::assertSame('rebooted', Gacela::get(CountingService::class)?->name());
+    }
+
+    /**
+     * Gacela autowires an unlisted class perfectly happily, so "an instance
+     * came back" would pass with the whole mapping deleted. What cannot is a
+     * constructor argument only Laravel supplies: an autowired one would carry
+     * the default instead.
+     */
+    public function test_a_service_listed_under_its_type_is_the_one_gacela_hands_back(): void
+    {
+        $app = $this->appWithCountingService();
+        $app->boot();
+
+        $service = Gacela::get(CountingService::class);
+
+        self::assertInstanceOf(CountingService::class, $service);
+        self::assertSame(CountingService::FROM_LARAVEL, $service->name());
+    }
+
+    /**
+     * The other audience, and the one every key reaches: a project's own
+     * `gacela.php` reads it through `getExternalService()` when it declares
+     * its bindings.
+     */
+    public function test_a_listed_service_is_offered_to_gacela_php_whatever_its_key(): void
+    {
+        $app = new TestApplication(['external_services' => ['counting' => 'app.counting']]);
+        $app->singleton('app.counting', static fn (): CountingService => new CountingService(CountingService::FROM_LARAVEL));
+        $app->boot();
+
+        self::assertArrayHasKey('counting', Config::getInstance()->getSetupGacela()->externalServices());
+    }
+
+    /**
+     * Configuring is not using: a bridge that built the database connection on
+     * every boot would cost more than it saves.
+     */
+    public function test_a_listed_service_is_not_built_until_it_is_asked_for(): void
+    {
+        $this->appWithCountingService()->boot();
+
+        self::assertSame(0, CountingService::$constructed, 'booting alone must not construct it');
+
+        Gacela::get(CountingService::class);
+
+        self::assertSame(1, CountingService::$constructed);
+    }
+
+    public function test_a_service_nobody_listed_is_not_bound(): void
+    {
+        (new TestApplication())->boot();
+
+        self::assertNull(Gacela::get('counting'));
+    }
+
+    /**
+     * `register()` is where the defaults land in the repository, so a project
+     * reading `config('gacela.command_prefix')` sees one even before boot.
+     */
+    public function test_registering_merges_the_default_config(): void
+    {
+        $app = new TestApplication();
+        (new GacelaServiceProvider($app))->register();
+
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $app->make('config');
+
+        self::assertSame('gacela:', $config->get('gacela.command_prefix'));
+    }
+
+    public function test_the_app_root_dir_is_the_projects_to_choose(): void
+    {
+        $app = new TestApplication(['app_root_dir' => __DIR__ . '/Fixtures']);
+        $app->boot();
+
+        self::assertSame(__DIR__ . '/Fixtures', Config::getInstance()->getAppRootDir());
+    }
+
+    public function test_an_unknown_config_key_fails_boot_naming_the_key(): void
+    {
+        $app = new TestApplication(['cache_dri' => '/tmp/gacela']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cache_dri');
+
+        $app->boot();
+    }
+
+    public function test_the_config_is_publishable(): void
+    {
+        (new TestApplication())->boot();
+
+        $paths = ServiceProvider::pathsToPublish(GacelaServiceProvider::class, 'gacela-config');
+
+        self::assertArrayHasKey(Configuration::DEFAULTS_FILE, $paths);
+    }
+
+    public function test_artisan_lists_the_commands_under_the_gacela_prefix(): void
+    {
+        $app = new TestApplication();
+        $app->boot();
+
+        $artisan = $this->artisan($app);
+
+        foreach (GacelaCommands::names() as $name) {
+            self::assertTrue($artisan->has('gacela:' . $name), 'missing gacela:' . $name);
+        }
+
+        self::assertFalse($artisan->has('make:module'), 'artisan owns make:*; the bare name must stay free');
+    }
+
+    public function test_the_prefix_is_the_projects_to_choose(): void
+    {
+        $app = new TestApplication(['command_prefix' => 'g:']);
+        $app->boot();
+
+        self::assertTrue($this->artisan($app)->has('g:make:module'));
+    }
+
+    public function test_optimize_warms_and_clears_through_the_gacela_commands(): void
+    {
+        (new TestApplication())->boot();
+
+        self::assertSame('gacela:cache:warm', ServiceProvider::$optimizeCommands['gacela'] ?? null);
+        self::assertSame('gacela:cache:clear', ServiceProvider::$optimizeClearCommands['gacela'] ?? null);
+    }
+
+    public function test_registering_no_commands_registers_no_optimize_hooks_either(): void
+    {
+        $app = new TestApplication(['register_commands' => false]);
+        $app->boot();
+
+        self::assertFalse($this->artisan($app)->has('gacela:make:module'));
+        self::assertArrayNotHasKey('gacela', ServiceProvider::$optimizeCommands);
+    }
+
+    public function test_disabling_the_bridge_registers_nothing(): void
+    {
+        $app = new TestApplication([
+            'enabled' => false,
+            'external_services' => ['counting' => 'app.counting'],
+        ]);
+        $app->boot();
+
+        self::assertFalse($this->artisan($app)->has('gacela:make:module'));
+        self::assertArrayNotHasKey('gacela', ServiceProvider::$optimizeCommands);
+    }
+
+    private function appWithCountingService(): TestApplication
+    {
+        $app = new TestApplication([
+            'external_services' => [CountingService::class => 'app.counting'],
+        ]);
+        $app->singleton('app.counting', static fn (): CountingService => new CountingService(CountingService::FROM_LARAVEL));
+
+        return $app;
+    }
+
+    private function artisan(TestApplication $app): Artisan
+    {
+        return new Artisan($app, new Dispatcher($app), 'testing');
+    }
+}

--- a/laravel-bridge/tests/LaravelBridgeTestCase.php
+++ b/laravel-bridge/tests/LaravelBridgeTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\LaravelBridge\Fixtures\CountingService;
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Support\ServiceProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Booting a provider leaves process-global state behind: Gacela's own
+ * singletons, and Laravel's -- `Artisan::starting()` closures and the
+ * optimize registries are static. Every test class that boots one must sweep
+ * all of it, so the sweeping lives here rather than in whichever class first
+ * failed under an unlucky seed.
+ */
+abstract class LaravelBridgeTestCase extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+        Artisan::forgetBootstrappers();
+        ServiceProvider::$optimizeCommands = [];
+        ServiceProvider::$optimizeClearCommands = [];
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src/
         - %currentWorkingDirectory%/symfony-bridge/src/
+        - %currentWorkingDirectory%/laravel-bridge/src/
     parallel:
         maximumNumberOfProcesses: 4
     excludePaths:
@@ -33,6 +34,10 @@ parameters:
         -
             identifier: gacela.suffixExtends
             path: src/Framework/*
+        # A *Laravel* service provider: the host's word, not a pillar.
+        -
+            identifier: gacela.suffixExtends
+            path: laravel-bridge/src/GacelaServiceProvider.php
         # Building a MethodReflection is unavoidable for a methodsClassReflectionExtension,
         # and PHPStan covers no way of doing it under its BC promise -- neither implementing
         # ExtendedMethodReflection nor constructing its own implementation of it. The class

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     <testsuite name="unit">
       <directory suffix="Test.php">tests/Unit</directory>
       <directory suffix="Test.php">symfony-bridge/tests</directory>
+      <directory suffix="Test.php">laravel-bridge/tests</directory>
     </testsuite>
     <testsuite name="integration">
       <directory suffix="Test.php">tests/Integration</directory>
@@ -31,6 +32,7 @@
     <include>
       <directory suffix=".php">src</directory>
       <directory suffix=".php">symfony-bridge/src</directory>
+      <directory suffix=".php">laravel-bridge/src</directory>
     </include>
   </source>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
     <projectFiles>
         <directory name="src"/>
         <directory name="symfony-bridge/src"/>
+        <directory name="laravel-bridge/src"/>
         <ignoreFiles>
             <directory name="vendor"/>
         </ignoreFiles>
@@ -40,6 +41,8 @@
         <PluginIssue name="GacelaSuffixExtends">
             <errorLevel type="suppress">
                 <directory name="src/Framework"/>
+                <!-- A *Laravel* service provider: the host's word, not a pillar. -->
+                <file name="laravel-bridge/src/GacelaServiceProvider.php"/>
             </errorLevel>
         </PluginIssue>
         <DeprecatedClass errorLevel="suppress" />

--- a/rector.php
+++ b/rector.php
@@ -27,6 +27,8 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/tests',
         __DIR__ . '/symfony-bridge/src',
         __DIR__ . '/symfony-bridge/tests',
+        __DIR__ . '/laravel-bridge/src',
+        __DIR__ . '/laravel-bridge/tests',
     ]);
 
     $rectorConfig->skip([
@@ -84,12 +86,19 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUnusedVariableAssignRector::class => [__DIR__ . '/tests'],
         // The container writes `#[Inject]` properties through
         // ReflectionProperty::setValue(); readonly would make those fixtures
-        // untestable for the mechanism they exist to cover.
-        ReadOnlyPropertyRector::class => [__DIR__ . '/tests'],
+        // untestable for the mechanism they exist to cover. The laravel-bridge
+        // listener does the same to its fixtures.
+        ReadOnlyPropertyRector::class => [
+            __DIR__ . '/tests',
+            __DIR__ . '/laravel-bridge/tests/Fixtures',
+        ],
         // `#[Before]`-attributed setup methods are invoked reflectively by PHPUnit;
         // rector sees them as unused. Removing them silently drops test isolation.
         RemoveUnusedPrivateMethodRector::class => [
             __DIR__ . '/tests/Unit/Framework/Testing/ContainerFixtureTest.php',
+            // A private #[Inject] setter that exists to be *refused*: no code
+            // path may call it, which is exactly what rector notices.
+            __DIR__ . '/laravel-bridge/tests/Fixtures/PrivateSetterConsumer.php',
         ],
         PrivatizeFinalClassMethodRector::class => [
             __DIR__ . '/tests/Unit/Framework/Testing/ContainerFixtureTest.php',


### PR DESCRIPTION
## 📚 Description

The Laravel counterpart to the Symfony bundle (#662), as #657 planned it: a `laravel-bridge/` package whose `GacelaServiceProvider` does the wiring every Laravel/Gacela project writes by hand — and honors `#[Inject]` on the classes Laravel builds.

Closes #664

## 🔖 Changes

- `GacelaServiceProvider` bootstraps Gacela when the application boots, with `base_path()` as the default root; every boot bootstraps again, so a rebooted application (package tests, Octane workers) runs on its own configuration.
- The bootstrapper resets the in-memory cache per bootstrap: a re-bootstrap that kept the locator would keep serving the previous boot's container — the #597 class of bug, one layer down. The suite's random order found exactly that; `test_a_second_boot_serves_the_second_applications_services` now pins it deterministically.
- `config/gacela.php` is publishable (`--tag=gacela-config`) and validated at boot: Laravel has no compile step, so an unknown or mistyped key fails there, naming the key — the bundle's validated-tree philosophy at the earliest moment Laravel offers.
- `external_services` maps Laravel bindings into Gacela lazily; a key that names a type additionally becomes a Gacela binding (the #662 fix), so it resolves through `Gacela::get()`, autowiring and `#[Inject]`.
- The artisan commands register under a `gacela:` prefix — artisan owns `make:*`, the same collision MakerBundle forces on the bundle — and `artisan optimize` / `optimize:clear` warm and clear Gacela's caches through `ServiceProvider::optimizes()`.
- `Gacela\LaravelBridge\Attribute\Inject` extends the Gacela attribute (non-`final` for exactly this) and implements Laravel's `ContextualAttribute`, so Laravel resolves constructor parameters through Gacela natively; the explicit class is required there, and leaving it off fails with directions rather than a silently autowired substitute.
- `GacelaInjectListener` honors `#[Inject]` on properties and setters of Laravel-resolved instances via `afterResolving`, under either attribute namespace (`IS_INSTANCEOF`, the container's own contract), including a parent's private properties; `readonly` properties and static or non-public setters are refused by name.
- `laravel-bridge/src` joins every gate: phpunit (unit suite + coverage source), psalm, phpstan, rector, php-cs-fixer and infection. Filtered MSI: 97%.
- Root `README.md` links the provider next to the bundle; `CHANGELOG.md` under `## Unreleased`.
- Dev dependencies: `illuminate/{config,console,container,contracts,events,support}` `^11.28 || ^12.0` (contextual attributes and `optimizes()` need 11.28+), mirroring how the bundle pins `symfony/*`.
