### PR TITLE
fix(symfony-bridge): serve the rebooted kernel's services, not the first one's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Publish the scaffolder's templates into the project with `stubs:publish`, and generate from them per file, falling back to the built-in ones
 - Report a published stub that lost a placeholder, or one the scaffolder never reads, in `doctor`
 
+### Fixed
+
+- Serve the rebooted kernel's services after a second `GacelaBundle` boot, instead of the previous kernel's out of a stale locator
+
 ## [2.1.0](https://github.com/gacela-project/gacela/compare/2.0.0...2.1.0) - 2026-08-09
 
 ### Added

--- a/infection.json5
+++ b/infection.json5
@@ -105,6 +105,9 @@
                 // would break on an unrelated upstream release.
                 // Not a TODO. The forwarding itself is required by the interface.
                 "Gacela\\Framework\\Container\\Container::warmUp",
+                // Bundle::build() is empty in Symfony's base class; the call is
+                // kept as the documented override convention, not as behavior.
+                "Gacela\\SymfonyBridge\\GacelaBundle::build",
             ],
         },
         IfNegation: {
@@ -249,8 +252,9 @@
                 "Gacela\\Console\\Domain\\FilenameSanitizer\\FilenameSanitizer::sanitize",
                 // getName() is ?string by signature only: every command sets a
                 // name in configure(), so the cast defends a null that cannot
-                // occur. Same line, same reason, in the Symfony twin.
+                // occur. Same line, same reason, in both bridges.
                 "Gacela\\LaravelBridge\\GacelaCommands::names",
+                "Gacela\\SymfonyBridge\\GacelaCommands::names",
             ],
         },
         UnwrapArrayMap: {

--- a/symfony-bridge/src/GacelaBootstrapper.php
+++ b/symfony-bridge/src/GacelaBootstrapper.php
@@ -39,6 +39,12 @@ final class GacelaBootstrapper
     public function bootstrap(): void
     {
         Gacela::bootstrap($this->appRootDir, function (GacelaConfig $config): void {
+            // Without this, a re-bootstrap keeps the previous boot's locator,
+            // which keeps serving the previous boot's container -- the #597
+            // class of bug, one layer down (#666). A first boot resets nothing
+            // but empty caches, so it only costs where it is needed.
+            $config->resetInMemoryCache();
+
             $this->applyOptions($config);
             $this->applyExternalServices($config);
         });

--- a/symfony-bridge/tests/Fixtures/TestKernel.php
+++ b/symfony-bridge/tests/Fixtures/TestKernel.php
@@ -29,11 +29,13 @@ final class TestKernel extends Kernel
     /**
      * @param array<string, mixed>       $gacelaConfig     what `gacela.yaml` would say
      * @param array<string, class-string> $extraServices   service id => class, registered public
+     * @param string                     $serviceName      the name those services carry, so a second kernel's are distinguishable
      */
     public function __construct(
         private readonly array $gacelaConfig = [],
         private readonly array $extraServices = [],
         string $environment = 'test',
+        private readonly string $serviceName = CountingService::FROM_SYMFONY,
     ) {
         $this->id = bin2hex(random_bytes(6));
 
@@ -55,7 +57,7 @@ final class TestKernel extends Kernel
 
             foreach ($this->extraServices as $id => $class) {
                 $definition = new Definition($class);
-                $definition->setArguments([CountingService::FROM_SYMFONY]);
+                $definition->setArguments([$this->serviceName]);
                 $definition->setPublic(true);
                 $container->setDefinition($id, $definition);
             }

--- a/symfony-bridge/tests/GacelaBootstrapperTest.php
+++ b/symfony-bridge/tests/GacelaBootstrapperTest.php
@@ -8,7 +8,6 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\SymfonyBridge\GacelaBootstrapper;
 use GacelaTest\SymfonyBridge\Fixtures\CountingService;
-use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
@@ -16,16 +15,9 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  * The bootstrapper on its own, where the two options that decide the file cache
  * can be stated one at a time.
  */
-final class GacelaBootstrapperTest extends TestCase
+final class GacelaBootstrapperTest extends SymfonyBridgeTestCase
 {
     private const APP_ROOT = __DIR__ . '/Fixtures';
-
-    protected function tearDown(): void
-    {
-        Gacela::resetCache();
-        Config::resetInstance();
-        CountingService::$constructed = 0;
-    }
 
     public function test_it_bootstraps_from_the_given_application_root(): void
     {

--- a/symfony-bridge/tests/GacelaBootstrapperTest.php
+++ b/symfony-bridge/tests/GacelaBootstrapperTest.php
@@ -53,6 +53,20 @@ final class GacelaBootstrapperTest extends TestCase
     }
 
     /**
+     * The explicit-on path is its own branch, and "off is the default anyway"
+     * would let it rot unnoticed: turning it on must both enable the cache and
+     * carry the directory along.
+     */
+    public function test_the_file_cache_can_be_turned_on_explicitly(): void
+    {
+        $cacheDir = self::APP_ROOT . '/bootstrapper-cache';
+        $this->bootstrap(['cache_dir' => $cacheDir, 'file_cache' => true]);
+
+        self::assertTrue(Config::getInstance()->getSetupGacela()->isFileCacheEnabled());
+        self::assertSame($cacheDir, Config::getInstance()->getSetupGacela()->getFileCacheDirectory());
+    }
+
+    /**
      * Saying nothing must change nothing: the bundle's defaults are Gacela's
      * defaults, not a second opinion about them.
      */

--- a/symfony-bridge/tests/GacelaBundleTest.php
+++ b/symfony-bridge/tests/GacelaBundleTest.php
@@ -53,6 +53,26 @@ final class GacelaBundleTest extends TestCase
     }
 
     /**
+     * The sharper variant of the same lesson: the locator memoizes instances,
+     * and a re-bootstrap that kept it would keep serving the first kernel's
+     * services no matter what the second one listed. Configuration alone
+     * cannot see this -- only asking for a *service* can (#666).
+     */
+    public function test_a_second_boot_serves_the_second_kernels_services(): void
+    {
+        $this->kernelWithCountingService()->boot();
+        self::assertSame(CountingService::FROM_SYMFONY, Gacela::get(CountingService::class)?->name());
+
+        (new TestKernel(
+            ['external_services' => [CountingService::class => 'app.counting']],
+            ['app.counting' => CountingService::class],
+            serviceName: 'rebooted',
+        ))->boot();
+
+        self::assertSame('rebooted', Gacela::get(CountingService::class)?->name());
+    }
+
+    /**
      * Gacela autowires an unlisted class perfectly happily, so "an instance
      * came back" would pass with the whole mapping deleted. What cannot is a
      * constructor argument only Symfony supplies: an autowired one would carry

--- a/symfony-bridge/tests/GacelaBundleTest.php
+++ b/symfony-bridge/tests/GacelaBundleTest.php
@@ -11,7 +11,6 @@ use Gacela\SymfonyBridge\GacelaBundle;
 use Gacela\SymfonyBridge\GacelaInjectCompilerPass;
 use GacelaTest\SymfonyBridge\Fixtures\CountingService;
 use GacelaTest\SymfonyBridge\Fixtures\TestKernel;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 use function array_map;
@@ -20,15 +19,8 @@ use function array_map;
  * The bundle driven through a real kernel, because everything it does happens
  * during compilation or boot -- neither of which a unit test can stand in for.
  */
-final class GacelaBundleTest extends TestCase
+final class GacelaBundleTest extends SymfonyBridgeTestCase
 {
-    protected function tearDown(): void
-    {
-        Gacela::resetCache();
-        Config::resetInstance();
-        CountingService::$constructed = 0;
-    }
-
     public function test_booting_the_kernel_bootstraps_gacela(): void
     {
         $kernel = new TestKernel();

--- a/symfony-bridge/tests/GacelaCacheWarmerTest.php
+++ b/symfony-bridge/tests/GacelaCacheWarmerTest.php
@@ -10,13 +10,12 @@ use Gacela\Framework\ClassResolver\Cache\ClassNamePhpCache;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\SymfonyBridge\GacelaCacheWarmer;
-use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 use function glob;
 use function unlink;
 
-final class GacelaCacheWarmerTest extends TestCase
+final class GacelaCacheWarmerTest extends SymfonyBridgeTestCase
 {
     private const APP_ROOT = __DIR__ . '/Fixtures';
 
@@ -41,8 +40,7 @@ final class GacelaCacheWarmerTest extends TestCase
 
         @rmdir(self::CACHE_DIR);
 
-        Gacela::resetCache();
-        Config::resetInstance();
+        parent::tearDown();
     }
 
     /**

--- a/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
+++ b/symfony-bridge/tests/GacelaInjectCompilerPassTest.php
@@ -131,6 +131,21 @@ final class GacelaInjectCompilerPassTest extends TestCase
     }
 
     /**
+     * Same lesson for a constructor-less definition: the scan must step over
+     * it, not stop at it -- skipping and stopping only look alike when the
+     * skipped definition happens to be the last one.
+     */
+    public function test_a_constructorless_definition_is_skipped_without_stopping_the_scan(): void
+    {
+        $this->container->register('app.bare', ConcreteBar::class);
+        $this->container->register('app.service', ServiceWithInject::class);
+
+        $this->pass->process($this->container);
+
+        self::assertInstanceOf(Definition::class, $this->argumentFor('app.service', '$foo'));
+    }
+
+    /**
      * The generated factory definition is an implementation detail of the
      * argument it fills, so it has no business being reachable from the
      * container by id.

--- a/symfony-bridge/tests/SymfonyBridgeTestCase.php
+++ b/symfony-bridge/tests/SymfonyBridgeTestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge;
+
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\SymfonyBridge\Fixtures\CountingService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Booting a kernel leaves process-global state behind: Gacela's singletons
+ * and the fixture's construction counter. Every test class that boots one
+ * must sweep all of it, so the sweeping lives here once -- the same shape as
+ * the Laravel bridge's LaravelBridgeTestCase, minus the host statics Symfony
+ * does not have.
+ */
+abstract class SymfonyBridgeTestCase extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+        CountingService::$constructed = 0;
+    }
+}


### PR DESCRIPTION
## 📚 Description

A rebooted kernel answered configuration questions with the second boot's answers and *service* questions with the first boot's services. `Gacela::bootstrap()` resets the locator only when `resetInMemoryCache()` was asked for (default off), so `Locator::$instance` — the static holding the container and a per-class instance cache — survived the reboot and kept serving the first kernel's instances. The bundle's existing reboot test passed because it only observed `Config`; the Laravel bridge hit the same bug family under its suite's random order (#665) and this is the Symfony side of the fix.

Closes #666

## 🔖 Changes

- `GacelaBootstrapper` calls `$config->resetInMemoryCache()` inside the bootstrap closure — the same line, for the same reason, as the Laravel bridge's bootstrapper. A first boot resets nothing but empty caches, so it only costs where it is needed.
- `test_a_second_boot_serves_the_second_kernels_services` pins it: boots a kernel whose listed service carries a distinguishable name, reboots with another, and asserts `Gacela::get()` answers with the second kernel's. Fails without the fix.
- `TestKernel` gained a `serviceName` parameter so a second kernel's services are tellable from the first's.
- Every remaining `symfony-bridge/src` mutant is dead — covered MSI 100%: the compiler pass's constructor-less skip is proven to step over rather than stop (`continue` vs `break` only look alike on the last definition), explicit `file_cache: true` is pinned alongside the off case, and two provably-equivalent mutants carry justified `infection.json5` entries (`GacelaCommands::names()` cast twin of the Laravel entry; `parent::build()` empty by contract).
- `ref:` commit: the three test classes that boot a kernel shared one repeated tearDown — now `SymfonyBridgeTestCase`, the Symfony twin of `LaravelBridgeTestCase`.
- `CHANGELOG.md` `## Unreleased` → `### Fixed`.
