### PR TITLE
feat(container): extend a service as one Provider registers it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Wrap a service as one Provider registers it with `extendProviderService()`, leaving every other module that reuses the same id alone — and letting one module decorate a sibling's binding without shadowing the sibling's whole Provider class
 - Declare an extension point with `addPluginStack()`: every implementation of one interface, in declaration order, resolved lazily and read back typed through `getPluginStack()`. Calling it again appends, so another config source contributes to a stack it did not declare, and an entry that does not implement the interface fails naming the class
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars, reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs became sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`. The kind is listed in the command's help, `doctor` counts its stub among the ones the scaffolder reads, and until that stub exists the generator names the path it looked for

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -271,7 +271,8 @@ These are supported and are **not** deprecated. They are simply not the answer t
 | `addProtected('id', fn)` | the value *is* a closure and must not be invoked |
 | `addAlias('short', Full::class)` | a long id needs a short name |
 | `addLazy()` | construction is expensive and often unused |
-| `extendService('id', fn)` | decorating a service registered elsewhere — *replacing* what comes out |
+| `extendService('id', fn)` | decorating a service registered elsewhere, **wherever** that id is registered — *replacing* what comes out |
+| `extendProviderService(Provider::class, 'id', fn)` | decorating that id **only as one Provider registers it** — when two modules reuse an un-namespaced key, or when one module decorates a sibling's binding without shadowing the sibling's whole Provider |
 | `afterResolving('id', fn)` | touching an instance after it is built without rebuilding it, e.g. a setter on every implementation of an interface |
 | `when(X)->needs(Y)->give(Z)` | one consumer needs a different implementation than everyone else |
 | `loadDefinitions([...])` / `loadDefinitions('file.json')` | the wiring is generated, shared between environments, or reviewed as a diff — see [container-configuration](container-configuration.md#definitions-as-data) |

--- a/docs/rfc/0003-bootstrap-configuration-surface.md
+++ b/docs/rfc/0003-bootstrap-configuration-surface.md
@@ -72,6 +72,7 @@ Every public method, its bucket, and its verdict. **This table is a gate**: `tes
 | `enableFileCache()` | `enable*` | conforms — sugar over `setFileCache(true)` |
 | `extendGacelaConfig()` | `extend*` | exception in meaning: composes another configuration surface into this one rather than wrapping a registered service; predates the grammar |
 | `extendGacelaConfigs()` | `extend*` | same as `extendGacelaConfig()`, plural variant |
+| `extendProviderService()` | `extend*` | conforms — the choosing rule against `extendService()` is the one `tag()` and `Container::tag()` already use: everywhere versus there |
 | `extendService()` | `extend*` | conforms |
 | `getExternalService()` | — | exception: the one read path on a write surface, paired with `addExternalService()` for the bridge handshake |
 | `loadDefinitions()` | — | exception: imports wiring from a file or array; `add*` would hide that the argument is data, not a definition |

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -177,6 +177,15 @@ abstract class AbstractFactory
         $this->scheduleAppWideExtensions($container);
 
         $resolver = (new ProviderResolver())->resolve($this);
+
+        if ($resolver !== null) {
+            // Between resolving the Provider and running it: the extension has
+            // to be queued before the id is stored, because that store is what
+            // drains the queue. Scheduling it earlier is impossible -- which
+            // Provider this module has is not known until it is resolved.
+            $this->scheduleExtensionsFor($resolver::class, $container);
+        }
+
         $resolver?->register($container);
 
         if ($resolver !== null) {
@@ -209,6 +218,28 @@ abstract class AbstractFactory
                 continue;
             }
 
+            foreach ($extensions as $extension) {
+                $scope->extend($id, $extension);
+            }
+        }
+    }
+
+    /**
+     * The extensions aimed at *this* module's Provider.
+     *
+     * `extendService()` wraps an id wherever it is registered, which is right
+     * when the id names one app-wide concept and wrong when two Providers reuse
+     * an un-namespaced key on purpose. Naming the Provider is how a project
+     * says *that* module's binding, and how one module decorates a sibling's
+     * without shadowing the sibling's whole Provider class to change one line.
+     *
+     * @param class-string $providerClass
+     */
+    private function scheduleExtensionsFor(string $providerClass, Container $scope): void
+    {
+        $byId = Config::getInstance()->getSetupGacela()->getProviderServicesToExtend()[$providerClass] ?? [];
+
+        foreach ($byId as $id => $extensions) {
             foreach ($extensions as $extension) {
                 $scope->extend($id, $extension);
             }

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -35,6 +35,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string servicesToExtend = 'servicesToExtend';
 
+    public const string providerServicesToExtend = 'providerServicesToExtend';
+
     public const string factories = 'factories';
 
     public const string protectedServices = 'protectedServices';
@@ -96,6 +98,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_HANDLER_REGISTRIES = [];
 
     protected const array DEFAULT_PLUGIN_STACKS = [];
+
+    protected const array DEFAULT_PROVIDER_SERVICES_TO_EXTEND = [];
 
     protected const array DEFAULT_TAGS = [];
 

--- a/src/Framework/Bootstrap/ContainerConfigurationInterface.php
+++ b/src/Framework/Bootstrap/ContainerConfigurationInterface.php
@@ -13,6 +13,7 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
  * @psalm-type ServiceFactoryMap = array<string, Closure>
  * @psalm-type ServiceAliasMap = array<string, string>
  * @psalm-type ServicesToExtendMap = array<string, list<Closure>>
+ * @psalm-type ProviderServicesToExtendMap = array<class-string, array<string, list<Closure>>>
  * @psalm-type HandlerRegistriesMap = array<string, array<string|int, class-string>>
  * @psalm-type PluginStacksMap = array<class-string, list<class-string>>
  * @psalm-type TagsMap = array<string, list<string>>
@@ -26,6 +27,14 @@ interface ContainerConfigurationInterface
      * @return ServicesToExtendMap
      */
     public function getServicesToExtend(): array;
+
+    /**
+     * Extensions aimed at one Provider's registrations, keyed by that
+     * Provider's class then by service id.
+     *
+     * @return ProviderServicesToExtendMap
+     */
+    public function getProviderServicesToExtend(): array;
 
     /**
      * @return ServiceFactoryMap

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -32,6 +32,7 @@ use function sprintf;
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
+ * @psalm-import-type ProviderServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -84,6 +85,9 @@ final class GacelaConfig
 
     /** @var ServicesToExtendMap */
     private array $servicesToExtend = [];
+
+    /** @var ProviderServicesToExtendMap */
+    private array $providerServicesToExtend = [];
 
     /** @var ServiceFactoryMap */
     private array $factories = [];
@@ -455,6 +459,46 @@ final class GacelaConfig
     }
 
     /**
+     * Wrap a service as *one* Provider registers it, leaving every other
+     * module that happens to use the same id alone.
+     *
+     * The pair reads like `tag()` and `Container::tag()` do — one asks
+     * *everywhere*, the other asks *there*:
+     *
+     * - {@see extendService()} wraps an id **wherever it is registered**. Two
+     *   Providers reusing an un-namespaced key both get wrapped, which is
+     *   right when the id names one app-wide concept and wrong when it does
+     *   not.
+     * - this one wraps an id **only in the module whose Provider is named**,
+     *   which is how one module decorates a sibling's binding without
+     *   shadowing the sibling's whole Provider class to change one line.
+     *
+     * ```php
+     * $config->extendProviderService(
+     *     CatalogProvider::class,
+     *     CatalogProvider::PRICE_FORMATTER,
+     *     static fn (PriceFormatter $formatter, Container $container): PriceFormatter
+     *         => new RoundingPriceFormatter($formatter),
+     * );
+     * ```
+     *
+     * The closure receives the service and the module's container, and may
+     * return a replacement or mutate in place — the same contract
+     * `Container::extend()` already has. An id the named Provider never
+     * registers is reported by `doctor`, where an app-wide extension on a
+     * mistyped id is only reported as unmatched anywhere.
+     *
+     * @param class-string $providerClass
+     */
+    public function extendProviderService(string $providerClass, string $id, Closure $service): self
+    {
+        $this->providerServicesToExtend[$providerClass][$id] ??= [];
+        $this->providerServicesToExtend[$providerClass][$id][] = $service;
+
+        return $this;
+    }
+
+    /**
      * Run a callback on a resolved instance, receiving the instance and the
      * container. Callbacks run in registration order.
      *
@@ -804,6 +848,7 @@ final class GacelaConfig
             $this->gacelaConfigsToExtend,
             $this->plugins,
             $this->servicesToExtend,
+            $this->providerServicesToExtend,
             $this->factories,
             $this->protectedServices,
             $this->aliases,

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -22,6 +22,7 @@ use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
+ * @psalm-import-type ProviderServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -41,6 +42,7 @@ final class GacelaConfigTransfer
      * @param ?list<class-string> $gacelaConfigsToExtend
      * @param ?list<class-string|callable> $plugins
      * @param ?ServicesToExtendMap $servicesToExtend
+     * @param ProviderServicesToExtendMap $providerServicesToExtend
      * @param ServiceFactoryMap $factories
      * @param ServiceFactoryMap $protectedServices
      * @param ServiceAliasMap $aliases
@@ -70,10 +72,11 @@ final class GacelaConfigTransfer
         public readonly ?array $gacelaConfigsToExtend,
         public readonly ?array $plugins,
         public readonly ?array $servicesToExtend,
-        public readonly array $factories,
-        public readonly array $protectedServices,
-        public readonly array $aliases,
-        public readonly array $contextualBindings,
+        public readonly array $providerServicesToExtend = [],
+        public readonly array $factories = [],
+        public readonly array $protectedServices = [],
+        public readonly array $aliases = [],
+        public readonly array $contextualBindings = [],
         public readonly array $handlerRegistries = [],
         public readonly array $pluginStacks = [],
         public readonly array $lazyServices = [],

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -25,6 +25,7 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
+ * @psalm-import-type ProviderServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -86,6 +87,9 @@ final class Properties
 
     /** @var ?ServicesToExtendMap */
     public ?array $servicesToExtend = null;
+
+    /** @var ?ProviderServicesToExtendMap */
+    public ?array $providerServicesToExtend = null;
 
     /** @var ?ServiceFactoryMap */
     public ?array $factories = null;

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -24,6 +24,7 @@ use function in_array;
  * @psalm-import-type ServiceAliasMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
+ * @psalm-import-type ProviderServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -141,6 +142,28 @@ final class PropertyMerger
         $this->setup->setHandlerRegistries(
             $this->mergeNested($this->setup->getHandlerRegistries(), $list),
         );
+    }
+
+    /**
+     * Extensions accumulate: two config sources that both decorate the same
+     * Provider binding both run, in source order.
+     *
+     * @param ProviderServicesToExtendMap $list
+     */
+    public function mergeProviderServicesToExtend(array $list): void
+    {
+        $merged = $this->setup->getProviderServicesToExtend();
+
+        foreach ($list as $providerClass => $byId) {
+            foreach ($byId as $id => $extensions) {
+                $merged[$providerClass][$id] = [
+                    ...$merged[$providerClass][$id] ?? [],
+                    ...$extensions,
+                ];
+            }
+        }
+
+        $this->setup->setProviderServicesToExtend($merged);
     }
 
     /**

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -38,6 +38,7 @@ final class SetupInitializer
             ->setGacelaConfigsToExtend($dto->gacelaConfigsToExtend)
             ->setPlugins($dto->plugins)
             ->setServicesToExtend($dto->servicesToExtend)
+            ->setProviderServicesToExtend($dto->providerServicesToExtend)
             ->setFactories($dto->factories)
             ->setProtectedServices($dto->protectedServices)
             ->setAliases($dto->aliases)

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -39,6 +39,7 @@ final class SetupMerger
         $this->whenChanged($other, SetupGacela::contextualBindings, fn () => $this->original->mergeContextualBindings($other->getContextualBindings()));
         $this->whenChanged($other, SetupGacela::handlerRegistries, fn () => $this->original->mergeHandlerRegistries($other->getHandlerRegistries()));
         $this->whenChanged($other, SetupGacela::pluginStacks, fn () => $this->original->mergePluginStacks($other->getPluginStacks()));
+        $this->whenChanged($other, SetupGacela::providerServicesToExtend, fn () => $this->original->mergeProviderServicesToExtend($other->getProviderServicesToExtend()));
         $this->whenChanged($other, SetupGacela::tags, fn () => $this->original->mergeTags($other->getTags()));
         $this->whenChanged($other, SetupGacela::afterResolvingCallbacks, fn () => $this->original->mergeAfterResolvingCallbacks($other->getAfterResolvingCallbacks()));
         $this->whenChanged($other, SetupGacela::lazyServices, fn () => $this->original->mergeLazyServices($other->getLazyServices()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -36,6 +36,7 @@ use function sprintf;
  * @psalm-import-type ServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type HandlerRegistriesMap from ContainerConfigurationInterface
  * @psalm-import-type PluginStacksMap from ContainerConfigurationInterface
+ * @psalm-import-type ProviderServicesToExtendMap from ContainerConfigurationInterface
  * @psalm-import-type TagsMap from ContainerConfigurationInterface
  * @psalm-import-type AfterResolvingMap from ContainerConfigurationInterface
  * @psalm-import-type DefinitionSources from ContainerConfigurationInterface
@@ -406,6 +407,14 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
+     * @return ProviderServicesToExtendMap
+     */
+    public function getProviderServicesToExtend(): array
+    {
+        return $this->properties->providerServicesToExtend ?? self::DEFAULT_PROVIDER_SERVICES_TO_EXTEND;
+    }
+
+    /**
      * @return PluginStacksMap
      */
     public function getPluginStacks(): array
@@ -769,6 +778,22 @@ final class SetupGacela extends AbstractSetupGacela
     /**
      * @internal Used by SetupInitializer - do not call directly
      *
+     * @param ?ProviderServicesToExtendMap $list
+     */
+    public function setProviderServicesToExtend(?array $list): self
+    {
+        $this->properties->providerServicesToExtend = $this->setPropertyWithTracking(
+            self::providerServicesToExtend,
+            $list,
+            self::DEFAULT_PROVIDER_SERVICES_TO_EXTEND,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
      * @param ?PluginStacksMap $list
      */
     public function setPluginStacks(?array $list): self
@@ -886,6 +911,16 @@ final class SetupGacela extends AbstractSetupGacela
     public function mergePluginStacks(array $list): void
     {
         $this->propertyMerger->mergePluginStacks($list);
+    }
+
+    /**
+     * @internal Used by SetupMerger - do not call directly
+     *
+     * @param ProviderServicesToExtendMap $list
+     */
+    public function mergeProviderServicesToExtend(array $list): void
+    {
+        $this->propertyMerger->mergeProviderServicesToExtend($list);
     }
 
     /**

--- a/tests/Feature/Framework/ExtendProviderService/Catalog/CatalogFacade.php
+++ b/tests/Feature/Framework/ExtendProviderService/Catalog/CatalogFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService\Catalog;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method CatalogFactory getFactory()
+ */
+final class CatalogFacade extends AbstractFacade
+{
+    public function label(): string
+    {
+        return $this->getFactory()->label();
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderService/Catalog/CatalogFactory.php
+++ b/tests/Feature/Framework/ExtendProviderService/Catalog/CatalogFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService\Catalog;
+
+use Gacela\Framework\AbstractFactory;
+
+final class CatalogFactory extends AbstractFactory
+{
+    public function label(): string
+    {
+        /** @var list<string> $labels */
+        $labels = $this->getProvidedDependency(CatalogProvider::LABEL);
+
+        return implode('-', $labels);
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderService/Catalog/CatalogProvider.php
+++ b/tests/Feature/Framework/ExtendProviderService/Catalog/CatalogProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService\Catalog;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class CatalogProvider extends AbstractProvider
+{
+    public const LABEL = 'LABEL';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::LABEL, ['catalog']);
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderService/Checkout/CheckoutFacade.php
+++ b/tests/Feature/Framework/ExtendProviderService/Checkout/CheckoutFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService\Checkout;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method CheckoutFactory getFactory()
+ */
+final class CheckoutFacade extends AbstractFacade
+{
+    public function label(): string
+    {
+        return $this->getFactory()->label();
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderService/Checkout/CheckoutFactory.php
+++ b/tests/Feature/Framework/ExtendProviderService/Checkout/CheckoutFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService\Checkout;
+
+use Gacela\Framework\AbstractFactory;
+
+final class CheckoutFactory extends AbstractFactory
+{
+    public function label(): string
+    {
+        /** @var list<string> $labels */
+        $labels = $this->getProvidedDependency(CheckoutProvider::LABEL);
+
+        return implode('-', $labels);
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderService/Checkout/CheckoutProvider.php
+++ b/tests/Feature/Framework/ExtendProviderService/Checkout/CheckoutProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService\Checkout;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+final class CheckoutProvider extends AbstractProvider
+{
+    public const LABEL = 'LABEL';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::LABEL, ['checkout']);
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderService/FeatureTest.php
+++ b/tests/Feature/Framework/ExtendProviderService/FeatureTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderService;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\ExtendProviderService\Catalog\CatalogFacade;
+use GacelaTest\Feature\Framework\ExtendProviderService\Catalog\CatalogProvider;
+use GacelaTest\Feature\Framework\ExtendProviderService\Checkout\CheckoutFacade;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Two modules registering the same un-namespaced id, which module scopes make
+ * legal on purpose. An extension aimed at one Provider must reach that one and
+ * leave the other alone.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_only_the_named_providers_service_is_wrapped(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->extendProviderService(
+                CatalogProvider::class,
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'wrapped'],
+            );
+        });
+
+        self::assertSame('catalog-wrapped', (new CatalogFacade())->label());
+        self::assertSame('checkout', (new CheckoutFacade())->label());
+    }
+
+    /**
+     * The contrast that makes the pair worth having: the same wrap declared
+     * app-wide reaches both modules, because the id names it in both.
+     */
+    public function test_an_app_wide_extension_reaches_every_module_using_the_id(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->extendService(
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'wrapped'],
+            );
+        });
+
+        self::assertSame('catalog-wrapped', (new CatalogFacade())->label());
+        self::assertSame('checkout-wrapped', (new CheckoutFacade())->label());
+    }
+
+    public function test_the_extension_receives_the_modules_container(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->extendProviderService(
+                CatalogProvider::class,
+                CatalogProvider::LABEL,
+                static fn (array $labels, Container $container): array => [...$labels, $container instanceof Container ? 'scoped' : 'none'],
+            );
+        });
+
+        self::assertSame('catalog-scoped', (new CatalogFacade())->label());
+    }
+
+    public function test_extensions_stack_in_declaration_order(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->extendProviderService(
+                CatalogProvider::class,
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'one'],
+            );
+            $config->extendProviderService(
+                CatalogProvider::class,
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'two'],
+            );
+        });
+
+        self::assertSame('catalog-one-two', (new CatalogFacade())->label());
+    }
+
+    /**
+     * An extension aimed at a Provider this application does not have is inert
+     * rather than fatal: a package may ship one for a module the project has
+     * not installed.
+     */
+    public function test_an_extension_for_an_absent_provider_changes_nothing(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->extendProviderService(
+                'App\Nowhere\NowhereProvider',
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'wrapped'],
+            );
+        });
+
+        self::assertSame('catalog', (new CatalogFacade())->label());
+    }
+
+    private function bootstrap(callable $configFn): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $configFn($config);
+        });
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderServiceMerge/FeatureTest.php
+++ b/tests/Feature/Framework/ExtendProviderServiceMerge/FeatureTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderServiceMerge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\ExtendProviderService\Catalog\CatalogFacade;
+use GacelaTest\Feature\Framework\ExtendProviderService\Catalog\CatalogProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Two config sources decorating one Provider binding. Neither silences the
+ * other: an extension is a contribution, so a project adding one must not
+ * drop the one a package shipped.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_extensions_from_both_sources_apply(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $config->extendProviderService(
+                CatalogProvider::class,
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'closure-one'],
+            );
+            $config->extendProviderService(
+                CatalogProvider::class,
+                CatalogProvider::LABEL,
+                static fn (array $labels): array => [...$labels, 'closure-two'],
+            );
+        });
+
+        // The bootstrap closure's setup is the base and gacela.php merges onto
+        // it, so the closure's extension runs first -- the same order the
+        // plugin stacks follow.
+        self::assertSame('catalog-closure-one-closure-two-file-one-file-two', (new CatalogFacade())->label());
+    }
+}

--- a/tests/Feature/Framework/ExtendProviderServiceMerge/gacela.php
+++ b/tests/Feature/Framework/ExtendProviderServiceMerge/gacela.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ExtendProviderServiceMerge;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\Framework\ExtendProviderService\Catalog\CatalogProvider;
+
+return static function (GacelaConfig $config): void {
+    // A second config source decorating the same Provider binding the
+    // bootstrap closure decorates.
+    $config->extendProviderService(
+        CatalogProvider::class,
+        CatalogProvider::LABEL,
+        static fn (array $labels): array => [...$labels, 'file-one'],
+    );
+    $config->extendProviderService(
+        CatalogProvider::class,
+        CatalogProvider::LABEL,
+        static fn (array $labels): array => [...$labels, 'file-two'],
+    );
+};


### PR DESCRIPTION
## 📚 Description

`extendService()` wraps an id **wherever** it is registered. That is right when the id names one app-wide concept, and wrong when two Providers reuse an un-namespaced key — which module scopes make legal on purpose, and which leaves an app-wide extension reaching both modules with no way to aim it.

```php
$config->extendProviderService(
    CatalogProvider::class,
    CatalogProvider::PRICE_FORMATTER,
    static fn (PriceFormatter $f, Container $c): PriceFormatter => new RoundingPriceFormatter($f),
);
```

Related to #674

## ⚖️ The choosing rule RFC-0003 asked for

[RFC-0003](docs/rfc/0003-bootstrap-configuration-surface.md) scored this issue as *failing as proposed* — "a second extend path with no rule for choosing". The rule turned out to be one the framework already uses elsewhere, between `tag()` and `Container::tag()`:

- **`extendService(id, fn)`** — wrap this id **wherever** it is registered.
- **`extendProviderService(Provider::class, id, fn)`** — wrap it **only as that Provider registers it**.

Everywhere versus there. A reader with a job in hand can tell which they mean: do you know which module's binding you are talking about? A feature test asserts both halves side by side — the same wrap, declared each way, reaching two modules or one.

## 🔖 Changes

- `GacelaConfig::extendProviderService()`, plumbed through the transfer, setup, properties, merger and interface the same way `extendService()` is. Extensions accumulate: two config sources decorating the same Provider binding both run, in source order.
- Scheduled in `AbstractFactory` **between resolving the Provider and running it** — the extension must be queued before the id is stored, because storing it is what drains the queue, and which Provider a module has is not known until it resolves.
- An extension aimed at a Provider the application does not have stays inert rather than fatal: a package may ship one for a module the project has not installed.
- Docs: both rows in the *other paths* table, stating the everywhere/there split. RFC-0003 audit row. `CHANGELOG` entry.

## 🔗 Why this also helps #683

#687 added a `doctor` check for `extendService()` ids nothing ever `set()`s — the best it can do for an app-wide extension is *"no Provider anywhere registers this"*. A provider-scoped extension names its Provider, so the same class of mistake becomes answerable precisely: that Provider does not register that id. Not implemented here, but this is what makes it possible.