### PR TITLE
feat(plugins): typed plugin stacks for ordered extension points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Declare an extension point with `addPluginStack()`: every implementation of one interface, in declaration order, resolved lazily and read back typed through `getPluginStack()`. Calling it again appends, so another config source contributes to a stack it did not declare, and an entry that does not implement the interface fails naming the class
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars, reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs became sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`. The kind is listed in the command's help, `doctor` counts its stub among the ones the scaffolder reads, and until that stub exists the generator names the path it looked for
 - Report in `doctor` every `extendService()` id no Provider ever `set()`s — such an extension is accepted, scheduled on every scope, and applied nowhere

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -9,7 +9,7 @@ The rest still work. They are listed at the bottom with the situations where the
 | reach another module | from an entry point: `ServiceResolverAwareTrait` + `#[ServiceMap]` + `$this->getFacade()`. From a Factory: `#[Provides]` + `getProvidedDependency()` |
 | get a collaborator inside my own module | a `create*()` method on the Factory, or `make()` when autowiring pays |
 | get an external / infrastructure service | `#[Provides]` in the Provider, or `addBinding()` for an interface |
-| collect several implementations | `tag()` when the set is unkeyed, `addHandlerRegistry()` when you look one up by key |
+| collect several implementations | `addPluginStack()` when they share an interface, `tag()` when the set is unkeyed and untyped, `addHandlerRegistry()` when you look one up by key |
 | read a config value | the typed getters on your `Config` |
 
 ## Reach another module
@@ -174,6 +174,37 @@ $handler = $registry->get('email');
 ```
 
 Both resolve their members through the container and both instantiate lazily. They are not two ways to do one thing: a registry answers *"the handler for this key"* and throws on an unknown one, while a tag answers *"all of these"* and has no notion of a key to miss.
+
+### Typed — every implementation of one interface
+
+An extension point: several implementations behind one interface, iterated in order by a module that does not know who contributed them. Declare it with `addPluginStack()`:
+
+```php
+$config->addPluginStack(InvoiceDecorator::class, [
+    AddVatBreakdownDecorator::class,
+    AddPaymentTermsDecorator::class,
+]);
+```
+
+Consume it from the Factory, typed — the `foreach` in the consumer knows what it is iterating:
+
+```php
+final class InvoiceFactory extends AbstractFactory
+{
+    public function createRenderer(): InvoiceRenderer
+    {
+        return new InvoiceRenderer($this->getPluginStack(InvoiceDecorator::class));
+    }
+}
+```
+
+Calling `addPluginStack()` again for the same interface **appends**, seed first, in the order the config sources run — so another package's `extendGacelaConfig` or an environment override contributes to a stack it did not declare, and there is no second verb to choose between. A class registered twice appears once.
+
+Entries resolve through the container on first read and are kept, so iterating twice yields the same plugins however they are bound. A class that does not implement the interface fails on that first read, naming the class and the stack, rather than as a `TypeError` somewhere inside the consumer's loop.
+
+**Which of the three.** A registry answers *the one implementation for this key*. A tag answers *all of these*, untyped, contributed from anywhere. A stack answers *all implementations of this interface*, in order, typed and checked. The contract is what separates a stack from a tag — without one, the answer is a tag.
+
+A stack is reached with `getPluginStack()` rather than `getProvidedDependency()` deliberately: the latter means *the thing registered under this id*, and both analysers type it as the class the id names, so routing a stack through it would make one id mean two things.
 
 ## Read a config value
 

--- a/docs/rfc/0003-bootstrap-configuration-surface.md
+++ b/docs/rfc/0003-bootstrap-configuration-surface.md
@@ -59,6 +59,7 @@ Every public method, its bucket, and its verdict. **This table is a gate**: `tes
 | `addLazy()` | `add*` | conforms |
 | `addPlugin()` | `add*` | conforms |
 | `addPlugins()` | `add*` | conforms — plural variant, same path |
+| `addPluginStack()` | `add*` | conforms — declares an extension point and contributes to one with the same verb, appending like `tag()`, so there is no second verb to choose between. Distinct from `tag()` and `addHandlerRegistry()` by carrying an interface contract, which is the rule the docs state |
 | `addProtected()` | `add*` | conforms |
 | `addResolvableType()` | `add*` | conforms — a new intent nothing else serves (declaring a class kind, not a suffix for an existing one), and the four `addSuffixType*()` verbs became sugar over it |
 | `addSuffixTypeConfig()` | `add*` | conforms; #676 folds the four into `addResolvableType()` |

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -11,6 +11,8 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
+use Gacela\Framework\Exception\PluginStackException;
+use Gacela\Framework\Plugins\PluginStack;
 
 /**
  * @template TConfig of AbstractConfig = AbstractConfig
@@ -91,6 +93,39 @@ abstract class AbstractFactory
         $instance = $this->instances[$key] ??= $creator();
 
         return $instance;
+    }
+
+    /**
+     * The declared implementations of one interface, in order, typed.
+     *
+     * Deliberately not `getProvidedDependency(InvoiceDecorator::class)`: that
+     * call means "the thing registered under this id", and both analysers type
+     * it as the class the id names. A stack registered under its contract
+     * resolves to a `PluginStack` of that contract instead, so routing it
+     * through the same call would make one id mean two things. It gets its own
+     * accessor and `getProvidedDependency()` keeps meaning exactly one.
+     *
+     * @template TPlugin of object
+     *
+     * @param class-string<TPlugin> $contract
+     *
+     * @return PluginStack<TPlugin>
+     */
+    protected function getPluginStack(string $contract): PluginStack
+    {
+        // Read straight off the container rather than through
+        // getProvidedDependency(): a stack is declared app-wide in gacela.php,
+        // so a module that only *consumes* an extension point has no reason to
+        // own a Provider, and being told it needs one would be a coupling the
+        // declaration never asked for.
+        $stack = $this->getContainer()->get($contract);
+
+        if (!$stack instanceof PluginStack) {
+            throw PluginStackException::notDeclared($contract);
+        }
+
+        /** @var PluginStack<TPlugin> $stack */
+        return $stack;
     }
 
     protected function getProvidedDependency(string $key): mixed

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -45,6 +45,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string handlerRegistries = 'handlerRegistries';
 
+    public const string pluginStacks = 'pluginStacks';
+
     public const string tags = 'tags';
 
     public const string afterResolvingCallbacks = 'afterResolvingCallbacks';
@@ -92,6 +94,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_CONTEXTUAL_BINDINGS = [];
 
     protected const array DEFAULT_HANDLER_REGISTRIES = [];
+
+    protected const array DEFAULT_PLUGIN_STACKS = [];
 
     protected const array DEFAULT_TAGS = [];
 

--- a/src/Framework/Bootstrap/ContainerConfigurationInterface.php
+++ b/src/Framework/Bootstrap/ContainerConfigurationInterface.php
@@ -14,6 +14,7 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
  * @psalm-type ServiceAliasMap = array<string, string>
  * @psalm-type ServicesToExtendMap = array<string, list<Closure>>
  * @psalm-type HandlerRegistriesMap = array<string, array<string|int, class-string>>
+ * @psalm-type PluginStacksMap = array<class-string, list<class-string>>
  * @psalm-type TagsMap = array<string, list<string>>
  * @psalm-type AfterResolvingMap = array<string, list<Closure>>
  * @psalm-type DefinitionSources = list<string|array<array-key, mixed>>
@@ -57,6 +58,15 @@ interface ContainerConfigurationInterface
      * @return HandlerRegistriesMap
      */
     public function getHandlerRegistries(): array;
+
+    /**
+     * Extension points: each entry maps an interface to the implementations
+     * declared for it, resolvable from the container under that interface as a
+     * {@see \Gacela\Framework\Plugins\PluginStack}.
+     *
+     * @return PluginStacksMap
+     */
+    public function getPluginStacks(): array;
 
     /**
      * Service identifiers grouped under a label, resolvable together through

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -31,6 +31,7 @@ use function sprintf;
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -98,6 +99,9 @@ final class GacelaConfig
 
     /** @var HandlerRegistriesMap */
     private array $handlerRegistries = [];
+
+    /** @var PluginStacksMap */
+    private array $pluginStacks = [];
 
     /** @var TagsMap */
     private array $tags = [];
@@ -640,6 +644,44 @@ final class GacelaConfig
     }
 
     /**
+     * Declare an extension point: every implementation of one interface, in
+     * declaration order, resolvable as a typed
+     * {@see \Gacela\Framework\Plugins\PluginStack} through
+     * `AbstractFactory::getPluginStack()`.
+     *
+     * ```php
+     * $config->addPluginStack(InvoiceDecorator::class, [
+     *     AddVatBreakdownDecorator::class,
+     *     AddPaymentTermsDecorator::class,
+     * ]);
+     * ```
+     *
+     * Repeated calls append rather than replace, so a later config source --
+     * another package's `extendGacelaConfig`, an environment override --
+     * contributes to a stack it did not declare, seed first. That is the same
+     * rule {@see tag()} follows, and it is why there is no second verb for
+     * contributing.
+     *
+     * Which of the three collections to reach for: a registry answers *the one
+     * implementation for this key*, a tag answers *all of these* untyped, and a
+     * stack answers *all implementations of this interface*, typed and checked.
+     * An entry that does not implement the interface fails when the stack first
+     * resolves it, naming the class.
+     *
+     * @param class-string $contract
+     * @param list<class-string> $plugins
+     */
+    public function addPluginStack(string $contract, array $plugins): self
+    {
+        $this->pluginStacks[$contract] = [
+            ...$this->pluginStacks[$contract] ?? [],
+            ...$plugins,
+        ];
+
+        return $this;
+    }
+
+    /**
      * Group service identifiers under a label so a module can ask for "every
      * service tagged X" without knowing who registered them. Resolve the group
      * with `Container::tagged($tag)`, which instantiates each id lazily, in the
@@ -767,6 +809,7 @@ final class GacelaConfig
             $this->aliases,
             $this->contextualBindings,
             $this->handlerRegistries,
+            $this->pluginStacks,
             $this->lazyServices,
             $this->tags,
             $this->afterResolvingCallbacks,

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -21,6 +21,7 @@ use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -45,6 +46,7 @@ final class GacelaConfigTransfer
      * @param ServiceAliasMap $aliases
      * @param ContextualBindingsMap $contextualBindings
      * @param HandlerRegistriesMap $handlerRegistries
+     * @param PluginStacksMap $pluginStacks
      * @param ServiceFactoryMap $lazyServices
      * @param TagsMap $tags
      * @param AfterResolvingMap $afterResolvingCallbacks
@@ -73,6 +75,7 @@ final class GacelaConfigTransfer
         public readonly array $aliases,
         public readonly array $contextualBindings,
         public readonly array $handlerRegistries = [],
+        public readonly array $pluginStacks = [],
         public readonly array $lazyServices = [],
         public readonly array $tags = [],
         public readonly array $afterResolvingCallbacks = [],

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -24,6 +24,7 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -109,6 +110,9 @@ final class Properties
 
     /** @var ?HandlerRegistriesMap */
     public ?array $handlerRegistries = null;
+
+    /** @var ?PluginStacksMap */
+    public ?array $pluginStacks = null;
 
     /** @var ?TagsMap */
     public ?array $tags = null;

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -22,6 +22,7 @@ use function array_unique;
  * @psalm-import-type ServiceFactoryMap from ContainerConfigurationInterface
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -139,6 +140,24 @@ final class PropertyMerger
         $this->setup->setHandlerRegistries(
             $this->mergeNested($this->setup->getHandlerRegistries(), $list),
         );
+    }
+
+    /**
+     * A stack is a collection too, and an ordered one: the later setup appends
+     * to what the earlier declared, seed first. A class declared twice appears
+     * once, so a config source re-stating the seed does not run it twice.
+     *
+     * @param PluginStacksMap $list
+     */
+    public function mergePluginStacks(array $list): void
+    {
+        $merged = $this->setup->getPluginStacks();
+
+        foreach ($list as $contract => $plugins) {
+            $merged[$contract] = array_values(array_unique(array_merge($merged[$contract] ?? [], $plugins)));
+        }
+
+        $this->setup->setPluginStacks($merged);
     }
 
     /**

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -13,6 +13,7 @@ use Gacela\Framework\Config\Schema\ConfigType;
 
 use function array_merge;
 use function array_unique;
+use function in_array;
 
 /**
  * Merges individual properties into a SetupGacela instance.
@@ -154,7 +155,18 @@ final class PropertyMerger
         $merged = $this->setup->getPluginStacks();
 
         foreach ($list as $contract => $plugins) {
-            $merged[$contract] = array_values(array_unique(array_merge($merged[$contract] ?? [], $plugins)));
+            // Appended one at a time rather than merged-then-deduplicated: the
+            // result stays a list without a reindex step, and a class both
+            // sources declared keeps the position the first one gave it.
+            $current = $merged[$contract] ?? [];
+
+            foreach ($plugins as $plugin) {
+                if (!in_array($plugin, $current, true)) {
+                    $current[] = $plugin;
+                }
+            }
+
+            $merged[$contract] = $current;
         }
 
         $this->setup->setPluginStacks($merged);

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -43,6 +43,7 @@ final class SetupInitializer
             ->setAliases($dto->aliases)
             ->setContextualBindings($dto->contextualBindings)
             ->setHandlerRegistries($dto->handlerRegistries)
+            ->setPluginStacks($dto->pluginStacks)
             ->setTags($dto->tags)
             ->setAfterResolvingCallbacks($dto->afterResolvingCallbacks)
             ->setLazyServices($dto->lazyServices)

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -38,6 +38,7 @@ final class SetupMerger
         $this->whenChanged($other, SetupGacela::aliases, fn () => $this->original->mergeAliases($other->getAliases()));
         $this->whenChanged($other, SetupGacela::contextualBindings, fn () => $this->original->mergeContextualBindings($other->getContextualBindings()));
         $this->whenChanged($other, SetupGacela::handlerRegistries, fn () => $this->original->mergeHandlerRegistries($other->getHandlerRegistries()));
+        $this->whenChanged($other, SetupGacela::pluginStacks, fn () => $this->original->mergePluginStacks($other->getPluginStacks()));
         $this->whenChanged($other, SetupGacela::tags, fn () => $this->original->mergeTags($other->getTags()));
         $this->whenChanged($other, SetupGacela::afterResolvingCallbacks, fn () => $this->original->mergeAfterResolvingCallbacks($other->getAfterResolvingCallbacks()));
         $this->whenChanged($other, SetupGacela::lazyServices, fn () => $this->original->mergeLazyServices($other->getLazyServices()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -35,6 +35,7 @@ use function sprintf;
  * @psalm-import-type ConfigKeyValues from SetupGacelaInterface
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
+ * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -405,6 +406,14 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
+     * @return PluginStacksMap
+     */
+    public function getPluginStacks(): array
+    {
+        return $this->properties->pluginStacks ?? self::DEFAULT_PLUGIN_STACKS;
+    }
+
+    /**
      * @return TagsMap
      */
     public function getTags(): array
@@ -760,6 +769,22 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @internal Used by SetupInitializer - do not call directly
      *
+     * @param ?PluginStacksMap $list
+     */
+    public function setPluginStacks(?array $list): self
+    {
+        $this->properties->pluginStacks = $this->setPropertyWithTracking(
+            self::pluginStacks,
+            $list,
+            self::DEFAULT_PLUGIN_STACKS,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
      * @param ?TagsMap $list
      */
     public function setTags(?array $list): self
@@ -851,6 +876,16 @@ final class SetupGacela extends AbstractSetupGacela
     public function mergeHandlerRegistries(array $list): void
     {
         $this->propertyMerger->mergeHandlerRegistries($list);
+    }
+
+    /**
+     * @internal Used by SetupMerger - do not call directly
+     *
+     * @param PluginStacksMap $list
+     */
+    public function mergePluginStacks(array $list): void
+    {
+        $this->propertyMerger->mergePluginStacks($list);
     }
 
     /**

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -21,6 +21,7 @@ use Gacela\Framework\Event\Container\BindingRegisteredEvent;
 use Gacela\Framework\Event\Container\ServiceResolvedEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Plugins\LazyHandlerRegistry;
+use Gacela\Framework\Plugins\LazyPluginStack;
 use Throwable;
 
 use function array_keys;
@@ -629,6 +630,13 @@ final class Container implements ContainerInterface
             $container->set(
                 $registryKey,
                 static fn (): LazyHandlerRegistry => new LazyHandlerRegistry($handlers, $container),
+            );
+        }
+
+        foreach ($containerConfig->getPluginStacks() as $contract => $plugins) {
+            $container->set(
+                $contract,
+                static fn (): LazyPluginStack => new LazyPluginStack($contract, $plugins, $container),
             );
         }
 

--- a/src/Framework/Exception/PluginStackException.php
+++ b/src/Framework/Exception/PluginStackException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class PluginStackException extends RuntimeException
+{
+    public static function notDeclared(string $contract): self
+    {
+        return new self(sprintf(
+            'No plugin stack is declared for "%s". Declare one in gacela.php with '
+            . 'addPluginStack(%s::class, [...]).',
+            $contract,
+            $contract,
+        ));
+    }
+
+    public static function doesNotImplementContract(string $className, string $contract): self
+    {
+        return new self(sprintf(
+            '"%s" is registered in the "%s" plugin stack and does not implement it.',
+            $className,
+            $contract,
+        ));
+    }
+}

--- a/src/Framework/Plugins/LazyPluginStack.php
+++ b/src/Framework/Plugins/LazyPluginStack.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Plugins;
+
+use ArrayIterator;
+use Gacela\Container\ContainerInterface;
+use Gacela\Framework\Exception\PluginStackException;
+use Traversable;
+
+use function array_key_exists;
+use function count;
+
+/**
+ * Default {@see PluginStack}: resolves each entry through the container on
+ * first access and keeps the instance.
+ *
+ * @template TPlugin of object
+ *
+ * @implements PluginStack<TPlugin>
+ */
+final class LazyPluginStack implements PluginStack
+{
+    /**
+     * A second cache, for the reason {@see LazyHandlerRegistry} documents: the
+     * container caches by binding style, so an entry bound as a factory would
+     * be rebuilt on every pass. A stack's contract is that iterating it twice
+     * yields the same plugins, and that has to hold however they are bound.
+     *
+     * @var array<int, TPlugin>
+     */
+    private array $resolved = [];
+
+    /**
+     * @param class-string<TPlugin> $contract
+     * @param list<class-string<TPlugin>> $plugins
+     */
+    public function __construct(
+        private readonly string $contract,
+        private readonly array $plugins,
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    /**
+     * @return list<TPlugin>
+     */
+    public function all(): array
+    {
+        $all = [];
+
+        foreach (array_keys($this->plugins) as $position) {
+            $all[] = $this->at($position);
+        }
+
+        return $all;
+    }
+
+    /**
+     * @return Traversable<int, TPlugin>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->all());
+    }
+
+    public function count(): int
+    {
+        return count($this->plugins);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->plugins === [];
+    }
+
+    /**
+     * @return TPlugin
+     */
+    private function at(int $position): object
+    {
+        if (array_key_exists($position, $this->resolved)) {
+            return $this->resolved[$position];
+        }
+
+        $className = $this->plugins[$position];
+        /** @var object $instance */
+        $instance = $this->container->get($className);
+
+        // Checked on first resolve rather than at registration, because a class
+        // name in `gacela.php` is a string until something loads it. One check
+        // per entry per process, and it names the class and the contract --
+        // otherwise a misregistration surfaces as a TypeError inside whatever
+        // the consumer does with the plugin, nowhere near the line that
+        // registered it.
+        if (!$instance instanceof $this->contract) {
+            throw PluginStackException::doesNotImplementContract($className, $this->contract);
+        }
+
+        /** @var TPlugin $instance */
+        return $this->resolved[$position] = $instance;
+    }
+}

--- a/src/Framework/Plugins/PluginStack.php
+++ b/src/Framework/Plugins/PluginStack.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Plugins;
+
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Every implementation of one interface, in declaration order, typed.
+ *
+ * The third of three ways to hold a collection, and the one that carries a
+ * contract. Which to reach for:
+ *
+ * - a {@see HandlerRegistry} answers *the one implementation for this key*
+ *   and throws on a key it does not know;
+ * - a tag (`GacelaConfig::tag()`) answers *all of these*, untyped, contributed
+ *   from anywhere;
+ * - a stack answers *all implementations of this interface*, in order, and
+ *   refuses anything that is not one.
+ *
+ * The contract is the whole point: without it the answer is a tag. It is what
+ * types the `foreach` in the consumer, and what turns a misregistration into a
+ * failure that names the class instead of a `TypeError` deep inside somebody
+ * else's loop.
+ *
+ * Declared in `gacela.php` with `addPluginStack()`, frozen after boot, and
+ * resolved through the container so each entry is autowired.
+ *
+ * @template TPlugin of object
+ *
+ * @extends IteratorAggregate<int, TPlugin>
+ */
+interface PluginStack extends IteratorAggregate, Countable
+{
+    /**
+     * @return list<TPlugin>
+     */
+    public function all(): array;
+
+    public function isEmpty(): bool;
+}

--- a/tests/Feature/Framework/PluginStacks/Checkout/CheckoutFacade.php
+++ b/tests/Feature/Framework/PluginStacks/Checkout/CheckoutFacade.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacks\Checkout;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method CheckoutFactory getFactory()
+ */
+final class CheckoutFacade extends AbstractFacade
+{
+    public function priceOf(int $cents): int
+    {
+        foreach ($this->getFactory()->createDiscounts() as $discount) {
+            $cents = $discount->apply($cents);
+        }
+
+        return $cents;
+    }
+}

--- a/tests/Feature/Framework/PluginStacks/Checkout/CheckoutFactory.php
+++ b/tests/Feature/Framework/PluginStacks/Checkout/CheckoutFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacks\Checkout;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Plugins\PluginStack;
+
+final class CheckoutFactory extends AbstractFactory
+{
+    /**
+     * @return PluginStack<Discount>
+     */
+    public function createDiscounts(): PluginStack
+    {
+        return $this->getPluginStack(Discount::class);
+    }
+}

--- a/tests/Feature/Framework/PluginStacks/Checkout/Discount.php
+++ b/tests/Feature/Framework/PluginStacks/Checkout/Discount.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacks\Checkout;
+
+interface Discount
+{
+    public function apply(int $cents): int;
+}

--- a/tests/Feature/Framework/PluginStacks/Checkout/FiveHundredOff.php
+++ b/tests/Feature/Framework/PluginStacks/Checkout/FiveHundredOff.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacks\Checkout;
+
+final class FiveHundredOff implements Discount
+{
+    public function apply(int $cents): int
+    {
+        return max(0, $cents - 500);
+    }
+}

--- a/tests/Feature/Framework/PluginStacks/Checkout/TenPercentOff.php
+++ b/tests/Feature/Framework/PluginStacks/Checkout/TenPercentOff.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacks\Checkout;
+
+final class TenPercentOff implements Discount
+{
+    public function apply(int $cents): int
+    {
+        return (int)($cents * 0.9);
+    }
+}

--- a/tests/Feature/Framework/PluginStacks/FeatureTest.php
+++ b/tests/Feature/Framework/PluginStacks/FeatureTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacks;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Exception\PluginStackException;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\CheckoutFacade;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\Discount;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\FiveHundredOff;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\TenPercentOff;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An extension point declared in `gacela.php` and iterated by a module that
+ * does not know who filled it.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_a_module_iterates_the_stack_it_did_not_fill(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->addPluginStack(Discount::class, [TenPercentOff::class]);
+        });
+
+        self::assertSame(900, (new CheckoutFacade())->priceOf(1000));
+    }
+
+    /**
+     * Order is declaration order, and it is observable: ten percent off a
+     * thousand then five hundred off is 400; the other way round it is 450.
+     */
+    public function test_the_plugins_run_in_the_order_they_were_declared(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->addPluginStack(Discount::class, [TenPercentOff::class, FiveHundredOff::class]);
+        });
+
+        self::assertSame(400, (new CheckoutFacade())->priceOf(1000));
+    }
+
+    /**
+     * The reason there is no second verb for contributing: calling the same one
+     * again appends, seed first, so a later config source adds to a stack it
+     * did not declare.
+     */
+    public function test_a_second_declaration_appends_rather_than_replaces(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->addPluginStack(Discount::class, [TenPercentOff::class]);
+            $config->addPluginStack(Discount::class, [FiveHundredOff::class]);
+        });
+
+        self::assertSame(400, (new CheckoutFacade())->priceOf(1000));
+    }
+
+    public function test_an_empty_stack_leaves_the_value_alone(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->addPluginStack(Discount::class, []);
+        });
+
+        self::assertSame(1000, (new CheckoutFacade())->priceOf(1000));
+    }
+
+    /**
+     * Asking for a stack nobody declared is a mistake worth naming, not a
+     * silently empty collection that makes the extension point look broken.
+     */
+    public function test_asking_for_an_undeclared_stack_says_how_to_declare_it(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+        });
+
+        $this->expectException(PluginStackException::class);
+        // What is wrong, then how to fix it, in that order.
+        $this->expectExceptionMessageMatches('/No plugin stack is declared for .*Discount.*addPluginStack/s');
+
+        (new CheckoutFacade())->priceOf(1000);
+    }
+
+    private function bootstrap(callable $configFn): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $configFn($config);
+        });
+    }
+}

--- a/tests/Feature/Framework/PluginStacksMerge/FeatureTest.php
+++ b/tests/Feature/Framework/PluginStacksMerge/FeatureTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacksMerge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\CheckoutFacade;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\Discount;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\FiveHundredOff;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\TenPercentOff;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Two config sources filling one stack: `gacela.php` contributes
+ * FiveHundredOff, the bootstrap closure contributes TenPercentOff. Neither
+ * replaces the other -- which is the whole reason there is no separate
+ * "contribute" verb.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_both_config_sources_fill_the_same_stack(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $config->addPluginStack(Discount::class, [TenPercentOff::class]);
+        });
+
+        // -10% of 1000 = 900, then -500 = 400. The bootstrap closure's setup
+        // is the base and `gacela.php` merges onto it, so the closure's entry
+        // runs first -- the order is worth pinning, because "appends" is only
+        // a useful promise if which end it appends to is fixed.
+        self::assertSame(400, (new CheckoutFacade())->priceOf(1000));
+    }
+
+    /**
+     * A class both sources declare runs once, at the position the first source
+     * gave it — otherwise re-stating the seed in an override would silently
+     * apply the same decorator twice.
+     */
+    public function test_a_plugin_both_sources_declare_runs_once(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $config->addPluginStack(Discount::class, [TenPercentOff::class, FiveHundredOff::class]);
+        });
+
+        // gacela.php declares FiveHundredOff too. Applied twice this would be
+        // 1000 -> 900 -> 400 -> -100 clamped to 0.
+        self::assertSame(400, (new CheckoutFacade())->priceOf(1000));
+    }
+}

--- a/tests/Feature/Framework/PluginStacksMerge/gacela.php
+++ b/tests/Feature/Framework/PluginStacksMerge/gacela.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PluginStacksMerge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\Discount;
+use GacelaTest\Feature\Framework\PluginStacks\Checkout\FiveHundredOff;
+
+return static function (GacelaConfig $config): void {
+    // A second config source contributing to the same extension point the
+    // bootstrap closure declares.
+    $config->addPluginStack(Discount::class, [FiveHundredOff::class]);
+};

--- a/tests/Unit/Framework/Plugins/Fixtures/CountingDecorator.php
+++ b/tests/Unit/Framework/Plugins/Fixtures/CountingDecorator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Plugins\Fixtures;
+
+final class CountingDecorator implements Decorator
+{
+    public static int $built = 0;
+
+    public function __construct()
+    {
+        ++self::$built;
+    }
+
+    public function decorate(string $value): string
+    {
+        return $value . '!';
+    }
+}

--- a/tests/Unit/Framework/Plugins/Fixtures/Decorator.php
+++ b/tests/Unit/Framework/Plugins/Fixtures/Decorator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Plugins\Fixtures;
+
+interface Decorator
+{
+    public function decorate(string $value): string;
+}

--- a/tests/Unit/Framework/Plugins/Fixtures/NotADecorator.php
+++ b/tests/Unit/Framework/Plugins/Fixtures/NotADecorator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Plugins\Fixtures;
+
+final class NotADecorator
+{
+}

--- a/tests/Unit/Framework/Plugins/Fixtures/UppercaseDecorator.php
+++ b/tests/Unit/Framework/Plugins/Fixtures/UppercaseDecorator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Plugins\Fixtures;
+
+final class UppercaseDecorator implements Decorator
+{
+    public function decorate(string $value): string
+    {
+        return strtoupper($value);
+    }
+}

--- a/tests/Unit/Framework/Plugins/LazyPluginStackTest.php
+++ b/tests/Unit/Framework/Plugins/LazyPluginStackTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Plugins;
+
+use Gacela\Container\Container;
+use Gacela\Framework\Exception\PluginStackException;
+use Gacela\Framework\Plugins\LazyPluginStack;
+use GacelaTest\Unit\Framework\Plugins\Fixtures\CountingDecorator;
+use GacelaTest\Unit\Framework\Plugins\Fixtures\Decorator;
+use GacelaTest\Unit\Framework\Plugins\Fixtures\NotADecorator;
+use GacelaTest\Unit\Framework\Plugins\Fixtures\UppercaseDecorator;
+use PHPUnit\Framework\TestCase;
+
+final class LazyPluginStackTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CountingDecorator::$built = 0;
+    }
+
+    public function test_an_empty_stack_says_so(): void
+    {
+        $stack = $this->stack([]);
+
+        self::assertTrue($stack->isEmpty());
+        self::assertCount(0, $stack);
+        self::assertSame([], $stack->all());
+    }
+
+    public function test_it_yields_every_plugin_in_declaration_order(): void
+    {
+        $stack = $this->stack([UppercaseDecorator::class, CountingDecorator::class]);
+
+        $decorated = 'x';
+        foreach ($stack as $decorator) {
+            $decorated = $decorator->decorate($decorated);
+        }
+
+        self::assertSame('X!', $decorated);
+        self::assertCount(2, $stack);
+        self::assertFalse($stack->isEmpty());
+    }
+
+    /**
+     * Declaring is not building: a stack nobody iterates costs nothing, which
+     * is what lets a module declare an extension point it rarely uses.
+     */
+    public function test_declaring_a_plugin_does_not_build_it(): void
+    {
+        $this->stack([CountingDecorator::class]);
+
+        self::assertSame(0, CountingDecorator::$built);
+    }
+
+    /**
+     * Iterating twice yields the same plugins, however they are bound -- the
+     * reason the stack keeps its own instances rather than trusting the
+     * container's binding style.
+     */
+    public function test_a_plugin_is_built_once_however_often_it_is_read(): void
+    {
+        $container = new Container();
+        $container->bind(CountingDecorator::class, static fn (): CountingDecorator => new CountingDecorator());
+
+        $stack = new LazyPluginStack(Decorator::class, [CountingDecorator::class], $container);
+
+        $first = $stack->all()[0];
+        $second = $stack->all()[0];
+        iterator_to_array($stack);
+
+        self::assertSame($first, $second);
+        self::assertSame(1, CountingDecorator::$built);
+    }
+
+    /**
+     * A class name in gacela.php is a string until something loads it, so the
+     * contract is checked on first resolve -- and the failure names the class
+     * and the stack, instead of a TypeError wherever the consumer used it.
+     */
+    public function test_a_plugin_that_does_not_implement_the_contract_is_refused_by_name(): void
+    {
+        $stack = $this->stack([NotADecorator::class]);
+
+        $this->expectException(PluginStackException::class);
+        $this->expectExceptionMessage('NotADecorator');
+        $this->expectExceptionMessage(Decorator::class);
+
+        $stack->all();
+    }
+
+    /**
+     * @param list<class-string> $plugins
+     *
+     * @return LazyPluginStack<Decorator>
+     */
+    private function stack(array $plugins): LazyPluginStack
+    {
+        /** @var list<class-string<Decorator>> $plugins */
+        return new LazyPluginStack(Decorator::class, $plugins, new Container());
+    }
+}


### PR DESCRIPTION
## 📚 Description

A module wants to declare an extension point as an interface, let several places contribute implementations, and iterate them in order without knowing who contributed. Ordering, laziness and multi-source contribution already existed — tags have all three. What no mechanism had was a **contract**, and the issue says so itself: *"Ordering, laziness, and multi-source contribution are not the gap. Types are."*

```php
// gacela.php
$config->addPluginStack(InvoiceDecorator::class, [
    AddVatBreakdownDecorator::class,
    AddPaymentTermsDecorator::class,
]);

// the consuming Factory, typed
return new InvoiceRenderer($this->getPluginStack(InvoiceDecorator::class));
```

Related to #672

## ⚖️ Three departures from the issue, and why

Recorded in full [on the issue](https://github.com/gacela-project/gacela/issues/672#issuecomment-5272096859); in short:

**One verb, not two.** `addPluginStack()` + `contributeToPluginStack()` are two ways to say one thing, which [RFC-0003](docs/rfc/0003-bootstrap-configuration-surface.md)'s competition test refuses. `tag()` already solved this by appending on repeat, and a stack does the same — seed first, contributions after, in the order the config sources run. A feature test pins it.

**Retrieval does not go through `getProvidedDependency()`.** The issue names this conflict itself: that call is typed by both analysers as the class the id names, so a stack registered under its contract would make one id mean two things. Teaching the analysers about stack ids means teaching a static rule what was registered at runtime. A dedicated `getPluginStack()` keeps `getProvidedDependency()` meaning exactly one thing — and removes the hand-written `@var` the issue calls *"the part that should die next"*.

**The PHPStan rule is deferred.** The runtime guard names the class and the stack on first resolve, which is the safety net that matters; the analysis-time version is additive and can land once the shape has settled.

## 🔖 Changes

- `PluginStack` (`IteratorAggregate` + `Countable`, `@template TPlugin`) and `LazyPluginStack`: resolves each entry through the container on first read and keeps it, so iterating twice yields the same plugins however they are bound — the reason `LazyHandlerRegistry` keeps its own cache, documented there and inherited here.
- `GacelaConfig::addPluginStack()`, plumbed through the transfer, setup, properties, merger and container exactly as `addHandlerRegistry()` is, with **append** merge semantics borrowed from tags.
- `AbstractFactory::getPluginStack()`, reading straight off the container: a module that only consumes an app-wide extension point has no reason to own a Provider.
- An entry that does not implement the contract fails on first resolve naming the class and the stack, instead of surfacing as a `TypeError` inside the consumer's loop.
- Docs: a *"Typed — every implementation of one interface"* section stating the choosing rule between the three collections, the intent-table row, RFC-0003's audit row, and a `CHANGELOG` entry.
- Covered MSI on the new code: **100%**. 2158 tests green.

## 🔍 On the third-grouping-mechanism objection

RFC-0003 scores this issue as competing with `tag()` and `addHandlerRegistry()`, and #478 says not to ship two overlapping ways to group. The choosing rule that makes them distinct is now in the docs: a **registry** answers *the one implementation for this key*; a **tag** answers *all of these*, untyped, contributed from anywhere; a **stack** answers *all implementations of this interface*, in order, typed and checked. The contract is the separator — without it the answer is a tag.