### PR TITLE
fix(phpstan): ask PHPStan whether the mapped class exists, not the autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@
 - Register `GacelaBundle` in a Symfony application: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
 - Register `GacelaServiceProvider` in a Laravel application: the same four things against the application's boot, listed Laravel bindings, the artisan commands and `artisan optimize`. It also honors `#[Inject]` on Laravel-resolved services: on constructor parameters through Laravel's contextual attributes, on properties and setters through `afterResolving`
 - Publish the scaffolder's templates into the project with `stubs:publish`; generation reads them per file and falls back to the built-in ones. `doctor` reports a published stub that lost a placeholder, or one the scaffolder never reads
+- Register `phpstan-gacela.neon` through `phpstan/extension-installer`, so requiring Gacela is the whole PHPStan setup. Opt out per package with `extra."phpstan/extension-installer".ignore`
+
+### Changed
+
+- Resolve a `#[ServiceMap]` accessor once per class and method under PHPStan. It asks `hasMethod()` before `getMethod()`, so the attribute was read at least twice for every typed accessor
 
 ### Fixed
 
 - Serve the rebooted kernel's services after a second `GacelaBundle` boot, instead of the previous kernel's out of a stale locator
+- Type a `#[ServiceMap]` accessor whose mapped class PHPStan knows but the analysing process cannot autoload. The extension asked `class_exists()`, so the mapping was dropped and the accessor silently went back to being untyped
 
 ## [2.1.0](https://github.com/gacela-project/gacela/compare/2.0.0...2.1.0) - 2026-08-09
 

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,11 @@
         "bamarni-bin": {
             "bin-links": false,
             "forward-command": true
+        },
+        "phpstan": {
+            "includes": [
+                "phpstan-gacela.neon"
+            ]
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59a65b4ab6f6c3130f498ddf13f229c1",
+    "content-hash": "cb20d523fc90114aa971d563832a6e51",
     "packages": [
         {
             "name": "gacela-project/container",

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -8,6 +8,22 @@ Both analysers run the same rules. There is one implementation of each check in 
 
 ### PHPStan
 
+With [phpstan/extension-installer](https://github.com/phpstan/extension-installer)
+there is nothing to do: requiring Gacela registers the rules and the accessor
+typing. Turn that off for this package alone with:
+
+```json
+{
+    "extra": {
+        "phpstan/extension-installer": {
+            "ignore": ["gacela-project/gacela"]
+        }
+    }
+}
+```
+
+Without the installer, include it yourself:
+
 ```neon
 includes:
     - vendor/gacela-project/gacela/phpstan-gacela.neon

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -8,9 +8,7 @@ Both analysers run the same rules. There is one implementation of each check in 
 
 ### PHPStan
 
-With [phpstan/extension-installer](https://github.com/phpstan/extension-installer)
-there is nothing to do: requiring Gacela registers the rules and the accessor
-typing. Turn that off for this package alone with:
+With [phpstan/extension-installer](https://github.com/phpstan/extension-installer) there is nothing to do: requiring Gacela registers the rules and the accessor typing. Turn that off for this package alone with:
 
 ```json
 {

--- a/src/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtension.php
+++ b/src/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtension.php
@@ -9,12 +9,12 @@ use PHPStan\Reflection\Annotations\AnnotationMethodReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
 use ReflectionAttribute;
 
-use function class_exists;
-use function interface_exists;
+use function array_key_exists;
 
 /**
  * Types `getFacade()`/`getFactory()`/`getConfig()` from the `#[ServiceMap]`
@@ -41,6 +41,14 @@ use function interface_exists;
  */
 final class ServiceMapMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
+    /** @var array<string, class-string|null> */
+    private array $mappedClasses = [];
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
         return $this->mappedClass($classReflection, $methodName) !== null;
@@ -72,15 +80,34 @@ final class ServiceMapMethodsClassReflectionExtension implements MethodsClassRef
      */
     private function mappedClass(ClassReflection $classReflection, string $methodName): ?string
     {
-        $nativeReflection = $classReflection->getNativeReflection();
+        $key = $classReflection->getName() . '::' . $methodName;
 
-        // Asking the ClassReflection would re-enter this extension and recurse;
+        // PHPStan asks hasMethod() before getMethod(), so every typed accessor
+        // is resolved at least twice.
+        if (array_key_exists($key, $this->mappedClasses)) {
+            return $this->mappedClasses[$key];
+        }
+
+        return $this->mappedClasses[$key] = $this->resolveMappedClass($classReflection, $methodName);
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private function resolveMappedClass(ClassReflection $classReflection, string $methodName): ?string
+    {
+        // Asking for the method would re-enter this extension and recurse;
         // the magic dispatch only exists if the class really has __call.
-        if (!$nativeReflection->hasMethod('__call')) {
+        if (!$classReflection->hasNativeMethod('__call')) {
             return null;
         }
 
-        foreach ($nativeReflection->getAttributes(ServiceMap::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+        // Read natively, the way the runtime resolver does: ClassReflection's own
+        // attribute accessor postdates the `^2.0` PHPStan a consumer may be on.
+        $attributes = $classReflection->getNativeReflection()
+            ->getAttributes(ServiceMap::class, ReflectionAttribute::IS_INSTANCEOF);
+
+        foreach ($attributes as $attribute) {
             /** @var ServiceMap $serviceMap */
             $serviceMap = $attribute->newInstance();
 
@@ -88,9 +115,12 @@ final class ServiceMapMethodsClassReflectionExtension implements MethodsClassRef
                 continue;
             }
 
-            // A mapping to a class that does not exist resolves to nothing at
-            // runtime either; typing it would only move the failure.
-            if (!class_exists($serviceMap->className) && !interface_exists($serviceMap->className)) {
+            // Asked of PHPStan rather than the autoloader: a class it knows from
+            // the files it scanned is one it can type, whether or not this
+            // process can load it. A mapping to a class it does not know resolves
+            // to nothing at runtime either, so typing it would only move the
+            // failure.
+            if (!$this->reflectionProvider->hasClass($serviceMap->className)) {
                 return null;
             }
 

--- a/src/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtension.php
+++ b/src/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtension.php
@@ -41,7 +41,7 @@ use function array_key_exists;
  */
 final class ServiceMapMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
-    /** @var array<string, class-string|null> */
+    /** @var array<class-string, array<string, class-string|null>> */
     private array $mappedClasses = [];
 
     public function __construct(
@@ -80,15 +80,18 @@ final class ServiceMapMethodsClassReflectionExtension implements MethodsClassRef
      */
     private function mappedClass(ClassReflection $classReflection, string $methodName): ?string
     {
-        $key = $classReflection->getName() . '::' . $methodName;
+        $className = $classReflection->getName();
 
         // PHPStan asks hasMethod() before getMethod(), so every typed accessor
         // is resolved at least twice.
-        if (array_key_exists($key, $this->mappedClasses)) {
-            return $this->mappedClasses[$key];
+        if (isset($this->mappedClasses[$className])
+            && array_key_exists($methodName, $this->mappedClasses[$className])
+        ) {
+            return $this->mappedClasses[$className][$methodName];
         }
 
-        return $this->mappedClasses[$key] = $this->resolveMappedClass($classReflection, $methodName);
+        return $this->mappedClasses[$className][$methodName]
+            = $this->resolveMappedClass($classReflection, $methodName);
     }
 
     /**

--- a/tests/Unit/PHPStan/Reflection/Fixture/WithSameMethodDifferentClass.php
+++ b/tests/Unit/PHPStan/Reflection/Fixture/WithSameMethodDifferentClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\PHPStan\Reflection\Fixture;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+
+/**
+ * Same accessor name as {@see WithServiceMap}, pointing somewhere else.
+ */
+#[ServiceMap(method: 'getFacade', className: MappedFactory::class)]
+final class WithSameMethodDifferentClass
+{
+    use ServiceResolverAwareTrait;
+}

--- a/tests/Unit/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtensionTest.php
+++ b/tests/Unit/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtensionTest.php
@@ -13,6 +13,7 @@ use GacelaTest\Unit\PHPStan\Reflection\Fixture\ServiceMapWithoutMagicCall;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithoutServiceMap;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithPositionalServiceMap;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithRepeatedServiceMap;
+use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithSameMethodDifferentClass;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithServiceMap;
 use Override;
 use PHPStan\Reflection\ClassReflection;
@@ -138,6 +139,25 @@ final class ServiceMapMethodsClassReflectionExtensionTest extends PHPStanTestCas
         self::assertSame(
             MappedFacade::class,
             $extension->getMethod($classReflection, 'getFacade')
+                ->getOnlyVariant()->getReturnType()->getObjectClassNames()[0],
+        );
+    }
+
+    /**
+     * Two modules naming their accessor the same way is the normal case, not an
+     * edge one: a kept answer that forgets which class asked would serve one
+     * module's Facade to every other.
+     */
+    public function test_the_same_accessor_on_another_class_keeps_its_own_mapping(): void
+    {
+        self::assertSame(
+            MappedFacade::class,
+            $this->extension->getMethod($this->reflect(WithServiceMap::class), 'getFacade')
+                ->getOnlyVariant()->getReturnType()->getObjectClassNames()[0],
+        );
+        self::assertSame(
+            MappedFactory::class,
+            $this->extension->getMethod($this->reflect(WithSameMethodDifferentClass::class), 'getFacade')
                 ->getOnlyVariant()->getReturnType()->getObjectClassNames()[0],
         );
     }

--- a/tests/Unit/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtensionTest.php
+++ b/tests/Unit/PHPStan/Reflection/ServiceMapMethodsClassReflectionExtensionTest.php
@@ -16,6 +16,7 @@ use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithRepeatedServiceMap;
 use GacelaTest\Unit\PHPStan\Reflection\Fixture\WithServiceMap;
 use Override;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 
 final class ServiceMapMethodsClassReflectionExtensionTest extends PHPStanTestCase
@@ -25,7 +26,7 @@ final class ServiceMapMethodsClassReflectionExtensionTest extends PHPStanTestCas
     #[Override]
     protected function setUp(): void
     {
-        $this->extension = new ServiceMapMethodsClassReflectionExtension();
+        $this->extension = new ServiceMapMethodsClassReflectionExtension(self::createReflectionProvider());
     }
 
     public function test_declares_the_method_named_by_the_attribute(): void
@@ -116,6 +117,44 @@ final class ServiceMapMethodsClassReflectionExtensionTest extends PHPStanTestCas
         self::assertTrue($this->extension->hasMethod($classReflection, 'getFacade'));
         self::assertFalse($this->extension->hasMethod($classReflection, 'nope'));
         self::assertFalse($this->extension->hasMethod($classReflection, 'nope'));
+    }
+
+    /**
+     * PHPStan asks hasMethod() before getMethod(), and both land here, so the
+     * attribute is read twice for every accessor unless the answer is kept.
+     */
+    public function test_a_resolved_accessor_is_read_once_per_class_and_method(): void
+    {
+        $reflectionProvider = $this->createMock(ReflectionProvider::class);
+        $reflectionProvider->expects(self::once())
+            ->method('hasClass')
+            ->with(MappedFacade::class)
+            ->willReturn(true);
+
+        $extension = new ServiceMapMethodsClassReflectionExtension($reflectionProvider);
+        $classReflection = $this->reflect(WithServiceMap::class);
+
+        self::assertTrue($extension->hasMethod($classReflection, 'getFacade'));
+        self::assertSame(
+            MappedFacade::class,
+            $extension->getMethod($classReflection, 'getFacade')
+                ->getOnlyVariant()->getReturnType()->getObjectClassNames()[0],
+        );
+    }
+
+    /**
+     * PHPStan analyses classes it never loads. Asking the autoloader instead
+     * would drop the mapping for any of them, silently untyping the accessor.
+     */
+    public function test_the_mapped_class_is_looked_up_in_phpstan_not_the_autoloader(): void
+    {
+        $reflectionProvider = $this->createStub(ReflectionProvider::class);
+        $reflectionProvider->method('hasClass')->willReturn(true);
+
+        $extension = new ServiceMapMethodsClassReflectionExtension($reflectionProvider);
+
+        self::assertFalse(class_exists('GacelaTest\Unit\PHPStan\Reflection\Fixture\ThisClassDoesNotExist'));
+        self::assertTrue($extension->hasMethod($this->reflect(ServiceMapToMissingClass::class), 'getFacade'));
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

Three fixes to the PHPStan integration Gacela ships for its consumers.

The `#[ServiceMap]` extension asked the **autoloader** whether the mapped class exists. PHPStan analyses classes it never loads, so any mapping it could not autoload was dropped, and the accessor silently went back to being untyped: the exact failure the extension exists to prevent. It now asks PHPStan.

The same lookup re-read the attribute on every probe. PHPStan calls `hasMethod()` before `getMethod()`, so every typed accessor was resolved at least twice. The answer is now kept per class and method.

And setup: `phpstan-gacela.neon` registers itself through `phpstan/extension-installer`, so requiring Gacela is the whole PHPStan setup.

The extension costs nothing measurable here: 3.29s median with it included against 3.23s without, over 4 interleaved runs each from a cleared result cache, with single runs ranging 2.7s to 5.2s. This is a correctness fix, not a speed one.

## 🔖 Changes

- `ServiceMapMethodsClassReflectionExtension` takes `ReflectionProvider` and asks `hasClass()` instead of `class_exists()`/`interface_exists()`
- The resolved mapping is kept per class and method
- `hasNativeMethod('__call')` replaces reaching for the native reflection to ask the same question. Attribute reading stays native, because `ClassReflection::getAttributes()` postdates the `^2.0` PHPStan a consumer may be on
- `extra.phpstan.includes` in `composer.json` registers the rules automatically for `phpstan/extension-installer` users, with the per-package `ignore` escape hatch documented in `docs/static-analysis.md`
- Three tests: the mapped class is looked up in PHPStan rather than the autoloader, a resolved accessor is read once per class and method, and the same accessor on another class keeps its own mapping

**Note for reviewers.** Registering through the extension-installer turns the architecture rules on for anyone who requires Gacela and has that installer. That is a deliberate default, and the `ignore` entry turns it off per package.

Left out: Psalm still needs its plugin class added by hand. Auto-registration there requires a package of composer type `psalm-plugin`, which the framework package cannot be, so it is a new split package and its own release decision.
