### PR TITLE
ref(config): one place decides the merged-config cache identity

### DIFF
--- a/docs/rfc/0003-bootstrap-configuration-surface.md
+++ b/docs/rfc/0003-bootstrap-configuration-surface.md
@@ -1,7 +1,7 @@
 # RFC-0003: The bootstrap configuration surface
 
-- Status: **draft**
-- Relates to: #684, #525, #549, #478. Sequencing: #676 first among the open additions — it is the only one that shrinks the surface.
+- Status: **accepted** (2026-08-12). The audit table below is enforced by a test, so this stopped being a proposal the moment it merged.
+- Relates to: #684, #525, #549, #478. Sequencing: #676 first among the open additions — it was the only one that shrinks the surface, and it shipped.
 
 ## Why this exists
 
@@ -25,6 +25,13 @@ A new `GacelaConfig` method is **fine** when:
 A new method is a **defect** when a reader with a job in hand cannot tell which of two methods does it. That question is answerable at review time, unlike a count.
 
 Applied to the six open issues at the time of writing: #675 and #673 pass (new intents, no competitor). #676 improves the surface (four `addSuffixType*()` verbs become sugar over one `addResolvableType()`). #672 fails twice as proposed (two verbs for one intent, and a third way to group services after `tag()` and `addHandlerRegistry()` — the #478 rule). #674 fails as proposed (a second extend path with no rule for choosing). #679 fails as proposed (a second answer to *which class wins*, next to `setProjectNamespaces()`). "Fails as proposed" means the issue must name the rule for choosing before it adds the method, not that the feature is unwanted.
+
+**What "fails as proposed" turned into.** Three of those have since been answered rather than refused, which is the outcome this test is for:
+
+- **#676** shipped as scored, and the four suffix verbs are now sugar over `addResolvableType()`.
+- **#672** shipped with *one* verb instead of two — `addPluginStack()` appends on repeat, the way `tag()` does — and with a rule separating the three collections: a registry answers *the one implementation for this key*, a tag answers *all of these* untyped, a stack answers *all implementations of this interface*, typed. The contract is the separator.
+- **#674**'s rule turned out to be the one `tag()` and `Container::tag()` already use: `extendService()` wraps an id *wherever it is registered*, `extendProviderService()` wraps it *only as the named Provider registers it*. Everywhere versus there.
+- **#679**'s objection weakened on its own: #686 fixed the cache poisoning that was half its motivation, leaving `setProjectNamespaces()` answering *which tree wins across modules* and a resolution context answering *which variant inside one module wins*. Different questions, so not competitors.
 
 ## Two: the naming grammar
 

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -17,9 +17,7 @@ use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\ClassResolver\ClassResolverCache;
 use Gacela\Framework\ClassResolver\ResolvableTypes;
-use Gacela\Framework\Config\AppEnv;
 use Gacela\Framework\Config\Config;
-use Gacela\Framework\Config\MergedConfigCache;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\ServiceResolver\ServiceMap;
@@ -95,7 +93,7 @@ final class DoctorCommand extends Command
                 $config->getCacheDir(),
                 null,
                 $config->getAppRootDir(),
-                new MergedConfigCache($config->getCacheDir(), AppEnv::current(), $config->getAppRootDir()),
+                $config->mergedConfigCache(),
                 $configFactory->createConfigLoader()->sourceFiles(),
                 ClassResolverCache::bootstrapFingerprint(),
             ),

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -402,6 +402,22 @@ final class Config implements ConfigInterface
     }
 
     /**
+     * The merged-config cache this configuration reads and writes.
+     *
+     * Public because `doctor` reports on that file and used to build its own
+     * from the same three ingredients. Two places deciding a cache identity is
+     * how a checker ends up reporting on a file nothing writes -- and the
+     * identity is about to grow (#675), which is exactly when a second
+     * spelling starts to drift.
+     *
+     * @internal
+     */
+    public function mergedConfigCache(): MergedConfigCache
+    {
+        return $this->createMergedConfigCache();
+    }
+
+    /**
      * @throws ConfigException
      */
     private function assertConfigMatchesSchema(): void


### PR DESCRIPTION
## 📚 Description

`doctor` built its own `MergedConfigCache` from the same three ingredients `Config` uses (`DoctorCommand.php:98`), which made two places responsible for deciding which file a configuration reads. That is how a checker ends up reporting on a file nothing writes.

It matters now rather than later because that identity is about to grow: #675 adds config dimensions to the tuple that names the file, and a second spelling of an identity is exactly the thing that drifts when the identity changes. Landing the refactor first means #675 has one place to change.

Groundwork for #675.

## 🔖 Changes

- `Config::mergedConfigCache()` exposes the cache the configuration actually reads and writes; `doctor` asks for it instead of reconstructing it.
- RFC-0003 flips from **draft** to **accepted**. Its audit table has been enforced by `BootstrapSurfaceDocsTest` since it merged in #690, so it stopped being a proposal at that moment; the status line just never caught up.
- The RFC's competition-test section now records what became of the three issues it scored as *failing as proposed* — each was answered with a choosing rule rather than refused, which is what that test exists to produce:
  - **#672** shipped with one verb instead of two, plus the rule separating registry / tag / stack.
  - **#674**'s rule is the one `tag()` and `Container::tag()` already use — everywhere versus there.
  - **#679**'s objection weakened on its own once #686 fixed the cache poisoning that was half its motivation.

No behaviour change; 2148 tests green.