### PR TITLE
fix(bridges): require the framework they wire up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Serve the rebooted kernel's services after a second `GacelaBundle` boot, instead of the previous kernel's out of a stale locator
 - Type a `#[ServiceMap]` accessor whose mapped class PHPStan knows but the analysing process cannot autoload. The extension asked `class_exists()`, so the mapping was dropped and the accessor silently went back to being untyped
+- Require `gacela-project/gacela` from both bridges. They call `Gacela::bootstrap()` and read `GacelaConfig`, but declared only `gacela-project/container`, so installing either one on its own left the framework it wires up to chance. Inside this repository the root autoloader supplied it, which is what hid it
 
 ## [2.1.0](https://github.com/gacela-project/gacela/compare/2.0.0...2.1.0) - 2026-08-09
 

--- a/laravel-bridge/composer.json
+++ b/laravel-bridge/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": ">=8.3",
         "gacela-project/container": "^2.0.2",
+        "gacela-project/gacela": "^2.2",
         "illuminate/config": "^11.28 || ^12.0",
         "illuminate/console": "^11.28 || ^12.0",
         "illuminate/container": "^11.28 || ^12.0",

--- a/symfony-bridge/composer.json
+++ b/symfony-bridge/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": ">=8.3",
         "gacela-project/container": "^2.0.2",
+        "gacela-project/gacela": "^2.2",
         "symfony/config": "^7.0 || ^8.0",
         "symfony/console": "^7.0 || ^8.0",
         "symfony/dependency-injection": "^7.0 || ^8.0",


### PR DESCRIPTION
## 📚 Description

Both bridges call `Gacela::bootstrap()` and read `GacelaConfig`, but their manifests declared only `gacela-project/container`. Installed on their own, each would resolve without the framework it exists to wire up. Inside this repository the root autoloader supplies it, which is what hid it.

Found while reviewing what 2.2.0 announces: the changelog introduces the bundle and the provider, so their manifests should stand on their own before that ships.

## 🔖 Changes

- `gacela-project/gacela: ^2.2` added to `symfony-bridge/composer.json` and `laravel-bridge/composer.json`. The bridges ship from this repository and are tagged with it, so the constraint names the release they are developed against