### PR TITLE
feat(console): report an extendService() id nothing ever set()s in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Report an `extendService()` id no Provider ever `set()`s in `doctor` — the extension is otherwise accepted and applied nowhere, silently
+
 ### Fixed
 
 - Declare `psr/container` in both bridge manifests and `symfony/console` in the Laravel bridge's, instead of leaning on transitive luck; demote the Laravel bridge's test-only `illuminate/container` and `illuminate/events` to `require-dev`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,8 @@ Every stub substitutes `$NAMESPACE$`, `$MODULE_NAME$` and `$CLASS_NAME$`. `docto
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).
 
+Among the built-in checks, *service extensions* verifies every `extendService()` id against what the Providers actually `set()`: an extension on an id nothing ever stores — a typo, or an id registered only through `bind()`/`singleton()` — is accepted and applied nowhere at runtime, silently, so `doctor` is the surface that says so. Under `--strict` an unmatched id fails the run.
+
 ## Production
 
 | Command | What it does |

--- a/infection.json5
+++ b/infection.json5
@@ -79,6 +79,7 @@
             '.*preBootstrapDispatcher \\?\\?= new NullEventDispatcher.*',
             // Dedup bookkeeping: isset() treats `false` like `true`.
             '.*resolvedServiceIds\\[\\$id\\] = true;.*',
+            '.*\\$provided\\[\\$id\\] = true;.*',
             // The candidate list feeds implode(); reindexing cannot change the message.
             '.*array_values\\(array_unique\\(\\$candidates\\)\\).*',
             // Cache-key separator: collisions require crafting spl_object_id values,

--- a/src/Console/Application/Doctor/Check/ServiceExtensionTargetCheck.php
+++ b/src/Console/Application/Doctor/Check/ServiceExtensionTargetCheck.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+use Throwable;
+
+use function array_flip;
+use function count;
+use function is_subclass_of;
+use function sprintf;
+
+/**
+ * Every `extendService()` id, checked against what some Provider actually
+ * `set()`s.
+ *
+ * An extension on an id nothing ever stores is accepted, scheduled on every
+ * scope, and applied nowhere -- no exception, no event (#683). No runtime
+ * moment can prove the miss, because module scopes build lazily and an
+ * optional module may provide the id only in some deployments; a diagnostic
+ * command can afford what the runtime cannot: running every discovered
+ * Provider once, eagerly, into a throwaway scope.
+ *
+ * The union is `getRegisteredServices()` on purpose, not the broader
+ * `provides()`: the extension queue drains only through `set()`, so an id
+ * registered via `bind()`/`singleton()` is a real registration whose
+ * extension still never applies -- exactly what this check exists to say.
+ */
+final class ServiceExtensionTargetCheck implements HealthCheck
+{
+    /**
+     * @param list<AppModule> $modules
+     * @param list<string> $extensionIds ids passed to extendService()
+     * @param list<string> $appContainerServiceIds ids the app container itself stores
+     */
+    public function __construct(
+        private readonly array $modules,
+        private readonly array $extensionIds,
+        private readonly array $appContainerServiceIds,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'service extensions';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->extensionIds === []) {
+            return CheckResult::ok($this->name(), 'no service extensions registered');
+        }
+
+        $warnings = [];
+        $provided = array_flip($this->appContainerServiceIds);
+
+        foreach ($this->modules as $module) {
+            foreach ($this->providedIds($module, $warnings) as $id) {
+                $provided[$id] = true;
+            }
+        }
+
+        foreach ($this->extensionIds as $extensionId) {
+            if (!isset($provided[$extensionId])) {
+                $warnings[] = sprintf(
+                    "'%s' is extended, and no Provider set()s it -- the extension will never apply",
+                    $extensionId,
+                );
+            }
+        }
+
+        if ($warnings !== []) {
+            return CheckResult::warn(
+                $this->name(),
+                $warnings,
+                'check the id for a typo; an extension only applies once some Provider set()s that id -- bind() and singleton() do not drain it',
+            );
+        }
+
+        return CheckResult::ok($this->name(), sprintf('%d extension id(s) matched', count($this->extensionIds)));
+    }
+
+    /**
+     * What one module's Provider stores, read off a throwaway scope. A
+     * Provider that cannot run outside its deployment is reported instead of
+     * crashing the diagnosis of every other one.
+     *
+     * @param list<string> $warnings
+     *
+     * @return list<string>
+     */
+    private function providedIds(AppModule $module, array &$warnings): array
+    {
+        $providerClass = $module->providerClass();
+        if ($providerClass === null || !is_subclass_of($providerClass, AbstractProvider::class)) {
+            return [];
+        }
+
+        try {
+            $provider = new $providerClass();
+
+            $container = new Container();
+            $provider->register($container);
+
+            return $container->getRegisteredServices();
+        } catch (Throwable $throwable) {
+            $warnings[] = sprintf('%s failed to run: %s', $providerClass, $throwable->getMessage());
+
+            return [];
+        }
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -8,6 +8,7 @@ use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
+use Gacela\Console\Application\Doctor\Check\ServiceExtensionTargetCheck;
 use Gacela\Console\Application\Doctor\Check\StubHealthCheck;
 use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
 use Gacela\Console\Application\Doctor\CheckResult;
@@ -100,6 +101,11 @@ final class DoctorCommand extends Command
             new FilenameMismatchCheck($modules),
             new ConfigSchemaCheck($config->configSchema(), $config->getAllValues()),
             new StubHealthCheck($stubsDir, StubHealthCheck::readPublished($stubsDir)),
+            new ServiceExtensionTargetCheck(
+                $modules,
+                array_keys($config->getSetupGacela()->getServicesToExtend()),
+                Gacela::container()->getRegisteredServices(),
+            ),
         ];
 
         foreach (HealthCheckRegistry::createHealthChecker(Gacela::container())->checkAll()->getResults() as $moduleName => $status) {

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -78,8 +78,49 @@ final class DoctorCommandTest extends TestCase
             '✓ pillar filenames',
             '✓ config schema',
             '✓ published stubs',
+            '✓ service extensions',
             '✓ All checks passed',
         ], $this->statusLinesOf($tester));
+    }
+
+    /**
+     * An extension on an id no Provider ever set()s is accepted and applied
+     * nowhere (#683); doctor is the surface that says so.
+     */
+    public function test_an_extension_on_an_id_nobody_registers_warns_naming_the_id(): void
+    {
+        $cacheDir = $this->cacheDir;
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false, $cacheDir);
+            $config->extendService('ARRAY_AS_OBJETC', static function (): void {
+            });
+        });
+
+        $tester = new CommandTester(new DoctorCommand());
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), 'a warning must not fail a non-strict run');
+        self::assertContains('⚠ service extensions', $this->statusLinesOf($tester));
+        self::assertStringContainsString('ARRAY_AS_OBJETC', $tester->getDisplay());
+    }
+
+    public function test_an_unmatched_extension_fails_a_strict_run(): void
+    {
+        $cacheDir = $this->cacheDir;
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false, $cacheDir);
+            $config->extendService('ARRAY_AS_OBJETC', static function (): void {
+            });
+        });
+
+        $tester = new CommandTester(new DoctorCommand());
+        $tester->execute(['--strict' => true]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
     }
 
     public function test_a_registered_health_check_is_appended_to_the_built_in_ones(): void
@@ -89,7 +130,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
         // The registered check runs after the built-in ones, and its detail is shown.
-        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[5]);
+        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[6]);
         self::assertStringContainsString('FakeHealthCheck ran', $tester->getDisplay());
     }
 

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/BindOnlyProvider.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/BindOnlyProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures;
+
+use ArrayObject;
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Registers through singleton() only: real registrations, but not the store
+ * `extend()`'s queue drains from -- an extension on either id silently never
+ * applies (#683), so the check must flag them.
+ */
+final class BindOnlyProvider extends AbstractProvider
+{
+    public const SINGLETON_ID = 'bound.singleton.id';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->singleton(self::SINGLETON_ID, static fn (): ArrayObject => new ArrayObject());
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/SetProvider.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/SetProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures;
+
+use ArrayObject;
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class SetProvider extends AbstractProvider
+{
+    public const ID = 'known.id';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::ID, new ArrayObject());
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/StubFacade.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/StubFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures;
+
+use Gacela\Framework\AbstractFacade;
+
+final class StubFacade extends AbstractFacade
+{
+}

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/ThrowingProvider.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/ThrowingProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+use RuntimeException;
+
+final class ThrowingProvider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+        throw new RuntimeException('this provider needs a database');
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/ServiceExtensionTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/ServiceExtensionTargetCheckTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\ServiceExtensionTargetCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\BindOnlyProvider;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\SetProvider;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\StubFacade;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\ThrowingProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ServiceExtensionTargetCheckTest extends TestCase
+{
+    public function test_no_extensions_is_ok(): void
+    {
+        $result = (new ServiceExtensionTargetCheck([], [], []))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertContains('no service extensions registered', $result->details);
+    }
+
+    public function test_an_id_a_provider_sets_is_matched(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(SetProvider::class)],
+            [SetProvider::ID],
+            [],
+        );
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function test_a_mistyped_id_warns_naming_the_id(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(SetProvider::class)],
+            ['knwon.id'],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('knwon.id', $result->details[0]);
+    }
+
+    public function test_an_id_the_app_container_provides_is_matched(): void
+    {
+        $check = new ServiceExtensionTargetCheck([], ['app.id'], ['app.id']);
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    /**
+     * The queue only drains through `set()`. A singleton() registration is
+     * real, but an extension on its id still silently never applies -- the
+     * check must warn, which it does by reading `getRegisteredServices()`
+     * (the drain's own store) rather than the broader `provides()`.
+     */
+    public function test_an_id_registered_only_through_singleton_warns(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(BindOnlyProvider::class)],
+            [BindOnlyProvider::SINGLETON_ID],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString(BindOnlyProvider::SINGLETON_ID, $result->details[0]);
+    }
+
+    public function test_a_module_without_a_provider_is_skipped(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(null)],
+            ['some.id'],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        // Exactly the unmatched id: a skipped module must not add a
+        // provider-failure line of its own.
+        self::assertCount(1, $result->details);
+        self::assertStringContainsString('some.id', $result->details[0]);
+    }
+
+    public function test_a_provider_slot_holding_a_non_provider_class_is_skipped(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(StubFacade::class)],
+            ['some.id'],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        // Exactly the unmatched id: the class is skipped, not run and crashed.
+        self::assertCount(1, $result->details);
+        self::assertStringContainsString('some.id', $result->details[0]);
+    }
+
+    /**
+     * A Provider that cannot run outside its deployment must not crash the
+     * diagnosis of every other one.
+     */
+    public function test_a_throwing_provider_is_reported_and_the_rest_still_diagnosed(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(ThrowingProvider::class), $this->module(SetProvider::class)],
+            [SetProvider::ID],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString(ThrowingProvider::class, $result->details[0]);
+        self::assertStringContainsString('this provider needs a database', $result->details[0]);
+    }
+
+    /**
+     * @param class-string|null $providerClass
+     */
+    private function module(?string $providerClass): AppModule
+    {
+        return new AppModule(
+            'App\TestModule',
+            'TestModule',
+            StubFacade::class,
+            null,
+            null,
+            $providerClass,
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Description

`extendService()` accepts any id and never checks it against anything: an extension on an id no Provider ever `set()`s is accepted, scheduled on every scope, and applied nowhere — no exception, no event, nothing says why (#683's repro shows all three candidate surfaces staying silent). No runtime moment can prove the miss, because module scopes build lazily and an optional module may provide the id only in some deployments — which rules out both throw variants. A diagnostic command can afford what the runtime cannot: `doctor` now runs every discovered Provider once into a throwaway scope and warns on every extension id outside the union.

Closes #683

## 🔖 Changes

- `ServiceExtensionTargetCheck` under `src/Console/Application/Doctor/Check/`: unions the app container's stored ids with what each discovered module's Provider `set()`s (via `register()`, so `#[Provides]` counts too), and warns per unmatched `extendService()` id. `--strict` turns the warning into a failing exit for CI.
- The union reads `getRegisteredServices()` deliberately, not the broader `provides()`: the extension queue drains only through `set()`, so an id registered via `bind()`/`singleton()` is a real registration whose extension still never applies — an equally silent failure mode the issue's own repro never exercises. The check flags it for the right underlying reason, and a dedicated test pins that this stays keyed on the drain's own store.
- A Provider that cannot run outside its deployment (throws eagerly) is reported by name instead of crashing the diagnosis of every other one; a module without a Provider, or with a non-Provider class in the slot, is skipped without a line of its own.
- Wired into `DoctorCommand::buildChecks()`; the built-in check list grows to six.
- Failing-first unit suite (8 cases incl. the typo, the app-container id, and the `singleton()`-only id) plus two doctor feature tests: the mistyped id warns naming the id on a normal run, and fails the run under `--strict`.
- `docs/cli.md` documents the check next to the doctor entry; `CHANGELOG.md` `## Unreleased` → `### Added`.
- Covered MSI on the new check: 100%.

