### PR TITLE
docs: how to vary a module's wiring per entrypoint

### DIFF
--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -262,6 +262,54 @@ The abstract is a declared contract, not a scan: Gacela never searches your tree
 
 `addSuffixTypeFacade()` and its three siblings are now sugar over this call, and stay supported: they widen a pillar rather than declare a kind.
 
+## Vary the wiring per entrypoint
+
+One module often serves several entrypoints — a web request, a queue worker, a scheduled job — and the wiring differs: the worker wants a batching writer, the request a synchronous one.
+
+The tempting answer is a branch inside the Factory:
+
+```php
+public function createProductWriter(): ProductWriter
+{
+    return $this->getConfig()->isWorker()      // don't
+        ? new BatchingProductWriter()
+        : new SyncProductWriter();
+}
+```
+
+That hides the variant in control flow, where `debug:module` cannot show it and `cache:warm` cannot precompute past it.
+
+Each entrypoint already has its own bootstrap, so give it its own **project namespaces** instead. Configured namespaces are searched before the module's own, which is tried last:
+
+```php
+// bin/worker.php
+Gacela::bootstrap(dirname(__DIR__), static function (GacelaConfig $config): void {
+    $config->setProjectNamespaces(['App\Worker']);
+});
+```
+
+```
+src/
+├── Catalog/
+│   ├── CatalogFacade.php
+│   ├── CatalogFactory.php        synchronous writer
+│   └── Domain/ProductWriter.php
+└── Worker/
+    └── Catalog/
+        └── CatalogFactory.php    batching writer
+```
+
+`App\Worker\Catalog\CatalogFactory` now answers for `App\Catalog\CatalogFacade` under the worker bootstrap, and nothing changes for the web entrypoint, which sets no project namespaces at all.
+
+Four things worth knowing:
+
+- **You override only what differs.** The variant class extends the original and overrides the one method that changes; every other `create*()` still comes from the base Factory. A parallel tree of *whole* modules is not what this asks for.
+- **List order is resolution order.** `setProjectNamespaces(['App\Worker', 'App\Shared'])` tries `App\Worker` first, then `App\Shared`, then the module's own namespace. The first candidate that exists wins.
+- **It covers every pillar Gacela *resolves*** — Facade, Factory, Config and Provider, plus any [kind you declared](#resolve-a-kind-of-my-own). A Facade you reach with `new CatalogFacade()` is not resolved, so that call is untouched; one reached through `getFacade()` is.
+- **Each bootstrap gets its own cache file.** The on-disk class-name cache is keyed by a hash of `projectNamespaces` and suffix types, so a warm web cache can never answer for the worker — see [caching](caching.md). At deploy, run `cache:warm` once per entrypoint; see [production performance](production-performance.md).
+
+The honest limit: the variant lives *outside* the module folder, so the module no longer tells its own whole story. [#679](https://github.com/gacela-project/gacela/issues/679) tracks letting the variant live inside the module instead, and is waiting on a real application that finds the parallel tree painful enough to justify the cost.
+
 ## The other paths, and when they are right
 
 These are supported and are **not** deprecated. They are simply not the answer to "how do I get a dependency?" — reach for them when the situation below is actually yours.

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/FeatureTest.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/FeatureTest.php
@@ -8,6 +8,7 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleA\Facade as ThirdPartyModuleAFacade;
 use GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleB\Facade as ThirdPartyModuleBFacade;
+use GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleC\Facade as ThirdPartyModuleCFacade;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,6 +45,31 @@ final class FeatureTest extends TestCase
         $facade = new ThirdPartyModuleAFacade();
 
         self::assertSame('Hi, from vendor\ThirdParty\ModuleA::StringA2', $facade->stringValueA2());
+    }
+
+    /**
+     * The module-prefixed spelling, `{projectNamespace}\ModuleC\ModuleCFactory`,
+     * which is what `docs/getting-a-dependency.md` shows for per-entrypoint
+     * wiring. Its siblings above override with the bare `Factory` name, so this
+     * is the one that keeps the documented shape honest.
+     */
+    public function test_override_factory_named_with_the_module_prefix(): void
+    {
+        $facade = new ThirdPartyModuleCFacade();
+
+        self::assertSame('Overridden, from src\Main\ModuleC::StringC1', $facade->stringValueC1());
+    }
+
+    /**
+     * The override extends the vendor Factory and replaces one method, so
+     * everything it does not mention still resolves from the base -- the reason
+     * a variant is a small subclass rather than a copy of the module.
+     */
+    public function test_a_method_the_override_does_not_replace_still_comes_from_the_base(): void
+    {
+        $facade = new ThirdPartyModuleCFacade();
+
+        self::assertSame('Hi, from vendor\ThirdParty\ModuleC::StringC2', $facade->stringValueC2());
     }
 
     public function test_override_factory_from_second_highest_prio_namespace(): void

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/src/Main/ModuleC/ModuleCFactory.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/src/Main/ModuleC/ModuleCFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\src\Main\ModuleC;
+
+use GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleC\Factory as ThirdPartyFactory;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+use Override;
+
+/**
+ * Named with the module prefix, which is the shape `docs/getting-a-dependency.md`
+ * teaches for per-entrypoint wiring -- its sibling overrides in `ModuleA` and
+ * `ModuleB` use the bare `Factory` name, so without this the documented spelling
+ * is the one nothing exercises.
+ */
+final class ModuleCFactory extends ThirdPartyFactory
+{
+    #[Override]
+    public function createStringC1(): StringValueInterface
+    {
+        return new StringValue('Overridden, from src\Main\ModuleC::StringC1');
+    }
+}

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/vendor/ThirdParty/ModuleC/Facade.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/vendor/ThirdParty/ModuleC/Facade.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleC;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @method Factory getFactory()
+ */
+final class Facade extends AbstractFacade
+{
+    public function stringValueC1(): string
+    {
+        return $this->getFactory()
+            ->createStringC1()
+            ->value();
+    }
+
+    public function stringValueC2(): string
+    {
+        return $this->getFactory()
+            ->createStringC2()
+            ->value();
+    }
+}

--- a/tests/Feature/Framework/ResolveDifferentProjectNamespaces/vendor/ThirdParty/ModuleC/Factory.php
+++ b/tests/Feature/Framework/ResolveDifferentProjectNamespaces/vendor/ThirdParty/ModuleC/Factory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\ResolveDifferentProjectNamespaces\vendor\ThirdParty\ModuleC;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+
+class Factory extends AbstractFactory
+{
+    public function createStringC1(): StringValueInterface
+    {
+        return new StringValue('Hi, from vendor\ThirdParty\ModuleC::StringC1');
+    }
+
+    public function createStringC2(): StringValueInterface
+    {
+        return new StringValue('Hi, from vendor\ThirdParty\ModuleC::StringC2');
+    }
+}


### PR DESCRIPTION
## 📚 Description

A module serving a web request and a queue worker often wants different wiring — the worker a batching writer, the request a synchronous one. Gacela can already do this, and #679 says so plainly:

> `setProjectNamespaces()` gets close, and that deserves saying plainly: **per-entrypoint wiring is expressible today.**

But nothing told a reader that. `setProjectNamespaces()` is named in `docs/caching.md` and `docs/production-performance.md`, and in both it appears only as *an input to a cache key*. The one place the mechanism is actually demonstrated is a feature test.

Related to #679

## 🔖 Changes

A **Vary the wiring per entrypoint** section in `docs/getting-a-dependency.md`: the config-branch-inside-the-Factory anti-pattern it replaces, the bootstrap, the override tree, and four rules —

- **You override only what differs.** The variant extends the original Factory and replaces one method; everything else still resolves from the base. A parallel tree of *whole* modules is not what this asks for.
- **List order is resolution order**, with the module's own namespace tried last.
- **It covers every pillar Gacela resolves** — including a Facade reached through `getFacade()`, but not one you reach with `new`.
- **Each bootstrap gets its own cache file**, so a warm web cache cannot answer for the worker, with the per-entrypoint `cache:warm` step.

## ✅ The docs are executable

The section teaches the **module-prefixed** override spelling, `{projectNamespace}\ModuleC\ModuleCFactory`. Both existing overrides in that feature test use the **bare** `Factory` name — a different finder rule — so the documented shape was the one nothing exercised. Added `ModuleC` to pin it, plus a test that a method the override does not replace still comes from the base, which is what makes "small subclass, not a copy" true rather than aspirational.

Verified red before green: with the override file moved aside the test reports the vendor string, so it is not passing vacuously.

One trap worth noting for anyone adding fixtures there: `.gitignore` carries a bare `vendor/` rule, which silently swallows `tests/**/vendor/ThirdParty/...`. The new files needed `git add -f`; without it CI would have failed on a class that exists locally and nowhere else.

## 🔍 What this deliberately does not do

It does not implement #679. The remaining gap after this is one sentence — the variant lives *outside* the module folder — and the section says so and links the issue.

My [analysis there](https://github.com/gacela-project/gacela/issues/679#issuecomment-5273171624) is that the feature's stronger justification (a per-entrypoint `setProjectNamespaces()` corrupting a shared file cache) was removed by #686, which gave the class-name cache a per-bootstrap identity, and that what remains needs a real two-entrypoint application before it is worth two extra resolution candidates per namespace per type.
