### PR TITLE
fix(bridges): manifests declare what src imports, and only that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Declare `psr/container` in both bridge manifests and `symfony/console` in the Laravel bridge's, instead of leaning on transitive luck; demote the Laravel bridge's test-only `illuminate/container` and `illuminate/events` to `require-dev`
+
 ## [2.2.0](https://github.com/gacela-project/gacela/compare/2.1.0...2.2.0) - 2026-08-11
 
 ### Added

--- a/laravel-bridge/composer.json
+++ b/laravel-bridge/composer.json
@@ -24,12 +24,14 @@
         "gacela-project/gacela": "^2.2",
         "illuminate/config": "^11.28 || ^12.0",
         "illuminate/console": "^11.28 || ^12.0",
-        "illuminate/container": "^11.28 || ^12.0",
         "illuminate/contracts": "^11.28 || ^12.0",
-        "illuminate/events": "^11.28 || ^12.0",
-        "illuminate/support": "^11.28 || ^12.0"
+        "illuminate/support": "^11.28 || ^12.0",
+        "psr/container": "^1.1 || ^2.0",
+        "symfony/console": "^7.0 || ^8.0"
     },
     "require-dev": {
+        "illuminate/container": "^11.28 || ^12.0",
+        "illuminate/events": "^11.28 || ^12.0",
         "phpunit/phpunit": "^10.5"
     },
     "minimum-stability": "dev",

--- a/symfony-bridge/composer.json
+++ b/symfony-bridge/composer.json
@@ -1,9 +1,8 @@
 {
     "name": "gacela-project/symfony-bridge",
-    "type": "library",
     "description": "Symfony bundle for Gacela: bootstraps it from the kernel, maps host services into it, registers its console commands, and honors #[Inject] on Symfony-managed services.",
     "license": "MIT",
-    "homepage": "https://gacela-project.com",
+    "type": "library",
     "keywords": [
         "php",
         "gacela",
@@ -18,10 +17,12 @@
             "homepage": "https://chemaclass.com"
         }
     ],
+    "homepage": "https://gacela-project.com",
     "require": {
         "php": ">=8.3",
         "gacela-project/container": "^2.0.2",
         "gacela-project/gacela": "^2.2",
+        "psr/container": "^1.1 || ^2.0",
         "symfony/config": "^7.0 || ^8.0",
         "symfony/console": "^7.0 || ^8.0",
         "symfony/dependency-injection": "^7.0 || ^8.0",
@@ -30,6 +31,8 @@
     "require-dev": {
         "phpunit/phpunit": "^10.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Gacela\\SymfonyBridge\\": "src/"
@@ -39,7 +42,5 @@
         "psr-4": {
             "GacelaTest\\SymfonyBridge\\": "tests/"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }


### PR DESCRIPTION
## 📚 Description

Both bridge manifests disagreed with the code under their own `src/`, in both directions: imports the manifest never requires (`psr/container` in both; `symfony/console` in the Laravel bridge, whose boot path constructs fifteen `Command` subclasses that today arrive through `illuminate/console`'s internals — one dependency reshuffle away from a fatal at boot), and requirements only tests import (`illuminate/container`, `illuminate/events`). The nested manifests are the contract for the future split (#671) and for anyone consuming a bridge through a path or VCS repository.

Closes #682

## 🔖 Changes

- `psr/container` (`^1.1 || ^2.0`) is a direct requirement of both bridges — each types a constructor parameter against `Psr\Container\ContainerInterface`.
- `symfony/console` (`^7.0 || ^8.0`) is a direct requirement of the Laravel bridge — `GacelaCommands` and `GacelaServiceProvider` import `Command`, and `names()` constructs all fifteen Gacela commands built on it.
- `illuminate/container` and `illuminate/events` move to the Laravel bridge's `require-dev` — their only imports live under `tests/`: the host hands its container in, and the dispatcher exists to construct artisan in a test.
- `illuminate/config` and `illuminate/console` stay in `require`, deliberately, per the issue's analysis: never imported, but `boot()` resolves the `config` binding and `commands()` executes `Artisan::starting()` — runtime requirements resolved from the container rather than the autoloader.
- Verified standalone, mirroring the issue's repro: `composer install --no-dev` on each manifest resolves, and `composer why psr/container` / `composer why symfony/console` now answer with the bridge itself.
- `CHANGELOG.md` `## Unreleased` → `### Fixed`.
