### PR TITLE
fix: ship the Symfony and Laravel bridges to consumers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,8 +10,10 @@
 /.claude                 export-ignore
 /tests                   export-ignore
 /tools                   export-ignore
-/symfony-bridge          export-ignore
-/laravel-bridge          export-ignore
+/symfony-bridge/tests    export-ignore
+/laravel-bridge/tests    export-ignore
+/symfony-bridge/composer.json export-ignore
+/laravel-bridge/composer.json export-ignore
 /.editorconfig           export-ignore
 /.gitattributes          export-ignore
 /.gitignore              export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Declare which modules may depend on which, in one JSON file read by `debug:graph --check --rules` and by both analysers. `--format=json` writes the findings for a CI job that wants more than an exit code, and a rule that governs no module is reported, so it cannot outlive what it was written about
 - Declare what the configuration must contain with `declareConfigSchema()`, read by `validate:config`, `doctor` and `debug:config`. A declared default fills a key no config source provides, without ever overriding one that does; `debug:config` marks every key `declared`, `undeclared` or `missing`; and `validateConfigSchemaOnBoot()` checks the schema on every bootstrap, for local development
 - Replace another module in a test with `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()`, dropped again in `tearDown()`
-- Register `GacelaBundle` in a Symfony application: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
+- Register `GacelaBundle` in a Symfony application, straight out of the framework package: it bootstraps Gacela from the kernel, maps listed Symfony services into it, adds the console commands under a `gacela:` prefix, and warms Gacela's caches from `cache:warmup`
 - Register `GacelaServiceProvider` in a Laravel application: the same four things against the application's boot, listed Laravel bindings, the artisan commands and `artisan optimize`. It also honors `#[Inject]` on Laravel-resolved services: on constructor parameters through Laravel's contextual attributes, on properties and setters through `afterResolving`
 - Publish the scaffolder's templates into the project with `stubs:publish`; generation reads them per file and falls back to the built-in ones. `doctor` reports a published stub that lost a placeholder, or one the scaffolder never reads
 - Register `phpstan-gacela.neon` through `phpstan/extension-installer`, so requiring Gacela is the whole PHPStan setup. Opt out per package with `extra."phpstan/extension-installer".ignore`
@@ -18,9 +18,9 @@
 
 ### Fixed
 
+- Ship the Symfony and Laravel bridges to the people installing Gacela. `.gitattributes` stripped both directories from the dist archive, and their namespaces sat in `autoload-dev`, so nothing under `Gacela\SymfonyBridge` or `Gacela\LaravelBridge` reached a consumer. `GacelaInjectCompilerPass` has been unreachable that way since it shipped in 1.14.0
 - Serve the rebooted kernel's services after a second `GacelaBundle` boot, instead of the previous kernel's out of a stale locator
 - Type a `#[ServiceMap]` accessor whose mapped class PHPStan knows but the analysing process cannot autoload. The extension asked `class_exists()`, so the mapping was dropped and the accessor silently went back to being untyped
-- Require `gacela-project/gacela` from both bridges. They call `Gacela::bootstrap()` and read `GacelaConfig`, but declared only `gacela-project/container`, so installing either one on its own left the framework it wires up to chance. Inside this repository the root autoloader supplied it, which is what hid it
 
 ## [2.1.0](https://github.com/gacela-project/gacela/compare/2.0.0...2.1.0) - 2026-08-09
 

--- a/composer.json
+++ b/composer.json
@@ -57,14 +57,18 @@
     "suggest": {
         "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
         "gacela-project/gacela-yaml-config-reader": "Allows to read yml/yaml config files",
+        "illuminate/support": "Allows to register Gacela\\LaravelBridge\\GacelaServiceProvider in a Laravel application",
         "phpunit/phpunit": "Allows to extend Gacela\\Framework\\Testing\\GacelaTestCase in your tests",
-        "symfony/console": "Allows to use vendor/bin/gacela script"
+        "symfony/console": "Allows to use vendor/bin/gacela script",
+        "symfony/http-kernel": "Allows to register Gacela\\SymfonyBridge\\GacelaBundle in a Symfony application"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "Gacela\\": "src/"
+            "Gacela\\": "src/",
+            "Gacela\\LaravelBridge\\": "laravel-bridge/src/",
+            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/"
         }
     },
     "autoload-dev": {
@@ -72,9 +76,7 @@
             "GacelaData\\": "data/",
             "GacelaTest\\": "tests/",
             "GacelaTest\\LaravelBridge\\": "laravel-bridge/tests/",
-            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/",
-            "Gacela\\LaravelBridge\\": "laravel-bridge/src/",
-            "Gacela\\SymfonyBridge\\": "symfony-bridge/src/"
+            "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/"
         }
     },
     "bin": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,11 @@
 - [Production performance](production-performance.md) — full checklist to run Gacela fast in production
 - [Upgrading](../UPGRADE.md) — why to move to 2.0, and every breaking change with its replacement
 
+## Host frameworks
+
+- [Symfony bundle](../symfony-bridge/README.md) — bootstrap Gacela from the kernel, reach Symfony services, `bin/console gacela:*`
+- [Laravel provider](../laravel-bridge/README.md) — bootstrap Gacela when the app boots, reach Laravel services, `artisan gacela:*`
+
 ## RFCs
 
 - [RFC-0001: `#[Inject]` + `#[ServiceMapTyped]` — Symfony DI interop](rfc/0001-inject-symfony-di-interop.md)

--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -293,7 +293,7 @@ Trait gone. `@psalm-suppress` gone. Dependency visible to tooling.
 
 ### Symfony `Command` classes
 
-Symfony `Command` constructors are autowired by Symfony's own container. `#[Inject]` on a Symfony-managed class does not take effect on its own — a compiler pass is required to route `#[Inject]` parameters to Gacela before Symfony's autowire claims them. A dedicated `gacela/symfony-bridge` package ships this pass; adopt it in projects where Symfony owns the container.
+Symfony `Command` constructors are autowired by Symfony's own container. `#[Inject]` on a Symfony-managed class does not take effect on its own — a compiler pass is required to route `#[Inject]` parameters to Gacela before Symfony's autowire claims them. The [Symfony bundle](../symfony-bridge/README.md) that ships with Gacela registers this pass; adopt it in projects where Symfony owns the container.
 
 ## Class Attributes: `#[Singleton]`, `#[Factory]` and `#[Lazy]`
 

--- a/laravel-bridge/README.md
+++ b/laravel-bridge/README.md
@@ -4,8 +4,10 @@ Gacela inside a Laravel application: the service provider does the wiring every 
 
 ## Install
 
+The provider ships inside the framework package, so there is nothing extra to require:
+
 ```
-composer require gacela-project/laravel-bridge
+composer require gacela-project/gacela
 ```
 
 ```php
@@ -118,4 +120,4 @@ A `readonly` property is refused by name — it cannot be written after construc
 
 ## Status
 
-Experimental. API may change until it graduates out of `gacela/gacela`'s `laravel-bridge/` subfolder.
+Experimental. The API may still change. It ships from `gacela-project/gacela`'s `laravel-bridge/` subfolder rather than as a package of its own, so it is versioned with the framework.

--- a/symfony-bridge/README.md
+++ b/symfony-bridge/README.md
@@ -4,8 +4,10 @@ Gacela inside a Symfony application: the bundle does the wiring every Symfony/Ga
 
 ## Install
 
+The bundle ships inside the framework package, so there is nothing extra to require:
+
 ```
-composer require gacela-project/symfony-bridge
+composer require gacela-project/gacela
 ```
 
 ```php
@@ -102,4 +104,4 @@ The Gacela container must be registered as a Symfony service named `gacela.conta
 
 ## Status
 
-Experimental. API may change until it graduates out of `gacela/gacela`'s `symfony-bridge/` subfolder.
+Experimental. The API may still change. It ships from `gacela-project/gacela`'s `symfony-bridge/` subfolder rather than as a package of its own, so it is versioned with the framework.


### PR DESCRIPTION
## 📚 Description

The bundle and the provider that 2.2.0 announces could not be installed by anyone.

`.gitattributes` marked `/symfony-bridge` and `/laravel-bridge` as `export-ignore`, so Composer's dist archive contained neither directory: `git archive HEAD | tar -t | grep -c bridge` returned **0**. Their PSR-4 prefixes were in `autoload-dev`, so even before that exclusion landed nothing under `Gacela\SymfonyBridge` or `Gacela\LaravelBridge` was autoloadable for a consumer. `GacelaInjectCompilerPass` has been unreachable this way since it shipped in 1.14.0, and the archive has excluded it since 1.14.2 (be80c6ed).

They stay in this repository rather than becoming packages of their own. That keeps them versioned with the framework, and keeps the install to one `composer require`.

## 🔖 Changes

- Both bridge namespaces move from `autoload-dev` to `autoload`, so they load for consumers
- `.gitattributes` excludes each bridge's `tests/` and nested `composer.json` instead of the whole directory. The archive now carries 23 bridge paths where it carried none
- `suggest` names `symfony/http-kernel` and `illuminate/support` as what each bridge needs from its host
- Both READMEs drop the `composer require gacela-project/symfony-bridge` line, which pointed at a package that does not exist on Packagist, and say the bridges ship with the framework
- `docs/README.md` lists both bridges; `docs/container-configuration.md` stops describing the compiler pass as living in a separate package
- The nested `composer.json` files stay in git, so a split remains possible later

Gates run locally: php-cs-fixer, phpstan, psalm, and the 1412-test unit suite.