### PR TITLE
feat(config): select configuration by more than APP_ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Select configuration by more than `APP_ENV` with `addConfigDimension()`: each declared variable adds a link to the chain, so `config/app-prod-eu.php` refines `config/app-prod.php` refines `config/app.php`. An unset variable ends the chain, values are restricted to what a glob and a filename can safely carry, and the merged-config cache is named by the whole tuple so two regions sharing a cache directory never read each other's file
 - Wrap a service as one Provider registers it with `extendProviderService()`, leaving every other module that reuses the same id alone — and letting one module decorate a sibling's binding without shadowing the sibling's whole Provider class
 - Declare an extension point with `addPluginStack()`: every implementation of one interface, in declaration order, resolved lazily and read back typed through `getPluginStack()`. Calling it again appends, so another config source contributes to a stack it did not declare, and an entry that does not implement the interface fails naming the class
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars, reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs became sugar over it

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,10 +29,38 @@ When the same key appears in several places, later sources win:
 
 1. default config files matching the pattern (e.g. `config/app.php`)
 2. environment-suffixed files (`config/app-{APP_ENV}.php`, using the `APP_ENV` env var)
-3. the local file (second argument of `addAppConfig(...)`, conventionally `config/local.php`; not env-suffixed, meant for per-machine overrides)
-4. values set in code via `GacelaConfig::addAppConfigKeyValue(s)`
+3. one file per declared [config dimension](#config-dimensions), each refining the one before it
+4. the local file (second argument of `addAppConfig(...)`, conventionally `config/local.php`; not env-suffixed, meant for per-machine overrides)
+5. values set in code via `GacelaConfig::addAppConfigKeyValue(s)`
 
-Every boot re-reads and re-merges these files. That is what you want while developing, and what you do not want in production: `enableFileCache()` collapses the merged result into a single PHP file per app root and `APP_ENV`, so warm boots skip the scan entirely, and `cache:clear` drops it. It is **off by default** — see [production performance](production-performance.md).
+Every boot re-reads and re-merges these files. That is what you want while developing, and what you do not want in production: `enableFileCache()` collapses the merged result into a single PHP file per app root, `APP_ENV` and dimension tuple, so warm boots skip the scan entirely, and `cache:clear` drops it. It is **off by default** — see [production performance](production-performance.md).
+
+### Config dimensions
+
+`APP_ENV` answers *which environment*. A project that also varies configuration by region, tenant or brand declares further variables that answer the same way:
+
+```php
+// gacela.php
+$config->addConfigDimension('APP_REGION');
+$config->addConfigDimension('APP_TENANT');
+```
+
+With `APP_ENV=prod APP_REGION=eu`, the chain is `config/app.php`, then `config/app-prod.php`, then `config/app-prod-eu.php`. Each link refines the one before it, so the most specific file wins and the others still contribute the keys it does not mention.
+
+Three rules worth knowing:
+
+- **Declaration order is chain order.** `APP_REGION` then `APP_TENANT` means `app-prod-eu-acme.php`, never `app-prod-acme-eu.php`.
+- **An unset variable ends the chain.** With no `APP_REGION`, a tenant is never consulted — `app-prod--acme.php` would be a file with a hole in it and no meaning.
+- **Values are restricted** to letters, digits, `_`, `.` and `-`. A dimension reaches both a glob pattern and a cache filename, so anything else is refused at bootstrap rather than resolving somewhere unintended.
+
+The merged-config cache is named by the whole tuple, so two regions sharing one cache directory never read each other's file. `cache:warm` warms the tuple it runs as, so a deploy that serves several runs it once per tuple:
+
+```bash
+APP_REGION=eu vendor/bin/gacela cache:warm
+APP_REGION=us vendor/bin/gacela cache:warm
+```
+
+`gacela.php` itself does **not** grow dimension variants: it is read in order to *learn* which dimensions exist, so a `gacela-prod-eu.php` could never declare one.
 
 ## 3. Add your first module
 

--- a/docs/rfc/0003-bootstrap-configuration-surface.md
+++ b/docs/rfc/0003-bootstrap-configuration-surface.md
@@ -59,6 +59,7 @@ Every public method, its bucket, and its verdict. **This table is a gate**: `tes
 | `addAppConfigKeyValues()` | `add*` | conforms — plural variant, same path |
 | `addBinding()` | `add*` | conforms |
 | `addBindingIf()` | `add*` | conforms — conditional variant of `addBinding()` |
+| `addConfigDimension()` | `add*` | conforms — a new intent nothing else serves: `APP_ENV` selects configuration and nothing else could, so a second selector had no way to exist. Ordered, and calling twice contributes twice, which is what makes `add*` the right prefix over `set*` |
 | `addExternalService()` | `add*` | conforms |
 | `addFactory()` | `add*` | conforms |
 | `addHandlerRegistry()` | `add*` | conforms |

--- a/infection.json5
+++ b/infection.json5
@@ -210,6 +210,9 @@
         // to min(); shifting its origin by a constant changes no component.
         DecrementInteger: {
             ignore: [
+                // See the IncrementInteger note: an arbitrary but fixed slice
+                // of a digest.
+                "Gacela\\Framework\\Config\\MergedConfigCache::dimensionSuffix",
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
                 "Gacela\\Console\\ConsoleFactory::resolveScanPath",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
@@ -226,6 +229,13 @@
         IncrementInteger: {
             ignore: [
                 "Gacela\\Framework\\ClassResolver\\Cache\\AbstractPhpFileCache::absoluteFilename",
+                // Same arbitrary-slice reasoning as absoluteFilename above: the
+                // dimension suffix takes 12 hex characters out of a sha1 to
+                // scope a cache file to one tuple. Which 12 is arbitrary --
+                // any fixed window is equally stable and equally unique per
+                // tuple -- so killing it would mean asserting the digest,
+                // which pins the implementation rather than the behaviour.
+                "Gacela\\Framework\\Config\\MergedConfigCache::dimensionSuffix",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
@@ -236,6 +246,10 @@
         // prefix of the FQCN can never change the suffix comparison.
         UnwrapSubstr: {
             ignore: [
+                // The dimension suffix is a fixed-width slice of a digest; the
+                // full digest is equally unique and equally arbitrary, so only
+                // the filename's length changes.
+                "Gacela\\Framework\\Config\\MergedConfigCache::dimensionSuffix",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\StaticAnalysis\\ShortName::of",
                 "Gacela\\Framework\\ClassResolver\\ClassInfo::normalizeFilename",
@@ -474,6 +488,10 @@
                 // is_dir() check two lines down returns for exactly the same
                 // inputs. Only a TOCTOU race distinguishes them.
                 "Gacela\\Console\\Infrastructure\\FileContentIo::mkdir",
+                // The guard for a cache with no app root: without it the glob
+                // runs against a stem built from sha1(''), which matches no
+                // file this class ever writes. A fast path, not a branch.
+                "Gacela\\Framework\\Config\\MergedConfigCache::siblingTupleFilenames",
                 // The memo guard in matchOrder(): the pairs are a pure function
                 // of the declared suffixes, so recomputing them returns the same
                 // list. Only the work is observable, and the generation stamp is

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -25,6 +25,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string projectNamespaces = 'projectNamespaces';
 
+    public const string configDimensions = 'configDimensions';
+
     public const string appModulePaths = 'appModulePaths';
 
     public const string configKeyValues = 'configKeyValues';
@@ -70,6 +72,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const ?string DEFAULT_FILE_CACHE_DIRECTORY = GacelaFileCache::DEFAULT_DIRECTORY_VALUE;
 
     protected const array DEFAULT_PROJECT_NAMESPACES = [];
+
+    protected const array DEFAULT_CONFIG_DIMENSIONS = [];
 
     protected const array DEFAULT_APP_MODULE_PATHS = [];
 

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -57,6 +57,9 @@ final class GacelaConfig
     private ?array $projectNamespaces = null;
 
     /** @var list<string> */
+    private ?array $configDimensions = null;
+
+    /** @var list<string> */
     private ?array $appModulePaths = null;
 
     /** @var ConfigKeyValues */
@@ -209,6 +212,33 @@ final class GacelaConfig
     public function addSuffixTypeProvider(string $suffix): self
     {
         return $this->addResolvableType(ResolvableTypes::PROVIDER, null, [$suffix]);
+    }
+
+    /**
+     * Declare an environment variable that selects configuration, the way
+     * `APP_ENV` already does.
+     *
+     * ```php
+     * $config->addConfigDimension('APP_REGION');
+     * $config->addConfigDimension('APP_TENANT');
+     * ```
+     *
+     * With `APP_ENV=prod APP_REGION=eu`, `config/*.php` is read, then
+     * `config/*-prod.php`, then `config/*-prod-eu.php`; each layer refines the
+     * one before it, so more specific wins. Declaration order is the order of
+     * the chain, and a variable that is unset ends it -- with no region, a
+     * tenant is never consulted, because `app-prod--acme.php` would be a file
+     * with a hole in it and no meaning.
+     *
+     * A value may contain only letters, digits, `_`, `.` and `-`: it reaches a
+     * glob pattern and a cache filename, so anything else is refused at
+     * bootstrap rather than resolving somewhere unintended.
+     */
+    public function addConfigDimension(string $environmentVariable): self
+    {
+        $this->configDimensions[] = $environmentVariable;
+
+        return $this;
     }
 
     /**
@@ -840,6 +870,7 @@ final class GacelaConfig
             $this->fileCacheEnabled,
             $this->fileCacheDirectory,
             $this->projectNamespaces,
+            $this->configDimensions,
             $this->appModulePaths,
             $this->configKeyValues,
             $this->genericListeners,

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -64,6 +64,8 @@ final class GacelaConfigTransfer
         public readonly ?bool $fileCacheEnabled,
         public readonly ?string $fileCacheDirectory,
         public readonly ?array $projectNamespaces,
+        /** @var ?list<string> */
+        public readonly ?array $configDimensions,
         public readonly ?array $appModulePaths,
         public readonly ?array $configKeyValues,
         public readonly ?array $genericListeners,

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -63,6 +63,9 @@ final class Properties
     public ?array $projectNamespaces = null;
 
     /** @var ?list<string> */
+    public ?array $configDimensions = null;
+
+    /** @var ?list<string> */
     public ?array $appModulePaths = null;
 
     /** @var ?ConfigKeyValues */

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -57,6 +57,26 @@ final class PropertyMerger
     }
 
     /**
+     * Declaration order is the order of the chain, so a later source appends
+     * dimensions rather than reordering the ones already declared.
+     *
+     * @param list<string> $list
+     */
+    public function mergeConfigDimensions(array $list): void
+    {
+        $current = $this->setup->getConfigDimensions();
+        $merged = $current;
+
+        foreach ($list as $variable) {
+            if (!in_array($variable, $merged, true)) {
+                $merged[] = $variable;
+            }
+        }
+
+        $this->setup->setConfigDimensions($merged);
+    }
+
+    /**
      * @param ConfigKeyValues $list
      */
     public function mergeConfigKeyValues(array $list): void

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -27,6 +27,7 @@ final class SetupInitializer
             ->setFileCacheEnabled($dto->fileCacheEnabled)
             ->setFileCacheDirectory($dto->fileCacheDirectory)
             ->setProjectNamespaces($dto->projectNamespaces)
+            ->setConfigDimensions($dto->configDimensions)
             ->setAppModulePaths($dto->appModulePaths)
             ->setConfigKeyValues($dto->configKeyValues)
             ->setConfigSchema($dto->configSchema)

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -28,6 +28,7 @@ final class SetupMerger
 
         $this->whenChanged($other, SetupGacela::externalServices, fn () => $this->original->mergeExternalServices($other->externalServices()));
         $this->whenChanged($other, SetupGacela::projectNamespaces, fn () => $this->original->mergeProjectNamespaces($other->getProjectNamespaces()));
+        $this->whenChanged($other, SetupGacela::configDimensions, fn () => $this->original->mergeConfigDimensions($other->getConfigDimensions()));
         $this->whenChanged($other, SetupGacela::configKeyValues, fn () => $this->original->mergeConfigKeyValues($other->getConfigKeyValues()));
         $this->whenChanged($other, SetupGacela::configSchema, fn () => $this->original->mergeConfigSchema($other->getConfigSchema()));
         $this->whenChanged($other, SetupGacela::stubsDir, fn (): SetupGacela => $this->original->setStubsDir($other->getStubsDir()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -254,6 +254,30 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
+     * @param ?list<string> $list
+     */
+    public function setConfigDimensions(?array $list): self
+    {
+        $this->properties->configDimensions = $this->setPropertyWithTracking(
+            self::configDimensions,
+            $list,
+            self::DEFAULT_CONFIG_DIMENSIONS,
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getConfigDimensions(): array
+    {
+        return $this->properties->configDimensions ?? self::DEFAULT_CONFIG_DIMENSIONS;
+    }
+
+    /**
      * @return list<string>
      */
     public function getProjectNamespaces(): array
@@ -543,6 +567,16 @@ final class SetupGacela extends AbstractSetupGacela
     public function mergeProjectNamespaces(array $list): void
     {
         $this->propertyMerger->mergeProjectNamespaces($list);
+    }
+
+    /**
+     * @internal Used by SetupMerger - do not call directly
+     *
+     * @param list<string> $list
+     */
+    public function mergeConfigDimensions(array $list): void
+    {
+        $this->propertyMerger->mergeConfigDimensions($list);
     }
 
     /**

--- a/src/Framework/Bootstrap/SetupGacelaInterface.php
+++ b/src/Framework/Bootstrap/SetupGacelaInterface.php
@@ -22,6 +22,14 @@ interface SetupGacelaInterface extends BuilderConfigurationInterface, ContainerC
     public function getProjectNamespaces(): array;
 
     /**
+     * Environment variables that select configuration beyond APP_ENV, in
+     * declaration order.
+     *
+     * @return list<string>
+     */
+    public function getConfigDimensions(): array;
+
+    /**
      * Get the list of paths scanned when discovering application modules.
      * Empty array means scan the application root directory.
      *

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -475,6 +475,9 @@ final class Config implements ConfigInterface
             $this->getCacheDir(),
             AppEnv::current(),
             $this->getAppRootDir(),
+            // The tuple names the file. Without it two regions of one
+            // application share a cache and silently serve each other.
+            $this->getFactory()->dimensions()->values(),
         );
     }
 

--- a/src/Framework/Config/ConfigDimensions.php
+++ b/src/Framework/Config/ConfigDimensions.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Config;
+
+use Gacela\Framework\Exception\ConfigDimensionException;
+
+use function getenv;
+use function is_string;
+use function preg_match;
+
+/**
+ * The values selecting this configuration, beyond the environment.
+ *
+ * `APP_ENV` answers *which environment*; a dimension answers a further
+ * question the same way -- which region, which tenant, which brand. A project
+ * declares the variables it wants consulted, in order, and the resolved values
+ * form a tuple that selects config files and names the merged-config cache.
+ *
+ * @internal
+ */
+final class ConfigDimensions
+{
+    /**
+     * Reaches a glob pattern and a filename, so the alphabet is bounded. Wide
+     * enough that no plausible existing `APP_ENV` stops working, narrow enough
+     * that `/` and `..` cannot walk out of the config directory.
+     */
+    private const VALUE_PATTERN = '/^[A-Za-z0-9_.-]*$/';
+
+    /**
+     * @param list<string> $values
+     */
+    private function __construct(
+        private readonly array $values,
+    ) {
+    }
+
+    /**
+     * Read the declared variables, in order, stopping at the first unset one.
+     *
+     * Stopping matters: with region unset, a tenant value would otherwise
+     * produce `app-prod--acme.php` and a tuple with a hole in it, and no
+     * answer to what that file means. Terminating keeps the chain a strict
+     * prefix of itself, which is also what keeps `config/*-prod.php` from
+     * matching `app-prod-eu.php`.
+     *
+     * @param list<string> $declaredVariables
+     */
+    public static function fromEnvironment(array $declaredVariables): self
+    {
+        $values = [];
+
+        foreach ($declaredVariables as $variable) {
+            $value = getenv($variable);
+
+            if (!is_string($value) || $value === '') {
+                break;
+            }
+
+            if (preg_match(self::VALUE_PATTERN, $value) !== 1) {
+                throw ConfigDimensionException::invalidValue($variable, $value);
+            }
+
+            $values[] = $value;
+        }
+
+        return new self($values);
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    public static function fromValues(array $values): self
+    {
+        return new self($values);
+    }
+
+    public static function none(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function values(): array
+    {
+        return $this->values;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->values === [];
+    }
+
+    /**
+     * The suffixes a config file may carry, most general first.
+     *
+     * Cumulative rather than independent: `app-prod-eu.php` refines
+     * `app-prod.php`, which refines `app.php`. Independent passes would need a
+     * precedence lattice -- does `app-eu.php` beat `app-prod.php`? -- with no
+     * natural answer and a rule the docs would carry forever. A chain has one
+     * sentence: more specific wins.
+     *
+     * @param string $env the environment, which is the first link of the chain
+     *
+     * @return list<string>
+     */
+    public function suffixChain(string $env): array
+    {
+        if ($env === '') {
+            return [];
+        }
+
+        $chain = [$env];
+        $current = $env;
+
+        foreach ($this->values as $value) {
+            $current .= '-' . $value;
+            $chain[] = $current;
+        }
+
+        return $chain;
+    }
+}

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -116,6 +116,16 @@ final class ConfigFactory
     }
 
     /**
+     * The dimensions this project declared, resolved from the environment.
+     *
+     * @internal
+     */
+    public function dimensions(): ConfigDimensions
+    {
+        return ConfigDimensions::fromEnvironment($this->setup->getConfigDimensions());
+    }
+
+    /**
      * The memo, but only when it belongs to this factory's app root and setup.
      */
     private function memoized(): ?GacelaConfigFileInterface
@@ -174,9 +184,14 @@ final class ConfigFactory
 
     private function createPathNormalizer(): PathNormalizerInterface
     {
+        $chain = [];
+        foreach ($this->dimensions()->suffixChain($this->env()) as $suffix) {
+            $chain[] = new WithSuffixAbsolutePathStrategy($this->appRootDir, $suffix);
+        }
+
         return new AbsolutePathNormalizer([
             AbsolutePathNormalizer::WITHOUT_SUFFIX => new WithoutSuffixAbsolutePathStrategy($this->appRootDir),
             AbsolutePathNormalizer::WITH_SUFFIX => new WithSuffixAbsolutePathStrategy($this->appRootDir, $this->env()),
-        ]);
+        ], $chain);
     }
 }

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -79,7 +79,7 @@ final class ConfigLoader
     {
         return [
             $this->pathNormalizer->normalizePathPattern($configItem),
-            $this->pathNormalizer->normalizePathPatternWithEnvironment($configItem),
+            ...$this->pathNormalizer->normalizePathPatternsWithSuffixes($configItem),
         ];
     }
 

--- a/src/Framework/Config/MergedConfigCache.php
+++ b/src/Framework/Config/MergedConfigCache.php
@@ -6,7 +6,9 @@ namespace Gacela\Framework\Config;
 
 use Gacela\Framework\Cache\FileCache;
 
+use function implode;
 use function sha1;
+use function strlen;
 use function substr;
 
 final class MergedConfigCache
@@ -15,10 +17,14 @@ final class MergedConfigCache
 
     public const FILENAME_EXTENSION = '.php';
 
+    /**
+     * @param list<string> $dimensions the resolved values selecting this configuration, beyond the env
+     */
     public function __construct(
         private readonly string $cacheDir,
         private readonly string $env = '',
         private readonly string $appRootDir = '',
+        private readonly array $dimensions = [],
     ) {
     }
 
@@ -54,6 +60,15 @@ final class MergedConfigCache
     {
         FileCache::delete($this->filename());
 
+        // Every other dimension tuple of this application too. Clearing only
+        // the tuple this process happens to be leaves the other regions'
+        // answers on disk, and the next deploy of one of them reads its own
+        // stale file back. Anchored to this app's hash, so another
+        // application sharing the cache dir is not touched.
+        foreach ($this->siblingTupleFilenames() as $filename) {
+            FileCache::delete($filename);
+        }
+
         // Also drop a cache written before filenames were app-scoped, so
         // clearing leaves no stale pre-#465 file behind in a shared dir.
         $legacyFilename = $this->buildFilename('');
@@ -86,6 +101,55 @@ final class MergedConfigCache
             . self::FILENAME_PREFIX
             . $appSuffix
             . $envSuffix
+            . $this->dimensionSuffix()
             . self::FILENAME_EXTENSION;
+    }
+
+    /**
+     * Hashed rather than spelled out, and absent entirely when nothing is
+     * declared.
+     *
+     * Absent, because a project that declares no dimension must keep the
+     * filename it already has: spelling one out would invalidate every warm
+     * cache on upgrade for a feature the project does not use.
+     *
+     * Hashed, because further readable segments cannot be told apart from an
+     * env that contains the separator. `-prod-eu` is either the env `prod-eu`
+     * with no dimensions or the env `prod` in region `eu`, and hyphenated env
+     * names are ordinary -- so the two configurations would share one file and
+     * silently serve each other. The same reason the class-name cache carries
+     * an opaque bootstrap fingerprint instead of a readable one.
+     */
+    /**
+     * The dimension tuples of this app and env, whichever values they carry.
+     *
+     * @return list<string>
+     */
+    private function siblingTupleFilenames(): array
+    {
+        if ($this->appRootDir === '') {
+            return [];
+        }
+
+        $withoutExtension = substr($this->buildFilename(
+            '-' . substr(sha1($this->appRootDir), 0, 12),
+        ), 0, -strlen(self::FILENAME_EXTENSION));
+
+        // One dimension segment past the env, which is the only shape a tuple
+        // filename takes.
+        $stem = $this->dimensions === []
+            ? $withoutExtension
+            : substr($withoutExtension, 0, -strlen($this->dimensionSuffix()));
+
+        return glob($stem . '-*' . self::FILENAME_EXTENSION) ?: [];
+    }
+
+    private function dimensionSuffix(): string
+    {
+        if ($this->dimensions === []) {
+            return '';
+        }
+
+        return '-' . substr(sha1(implode("\0", $this->dimensions)), 0, 12);
     }
 }

--- a/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
+++ b/src/Framework/Config/PathNormalizer/AbsolutePathNormalizer.php
@@ -15,9 +15,11 @@ final class AbsolutePathNormalizer implements PathNormalizerInterface
 
     /**
      * @param array<string,AbsolutePathStrategyInterface> $absolutePathStrategies
+     * @param list<AbsolutePathStrategyInterface> $suffixChainStrategies one per link of the env-and-dimensions chain
      */
     public function __construct(
         private array $absolutePathStrategies,
+        private readonly array $suffixChainStrategies = [],
     ) {
     }
 
@@ -31,6 +33,23 @@ final class AbsolutePathNormalizer implements PathNormalizerInterface
     {
         return $this->absolutePathStrategies[self::WITH_SUFFIX]
             ->generateAbsolutePath($configItem->path());
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function normalizePathPatternsWithSuffixes(GacelaConfigItem $configItem): array
+    {
+        if ($this->suffixChainStrategies === []) {
+            return [$this->normalizePathPatternWithEnvironment($configItem)];
+        }
+
+        $patterns = [];
+        foreach ($this->suffixChainStrategies as $strategy) {
+            $patterns[] = $strategy->generateAbsolutePath($configItem->path());
+        }
+
+        return $patterns;
     }
 
     public function normalizePathLocal(GacelaConfigItem $configItem): string

--- a/src/Framework/Config/PathNormalizerInterface.php
+++ b/src/Framework/Config/PathNormalizerInterface.php
@@ -12,5 +12,14 @@ interface PathNormalizerInterface
 
     public function normalizePathPatternWithEnvironment(GacelaConfigItem $configItem): string;
 
+    /**
+     * One pattern per link of the environment-and-dimensions chain, most
+     * general first: `app-prod.php`, then `app-prod-eu.php`, and so on. With
+     * no dimension declared this is exactly the environment pattern.
+     *
+     * @return list<string>
+     */
+    public function normalizePathPatternsWithSuffixes(GacelaConfigItem $configItem): array;
+
     public function normalizePathLocal(GacelaConfigItem $configItem): string;
 }

--- a/src/Framework/Exception/ConfigDimensionException.php
+++ b/src/Framework/Exception/ConfigDimensionException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class ConfigDimensionException extends RuntimeException
+{
+    public static function invalidValue(string $variable, string $value): self
+    {
+        return new self(sprintf(
+            'The config dimension "%s" has the value "%s", which cannot be used: a dimension reaches both a '
+            . 'glob pattern and a cache filename, so it may contain only letters, digits, "_", "." and "-".',
+            $variable,
+            $value,
+        ));
+    }
+}

--- a/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config-f51331f0083f.php
+++ b/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config-f51331f0083f.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+];

--- a/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config/-f51331f0083f.php
+++ b/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config/-f51331f0083f.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+];

--- a/tests/Feature/Framework/ConfigDimensions/FeatureTest.php
+++ b/tests/Feature/Framework/ConfigDimensions/FeatureTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ConfigDimensions;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Exception\ConfigDimensionException;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Util\DirectoryUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * One application, one config directory, two regions.
+ */
+final class FeatureTest extends TestCase
+{
+    private const CACHE_DIR = __DIR__ . '/cache';
+
+    public static function tearDownAfterClass(): void
+    {
+        Gacela::resetCache();
+        DirectoryUtil::removeDir(self::CACHE_DIR);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('APP_ENV');
+        putenv('APP_REGION');
+        Gacela::resetCache();
+        DirectoryUtil::removeDir(self::CACHE_DIR);
+    }
+
+    public function test_each_layer_refines_the_one_before_it(): void
+    {
+        putenv('APP_ENV=prod');
+        putenv('APP_REGION=eu');
+        $this->bootstrap();
+
+        $config = Config::getInstance();
+
+        self::assertSame('prod-eu', $config->get('layer'), 'the most specific layer wins');
+        self::assertSame('kept', $config->get('prod-only'), 'the env layer still contributes');
+        self::assertSame('kept', $config->get('base-only'), 'and so does the base');
+    }
+
+    public function test_a_different_region_reads_its_own_layer(): void
+    {
+        putenv('APP_ENV=prod');
+        putenv('APP_REGION=us');
+        $this->bootstrap();
+
+        self::assertSame('prod-us', Config::getInstance()->get('layer'));
+    }
+
+    /**
+     * An unset dimension ends the chain rather than leaving a hole in it, so
+     * this reads the env layer and stops.
+     */
+    public function test_an_unset_dimension_ends_the_chain(): void
+    {
+        putenv('APP_ENV=prod');
+        $this->bootstrap();
+
+        self::assertSame('prod', Config::getInstance()->get('layer'));
+    }
+
+    /**
+     * The test #465 and #597 would have wanted: two regions, one cache
+     * directory, file cache on. Whichever boots first must not answer for the
+     * other.
+     */
+    public function test_two_regions_never_share_a_warm_cache(): void
+    {
+        putenv('APP_ENV=prod');
+        putenv('APP_REGION=eu');
+        $this->bootstrap(fileCache: true);
+        self::assertSame('prod-eu', Config::getInstance()->get('layer'));
+
+        Gacela::resetCache();
+
+        putenv('APP_REGION=us');
+        $this->bootstrap(fileCache: true);
+        self::assertSame('prod-us', Config::getInstance()->get('layer'));
+    }
+
+    /**
+     * A dimension reaches a glob pattern and a filename, so a value that could
+     * walk out of the config directory is refused where it is cheap to fix.
+     */
+    public function test_a_value_that_could_escape_the_config_directory_is_refused(): void
+    {
+        putenv('APP_ENV=prod');
+        putenv('APP_REGION=../../etc');
+
+        $this->expectException(ConfigDimensionException::class);
+        $this->expectExceptionMessage('APP_REGION');
+
+        $this->bootstrap();
+        Config::getInstance()->get('layer');
+    }
+
+    private function bootstrap(bool $fileCache = false): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($fileCache): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache($fileCache, self::CACHE_DIR);
+            $config->addAppConfig('config/*.php');
+            $config->addConfigDimension('APP_REGION');
+        });
+    }
+}

--- a/tests/Feature/Framework/ConfigDimensions/config/app-prod-eu.php
+++ b/tests/Feature/Framework/ConfigDimensions/config/app-prod-eu.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'layer' => 'prod-eu',
+];

--- a/tests/Feature/Framework/ConfigDimensions/config/app-prod-us.php
+++ b/tests/Feature/Framework/ConfigDimensions/config/app-prod-us.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'layer' => 'prod-us',
+];

--- a/tests/Feature/Framework/ConfigDimensions/config/app-prod.php
+++ b/tests/Feature/Framework/ConfigDimensions/config/app-prod.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'layer' => 'prod',
+    'prod-only' => 'kept',
+];

--- a/tests/Feature/Framework/ConfigDimensions/config/app.php
+++ b/tests/Feature/Framework/ConfigDimensions/config/app.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'layer' => 'base',
+    'base-only' => 'kept',
+];

--- a/tests/Unit/Framework/Config/ConfigDimensionsTest.php
+++ b/tests/Unit/Framework/Config/ConfigDimensionsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Config\ConfigDimensions;
+use Gacela\Framework\Exception\ConfigDimensionException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigDimensionsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('APP_REGION');
+        putenv('APP_TENANT');
+    }
+
+    public function test_declaring_nothing_resolves_to_nothing(): void
+    {
+        $dimensions = ConfigDimensions::fromEnvironment([]);
+
+        self::assertTrue($dimensions->isEmpty());
+        self::assertSame([], $dimensions->values());
+    }
+
+    public function test_declared_variables_resolve_in_declaration_order(): void
+    {
+        putenv('APP_REGION=eu');
+        putenv('APP_TENANT=acme');
+
+        $dimensions = ConfigDimensions::fromEnvironment(['APP_REGION', 'APP_TENANT']);
+
+        self::assertSame(['eu', 'acme'], $dimensions->values());
+    }
+
+    /**
+     * The chain ends at the first unset variable rather than skipping it: a
+     * tenant without a region would produce `app-prod--acme.php`, a file with
+     * a hole in it and no meaning, and it would break the prefix property that
+     * keeps `config/*-prod.php` from matching `app-prod-eu.php`.
+     */
+    public function test_an_unset_variable_ends_the_chain_rather_than_being_skipped(): void
+    {
+        putenv('APP_TENANT=acme');
+
+        $dimensions = ConfigDimensions::fromEnvironment(['APP_REGION', 'APP_TENANT']);
+
+        self::assertSame([], $dimensions->values());
+    }
+
+    public function test_an_empty_value_counts_as_unset(): void
+    {
+        putenv('APP_REGION=');
+
+        self::assertSame([], ConfigDimensions::fromEnvironment(['APP_REGION'])->values());
+    }
+
+    #[DataProvider('refusedValueProvider')]
+    public function test_a_value_a_glob_or_a_filename_could_not_carry_is_refused(string $value): void
+    {
+        putenv('APP_REGION=' . $value);
+
+        $this->expectException(ConfigDimensionException::class);
+        $this->expectExceptionMessage('APP_REGION');
+
+        ConfigDimensions::fromEnvironment(['APP_REGION']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function refusedValueProvider(): iterable
+    {
+        yield 'directory traversal' => ['../etc'];
+        yield 'path separator' => ['eu/west'];
+        yield 'glob wildcard' => ['e*'];
+        yield 'space' => ['eu west'];
+    }
+
+    public function test_the_ordinary_alphabet_is_accepted(): void
+    {
+        putenv('APP_REGION=eu-west_1.a');
+
+        self::assertSame(['eu-west_1.a'], ConfigDimensions::fromEnvironment(['APP_REGION'])->values());
+    }
+
+    public function test_the_chain_starts_at_the_environment_and_grows_one_link_per_value(): void
+    {
+        $dimensions = ConfigDimensions::fromValues(['eu', 'acme']);
+
+        self::assertSame(['prod', 'prod-eu', 'prod-eu-acme'], $dimensions->suffixChain('prod'));
+    }
+
+    public function test_without_dimensions_the_chain_is_the_environment_alone(): void
+    {
+        self::assertSame(['prod'], ConfigDimensions::none()->suffixChain('prod'));
+    }
+
+    /**
+     * No environment means no suffixed file to look for, dimensions or not:
+     * `app--eu.php` names nothing.
+     */
+    public function test_without_an_environment_there_is_no_chain_at_all(): void
+    {
+        self::assertSame([], ConfigDimensions::fromValues(['eu'])->suffixChain(''));
+    }
+}

--- a/tests/Unit/Framework/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Framework/Config/ConfigLoaderTest.php
@@ -112,6 +112,7 @@ final class ConfigLoaderTest extends TestCase
         $normalizer = $this->createStub(PathNormalizerInterface::class);
         $normalizer->method('normalizePathPattern')->willReturn('pattern');
         $normalizer->method('normalizePathPatternWithEnvironment')->willReturn('pattern-env');
+        $normalizer->method('normalizePathPatternsWithSuffixes')->willReturn(['pattern-env']);
         $normalizer->method('normalizePathLocal')->willReturn('/project/config/local.php');
 
         $pathFinder = $this->createMock(PathFinderInterface::class);
@@ -141,6 +142,7 @@ final class ConfigLoaderTest extends TestCase
         $normalizer = $this->createStub(PathNormalizerInterface::class);
         $normalizer->method('normalizePathPattern')->willReturn('pattern');
         $normalizer->method('normalizePathPatternWithEnvironment')->willReturn('pattern-env');
+        $normalizer->method('normalizePathPatternsWithSuffixes')->willReturn(['pattern-env']);
         $normalizer->method('normalizePathLocal')->willReturn($local);
 
         $pathFinder = $this->createStub(PathFinderInterface::class);

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -138,6 +138,93 @@ final class MergedConfigCacheTest extends TestCase
         );
     }
 
+    /**
+     * The BC lock: a project declaring no dimension must keep the filename it
+     * had, or every upgrade silently invalidates a warm cache.
+     */
+    public function test_declaring_no_dimension_keeps_the_existing_filename(): void
+    {
+        $before = new MergedConfigCache($this->cacheDir, 'prod', '/app/root');
+        $after = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', []);
+
+        self::assertSame($before->filename(), $after->filename());
+    }
+
+    public function test_a_declared_dimension_gives_the_file_its_own_name(): void
+    {
+        $plain = new MergedConfigCache($this->cacheDir, 'prod', '/app/root');
+        $eu = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+
+        self::assertNotSame($plain->filename(), $eu->filename());
+    }
+
+    public function test_two_dimension_tuples_never_share_a_file(): void
+    {
+        $eu = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+        $us = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['us']);
+
+        self::assertNotSame($eu->filename(), $us->filename());
+    }
+
+    /**
+     * The collision the readable-segment spelling would have shipped:
+     * `-{env}-{region}` cannot tell `prod-eu` with no region from `prod` in
+     * region `eu`, and hyphenated env names are ordinary. Hashing the
+     * dimensions keeps the two apart.
+     */
+    public function test_a_hyphenated_env_cannot_collide_with_a_dimension(): void
+    {
+        $hyphenatedEnv = new MergedConfigCache($this->cacheDir, 'prod-eu', '/app/root');
+        $envPlusRegion = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+
+        self::assertNotSame($hyphenatedEnv->filename(), $envPlusRegion->filename());
+    }
+
+    /**
+     * Order is meaning: region eu / tenant acme is not tenant eu / region acme.
+     */
+    public function test_the_order_of_the_dimensions_is_part_of_the_identity(): void
+    {
+        $one = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu', 'acme']);
+        $two = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['acme', 'eu']);
+
+        self::assertNotSame($one->filename(), $two->filename());
+    }
+
+    /**
+     * Clearing has to reap every tuple of this app, not just the one the
+     * current process happens to be. A region left behind is a stale answer
+     * the next deploy of that region reads back.
+     */
+    public function test_clearing_reaps_every_dimension_tuple_of_this_app(): void
+    {
+        $eu = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+        $us = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['us']);
+        $eu->write(['k' => 'eu']);
+        $us->write(['k' => 'us']);
+
+        $eu->clear();
+
+        self::assertFalse($eu->exists());
+        self::assertFalse($us->exists(), "the other region's tuple was left behind");
+    }
+
+    /**
+     * ...but not another application's, which is what the app hash is for.
+     */
+    public function test_clearing_leaves_another_apps_cache_alone(): void
+    {
+        $mine = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+        $theirs = new MergedConfigCache($this->cacheDir, 'prod', '/other/root', ['eu']);
+        $mine->write(['k' => 'mine']);
+        $theirs->write(['k' => 'theirs']);
+
+        $mine->clear();
+
+        self::assertFalse($mine->exists());
+        self::assertTrue($theirs->exists());
+    }
+
     public function test_different_envs_produce_isolated_cache_files(): void
     {
         $prod = new MergedConfigCache($this->cacheDir, 'prod');

--- a/tests/Unit/Framework/Config/MergedConfigCacheTest.php
+++ b/tests/Unit/Framework/Config/MergedConfigCacheTest.php
@@ -10,6 +10,7 @@ use GacelaTest\Fixtures\ReadOnlyDirTrait;
 use PHPUnit\Framework\TestCase;
 
 use function rmdir;
+use function strlen;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -223,6 +224,40 @@ final class MergedConfigCacheTest extends TestCase
 
         self::assertFalse($mine->exists());
         self::assertTrue($theirs->exists());
+    }
+
+    /**
+     * The reap is anchored on the app hash, so a cache with no app root has
+     * no siblings to speak of and must not sweep the directory.
+     */
+    public function test_clearing_an_unscoped_cache_reaps_no_siblings(): void
+    {
+        $scoped = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+        $scoped->write(['k' => 'v']);
+
+        (new MergedConfigCache($this->cacheDir, 'prod'))->clear();
+
+        self::assertTrue($scoped->exists());
+    }
+
+    /**
+     * And it only reaps merged-config caches: a neighbour in the same
+     * directory whose name happens to start the same way is not this class's
+     * to delete.
+     */
+    public function test_clearing_leaves_a_non_cache_neighbour_alone(): void
+    {
+        $cache = new MergedConfigCache($this->cacheDir, 'prod', '/app/root', ['eu']);
+        $cache->write(['k' => 'v']);
+
+        $stem = substr($cache->filename(), 0, -strlen(MergedConfigCache::FILENAME_EXTENSION));
+        $neighbour = $stem . '-notes.txt';
+        file_put_contents($neighbour, 'not a cache');
+
+        $cache->clear();
+
+        self::assertFileExists($neighbour);
+        unlink($neighbour);
     }
 
     public function test_different_envs_produce_isolated_cache_files(): void

--- a/tests/Unit/Framework/Config/PathNormalizer/AbsolutePathNormalizerTest.php
+++ b/tests/Unit/Framework/Config/PathNormalizer/AbsolutePathNormalizerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config\PathNormalizer;
+
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigItem;
+use Gacela\Framework\Config\PathNormalizer\AbsolutePathNormalizer;
+use Gacela\Framework\Config\PathNormalizer\WithoutSuffixAbsolutePathStrategy;
+use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
+use PHPUnit\Framework\TestCase;
+
+final class AbsolutePathNormalizerTest extends TestCase
+{
+    private const APP_ROOT = '/app';
+
+    public function test_the_plain_pattern_carries_no_suffix(): void
+    {
+        self::assertSame('/app/config/*.php', $this->normalizer()->normalizePathPattern($this->item()));
+    }
+
+    public function test_the_environment_pattern_carries_the_environment(): void
+    {
+        self::assertSame(
+            '/app/config/*-prod.php',
+            $this->normalizer()->normalizePathPatternWithEnvironment($this->item()),
+        );
+    }
+
+    /**
+     * With no dimension declared the chain is the environment pattern alone,
+     * which is what keeps a project that uses no dimension reading exactly the
+     * files it read before.
+     */
+    public function test_without_a_chain_the_suffixed_patterns_are_the_environment_alone(): void
+    {
+        self::assertSame(
+            ['/app/config/*-prod.php'],
+            $this->normalizer()->normalizePathPatternsWithSuffixes($this->item()),
+        );
+    }
+
+    public function test_a_chain_yields_one_pattern_per_link_most_general_first(): void
+    {
+        $normalizer = $this->normalizer([
+            new WithSuffixAbsolutePathStrategy(self::APP_ROOT, 'prod'),
+            new WithSuffixAbsolutePathStrategy(self::APP_ROOT, 'prod-eu'),
+        ]);
+
+        self::assertSame(
+            ['/app/config/*-prod.php', '/app/config/*-prod-eu.php'],
+            $normalizer->normalizePathPatternsWithSuffixes($this->item()),
+        );
+    }
+
+    public function test_the_local_path_carries_no_suffix(): void
+    {
+        $item = new GacelaConfigItem('config/*.php', 'config/local.php');
+
+        self::assertSame('/app/config/local.php', $this->normalizer()->normalizePathLocal($item));
+    }
+
+    /**
+     * @param list<WithSuffixAbsolutePathStrategy> $chain
+     */
+    private function normalizer(array $chain = []): AbsolutePathNormalizer
+    {
+        return new AbsolutePathNormalizer([
+            AbsolutePathNormalizer::WITHOUT_SUFFIX => new WithoutSuffixAbsolutePathStrategy(self::APP_ROOT),
+            AbsolutePathNormalizer::WITH_SUFFIX => new WithSuffixAbsolutePathStrategy(self::APP_ROOT, 'prod'),
+        ], $chain);
+    }
+
+    private function item(): GacelaConfigItem
+    {
+        return new GacelaConfigItem('config/*.php');
+    }
+}


### PR DESCRIPTION
## 📚 Description

`APP_ENV` answers *which environment*. A project that also varies configuration by region, tenant or brand had nowhere to say so, and ended up branching inside a `Config` class on a variable the framework never knew about.

```php
// gacela.php
$config->addConfigDimension('APP_REGION');
```

With `APP_ENV=prod APP_REGION=eu` the chain is `config/app.php` → `config/app-prod.php` → `config/app-prod-eu.php`, each refining the one before it.

Closes #675

## ⚠️ The bug this would have shipped

The obvious implementation extends the cache filename's `-{env}` with `-{region}`. That collides: **`(env=prod-eu, no region)` and `(env=prod, region=eu)` produce the identical filename**, and hyphenated env names (`prod-eu`, `staging-2`) are ordinary. With the file cache on, `loadMergedConfigValues()` serves that file *instead of* reading `config/` at all — so two regions would silently serve each other's configuration. That is #465 and #597 one axis later.

The dimensions are hashed into one opaque segment instead, the way #686 fingerprints the class-name cache. A test pins the collision case directly.

The segment is **absent entirely** when nothing is declared, so a project that uses no dimension keeps its existing filename and no warm cache is invalidated by upgrading — locked by a BC test.

## 🔖 Changes

- `ConfigDimensions`: resolves the declared variables in order, **stopping at the first unset one** — a tenant without a region would produce `app-prod--acme.php`, a file with a hole in it, and would break the prefix property that keeps `config/*-prod.php` from matching `app-prod-eu.php`.
- **Value validation the issue omits**: a dimension reaches a glob pattern *and* a filename, so values are restricted to `[A-Za-z0-9_.-]` and refused at bootstrap. `APP_REGION=../../etc` never reaches a path component.
- `MergedConfigCache` names the file by the whole tuple, and `clear()` now reaps **every** tuple of the application rather than only the current one — a region left behind is a stale answer its next deploy reads back. Anchored on the app hash, so another application sharing the cache directory is untouched, and a non-cache neighbour is left alone; both pinned by tests.
- `PathNormalizerInterface` gains the chain of suffixed patterns; `AbsolutePathNormalizer` gained its **first test** in the process.
- Docs: a *Config dimensions* section in getting-started with the three rules and the per-tuple `cache:warm` note; RFC-0003 audit row; CHANGELOG.
- Covered MSI on the new code: **100%**. 2197 tests green.

## 📐 Decisions taken, with reasons

- **Cumulative chain, not independent passes.** Independent passes need a precedence lattice — does `app-eu.php` beat `app-prod.php`? — with no natural answer and a rule the docs carry forever. A chain is one sentence: more specific wins.
- **An ordered list, not one named axis.** `add*` in RFC-0003 means *calling twice contributes twice*; a single axis would have to be `setConfigDimension()`, which fits the intent worse.
- **`gacela.php` grows no dimension variants** — decidable, not preference: it is read *in order to learn* which dimensions exist, so a `gacela-prod-eu.php` could never declare one.
- **`cache:warm` warms the tuple it runs as.** Warming all of them means enumerating dimension *values*, which needs a second declaration surface; `APP_REGION=eu … && APP_REGION=us …` is one shell line and zero framework code, and is documented as such.

## 🔍 Deliberately not here

`debug:config` per-key attribution (*which layer supplied this key*) is a bigger feature than dimensions: `ConfigLoader::loadAll()` returns a bare `array_merge` with no provenance, and on the warm-cache path there is no provenance to record at all. Bundling it would make the correctness-critical part wait on a display feature. Worth its own issue.