### PR TITLE
docs: split module boundaries and file cache out, document the profiler

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,14 @@
 - [Container configuration](container-configuration.md) — factories, aliases, contextual bindings
 - [Config schema](config-schema.md) — declare what the configuration must contain, and fail before a request does
 - [Static analysis](static-analysis.md) — the architecture rules, for PHPStan and Psalm alike
+- [Module boundaries](module-boundaries.md) — the cross-module rules, dependency-cycle gate, declared rules file, and CI graph review
 - [Module health checks](module-health-checks.md) — report module operational status
+- [Profiling](profiling.md) — instrument code with the in-memory `Profiler` and read it back with `profile:report`
 - [Events](events.md) — listen to Gacela internals: dispatch model, event catalog, cookbook
 - [Testing](testing.md) — `GacelaTestCase`: bootstrap isolation, config overrides, container assertions
 - [Caching](caching.md) — overview of Gacela's three caching layers and when to reach for each
 - [Cacheable methods](cacheable-methods.md) — cache facade method results with `#[Cacheable]`
+- [FileCache and ScopedCache](file-cache.md) — cache arbitrary application data with atomic writes and cascading invalidation
 - [Opcache preload](opcache-preload.md) — production performance tuning
 - [Production performance](production-performance.md) — full checklist to run Gacela fast in production
 - [Upgrading](../UPGRADE.md) — why to move to 2.0, and every breaking change with its replacement

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -45,88 +45,19 @@ See also: [Opcache preload](opcache-preload.md) for getting PHP itself to cache 
 
 ## Layer 2 — Cacheable facade methods
 
-Cache the *result* of a facade method with the `#[Cacheable]` attribute and `CacheableTrait`:
+Cache the *result* of a facade method with the `#[Cacheable]` attribute and `$this->cached()`. Storage is `InMemoryCacheStorage` by default, which means entries die with the request on PHP-FPM; for cross-request caching swap in a shared backend (APCu, Redis, PSR-16) via `CacheableConfig::setStorage()`.
 
-```php
-use Gacela\Framework\AbstractFacade;
-use Gacela\Framework\Attribute\Cacheable;
-use Gacela\Framework\Attribute\CacheableTrait;
-
-final class CatalogFacade extends AbstractFacade
-{
-    use CacheableTrait;
-
-    #[Cacheable(ttl: 3600)]
-    public function getPopularProducts(): array
-    {
-        return $this->cached(fn (): array =>
-            $this->getFactory()->createRepository()->fetchPopular(),
-        );
-    }
-}
-```
-
-Storage is `InMemoryCacheStorage` by default, which means entries die with the request on PHP-FPM. For cross-request caching swap in a shared backend (APCu, Redis, PSR-16) via `CacheableConfig::setStorage()`.
-
-Clear selectively:
-
-```php
-CatalogFacade::clearMethodCacheFor('getPopularProducts'); // one method, any args
-CatalogFacade::clearMethodCache();                        // the whole shared store, every facade
-```
-
-Full reference: [Cacheable methods](cacheable-methods.md).
+Full reference, including keys, invalidation, TTL overrides, and the storage contract: [Cacheable methods](cacheable-methods.md).
 
 ## Layer 3 — Value primitives
 
-When *your code* needs a cache — compiled artefacts, parsed data, a build pipeline — use `Gacela\Framework\Cache\FileCache`:
+When *your code* needs a cache — compiled artefacts, parsed data, a build pipeline — use `Gacela\Framework\Cache\FileCache`: one atomically written file per key, per-entry TTLs, batched writes, and stats. When invalidating one entry should cascade to every entry derived from it, wrap it in `ScopedCache`, its dependency-aware decorator.
 
-```php
-use Gacela\Framework\Cache\FileCache;
-
-$cache = new FileCache('/var/cache/myapp');
-
-$cache->put('user:42', $user, ttl: 600);
-$cache->get('user:42');     // $user, or null after TTL expiry
-$cache->forget('user:42');
-$cache->clear();
-```
-
-- One `.php` file per key (SHA1-hashed), written atomically via staged `.tmp` + `rename`.
-- TTL per entry; `ttl: 0` means forever.
-- `beginBatch()` / `commitBatch()` defer writes behind a single index-locked flush — useful for warming many entries at once.
-- `stats()` returns entry count, total bytes, and oldest/newest timestamps.
-- Safe against torn reads: concurrent readers see either the previous file or the new one, never a half-written one.
-
-### ScopedCache — dependency-aware decorator
-
-When invalidating one entry should cascade to every downstream entry that derived from it, wrap `FileCache` in `ScopedCache`:
-
-```php
-use Gacela\Framework\Cache\FileCache;
-use Gacela\Framework\Cache\ScopedCache;
-
-$cache = new ScopedCache(new FileCache('/var/cache/myapp'));
-
-$cache->put('ns:core', $envCore);
-$cache->put('file:a.php', $compiledA);
-$cache->put('fragment:a#1', $fragment);
-
-$cache->dependsOn('file:a.php', 'ns:core');
-$cache->dependsOn('fragment:a#1', 'file:a.php');
-
-$cache->invalidate('ns:core');          // cascades: file:a.php and fragment:a#1 also go
-$cache->invalidateLeaf('file:a.php');   // only this key; dependents stay valid
-```
-
-- `get` / `put` / `has` delegate straight to the underlying `FileCache` — zero overhead on the hot path.
-- The dependency graph is persisted alongside the values (`.gacela-scoped-cache-graph.php`) and survives process restarts.
-- Cycles are rejected eagerly at `dependsOn()` — self, two-node, and transitive.
-- Single-writer concurrency: multiple processes racing on `dependsOn()` may lose edges added between load and persist. The value store underneath remains read-safe under concurrency regardless.
+Full reference: [FileCache and ScopedCache](file-cache.md).
 
 ## Picking a layer
 
 - Make Gacela's own resolution faster → Layer 1, `enableFileCache()`.
-- Memoise a specific facade method → Layer 2, `#[Cacheable]`.
-- Cache arbitrary application data → Layer 3, `FileCache`.
-- Same, but invalidation must cascade → Layer 3, `ScopedCache`.
+- Memoise a specific facade method → Layer 2, [`#[Cacheable]`](cacheable-methods.md).
+- Cache arbitrary application data → Layer 3, [`FileCache`](file-cache.md).
+- Same, but invalidation must cascade → Layer 3, [`ScopedCache`](file-cache.md#scopedcache--dependency-aware-decorator).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ Every stub substitutes `$NAMESPACE$`, `$MODULE_NAME$` and `$CLASS_NAME$`. `docto
 | `debug:dependencies Foo::class` | A class's constructor parameters and whether the container can supply each. `--tree` walks the whole graph and marks every node `binding`, `instance`, `autowired` or `unresolvable` |
 | `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--allowed-cycles`, `--rules` to fail on dependencies your rules file forbids, `--compare-to` |
 
-`debug:graph --check` is the one built for CI; see [static analysis](static-analysis.md) for wiring it into a workflow.
+`debug:graph --check` is the one built for CI; see [module boundaries](module-boundaries.md) for wiring it into a workflow.
 
 ## Validating
 
@@ -63,6 +63,6 @@ Among the built-in checks, *service extensions* verifies every `extendService()`
 |---|---|
 | `cache:warm` | Pre-resolves every module class and populates the on-disk caches. `--clear` first, `--attributes` to pre-scan `#[ServiceMap]` |
 | `cache:clear` | Removes every Gacela cache file |
-| `profile:report` | Performance profiling report |
+| `profile:report` | Performance profiling report — the recording side is the [Profiler](profiling.md) |
 
 `cache:warm` only writes anything when the file cache is enabled; the deploy sequence is in [production performance](production-performance.md).

--- a/docs/file-cache.md
+++ b/docs/file-cache.md
@@ -1,0 +1,53 @@
+# FileCache and ScopedCache
+
+When *your code* needs a cache — compiled artefacts, parsed data, a build pipeline — use `Gacela\Framework\Cache\FileCache`. It is the value layer of [Gacela's caching](caching.md): the framework does not put anything in it on its own; your application decides the keys, the values, and the lifetimes.
+
+## FileCache
+
+```php
+use Gacela\Framework\Cache\FileCache;
+
+$cache = new FileCache('/var/cache/myapp');
+
+$cache->put('user:42', $user, ttl: 600);
+$cache->get('user:42');     // $user, or null after TTL expiry
+$cache->forget('user:42');
+$cache->clear();
+```
+
+- One `.php` file per key (SHA1-hashed), written atomically via staged `.tmp` + `rename`.
+- TTL per entry; `ttl: 0` means forever.
+- `beginBatch()` / `commitBatch()` defer writes behind a single index-locked flush — useful for warming many entries at once.
+- `stats()` returns entry count, total bytes, and oldest/newest timestamps.
+- Safe against torn reads: concurrent readers see either the previous file or the new one, never a half-written one.
+
+## ScopedCache — dependency-aware decorator
+
+When invalidating one entry should cascade to every downstream entry that derived from it, wrap `FileCache` in `ScopedCache`:
+
+```php
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\ScopedCache;
+
+$cache = new ScopedCache(new FileCache('/var/cache/myapp'));
+
+$cache->put('ns:core', $envCore);
+$cache->put('file:a.php', $compiledA);
+$cache->put('fragment:a#1', $fragment);
+
+$cache->dependsOn('file:a.php', 'ns:core');
+$cache->dependsOn('fragment:a#1', 'file:a.php');
+
+$cache->invalidate('ns:core');          // cascades: file:a.php and fragment:a#1 also go
+$cache->invalidateLeaf('file:a.php');   // only this key; dependents stay valid
+```
+
+- `get` / `put` / `has` delegate straight to the underlying `FileCache` — zero overhead on the hot path.
+- The dependency graph is persisted alongside the values (`.gacela-scoped-cache-graph.php`) and survives process restarts.
+- Cycles are rejected eagerly at `dependsOn()` — self, two-node, and transitive.
+- Single-writer concurrency: multiple processes racing on `dependsOn()` may lose edges added between load and persist. The value store underneath remains read-safe under concurrency regardless.
+
+## See also
+
+- [Caching](caching.md) — the three caching layers and how to pick one
+- [Cacheable methods](cacheable-methods.md) — caching facade method results instead of raw values

--- a/docs/module-boundaries.md
+++ b/docs/module-boundaries.md
@@ -1,0 +1,193 @@
+# Module Boundaries
+
+Module A may only reach module B through B's Facade. This page collects everything that enforces that claim and the agreements built on top of it: two opt-in analyser rules, a dependency-cycle gate on `debug:graph`, a declared rules file both readers share, and a CI review for graph changes.
+
+The rules run under PHPStan and Psalm alike; [Static analysis](static-analysis.md) covers installing the analysers, the always-on pillar rules, and suppression.
+
+## The cross-module rules
+
+This is the one check that cannot be on by default: nothing in a class name says where a module boundary falls, so it needs your root namespace.
+
+It comes in **two halves, meant to be enabled together**.
+
+The first matches the module names a source *writes* — a `new`, a static call, a class constant, a static property. The second resolves the receiver of a method call by **type**, because that is how a boundary actually gets crossed once dependencies go through Providers and constructors:
+
+```php
+public function __construct(
+    private readonly InvoiceRepository $invoices,  // App\Billing — another module
+) {
+}
+
+public function createProcessor(): Processor
+{
+    return new Processor($this->invoices->findAll());  // names nothing here
+}
+```
+
+The class appears once, in a type-hint. A check that only matched written names would report green on exactly the codebases most likely to be crossing boundaries.
+
+### PHPStan
+
+```neon
+services:
+    -
+        class: Gacela\PHPStan\Rules\CrossModuleViaFacadeRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: App\Modules
+            modulePathSegments: 1     # how many segments under the root identify a module
+            sharedNamespaces:         # optional shared kernels, exempt from the check
+                - App\Modules\Shared
+    -
+        class: Gacela\PHPStan\Rules\CrossModuleMethodCallRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: App\Modules
+            modulePathSegments: 1
+            sharedNamespaces:
+                - App\Modules\Shared
+```
+
+### Psalm
+
+One `<crossModule>` element enables both halves:
+
+```xml
+<plugins>
+    <pluginClass class="Gacela\Psalm\Plugin">
+        <crossModule rootNamespace="App\Modules" modulePathSegments="1">
+            <sharedNamespace>App\Modules\Shared</sharedNamespace>
+        </crossModule>
+    </pluginClass>
+</plugins>
+```
+
+A `<crossModule>` without a `rootNamespace` is a configuration error and stops the run. A rule that quietly does nothing is worse than no rule: it reads as a green check, and nothing would ever tell you the boundary went unchecked.
+
+### What it accepts
+
+- `sharedNamespaces` entries are exempt in both directions: references into them are always allowed, and classes inside them are not checked. Matching is namespace-boundary aware — `App\Modules\Shared` does not exempt `App\Modules\SharedFoo`.
+- A **call** on a `*Facade` or a `*FacadeInterface` is allowed; consumers type-hint the interface, which is the same sanctioned crossing. A **written reference** is allowed only for `*Facade`, because naming `SomeFacadeInterface::class` is not a call through one.
+- A receiver the analyser cannot resolve is not reported. An unknown type is not evidence of a violation, and guessing there would make the rule noise.
+- One line can produce two findings — `(new ShopService())->run()` both names the other module and calls into it. Those are two crossings with two corrections, so both are reported.
+
+To see the actual module dependency graph of your app, run `vendor/bin/gacela debug:graph` (formats: `text`, `mermaid`, `graphviz`, `json`).
+
+## Failing on dependency cycles
+
+`debug:graph --check` exits non-zero when two modules depend on each other:
+
+```bash
+vendor/bin/gacela debug:graph --check
+```
+
+A cycle is either a decision somebody made or a mistake nobody noticed, and until the decision is written down those are the same thing. Write it down in a JSON file and pass it in:
+
+```json
+[
+    {
+        "modules": ["App\\Billing", "App\\Invoicing"],
+        "reason": "reviewed 2026-07: bidirectional by design until the shared kernel lands"
+    }
+]
+```
+
+```bash
+vendor/bin/gacela debug:graph --check --allowed-cycles=allowed-module-cycles.json
+```
+
+The allow list is **self-invalidating**: an entry that no longer matches a real cycle fails the check just as loudly as an undeclared cycle. That is deliberate. An allow-list that outlives what it allows stops being a record of a decision and becomes a mute button, and nothing would tell you it had happened. A `reason` is required for the same reason — an allowance nobody justified is indistinguishable from a cycle nobody noticed.
+
+`debug:graph` with no `--check` stays exit-code-neutral, so adding the gate does not change what the command already did.
+
+## Declaring which modules may depend on which
+
+A cycle is the only thing the graph can refuse on its own. Everything else a team agrees on — billing must not reach back-office, reporting reads and nothing more — lives in prose, where no tool can see it and a violation arrives as one more import in a diff. Write it in a JSON file instead:
+
+```json
+{
+    "rules": [
+        {
+            "from": "App\\Payment",
+            "deny": ["App\\Admin"],
+            "reason": "reviewed 2026-08: billing must not reach back-office"
+        },
+        {
+            "from": "App\\Reporting",
+            "allow": ["App\\Shared"],
+            "reason": "read-only module: the shared kernel and nothing else"
+        }
+    ]
+}
+```
+
+- `deny` forbids the listed modules and leaves every other dependency alone.
+- `allow` is the opposite reading: those are the **only** modules reachable, and anything else is a violation. An empty `allow` is meaningful — a leaf module that may depend on nothing.
+- One entry cannot carry both, and a rule with no `reason` is refused.
+- A rule about `App\Payment` also governs `App\Payment\Refunds`, and matching is namespace-boundary aware: `App\Pay` never governs `App\Payment`.
+
+The same file is read in two places. In CI, over the whole graph:
+
+```bash
+vendor/bin/gacela debug:graph --check --rules=module-rules.json
+```
+
+and in the editor, per class, by whichever analyser you run:
+
+```neon
+# phpstan.neon
+services:
+    -
+        class: Gacela\PHPStan\Rules\DeclaredModuleDependencyRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            rootNamespace: App
+            rulesFile: %currentWorkingDirectory%/module-rules.json
+```
+
+```xml
+<!-- psalm.xml -->
+<pluginClass class="Gacela\Psalm\Plugin">
+    <moduleRules rootNamespace="App" file="module-rules.json"/>
+</pluginClass>
+```
+
+One file, two readers, on purpose: a boundary that holds in CI and not in the editor is a boundary nobody trusts.
+
+The rules are **self-invalidating**, like the cycle allow list. A `from`, `allow` or `deny` naming a namespace that matches no module fails the check — a rule about a module nobody has any more still reads as a boundary being watched. A `deny` that never fires is not an error; that is the rule doing its job.
+
+`--rules` cannot be combined with a filter argument: in a narrowed graph, a rule about a filtered-out module is indistinguishable from a rule about a module that no longer exists, and those two must not look alike.
+
+`--check --format=json` writes the findings as a report instead of lines, for a CI job that wants more than an exit code:
+
+```json
+{
+    "undeclaredCycles": [],
+    "staleAllowedCycles": [],
+    "forbiddenDependencies": [
+        {"from": "App\\Payment", "to": "App\\Admin", "reason": "reviewed 2026-08: billing must not reach back-office"}
+    ],
+    "unknownRuleNamespaces": []
+}
+```
+
+## Reviewing graph changes in CI
+
+A new cross-module edge enters a pull request as one more `use` statement, which is exactly as visible as every other import. `--compare-to` turns it into something a reviewer can see:
+
+```bash
+# on the base branch
+vendor/bin/gacela debug:graph --format=json > base-graph.json
+
+# on the branch under review
+vendor/bin/gacela debug:graph --compare-to=base-graph.json > graph-diff.md
+```
+
+The report is GitHub-flavoured markdown with a mermaid block GitHub renders natively in a comment, listing new and removed dependencies and drawing only the modules the change touches. When the graph is unchanged it writes **nothing** and exits `0` — so a CI job can test the file for emptiness and stay quiet on the pull requests that did not move the graph. An unreadable or invalid baseline exits `1`: that is a broken setup, not an unchanged graph, and the two must not look alike.
+
+`.github/workflows/module-graph.yml` in this repository is a working example.
+
+## See also
+
+- [Static analysis](static-analysis.md) — analyser setup, the pillar rules, typed accessors, suppression
+- [CLI commands](cli.md) — every `debug:graph` flag

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,51 @@
+# Profiling
+
+`Gacela\Framework\Profiler\Profiler` is an in-memory stopwatch for your own code: you mark the operations worth measuring, and it records how long each one took and how much memory the process was using when it finished. It is disabled by default and, while disabled, every call on it is a no-op, so instrumentation can stay in place at zero cost.
+
+## Recording spans
+
+Enable the profiler early in your bootstrap, then wrap the code you want to measure in matching `start()` / `stop()` calls with the same operation and subject:
+
+```php
+use Gacela\Framework\Profiler\Profiler;
+
+Profiler::getInstance()->enable();
+```
+
+```php
+$profiler = Profiler::getInstance();
+
+$profiler->start('db-query', 'users');
+$users = $repository->findAll();
+$profiler->stop('db-query', 'users');
+```
+
+- A span is identified by `operation:subject`. Different subjects under one operation stay separate entries and are aggregated per operation in the stats.
+- Nested and recursive spans with the same label are handled correctly: start times are kept as a stack, so a `stop()` closes the span its matching `start()` opened instead of collapsing both into one entry.
+- A `stop()` with no matching `start()` is ignored; there is no start time to measure from.
+- Durations are measured with `hrtime()` and reported in seconds. Each entry also records `memory_get_usage(true)` at the time it was stopped.
+- `disable()` drops any span still in flight, so a later `enable()` cannot pair a fresh `stop()` with a stale start.
+- `reset()` clears recorded entries and open spans.
+
+## Reading the results
+
+The profiler lives in process memory, so results are read in the same process that recorded them.
+
+In code, `getEntries()` returns every recorded span, and `getStats()` aggregates them:
+
+```php
+$stats = Profiler::getInstance()->getStats();
+
+$stats['total_operations'];  // int
+$stats['total_duration'];    // float, seconds
+$stats['avg_duration'];      // float, seconds
+$stats['peak_memory'];       // int, bytes
+$stats['by_operation'];      // per operation: count, total_duration, avg_duration
+```
+
+On the command line, `profile:report` renders the same data as a table (`--format=table|json|summary`), sorted by duration, memory, or operation (`--sort`). Because the profiler is per-process, the command shows the spans recorded during its own run: enable the profiler and instrument code inside `gacela.php` or the bootstrap closure, and whatever executes while the command boots is what appears in the report.
+
+## See also
+
+- [CLI commands](cli.md) — `profile:report` among the production commands
+- [Events](events.md) — lifecycle events, the other observability surface, better suited to tracing resolution

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -171,72 +171,9 @@ The rule is on by default and self-limiting: it only fires for a facade that exp
 
 ## Module boundaries
 
-Module A may only reach module B through B's Facade. This is the one check that cannot be on by default: nothing in a class name says where a module boundary falls, so it needs your root namespace.
+The two opt-in cross-module rules, the dependency-cycle gate on `debug:graph`, the declared module rules file, and the CI graph review have their own page: [Module boundaries](module-boundaries.md). Enable the rules there once the analyser setup above is in place.
 
-It comes in **two halves, meant to be enabled together**.
-
-The first matches the module names a source *writes* — a `new`, a static call, a class constant, a static property. The second resolves the receiver of a method call by **type**, because that is how a boundary actually gets crossed once dependencies go through Providers and constructors:
-
-```php
-public function __construct(
-    private readonly InvoiceRepository $invoices,  // App\Billing — another module
-) {
-}
-
-public function createProcessor(): Processor
-{
-    return new Processor($this->invoices->findAll());  // names nothing here
-}
-```
-
-The class appears once, in a type-hint. A check that only matched written names would report green on exactly the codebases most likely to be crossing boundaries.
-
-### PHPStan
-
-```neon
-services:
-    -
-        class: Gacela\PHPStan\Rules\CrossModuleViaFacadeRule
-        tags: [phpstan.rules.rule]
-        arguments:
-            rootNamespace: App\Modules
-            modulePathSegments: 1     # how many segments under the root identify a module
-            sharedNamespaces:         # optional shared kernels, exempt from the check
-                - App\Modules\Shared
-    -
-        class: Gacela\PHPStan\Rules\CrossModuleMethodCallRule
-        tags: [phpstan.rules.rule]
-        arguments:
-            rootNamespace: App\Modules
-            modulePathSegments: 1
-            sharedNamespaces:
-                - App\Modules\Shared
-```
-
-### Psalm
-
-```xml
-<plugins>
-    <pluginClass class="Gacela\Psalm\Plugin">
-        <crossModule rootNamespace="App\Modules" modulePathSegments="1">
-            <sharedNamespace>App\Modules\Shared</sharedNamespace>
-        </crossModule>
-    </pluginClass>
-</plugins>
-```
-
-A `<crossModule>` without a `rootNamespace` is a configuration error and stops the run. A rule that quietly does nothing is worse than no rule: it reads as a green check, and nothing would ever tell you the boundary went unchecked.
-
-### What it accepts
-
-- `sharedNamespaces` entries are exempt in both directions: references into them are always allowed, and classes inside them are not checked. Matching is namespace-boundary aware — `App\Modules\Shared` does not exempt `App\Modules\SharedFoo`.
-- A **call** on a `*Facade` or a `*FacadeInterface` is allowed; consumers type-hint the interface, which is the same sanctioned crossing. A **written reference** is allowed only for `*Facade`, because naming `SomeFacadeInterface::class` is not a call through one.
-- A receiver the analyser cannot resolve is not reported. An unknown type is not evidence of a violation, and guessing there would make the rule noise.
-- One line can produce two findings — `(new ShopService())->run()` both names the other module and calls into it. Those are two crossings with two corrections, so both are reported.
-
-To see the actual module dependency graph of your app, run `vendor/bin/gacela debug:graph` (formats: `text`, `mermaid`, `graphviz`, `json`).
-
-### One place the two analysers differ
+## One place the two analysers differ
 
 A facade whose public method comes from a **trait** is judged by PHPStan and not by Psalm:
 
@@ -250,120 +187,6 @@ final class CheckoutFacade extends AbstractFacade
 Both run the same rule; the difference is what each host hands a plugin. PHPStan analyses a trait's methods once **per class that uses it**, so the rule sees the method with the facade as its class. Psalm analyses them once, in the **trait's own** context — a trait extends nothing, and a trait-provided method does not appear in the using class's AST.
 
 There is no route to a trait method's body in a using class's context through Psalm's public plugin API, so this is a limitation to know about rather than something a future release quietly fixes. If your facades take methods from traits, PHPStan is the analyser that checks them.
-
-## Failing on dependency cycles
-
-`debug:graph --check` exits non-zero when two modules depend on each other:
-
-```bash
-vendor/bin/gacela debug:graph --check
-```
-
-A cycle is either a decision somebody made or a mistake nobody noticed, and until the decision is written down those are the same thing. Write it down in a JSON file and pass it in:
-
-```json
-[
-    {
-        "modules": ["App\\Billing", "App\\Invoicing"],
-        "reason": "reviewed 2026-07: bidirectional by design until the shared kernel lands"
-    }
-]
-```
-
-```bash
-vendor/bin/gacela debug:graph --check --allowed-cycles=allowed-module-cycles.json
-```
-
-The allow list is **self-invalidating**: an entry that no longer matches a real cycle fails the check just as loudly as an undeclared cycle. That is deliberate. An allow-list that outlives what it allows stops being a record of a decision and becomes a mute button, and nothing would tell you it had happened. A `reason` is required for the same reason — an allowance nobody justified is indistinguishable from a cycle nobody noticed.
-
-`debug:graph` with no `--check` stays exit-code-neutral, so adding the gate does not change what the command already did.
-
-## Declaring which modules may depend on which
-
-A cycle is the only thing the graph can refuse on its own. Everything else a team agrees on — billing must not reach back-office, reporting reads and nothing more — lives in prose, where no tool can see it and a violation arrives as one more import in a diff. Write it in a JSON file instead:
-
-```json
-{
-    "rules": [
-        {
-            "from": "App\\Payment",
-            "deny": ["App\\Admin"],
-            "reason": "reviewed 2026-08: billing must not reach back-office"
-        },
-        {
-            "from": "App\\Reporting",
-            "allow": ["App\\Shared"],
-            "reason": "read-only module: the shared kernel and nothing else"
-        }
-    ]
-}
-```
-
-- `deny` forbids the listed modules and leaves every other dependency alone.
-- `allow` is the opposite reading: those are the **only** modules reachable, and anything else is a violation. An empty `allow` is meaningful — a leaf module that may depend on nothing.
-- One entry cannot carry both, and a rule with no `reason` is refused.
-- A rule about `App\Payment` also governs `App\Payment\Refunds`, and matching is namespace-boundary aware: `App\Pay` never governs `App\Payment`.
-
-The same file is read in two places. In CI, over the whole graph:
-
-```bash
-vendor/bin/gacela debug:graph --check --rules=module-rules.json
-```
-
-and in the editor, per class, by whichever analyser you run:
-
-```neon
-# phpstan.neon
-services:
-    -
-        class: Gacela\PHPStan\Rules\DeclaredModuleDependencyRule
-        tags: [phpstan.rules.rule]
-        arguments:
-            rootNamespace: App
-            rulesFile: %currentWorkingDirectory%/module-rules.json
-```
-
-```xml
-<!-- psalm.xml -->
-<pluginClass class="Gacela\Psalm\Plugin">
-    <moduleRules rootNamespace="App" file="module-rules.json"/>
-</pluginClass>
-```
-
-One file, two readers, on purpose: a boundary that holds in CI and not in the editor is a boundary nobody trusts.
-
-The rules are **self-invalidating**, like the cycle allow list. A `from`, `allow` or `deny` naming a namespace that matches no module fails the check — a rule about a module nobody has any more still reads as a boundary being watched. A `deny` that never fires is not an error; that is the rule doing its job.
-
-`--rules` cannot be combined with a filter argument: in a narrowed graph, a rule about a filtered-out module is indistinguishable from a rule about a module that no longer exists, and those two must not look alike.
-
-`--check --format=json` writes the findings as a report instead of lines, for a CI job that wants more than an exit code:
-
-```json
-{
-    "undeclaredCycles": [],
-    "staleAllowedCycles": [],
-    "forbiddenDependencies": [
-        {"from": "App\\Payment", "to": "App\\Admin", "reason": "reviewed 2026-08: billing must not reach back-office"}
-    ],
-    "unknownRuleNamespaces": []
-}
-```
-
-## Reviewing graph changes in CI
-
-A new cross-module edge enters a pull request as one more `use` statement, which is exactly as visible as every other import. `--compare-to` turns it into something a reviewer can see:
-
-```bash
-# on the base branch
-vendor/bin/gacela debug:graph --format=json > base-graph.json
-
-# on the branch under review
-vendor/bin/gacela debug:graph --compare-to=base-graph.json > graph-diff.md
-```
-
-The report is GitHub-flavoured markdown with a mermaid block GitHub renders natively in a comment, listing new and removed dependencies and drawing only the modules the change touches. When the graph is unchanged it writes **nothing** and exits `0` — so a CI job can test the file for emptiness and stay quiet on the pull requests that did not move the graph. An unreadable or invalid baseline exits `1`: that is a broken setup, not an unchanged graph, and the two must not look alike.
-
-`.github/workflows/module-graph.yml` in this repository is a working example.
 
 ## Why the rules ship with the framework
 
@@ -391,7 +214,7 @@ composer remove --dev gacela-project/phpstan-extension
 | `parameters.gacela.modulesNamespace` | `rootNamespace`, on the two cross-module rules |
 | `parameters.gacela.excludedNamespaces` | `sharedNamespaces`, on the same two rules |
 
-Its `EnforceModuleBoundariesForMethodCallRule` is `CrossModuleMethodCallRule` here, and the boundary check now has a second half — the references a source names — that the package never covered. See [Module boundaries](#module-boundaries) for the configuration.
+Its `EnforceModuleBoundariesForMethodCallRule` is `CrossModuleMethodCallRule` here, and the boundary check now has a second half — the references a source names — that the package never covered. See [Module boundaries](module-boundaries.md) for the configuration.
 
 ## Troubleshooting
 
@@ -401,6 +224,7 @@ Its `EnforceModuleBoundariesForMethodCallRule` is `CrossModuleMethodCallRule` he
 
 ## See also
 
+- [Module boundaries](module-boundaries.md) — the cross-module rules, cycle gate, and rules file
 - [PHPStan: ignoring errors](https://phpstan.org/user-guide/ignoring-errors)
 - [Psalm configuration](https://psalm.dev/docs/running_psalm/configuration/)
 - [Gacela ServiceMap](https://gacela-project.com/docs/service-map/)


### PR DESCRIPTION
Docs restructure, mirroring gacela-project/gacela-project.com#57:

- New **module-boundaries.md**: the cross-module rules, cycle gate, rules file and CI graph review, moved out of static-analysis.md.
- New **file-cache.md**: the FileCache/ScopedCache reference, moved out of caching.md.
- New **profiling.md**: the Profiler API that `profile:report` reads, previously undocumented.
- README index and cross-links updated; all relative links verified.

Markdown only, no code changes.