### PR TITLE
ref: bridge polish — teardown dedup, honest docblock, interface-key parity test

### DIFF
--- a/laravel-bridge/tests/LaravelBridgeTestCase.php
+++ b/laravel-bridge/tests/LaravelBridgeTestCase.php
@@ -22,8 +22,9 @@ abstract class LaravelBridgeTestCase extends TestCase
 {
     protected function tearDown(): void
     {
+        // Gacela::resetCache() resets Config too -- listing it twice would
+        // imply it does not.
         Gacela::resetCache();
-        Config::resetInstance();
         CountingService::$constructed = 0;
         Artisan::forgetBootstrappers();
         ServiceProvider::$optimizeCommands = [];

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -246,7 +246,11 @@ final class GacelaConfig
     }
 
     /**
-     * Enable resetting the memory cache on each setup. Useful for functional tests.
+     * Reset the in-memory caches -- including the locator and its instance
+     * cache -- as part of this bootstrap. Anything that re-bootstraps inside
+     * one process wants this: functional tests, and both bridges call it on
+     * every boot, or a re-bootstrap keeps serving the previous boot's
+     * services out of the stale locator (#666).
      */
     public function resetInMemoryCache(): self
     {

--- a/symfony-bridge/tests/Fixtures/CountingService.php
+++ b/symfony-bridge/tests/Fixtures/CountingService.php
@@ -13,7 +13,7 @@ namespace GacelaTest\SymfonyBridge\Fixtures;
  * and they do not: a constructor argument only Symfony supplies is the fact
  * itself rather than a consequence of it.
  */
-final class CountingService
+final class CountingService implements ServiceContract
 {
     public const AUTOWIRED = 'autowired';
 

--- a/symfony-bridge/tests/Fixtures/ServiceContract.php
+++ b/symfony-bridge/tests/Fixtures/ServiceContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\SymfonyBridge\Fixtures;
+
+interface ServiceContract
+{
+    public function name(): string;
+}

--- a/symfony-bridge/tests/GacelaBootstrapperTest.php
+++ b/symfony-bridge/tests/GacelaBootstrapperTest.php
@@ -8,6 +8,7 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Gacela\SymfonyBridge\GacelaBootstrapper;
 use GacelaTest\SymfonyBridge\Fixtures\CountingService;
+use GacelaTest\SymfonyBridge\Fixtures\ServiceContract;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
@@ -85,6 +86,16 @@ final class GacelaBootstrapperTest extends SymfonyBridgeTestCase
         $this->bootstrap([], [CountingService::class => 'app.counting']);
 
         self::assertInstanceOf(CountingService::class, Gacela::get(CountingService::class));
+    }
+
+    /**
+     * An interface names a type as much as a class does.
+     */
+    public function test_a_service_listed_under_an_interface_is_bound(): void
+    {
+        $this->bootstrap([], [ServiceContract::class => 'app.counting']);
+
+        self::assertInstanceOf(CountingService::class, Gacela::get(ServiceContract::class));
     }
 
     /**

--- a/symfony-bridge/tests/SymfonyBridgeTestCase.php
+++ b/symfony-bridge/tests/SymfonyBridgeTestCase.php
@@ -20,8 +20,9 @@ abstract class SymfonyBridgeTestCase extends TestCase
 {
     protected function tearDown(): void
     {
+        // Gacela::resetCache() resets Config too -- listing it twice would
+        // imply it does not.
         Gacela::resetCache();
-        Config::resetInstance();
         CountingService::$constructed = 0;
     }
 }


### PR DESCRIPTION
## 📚 Description

Follow-up polish from the #667 review, in three small commits: the redundant `Config::resetInstance()` both bridge TestCases carried, the `resetInMemoryCache()` docblock that still called itself a functional-tests aside while both bridges call it on every boot, and the interface-key binding test the Symfony bootstrapper suite was missing next to its Laravel twin.

No behavior changes; nothing user-facing for the changelog.

## 🔖 Changes

- `ref:` `Gacela::resetCache()` resets `Config` too — both bridge base TestCases stop listing it twice, with a comment saying why once is right.
- `docs:` `GacelaConfig::resetInMemoryCache()` docblock now explains what it actually protects since #665/#666: anything that re-bootstraps inside one process, or the stale locator serves the previous boot's services.
- `test(symfony-bridge):` `test_a_service_listed_under_an_interface_is_bound` — the Laravel suite pins the interface-key path, the Symfony twin only pinned the class key. `CountingService` implements the new `ServiceContract` fixture, same shape on both sides.
