### PR TITLE
docs: each @method rule gains the sentence that scopes it

### DIFF
--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -55,7 +55,7 @@ public function createInvoiceSender(): InvoiceSender
 
 `FactoryDoesNotCallFacadeRule` enforces that, and it is registered by default in `phpstan-gacela.neon`: *"Factory must not call `$this->getFacade()`; same-module access goes through the Factory itself, cross-module access goes through the Provider."*
 
-**Why declare the pillar.** The accessor works without the attribute — the runtime falls back to reading a `@method` docblock, and then to scanning your file's `use` statements, both of which now raise a deprecation. But an undeclared accessor is also untyped: 2.0 reports it, and before that it evaluated to `mixed`, which switched off checking of everything reached *through* it. A `@method` docblock is equally fine for typing; PHPStan reads it natively, and it is still worth keeping alongside the attribute for IDEs.
+**Why declare the pillar.** The accessor works without the attribute — the runtime falls back to reading a `@method` docblock, and then to scanning your file's `use` statements, both of which now raise a deprecation. But an undeclared accessor is also untyped: 2.0 reports it, and before that it evaluated to `mixed`, which switched off checking of everything reached *through* it. The attribute alone types the accessor under both PHPStan and Psalm; a `@method` docblock adds IDE completion only, because PhpStorm reads `@method` and not `#[ServiceMap]`. Keeping one means writing the same fact twice — see [typed pillar accessors](static-analysis.md#typed-pillar-accessors) for the drift cost — and #678 proposes generating it so the copy cannot drift.
 
 Cross-module access goes through the other module's **Facade**, never its Factory or internals. `CrossModuleViaFacadeRule` enforces this if you enable it.
 

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -132,7 +132,7 @@ final class CheckoutController
 
 This matters more than it looks. The accessor was previously *suppressed* rather than typed, and a suppressed call is not a checked one — it evaluates to `mixed`, which silently switches off analysis of everything reached through it, not just the accessor itself. A typo in `placeOrder()` produced no error at all.
 
-A `@method CheckoutFacade getFacade()` docblock works too — both analysers read those natively — but then the same fact is written twice, and the copies drift.
+A `@method CheckoutFacade getFacade()` docblock works too — both analysers read those natively — but then the same fact is written twice, and the copies drift. The one reason to write both is the IDE, which reads `@method` and not the attribute; that tradeoff is described in [reach another module](getting-a-dependency.md#reach-another-module), and #678 proposes generating the copy so it cannot drift.
 
 **The PHPStan suppression is gone as of 2.0.** `phpstan-gacela.neon` no longer carries an `ignoreErrors` entry for undeclared pillar accessors, so a class that declares neither `#[ServiceMap]` nor a `@method` docblock has its `$this->getFacade()` reported as an undefined method. Psalm still ships its suppression in `psalm-gacela.xml` as a fallback, scheduled for removal in 3.0.
 


### PR DESCRIPTION
## 📚 Description

Two pages ruled on the same line of code and disagreed: `getting-a-dependency.md` called a `@method` docblock *"still worth keeping alongside the attribute"*, `static-analysis.md` warned the *"same fact is written twice, and the copies drift"*. Both prices are real, so neither page wins — each now carries its boundary, cross-linked both ways, and the stale *"PHPStan reads it natively"* / *"equally fine for typing"* claims are corrected: since the Psalm plugin, the attribute alone types the accessor under both analysers.

Closes #680

## 🔖 Changes

- `docs/getting-a-dependency.md`: the final sentence of *Why declare the pillar* becomes the scoped rule — attribute types under both analysers, docblock is IDE completion only, keeping one means a copy (linked to [typed pillar accessors]), #678 generates it.
- `docs/static-analysis.md`: the drift warning gains the IDE exception sentence and the same #678 pointer, linked back to [reach another module].
- Third-page check per the issue: rfc/0002 mentions `@method` as history, not advice — no further page needs the sentence.
- Wording only; the thirteen framework classes carrying both stay for #678.