### PR TITLE
docs: the bootstrap configuration surface, written down with its gate

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,6 +55,8 @@ $ ./vendor/bin/php-cs-fixer fix
 
 Please understand that we will not accept a pull request when its changes violate this project's coding guidelines.
 
+Adding a public method to `GacelaConfig`? Read [RFC-0003: the bootstrap configuration surface](../docs/rfc/0003-bootstrap-configuration-surface.md) first — it holds the competition test a new method must pass, the naming grammar, and the audited table a test will ask you to extend.
+
 ## Running Gacela's test suite
 
 Once you've installed all composer dependencies, you can simply test all suites running the following composer script:

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,5 +24,6 @@
 
 - [RFC-0001: `#[Inject]` + `#[ServiceMapTyped]` — Symfony DI interop](rfc/0001-inject-symfony-di-interop.md)
 - [RFC-0002: How many ways are there to obtain a dependency?](rfc/0002-dependency-paths-inventory.md) — the 25-path inventory behind the 2.0 "one primary path" question
+- [RFC-0003: The bootstrap configuration surface](rfc/0003-bootstrap-configuration-surface.md) — the competition test, the naming grammar, and the audited `GacelaConfig` table that gates new methods
 
 Full reference: [gacela-project.com](https://gacela-project.com/)

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -214,6 +214,6 @@ These are supported and are **not** deprecated. They are simply not the answer t
 
 The 2.0 inventory ([RFC-0002](rfc/0002-dependency-paths-inventory.md)) counted 25 paths and the obvious conclusion was "delete most of them". That would have been the wrong lesson.
 
-Reading a config value has **six** methods for one intent and nobody has ever complained, because they are the same path with typed variants — discovered together, impossible to confuse. The problem in the other intents was never the count. It was that unrelated mechanisms competed for the same job with no indication which one you were supposed to use.
+The problem in the other intents was never the count — it was unrelated mechanisms competing for the same job with no indication which one to use. That reasoning is now the framework's whole policy on public surface, written down with its gate in [RFC-0003: the bootstrap configuration surface](rfc/0003-bootstrap-configuration-surface.md).
 
 Naming a primary path fixes that. Deleting working escape hatches would only have broken applications that had a good reason to use one.

--- a/docs/rfc/0003-bootstrap-configuration-surface.md
+++ b/docs/rfc/0003-bootstrap-configuration-surface.md
@@ -1,0 +1,94 @@
+# RFC-0003: The bootstrap configuration surface
+
+- Status: **draft**
+- Relates to: #684, #525, #549, #478. Sequencing: #676 first among the open additions — it is the only one that shrinks the surface.
+
+## Why this exists
+
+`GacelaConfig` has **38 public methods** today (excluding `__construct`; counted from `src/Framework/Bootstrap/GacelaConfig.php`, and the gate below re-counts on every run). Six open issues — #672, #673, #674, #675, #676, #679 — each add at least one more. Without a written rule, six independent authors will each invent one.
+
+The rule already exists. It was settled by #525 (which named 33 methods as the defect) and #549 (which answered with one primary path per intent), and it lived as one paragraph inside [getting-a-dependency](../getting-a-dependency.md) — a page about reading dependencies, where nobody adding a bootstrap method would look. This RFC is that paragraph, promoted to doctrine and given teeth.
+
+## The policy
+
+> Reading a config value has **six** methods for one intent and nobody has ever complained, because they are the same path with typed variants, discovered together, impossible to confuse. The problem in the other intents was never the count. It was that unrelated mechanisms competed for the same job with no indication which one you were supposed to use.
+
+The count was never the problem. Two ways to do one job, with no rule for choosing, always was. After #549 named a primary path per intent, the surface grew from 33 to 38 with nobody violating anything — which is the proof that the count was the wrong metric.
+
+## One: the competition test
+
+A new `GacelaConfig` method is **fine** when:
+
+- it serves an intent nothing else serves, or
+- it is a typed or conditional variant of a path that already exists, discovered next to it (`addBindingIf()` next to `addBinding()`, `enableFileCache()` over `setFileCache(true)`).
+
+A new method is a **defect** when a reader with a job in hand cannot tell which of two methods does it. That question is answerable at review time, unlike a count.
+
+Applied to the six open issues at the time of writing: #675 and #673 pass (new intents, no competitor). #676 improves the surface (four `addSuffixType*()` verbs become sugar over one `addResolvableType()`). #672 fails twice as proposed (two verbs for one intent, and a third way to group services after `tag()` and `addHandlerRegistry()` — the #478 rule). #674 fails as proposed (a second extend path with no rule for choosing). #679 fails as proposed (a second answer to *which class wins*, next to `setProjectNamespaces()`). "Fails as proposed" means the issue must name the rule for choosing before it adds the method, not that the feature is unwanted.
+
+## Two: the naming grammar
+
+Five prefixes, each with one meaning. A reader who learns five prefixes navigates any number of methods:
+
+| Prefix | Meaning |
+|---|---|
+| `add*` | contributes to a collection; calling twice contributes twice |
+| `declare*` | states a shape or contract, checked by something else later |
+| `set*` | replaces a value; calling twice keeps the last |
+| `enable*` | toggles behavior on (sugar over the `set*` it shadows) |
+| `extend*` | wraps or composes something already registered |
+
+The grammar governs **new** methods. Existing methods that predate it are recorded below as exceptions, not renamed — churning every `gacela.php` in existence to satisfy a prefix would invert the cost the grammar exists to avoid.
+
+## Three: the audit
+
+Every public method, its bucket, and its verdict. **This table is a gate**: `tests/Integration/Architecture/BootstrapSurfaceDocsTest.php` fails when a public `GacelaConfig` method has no row here, or a row names a method that no longer exists. Adding a method means adding a row, which means writing down which rule admits it.
+
+| Method | Bucket | Verdict |
+|---|---|---|
+| `addAlias()` | `add*` | conforms |
+| `addAppConfig()` | `add*` | conforms |
+| `addAppConfigKeyValue()` | `add*` | conforms — typed variant of `addAppConfig()` |
+| `addAppConfigKeyValues()` | `add*` | conforms — plural variant, same path |
+| `addBinding()` | `add*` | conforms |
+| `addBindingIf()` | `add*` | conforms — conditional variant of `addBinding()` |
+| `addExternalService()` | `add*` | conforms |
+| `addFactory()` | `add*` | conforms |
+| `addHandlerRegistry()` | `add*` | conforms |
+| `addHealthCheck()` | `add*` | conforms |
+| `addLazy()` | `add*` | conforms |
+| `addPlugin()` | `add*` | conforms |
+| `addPlugins()` | `add*` | conforms — plural variant, same path |
+| `addProtected()` | `add*` | conforms |
+| `addSuffixTypeConfig()` | `add*` | conforms; #676 folds the four into `addResolvableType()` |
+| `addSuffixTypeFacade()` | `add*` | conforms; see above |
+| `addSuffixTypeFactory()` | `add*` | conforms; see above |
+| `addSuffixTypeProvider()` | `add*` | conforms; see above |
+| `afterResolving()` | — | exception: the verb names the container lifecycle moment it hooks; `addAfterResolvingCallback()` would name the mechanics and lose the moment |
+| `declareConfigSchema()` | `declare*` | conforms |
+| `disableEventListeners()` | — | exception: `enable*`'s negative twin; the grammar deliberately has no `disable*` row because most toggles default off, and this one defaults on |
+| `enableFileCache()` | `enable*` | conforms — sugar over `setFileCache(true)` |
+| `extendGacelaConfig()` | `extend*` | exception in meaning: composes another configuration surface into this one rather than wrapping a registered service; predates the grammar |
+| `extendGacelaConfigs()` | `extend*` | same as `extendGacelaConfig()`, plural variant |
+| `extendService()` | `extend*` | conforms |
+| `getExternalService()` | — | exception: the one read path on a write surface, paired with `addExternalService()` for the bridge handshake |
+| `loadDefinitions()` | — | exception: imports wiring from a file or array; `add*` would hide that the argument is data, not a definition |
+| `registerGenericListener()` | — | exception: semantically `add*`; predates the grammar, recorded rather than renamed |
+| `registerSpecificListener()` | — | same as `registerGenericListener()` |
+| `resetInMemoryCache()` | — | exception: an operational instruction to the bootstrap, not surface configuration; both host bridges call it per boot (#666) |
+| `setAppModulePaths()` | `set*` | conforms |
+| `setFileCache()` | `set*` | conforms |
+| `setProjectNamespaces()` | `set*` | conforms |
+| `setStubsDir()` | `set*` | conforms |
+| `tag()` | — | exception: the domain word is the API; `addTag()` would read as tagging a tag |
+| `toTransfer()` | — | exception: internal egress to the setup DTO; `@internal` in spirit, listed because it is public |
+| `validateConfigSchemaOnBoot()` | — | exception: semantically `enable*` (`enableConfigSchemaValidationOnBoot()` conforms and says less); recorded rather than renamed |
+| `when()` | — | exception: the head of the contextual-binding DSL (`when(X)->needs(Y)->give(Z)`); a prefix would break the sentence it starts |
+
+Eleven exceptions, each with the reason it stays. A twelfth needs a reason this table can hold.
+
+## Non-goals
+
+- **Splitting `GacelaConfig` into facets** (`$config->schema()->declare(...)`): breaks the flat surface the docs teach, churns every `gacela.php` in existence, and the settled doctrine says the count was never the complaint.
+- **Renaming existing methods**: the grammar governs new methods; the audit records the old ones.
+- **A hard cap on the method count**: the count is not the metric.

--- a/tests/Integration/Architecture/BootstrapSurfaceDocsTest.php
+++ b/tests/Integration/Architecture/BootstrapSurfaceDocsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+use function array_keys;
+use function file_get_contents;
+use function preg_match_all;
+use function sprintf;
+
+/**
+ * Holds RFC-0003's audit table against the code.
+ *
+ * The table is not decoration: it is the rule that admitted every public
+ * `GacelaConfig` method, one row each. A method without a row was added
+ * without saying which rule admits it, and a row without a method is doctrine
+ * about something that no longer exists.
+ */
+final class BootstrapSurfaceDocsTest extends TestCase
+{
+    private const RFC = __DIR__ . '/../../../docs/rfc/0003-bootstrap-configuration-surface.md';
+
+    public function test_every_public_method_has_a_row_in_the_audit_table(): void
+    {
+        $audited = $this->auditedMethods();
+
+        foreach ($this->publicMethods() as $method) {
+            self::assertArrayHasKey(
+                $method,
+                $audited,
+                sprintf(
+                    "%s() is public on GacelaConfig but has no row in RFC-0003's audit table. "
+                    . 'Add the row -- it is where you write down which rule admits the method.',
+                    $method,
+                ),
+            );
+        }
+    }
+
+    public function test_the_audit_table_names_no_method_that_stopped_existing(): void
+    {
+        $public = [];
+        foreach ($this->publicMethods() as $method) {
+            $public[$method] = true;
+        }
+
+        foreach (array_keys($this->auditedMethods()) as $audited) {
+            self::assertArrayHasKey(
+                $audited,
+                $public,
+                sprintf("RFC-0003's audit table lists %s(), which is not a public GacelaConfig method anymore.", $audited),
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function publicMethods(): array
+    {
+        $methods = [];
+
+        foreach ((new ReflectionClass(GacelaConfig::class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isConstructor()) {
+                continue;
+            }
+
+            if ($method->isStatic()) {
+                continue;
+            }
+
+            $methods[] = $method->getName();
+        }
+
+        return $methods;
+    }
+
+    /**
+     * The audit rows: every backticked `method()` opening a table row.
+     *
+     * @return array<string, true>
+     */
+    private function auditedMethods(): array
+    {
+        $markdown = (string)file_get_contents(self::RFC);
+
+        preg_match_all('/^\| `(\w+)\(\)`/m', $markdown, $matches);
+
+        $methods = [];
+        foreach ($matches[1] as $method) {
+            $methods[$method] = true;
+        }
+
+        return $methods;
+    }
+}


### PR DESCRIPTION
## 📚 Description

`GacelaConfig` has 38 public methods (the issue counted 39 — the exact number is re-counted by the gate on every run), and six open issues each add more. The rule that governs that surface existed as one paragraph inside `getting-a-dependency.md`, where nobody adding a bootstrap method would look. RFC-0003 promotes it to doctrine and gives it teeth.

Closes #684

## 🔖 Changes

- `docs/rfc/0003-bootstrap-configuration-surface.md`: the competition test (fine when it serves an unserved intent or is a typed variant of an existing path; a defect when a reader with a job in hand cannot tell which of two methods does it — with the six open issues scored against it), the five-prefix naming grammar (`add*`, `declare*`, `set*`, `enable*`, `extend*`), and the full 38-method audit — eleven exceptions, each with the reason it stays. Non-goals as the issue fixed them: no facets, no renames, no count cap.
- **The audit table is a gate**: `tests/Integration/Architecture/BootstrapSurfaceDocsTest` (same pattern as `StaticAnalysisDocsTest`) fails when a public method has no row, or a row names a method that stopped existing — both directions, 76 assertions today.
- The policy paragraph moves from `getting-a-dependency.md` into the RFC with a link left behind; `docs/README.md` and `.github/CONTRIBUTING.md` link the RFC from where the next author will actually look.
- Status: **draft** — flipping it to accepted is the maintainer's call, not this PR's.