### PR TITLE
feat(console): check each package's composer.json against what it imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars, reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs became sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`. The kind is listed in the command's help, `doctor` counts its stub among the ones the scaffolder reads, and until that stub exists the generator names the path it looked for
 - Report in `doctor` every `extendService()` id no Provider ever `set()`s — such an extension is accepted, scheduled on every scope, and applied nowhere
+- Report in `doctor` any package importing a namespace its own `composer.json` never mentions. A sub-package of a monorepo resolves fine against the root autoloader and fatals the day it is installed alone — the bug this repository shipped in both bridges once already. Every manifest section counts as a mention, because a phar-distributed package declares no autoload prefix and demanding a particular section would name the wrong package to add
 - Generate editor metadata for `getProvidedDependency()` with `ide:meta`, from the `#[Provides]` attributes: an id naming a class resolves to it, and each string id is typed by the return type of the method that registers it. An id two providers type differently is listed rather than written, because one application-wide answer would be wrong in one of the two modules; `doctor` reports metadata the attributes no longer produce
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,7 +60,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 | Command | What it does |
 |---|---|
-| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md). Takes an optional namespace to restrict module-scoped checks, and `--strict` to exit non-zero on warnings too |
+| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md) and each package's `composer.json` against what it imports. Takes an optional namespace to restrict module-scoped checks, and `--strict` to exit non-zero on warnings too |
 | `validate:config` | Checks the configuration for errors and best-practice violations, and against the [declared schema](config-schema.md) |
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).

--- a/infection.json5
+++ b/infection.json5
@@ -272,8 +272,29 @@
                 "Gacela\\SymfonyBridge\\GacelaCommands::names",
             ],
         },
+        // Truncating the collected list to one entry is only visible when a
+        // manifest declares two of something and both matter to the same
+        // assertion; the reader collects, it does not decide, so the cases
+        // that would tell them apart are the ones already pinned by name.
+        ArrayOneItem: {
+            ignore: [
+                "Gacela\\Console\\Domain\\PackageManifest\\ComposerPackage::keysOf",
+                "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
+            ],
+        },
+        // A psr-4 directory written "src/" resolves to the same directory with
+        // or without the trim: the filesystem accepts the doubled separator,
+        // which is what the trailing-separator test proves.
+        UnwrapTrim: {
+            ignore: [
+                "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
+            ],
+        },
         UnwrapArrayMap: {
-            ignore: ["Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get"],
+            ignore: [
+                "Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get",
+                "Gacela\\Console\\Domain\\PackageManifest\\NamespacePackageMap::from",
+            ],
         },
         // affectedModules() keys its accumulator by module name to deduplicate;
         // array_values() only restores the list shape the return type declares,
@@ -311,6 +332,11 @@
         },
         FunctionCallRemoval: {
             ignore: [
+                // sort() makes the walk order of a directory listing repeatable. A
+                // filesystem that already returns entries in order makes removing it
+                // unobservable, and pinning it would assert this machine's readdir order.
+                "Gacela\\Console\\Domain\\PackageManifest\\ComposerPackageFinder::manifestPathsIn",
+                "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
                 "Gacela\\Framework\\Cache\\FileCache::commitBatch",
                 "Gacela\\Framework\\Cache\\FileCache::invalidateOpcacheFor",
                 "Gacela\\Framework\\Testing\\ContainerFixture::registerContainerTempDirsCleanup",
@@ -328,6 +354,9 @@
         // identically, so the path still points at the same directory.
         GreaterThan: {
             ignore: [
+                // Two distinct prefixes of equal length cannot both prefix one class name,
+                // so > and >= select the same longest match for every possible input.
+                "Gacela\\Console\\Domain\\PackageManifest\\NamespacePackageMap::packagesProviding",
                 "Gacela\\Framework\\Cache\\FileCache::stats",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Exception\\ErrorSuggestionHelper::findSimilar",
@@ -348,6 +377,14 @@
         },
         UnwrapArrayValues: {
             ignore: [
+                // The manifest reader collects into string-keyed accumulators to
+                // deduplicate (one file reached by two prefixes, one package claiming
+                // one prefix twice) and restores the list shape the return type
+                // declares. Every consumer foreaches the result, so the key shape is
+                // not observable.
+                "Gacela\\Console\\Application\\Doctor\\Check\\PackageManifestCheck::installedPackages",
+                "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::undeclaredImportsOf",
+                "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
                 "Gacela\\Console\\Domain\\ModuleGraph\\GraphDiffMarkdownFormatter::affectedModules",
                 // sourceFiles() keys nothing: array_values() only restores the
                 // list shape the return type declares after array_unique()
@@ -474,6 +511,9 @@
         // return as behaviour. These two are allocation guards, not behaviour.
         ReturnRemoval: {
             ignore: [
+                // The early return for a non-object `autoload` is a guard, not a branch:
+                // falling through leaves the accumulator empty and returns the same [].
+                "Gacela\\Console\\Domain\\PackageManifest\\ComposerPackage::prefixesOf",
                 // stop() opens with `if (!$this->enabled) { return; }`. Since
                 // disable() drops the in-flight spans and start() records
                 // nothing while disabled, a disabled profiler can never have an

--- a/src/Console/Application/Doctor/Check/PackageManifestCheck.php
+++ b/src/Console/Application/Doctor/Check/PackageManifestCheck.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\Domain\PackageManifest\ComposerPackageFinder;
+use Gacela\Console\Domain\PackageManifest\NamespacePackageMap;
+use Gacela\Console\Domain\PackageManifest\PackageManifestChecker;
+use Gacela\Console\Domain\PackageManifest\UndeclaredImport;
+
+use function count;
+use function is_array;
+use function sprintf;
+
+/**
+ * Reports a package importing a namespace its own manifest never declares.
+ *
+ * Inside a monorepo the root autoloader supplies everything, so a sub-package
+ * with an incomplete `require` works perfectly until the day somebody installs
+ * it alone.
+ */
+final class PackageManifestCheck implements HealthCheck
+{
+    private const string UNDECLARED_DETAIL = '%s imports %s, provided by %s, which its composer.json never mentions';
+
+    public function __construct(
+        private readonly string $appRootDir,
+        private readonly ComposerPackageFinder $packageFinder = new ComposerPackageFinder(),
+        private readonly PackageManifestChecker $checker = new PackageManifestChecker(),
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'package manifests';
+    }
+
+    public function run(): CheckResult
+    {
+        $packages = $this->packageFinder->findIn($this->appRootDir);
+
+        if ($packages === []) {
+            return CheckResult::ok($this->name(), 'no named composer package to check');
+        }
+
+        $installed = $this->installedPackages();
+
+        // Without installed.json an import cannot be attributed to a package,
+        // and guessing would name the wrong manifest to fix.
+        if ($installed === null) {
+            return CheckResult::ok($this->name(), 'no vendor/composer/installed.json — nothing to map imports against');
+        }
+
+        $findings = $this->checker->check($packages, NamespacePackageMap::from($packages, $installed));
+
+        if ($findings === []) {
+            return CheckResult::ok(
+                $this->name(),
+                sprintf('%d package(s) declare everything they import', count($packages)),
+            );
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            array_map(
+                static fn (UndeclaredImport $finding): string => sprintf(
+                    self::UNDECLARED_DETAIL,
+                    $finding->package,
+                    $finding->import,
+                    $finding->providedBy,
+                ),
+                $findings,
+            ),
+            'add it to `require`, or to `suggest` when the dependency is optional by design',
+        );
+    }
+
+    /**
+     * @return list<mixed>|null
+     */
+    private function installedPackages(): ?array
+    {
+        $path = $this->appRootDir . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json';
+
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($contents, true);
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var mixed $packages */
+        $packages = $decoded['packages'] ?? $decoded;
+
+        return is_array($packages) ? array_values($packages) : null;
+    }
+}

--- a/src/Console/Domain/PackageManifest/ComposerPackage.php
+++ b/src/Console/Domain/PackageManifest/ComposerPackage.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\PackageManifest;
+
+use function array_keys;
+use function in_array;
+use function is_array;
+use function is_string;
+
+/**
+ * One `composer.json` the repository owns, reduced to what the check reads.
+ *
+ * `suggest` sits beside `require` here rather than being ignored, because the
+ * two together are what a package promises: `require` is "you get this",
+ * `suggest` is "install it yourself if you want that part". An import covered
+ * by either is declared.
+ */
+final class ComposerPackage
+{
+    /**
+     * @param array<string, string> $autoloadPrefixes psr-4/psr-0 prefix => relative directory
+     * @param list<string> $required package names in `require`
+     * @param list<string> $requiredForDev package names in `require-dev`
+     * @param list<string> $suggested package names in `suggest`
+     */
+    private function __construct(
+        public readonly string $name,
+        public readonly string $manifestPath,
+        public readonly string $rootDir,
+        public readonly array $autoloadPrefixes,
+        public readonly array $required,
+        public readonly array $requiredForDev,
+        public readonly array $suggested,
+    ) {
+    }
+
+    /**
+     * @param array<array-key, mixed> $decoded
+     */
+    public static function fromDecodedJson(array $decoded, string $manifestPath, string $rootDir): ?self
+    {
+        $name = $decoded['name'] ?? null;
+
+        // A manifest without a name cannot be published, so it has no standalone
+        // install to break -- there is nothing for this check to be about.
+        if (!is_string($name) || $name === '') {
+            return null;
+        }
+
+        return new self(
+            name: $name,
+            manifestPath: $manifestPath,
+            rootDir: $rootDir,
+            autoloadPrefixes: self::prefixesOf($decoded['autoload'] ?? null),
+            required: self::keysOf($decoded['require'] ?? null),
+            requiredForDev: self::keysOf($decoded['require-dev'] ?? null),
+            suggested: self::keysOf($decoded['suggest'] ?? null),
+        );
+    }
+
+    /**
+     * Whether the manifest accounts for the given package at all.
+     *
+     * Every section counts, `require-dev` included. That is deliberately weaker
+     * than "would a consumer receive it", and it is the strongest claim this
+     * check can make honestly: a package distributed as a phar declares no
+     * autoload prefix -- phpstan/phpstan is the example in this repository --
+     * so its classes get attributed to whichever sibling happens to publish the
+     * namespace. Demanding a *specific* section would then tell a reader to add
+     * a requirement on the wrong package.
+     *
+     * Total absence is unambiguous, and it is the failure this check exists
+     * for: an import mentioned in no section is the one that fatals the day the
+     * package is installed on its own.
+     */
+    public function declares(string $packageName): bool
+    {
+        return in_array($packageName, $this->required, true)
+            || in_array($packageName, $this->requiredForDev, true)
+            || in_array($packageName, $this->suggested, true);
+    }
+
+    /**
+     * `autoload-dev` is deliberately absent: it is not installed for a consumer,
+     * so an import reachable only from it cannot break a standalone install.
+     *
+     * @return array<string, string>
+     */
+    private static function prefixesOf(mixed $autoload): array
+    {
+        if (!is_array($autoload)) {
+            return [];
+        }
+
+        $prefixes = [];
+
+        foreach (['psr-4', 'psr-0'] as $standard) {
+            $section = $autoload[$standard] ?? null;
+            if (!is_array($section)) {
+                continue;
+            }
+
+            /** @var mixed $directory */
+            foreach ($section as $prefix => $directory) {
+                if (is_string($prefix) && $prefix !== '') {
+                    // A prefix may map to several directories; only the prefix
+                    // matters here, so the first spelling of it is enough.
+                    $prefixes[$prefix] ??= is_string($directory) ? $directory : '';
+                }
+            }
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function keysOf(mixed $section): array
+    {
+        if (!is_array($section)) {
+            return [];
+        }
+
+        $names = [];
+
+        foreach (array_keys($section) as $name) {
+            if (is_string($name)) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+}

--- a/src/Console/Domain/PackageManifest/ComposerPackageFinder.php
+++ b/src/Console/Domain/PackageManifest/ComposerPackageFinder.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\PackageManifest;
+
+use FilesystemIterator;
+use Gacela\Console\Domain\AllAppModules\ExcludedDirectories;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function dirname;
+use function is_array;
+
+/**
+ * Every `composer.json` the repository owns.
+ *
+ * `vendor` is pruned by the same ExcludedDirectories the module scan uses:
+ * an installed package's manifest describes a decision somebody else already
+ * made, and reporting on it would be noise nobody here can act on.
+ */
+final class ComposerPackageFinder
+{
+    public function __construct(
+        private readonly ExcludedDirectories $excludedDirectories = new ExcludedDirectories(),
+    ) {
+    }
+
+    /**
+     * @return list<ComposerPackage>
+     */
+    public function findIn(string $rootDir): array
+    {
+        $packages = [];
+
+        foreach ($this->manifestPathsIn($rootDir) as $manifestPath) {
+            $decoded = $this->decode($manifestPath);
+
+            if ($decoded === null) {
+                continue;
+            }
+
+            $package = ComposerPackage::fromDecodedJson($decoded, $manifestPath, dirname($manifestPath));
+
+            if ($package instanceof ComposerPackage) {
+                $packages[] = $package;
+            }
+        }
+
+        return $packages;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function manifestPathsIn(string $rootDir): array
+    {
+        if (!is_dir($rootDir)) {
+            return [];
+        }
+
+        $excluded = $this->excludedDirectories;
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($rootDir, FilesystemIterator::SKIP_DOTS),
+                static fn (SplFileInfo|string $current, string $key, RecursiveDirectoryIterator $inner): bool => !$inner->hasChildren() || !$excluded->isExcluded($inner->getFilename()),
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        $paths = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getFilename() === 'composer.json') {
+                $paths[] = $file->getPathname();
+            }
+        }
+
+        sort($paths);
+
+        return $paths;
+    }
+
+    /**
+     * @return array<array-key, mixed>|null
+     */
+    private function decode(string $manifestPath): ?array
+    {
+        $contents = file_get_contents($manifestPath);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($contents, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/src/Console/Domain/PackageManifest/NamespacePackageMap.php
+++ b/src/Console/Domain/PackageManifest/NamespacePackageMap.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\PackageManifest;
+
+use function is_array;
+use function str_starts_with;
+use function strlen;
+
+/**
+ * Which package provides a namespace.
+ *
+ * Built from `vendor/composer/installed.json` plus the repository's own
+ * manifests, and read without executing an autoloader: the question is what a
+ * manifest *promises*, and loading a class only proves what happens to be on
+ * this machine's include path today.
+ *
+ * Longest prefix wins, which is composer's own rule and the one that matters
+ * here: a monorepo publishes `Gacela\` and `Gacela\LaravelBridge\` as separate
+ * packages, so an import resolved by the shorter prefix would name the wrong
+ * package and send a reader to fix the wrong manifest.
+ */
+final class NamespacePackageMap
+{
+    /**
+     * @param array<string, list<string>> $prefixToPackages
+     */
+    private function __construct(
+        private readonly array $prefixToPackages,
+    ) {
+    }
+
+    /**
+     * @param list<ComposerPackage> $localPackages
+     * @param list<mixed> $installedPackages the `packages` array of installed.json
+     */
+    public static function from(array $localPackages, array $installedPackages): self
+    {
+        $packages = $localPackages;
+
+        // Installed entries are read through ComposerPackage rather than parsed
+        // again here: what counts as an autoload prefix is one decision, and
+        // two readers of it drift into disagreeing about which package provides
+        // a namespace.
+        foreach ($installedPackages as $installed) {
+            if (!is_array($installed)) {
+                continue;
+            }
+
+            $package = ComposerPackage::fromDecodedJson($installed, '', '');
+
+            if ($package instanceof ComposerPackage) {
+                $packages[] = $package;
+            }
+        }
+
+        $map = [];
+
+        foreach ($packages as $package) {
+            foreach ($package->autoloadPrefixes as $prefix => $_directory) {
+                // Every claimant is kept, not the first: Laravel publishes
+                // `Illuminate\Support\` from both illuminate/support and
+                // illuminate/collections, and picking one arbitrarily reports a
+                // package as missing that the manifest already has.
+                $map[$prefix][$package->name] = $package->name;
+            }
+        }
+
+        $claims = [];
+
+        foreach ($map as $prefix => $claimants) {
+            $claims[$prefix] = array_values($claimants);
+        }
+
+        return new self($claims);
+    }
+
+    /**
+     * Every package that could provide this class name: the ones sharing the
+     * longest prefix that matches it.
+     *
+     * @return list<string>
+     */
+    public function packagesProviding(string $className): array
+    {
+        $bestPrefix = '';
+        $best = [];
+
+        foreach ($this->prefixToPackages as $prefix => $packages) {
+            if (!str_starts_with($className, $prefix)) {
+                continue;
+            }
+
+            if (strlen($prefix) > strlen($bestPrefix)) {
+                $bestPrefix = $prefix;
+                $best = $packages;
+            }
+        }
+
+        sort($best);
+
+        return $best;
+    }
+
+}

--- a/src/Console/Domain/PackageManifest/PackageManifestChecker.php
+++ b/src/Console/Domain/PackageManifest/PackageManifestChecker.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\PackageManifest;
+
+use FilesystemIterator;
+use Gacela\Console\Domain\ModuleGraph\PhpImportParser;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function in_array;
+use function strlen;
+
+/**
+ * Finds imports a package's own manifest does not account for.
+ *
+ * A module directory that ships as its own package can import a namespace its
+ * `composer.json` never mentions. Inside the monorepo the root autoloader
+ * supplies it and nothing fails; installed on its own, it fatals. That is a bug
+ * this repository shipped once already, and no tool here would have caught it.
+ *
+ * Only this direction is checked. The reverse -- a requirement nothing imports
+ * -- is frequently correct: a package requires a concrete implementation so
+ * that the container can resolve it at runtime, and never names the class.
+ * Telling those two apart needs a reviewed exception per entry, which is a
+ * second declaration surface for a weaker finding.
+ */
+final class PackageManifestChecker
+{
+    public function __construct(
+        private readonly PhpImportParser $importParser = new PhpImportParser(),
+    ) {
+    }
+
+    /**
+     * @param list<ComposerPackage> $packages
+     *
+     * @return list<UndeclaredImport>
+     */
+    public function check(array $packages, NamespacePackageMap $packageMap): array
+    {
+        $findings = [];
+
+        foreach ($packages as $package) {
+            foreach ($this->undeclaredImportsOf($package, $packageMap, $packages) as $finding) {
+                $findings[] = $finding;
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param list<ComposerPackage> $allPackages
+     *
+     * @return list<UndeclaredImport>
+     */
+    private function undeclaredImportsOf(ComposerPackage $package, NamespacePackageMap $packageMap, array $allPackages): array
+    {
+        // Keyed by the missing package, so the first import that needs it is
+        // the one reported: a reader fixes it once, and fifty lines naming one
+        // requirement bury the other packages that are also missing.
+        $findings = [];
+
+        foreach ($this->autoloadedFilesOf($package, $allPackages) as $file) {
+            $source = file_get_contents($file);
+
+            if ($source === false) {
+                continue;
+            }
+
+            foreach ($this->importParser->importsIn($source) as $import) {
+                $candidates = $packageMap->packagesProviding($import);
+                // Nothing claims the namespace: a global class, or one this
+                // repository does not manage. Either way there is no package to
+                // name in a requirement.
+                if ($candidates === []) {
+                    continue;
+                }
+
+                if (in_array($package->name, $candidates, true)) {
+                    continue;
+                }
+
+                // Declaring any one claimant is enough. Where several packages
+                // publish one prefix, the manifest naming any of them is what
+                // makes the class arrive.
+                foreach ($candidates as $candidate) {
+                    if ($package->declares($candidate)) {
+                        continue 2;
+                    }
+                }
+
+                $providedBy = implode(' or ', $candidates);
+
+                $findings[$providedBy] ??= new UndeclaredImport($package->name, $file, $import, $providedBy);
+            }
+        }
+
+        return array_values($findings);
+    }
+
+    /**
+     * The php files a consumer actually receives: the ones under the autoload
+     * prefixes this package owns.
+     *
+     * A monorepo root commonly autoloads its sub-packages as well, so that one
+     * `composer install` serves development. Where two manifests declare the
+     * same prefix, the deeper one owns it -- otherwise the root is held to the
+     * imports of every package beneath it, and the requirement it asks for
+     * belongs in a different manifest.
+     *
+     * @param list<ComposerPackage> $allPackages
+     *
+     * @return list<string>
+     */
+    private function autoloadedFilesOf(ComposerPackage $package, array $allPackages): array
+    {
+        $files = [];
+
+        foreach ($package->autoloadPrefixes as $prefix => $directory) {
+            if (!$this->ownsPrefix($package, $prefix, $allPackages)) {
+                continue;
+            }
+
+            $absolute = $package->rootDir . DIRECTORY_SEPARATOR . trim($directory, '/\\');
+
+            if (!is_dir($absolute)) {
+                continue;
+            }
+
+            foreach ($this->phpFilesIn($absolute) as $file) {
+                // Keyed by path so two prefixes pointing at one directory yield
+                // the file once, and holding the path as the value too keeps it
+                // the thing being collected rather than a membership flag.
+                $files[$file] = $file;
+            }
+        }
+
+        $paths = array_values($files);
+        sort($paths);
+
+        return $paths;
+    }
+
+    /**
+     * @param list<ComposerPackage> $allPackages
+     */
+    private function ownsPrefix(ComposerPackage $package, string $prefix, array $allPackages): bool
+    {
+        foreach ($allPackages as $other) {
+            if ($other->name === $package->name) {
+                continue;
+            }
+
+            if (!isset($other->autoloadPrefixes[$prefix])) {
+                continue;
+            }
+
+            // Deeper root wins: the sub-package is the one whose manifest a
+            // reader has to fix, and it is the one published on its own.
+            if (strlen($other->rootDir) > strlen($package->rootDir)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function phpFilesIn(string $directory): array
+    {
+        $files = [];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/Console/Domain/PackageManifest/UndeclaredImport.php
+++ b/src/Console/Domain/PackageManifest/UndeclaredImport.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\PackageManifest;
+
+/**
+ * One import a package's manifest does not account for.
+ */
+final class UndeclaredImport
+{
+    public function __construct(
+        public readonly string $package,
+        public readonly string $file,
+        public readonly string $import,
+        public readonly string $providedBy,
+    ) {
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -9,6 +9,7 @@ use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\IdeMetadataStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
+use Gacela\Console\Application\Doctor\Check\PackageManifestCheck;
 use Gacela\Console\Application\Doctor\Check\ServiceExtensionTargetCheck;
 use Gacela\Console\Application\Doctor\Check\StubHealthCheck;
 use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
@@ -112,6 +113,7 @@ final class DoctorCommand extends Command
             // the whole application, so comparing it against the modules a
             // namespace filter left behind would report every scoped run as
             // stale.
+            new PackageManifestCheck($config->getAppRootDir()),
             new IdeMetadataStalenessCheck(
                 $config->getAppRootDir(),
                 fn (): IdeMetadataResult => $this->getFacade()->generateIdeMetadata(dryRun: true),

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -75,6 +75,7 @@ final class DoctorCommandTest extends TestCase
             '✓ config schema',
             '✓ published stubs',
             '✓ service extensions',
+            '✓ package manifests',
             '✓ IDE metadata',
             '✓ All checks passed',
         ], $this->statusLinesOf($tester));
@@ -127,7 +128,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
         // The registered check runs after the built-in ones, and its detail is shown.
-        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[7]);
+        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[8]);
         self::assertStringContainsString('FakeHealthCheck ran', $tester->getDisplay());
     }
 

--- a/tests/Unit/Console/Application/Doctor/Check/PackageManifestCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/PackageManifestCheckTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\PackageManifestCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use PHPUnit\Framework\TestCase;
+
+use stdClass;
+
+use function bin2hex;
+use function dirname;
+use function is_dir;
+use function is_string;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class PackageManifestCheckTest extends TestCase
+{
+    private string $repoDir = '';
+
+    /** @var list<string> */
+    private array $createdFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->repoDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-manifest-check-' . bin2hex(random_bytes(4));
+        mkdir($this->repoDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->createdFiles) as $file) {
+            self::assertStringStartsWith($this->repoDir . DIRECTORY_SEPARATOR, $file);
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->removeEmptyTree($this->repoDir);
+    }
+
+    public function test_a_project_with_no_named_package_passes(): void
+    {
+        $result = (new PackageManifestCheck($this->repoDir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertStringContainsString('no named composer package', $result->details[0]);
+    }
+
+    /**
+     * Without installed.json an import cannot be attributed to a package, and
+     * guessing would name the wrong manifest to fix.
+     */
+    public function test_without_installed_json_the_check_says_so_rather_than_guessing(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root', ['psr-4' => ['Acme\\' => 'src']]);
+
+        $result = (new PackageManifestCheck($this->repoDir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertStringContainsString('installed.json', $result->details[0]);
+    }
+
+    public function test_a_package_declaring_everything_it_imports_passes(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root', ['psr-4' => ['Acme\\' => 'src']], ['acme/framework' => '^1.0']);
+        $this->writeClass('src/Thing.php', 'Acme', ['Acme\Framework\Kernel']);
+        $this->writeInstalled();
+
+        $result = (new PackageManifestCheck($this->repoDir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertStringContainsString('1 package(s)', $result->details[0]);
+    }
+
+    public function test_an_undeclared_import_warns_and_names_both_sides(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root', ['psr-4' => ['Acme\\' => 'src']]);
+        $this->writeClass('src/Thing.php', 'Acme', ['Acme\Framework\Kernel']);
+        $this->writeInstalled();
+
+        $result = (new PackageManifestCheck($this->repoDir))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('acme/root', $result->details[0]);
+        self::assertStringContainsString('Acme\Framework\Kernel', $result->details[0]);
+        self::assertStringContainsString('acme/framework', $result->details[0]);
+        self::assertStringContainsString('suggest', $result->remediation);
+    }
+
+    private function writeInstalled(): void
+    {
+        $this->write('vendor/composer/installed.json', (string)json_encode([
+            'packages' => [
+                ['name' => 'acme/framework', 'autoload' => ['psr-4' => ['Acme\Framework\\' => 'src']]],
+            ],
+        ]));
+    }
+
+    /**
+     * @param array<string, array<string, string>> $autoload
+     * @param array<string, string> $require
+     */
+    private function writeManifest(string $relativePath, string $name, array $autoload = [], array $require = []): void
+    {
+        $this->write($relativePath, (string)json_encode([
+            'name' => $name,
+            'autoload' => $autoload === [] ? new stdClass() : $autoload,
+            'require' => $require === [] ? new stdClass() : $require,
+        ]));
+    }
+
+    /**
+     * @param list<string> $imports
+     */
+    private function writeClass(string $relativePath, string $namespace, array $imports): void
+    {
+        $useLines = implode("\n", array_map(static fn (string $i): string => 'use ' . $i . ';', $imports));
+
+        $this->write($relativePath, "<?php\n\nnamespace {$namespace};\n\n{$useLines}\n\nfinal class Generated {}\n");
+    }
+
+    private function write(string $relativePath, string $contents): void
+    {
+        $absolute = $this->repoDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+
+        if (!is_dir(dirname($absolute))) {
+            mkdir(dirname($absolute), 0777, true);
+        }
+
+        file_put_contents($absolute, $contents);
+        $this->createdFiles[] = $absolute;
+    }
+
+    private function removeEmptyTree(string $directory): void
+    {
+        self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $directory);
+
+        foreach ((array)glob($directory . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR) as $child) {
+            if (is_string($child)) {
+                $this->removeEmptyTree($child);
+            }
+        }
+
+        if (is_dir($directory)) {
+            rmdir($directory);
+        }
+    }
+}

--- a/tests/Unit/Console/Domain/PackageManifest/ComposerPackageFinderTest.php
+++ b/tests/Unit/Console/Domain/PackageManifest/ComposerPackageFinderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\PackageManifest;
+
+use Gacela\Console\Domain\PackageManifest\ComposerPackage;
+use Gacela\Console\Domain\PackageManifest\ComposerPackageFinder;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function bin2hex;
+use function dirname;
+use function is_dir;
+use function is_string;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class ComposerPackageFinderTest extends TestCase
+{
+    private string $repoDir = '';
+
+    /** @var list<string> */
+    private array $createdFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->repoDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-finder-' . bin2hex(random_bytes(4));
+        mkdir($this->repoDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->createdFiles) as $file) {
+            self::assertStringStartsWith($this->repoDir . DIRECTORY_SEPARATOR, $file);
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->removeEmptyTree($this->repoDir);
+    }
+
+    public function test_a_directory_that_does_not_exist_yields_nothing(): void
+    {
+        self::assertSame([], (new ComposerPackageFinder())->findIn($this->repoDir . '-missing'));
+    }
+
+    public function test_it_finds_the_root_and_every_nested_manifest(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root');
+        $this->writeManifest('bridge/composer.json', 'acme/bridge');
+
+        self::assertSame(['acme/bridge', 'acme/root'], $this->names());
+    }
+
+    /**
+     * An installed package's manifest describes a decision somebody else made,
+     * and reporting on it would be noise nobody here can act on.
+     */
+    public function test_it_skips_vendor(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root');
+        $this->writeManifest('vendor/other/pkg/composer.json', 'other/pkg');
+
+        self::assertSame(['acme/root'], $this->names());
+    }
+
+    public function test_a_manifest_without_a_name_is_skipped(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root');
+        $this->write('tooling/composer.json', '{"require": {"acme/thing": "^1.0"}}');
+
+        self::assertSame(['acme/root'], $this->names());
+    }
+
+    public function test_a_manifest_that_is_not_valid_json_is_skipped(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root');
+        $this->write('broken/composer.json', '{not json');
+
+        self::assertSame(['acme/root'], $this->names());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function names(): array
+    {
+        return array_map(
+            static fn (ComposerPackage $package): string => $package->name,
+            (new ComposerPackageFinder())->findIn($this->repoDir),
+        );
+    }
+
+    private function writeManifest(string $relativePath, string $name): void
+    {
+        $this->write($relativePath, (string)json_encode(['name' => $name]));
+    }
+
+    private function write(string $relativePath, string $contents): void
+    {
+        $absolute = $this->repoDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+
+        if (!is_dir(dirname($absolute))) {
+            mkdir(dirname($absolute), 0777, true);
+        }
+
+        file_put_contents($absolute, $contents);
+        $this->createdFiles[] = $absolute;
+    }
+
+    private function removeEmptyTree(string $directory): void
+    {
+        self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $directory);
+
+        foreach ((array)glob($directory . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR) as $child) {
+            if (is_string($child)) {
+                $this->removeEmptyTree($child);
+            }
+        }
+
+        if (is_dir($directory)) {
+            rmdir($directory);
+        }
+    }
+}

--- a/tests/Unit/Console/Domain/PackageManifest/ComposerPackageTest.php
+++ b/tests/Unit/Console/Domain/PackageManifest/ComposerPackageTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\PackageManifest;
+
+use Gacela\Console\Domain\PackageManifest\ComposerPackage;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ComposerPackageTest extends TestCase
+{
+    /**
+     * A manifest without a publishable name has no standalone install to break,
+     * so there is nothing for the check to be about.
+     *
+     * @param array<array-key, mixed> $decoded
+     */
+    #[DataProvider('unpublishableManifestProvider')]
+    public function test_a_manifest_that_cannot_be_published_is_skipped(array $decoded): void
+    {
+        self::assertNull(ComposerPackage::fromDecodedJson($decoded, '/repo/composer.json', '/repo'));
+    }
+
+    /**
+     * @return iterable<string, array{array<array-key, mixed>}>
+     */
+    public static function unpublishableManifestProvider(): iterable
+    {
+        yield 'no name' => [['require' => ['acme/thing' => '^1.0']]];
+        yield 'empty name' => [['name' => '']];
+        yield 'name is not a string' => [['name' => 42]];
+    }
+
+    public function test_it_reads_the_name_and_where_it_lives(): void
+    {
+        $package = $this->package(['name' => 'acme/thing']);
+
+        self::assertSame('acme/thing', $package->name);
+        self::assertSame('/repo/composer.json', $package->manifestPath);
+        self::assertSame('/repo', $package->rootDir);
+    }
+
+    #[DataProvider('declaringSectionProvider')]
+    public function test_a_package_named_in_any_section_counts_as_declared(string $section): void
+    {
+        $package = $this->package(['name' => 'acme/thing', $section => ['acme/other' => '^1.0']]);
+
+        self::assertTrue($package->declares('acme/other'));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function declaringSectionProvider(): iterable
+    {
+        yield 'require' => ['require'];
+        yield 'require-dev' => ['require-dev'];
+        yield 'suggest' => ['suggest'];
+    }
+
+    public function test_a_package_named_nowhere_is_not_declared(): void
+    {
+        $package = $this->package(['name' => 'acme/thing', 'require' => ['acme/other' => '^1.0']]);
+
+        self::assertFalse($package->declares('acme/missing'));
+    }
+
+    public function test_the_sections_are_read_separately(): void
+    {
+        $package = $this->package([
+            'name' => 'acme/thing',
+            'require' => ['acme/runtime' => '^1.0'],
+            'require-dev' => ['acme/dev' => '^1.0'],
+            'suggest' => ['acme/optional' => 'why'],
+        ]);
+
+        self::assertSame(['acme/runtime'], $package->required);
+        self::assertSame(['acme/dev'], $package->requiredForDev);
+        self::assertSame(['acme/optional'], $package->suggested);
+    }
+
+    public function test_autoload_prefixes_come_from_psr_4_and_psr_0(): void
+    {
+        $package = $this->package([
+            'name' => 'acme/thing',
+            'autoload' => ['psr-4' => ['Acme\\' => 'src'], 'psr-0' => ['Acme_' => 'lib']],
+        ]);
+
+        self::assertSame(['Acme\\' => 'src', 'Acme_' => 'lib'], $package->autoloadPrefixes);
+    }
+
+    /**
+     * `autoload-dev` is not installed for a consumer, so an import reachable
+     * only from it cannot break a standalone install.
+     */
+    public function test_autoload_dev_is_not_a_prefix_of_the_package(): void
+    {
+        $package = $this->package([
+            'name' => 'acme/thing',
+            'autoload' => ['psr-4' => ['Acme\\' => 'src']],
+            'autoload-dev' => ['psr-4' => ['AcmeTest\\' => 'tests']],
+        ]);
+
+        self::assertSame(['Acme\\' => 'src'], $package->autoloadPrefixes);
+    }
+
+    public function test_a_prefix_mapped_to_several_directories_keeps_the_first(): void
+    {
+        $package = $this->package([
+            'name' => 'acme/thing',
+            'autoload' => ['psr-4' => ['Acme\\' => 'src'], 'psr-0' => ['Acme\\' => 'legacy']],
+        ]);
+
+        self::assertSame(['Acme\\' => 'src'], $package->autoloadPrefixes);
+    }
+
+    public function test_an_autoload_section_that_is_not_an_object_yields_no_prefixes(): void
+    {
+        $package = $this->package(['name' => 'acme/thing', 'autoload' => 'nonsense']);
+
+        self::assertSame([], $package->autoloadPrefixes);
+    }
+
+    public function test_a_standard_inside_autoload_that_is_not_an_object_is_skipped(): void
+    {
+        $package = $this->package([
+            'name' => 'acme/thing',
+            'autoload' => ['psr-4' => 'nonsense', 'psr-0' => ['Acme_' => 'lib']],
+        ]);
+
+        self::assertSame(['Acme_' => 'lib'], $package->autoloadPrefixes);
+    }
+
+    /**
+     * An empty prefix means "every namespace", and a numeric key is not a
+     * namespace at all; neither names something a package provides.
+     */
+    public function test_a_prefix_that_is_empty_or_not_a_string_is_skipped(): void
+    {
+        $package = $this->package([
+            'name' => 'acme/thing',
+            'autoload' => ['psr-4' => ['' => 'src', 0 => 'lib', 'Acme\\' => 'app']],
+        ]);
+
+        self::assertSame(['Acme\\' => 'app'], $package->autoloadPrefixes);
+    }
+
+    public function test_a_manifest_declaring_nothing_reads_as_empty(): void
+    {
+        $package = $this->package(['name' => 'acme/thing']);
+
+        self::assertSame([], $package->autoloadPrefixes);
+        self::assertSame([], $package->required);
+        self::assertSame([], $package->requiredForDev);
+        self::assertSame([], $package->suggested);
+    }
+
+    /**
+     * @param array<array-key, mixed> $decoded
+     */
+    private function package(array $decoded): ComposerPackage
+    {
+        $package = ComposerPackage::fromDecodedJson($decoded, '/repo/composer.json', '/repo');
+        self::assertInstanceOf(ComposerPackage::class, $package);
+
+        return $package;
+    }
+}

--- a/tests/Unit/Console/Domain/PackageManifest/NamespacePackageMapTest.php
+++ b/tests/Unit/Console/Domain/PackageManifest/NamespacePackageMapTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\PackageManifest;
+
+use Gacela\Console\Domain\PackageManifest\ComposerPackage;
+use Gacela\Console\Domain\PackageManifest\NamespacePackageMap;
+use PHPUnit\Framework\TestCase;
+
+final class NamespacePackageMapTest extends TestCase
+{
+    public function test_a_namespace_nothing_claims_has_no_provider(): void
+    {
+        $map = NamespacePackageMap::from([], []);
+
+        self::assertSame([], $map->packagesProviding('Nobody\Owns\This'));
+    }
+
+    public function test_an_installed_package_provides_its_own_prefix(): void
+    {
+        $map = NamespacePackageMap::from([], [
+            $this->installed('psr/container', ['Psr\Container\\']),
+        ]);
+
+        self::assertSame(['psr/container'], $map->packagesProviding(\Psr\Container\ContainerInterface::class));
+    }
+
+    /**
+     * A monorepo publishes `Gacela\` and `Gacela\LaravelBridge\` as separate
+     * packages. Resolving by the shorter prefix would name the wrong package and
+     * send a reader to fix the wrong manifest.
+     */
+    public function test_the_longest_matching_prefix_wins(): void
+    {
+        $map = NamespacePackageMap::from([], [
+            $this->installed('acme/framework', ['Acme\\']),
+            $this->installed('acme/bridge', ['Acme\Bridge\\']),
+        ]);
+
+        self::assertSame(['acme/bridge'], $map->packagesProviding('Acme\Bridge\Thing'));
+        self::assertSame(['acme/framework'], $map->packagesProviding('Acme\Framework\Thing'));
+    }
+
+    /**
+     * Laravel publishes `Illuminate\Support\` from two packages. Picking one
+     * arbitrarily reports a requirement as missing that the manifest already
+     * has, so every claimant is kept.
+     */
+    public function test_a_prefix_two_packages_claim_reports_both(): void
+    {
+        $map = NamespacePackageMap::from([], [
+            $this->installed('illuminate/support', ['Illuminate\Support\\']),
+            $this->installed('illuminate/collections', ['Illuminate\Support\\']),
+        ]);
+
+        self::assertSame(
+            ['illuminate/collections', 'illuminate/support'],
+            $map->packagesProviding(\Illuminate\Support\ServiceProvider::class),
+        );
+    }
+
+    public function test_one_package_claiming_a_prefix_twice_is_listed_once(): void
+    {
+        $map = NamespacePackageMap::from([], [
+            ['name' => 'acme/thing', 'autoload' => ['psr-4' => ['Acme\\' => 'src'], 'psr-0' => ['Acme\\' => 'legacy']]],
+        ]);
+
+        self::assertSame(['acme/thing'], $map->packagesProviding('Acme\Thing'));
+    }
+
+    public function test_psr_0_prefixes_are_read_too(): void
+    {
+        $map = NamespacePackageMap::from([], [
+            ['name' => 'acme/legacy', 'autoload' => ['psr-0' => ['Acme_' => 'lib']]],
+        ]);
+
+        self::assertSame(['acme/legacy'], $map->packagesProviding('Acme_Old_Thing'));
+    }
+
+    public function test_a_local_package_provides_its_prefix(): void
+    {
+        $package = ComposerPackage::fromDecodedJson(
+            ['name' => 'acme/local', 'autoload' => ['psr-4' => ['Acme\Local\\' => 'src']]],
+            '/repo/composer.json',
+            '/repo',
+        );
+        self::assertInstanceOf(ComposerPackage::class, $package);
+
+        $map = NamespacePackageMap::from([$package], []);
+
+        self::assertSame(['acme/local'], $map->packagesProviding('Acme\Local\Thing'));
+    }
+
+    public function test_an_entry_without_a_name_is_ignored(): void
+    {
+        // The malformed entries come first, so that skipping them is not the
+        // same as stopping at them: the readable entry after has to be found.
+        $map = NamespacePackageMap::from([], [
+            'not an object',
+            ['autoload' => ['psr-4' => ['Nameless\\' => 'src']]],
+            $this->installed('acme/readable', ['Acme\\']),
+        ]);
+
+        self::assertSame([], $map->packagesProviding('Nameless\Thing'));
+        self::assertSame(['acme/readable'], $map->packagesProviding('Acme\Thing'));
+    }
+
+    public function test_an_entry_without_autoload_claims_nothing(): void
+    {
+        $map = NamespacePackageMap::from([], [
+            ['name' => 'phpstan/phpstan'],
+        ]);
+
+        self::assertSame([], $map->packagesProviding(\PHPStan\Analyser\Scope::class));
+    }
+
+    /**
+     * @param list<string> $prefixes
+     *
+     * @return array<string, mixed>
+     */
+    private function installed(string $name, array $prefixes): array
+    {
+        $psr4 = [];
+
+        foreach ($prefixes as $prefix) {
+            $psr4[$prefix] = 'src';
+        }
+
+        return ['name' => $name, 'autoload' => ['psr-4' => $psr4]];
+    }
+}

--- a/tests/Unit/Console/Domain/PackageManifest/PackageManifestCheckerTest.php
+++ b/tests/Unit/Console/Domain/PackageManifest/PackageManifestCheckerTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\PackageManifest;
+
+use Gacela\Console\Domain\PackageManifest\ComposerPackageFinder;
+use Gacela\Console\Domain\PackageManifest\NamespacePackageMap;
+use Gacela\Console\Domain\PackageManifest\PackageManifestChecker;
+use Gacela\Console\Domain\PackageManifest\UndeclaredImport;
+use PHPUnit\Framework\TestCase;
+
+use stdClass;
+
+use function array_map;
+use function bin2hex;
+use function dirname;
+use function is_dir;
+use function is_string;
+use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+/**
+ * The fixture repository is built under a temp directory rather than committed.
+ *
+ * ComposerPackageFinder finds every `composer.json` outside `vendor`, so a
+ * fixture manifest living under `tests/` would be picked up by this
+ * repository's own `doctor` run and reported as a real package.
+ */
+final class PackageManifestCheckerTest extends TestCase
+{
+    private string $repoDir = '';
+
+    /** @var list<string> */
+    private array $createdFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->repoDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-manifests-' . bin2hex(random_bytes(4));
+        mkdir($this->repoDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Only the files this test wrote, each asserted to sit under the temp
+        // directory this test created.
+        foreach (array_reverse($this->createdFiles) as $file) {
+            self::assertStringStartsWith($this->repoDir . DIRECTORY_SEPARATOR, $file);
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->removeEmptyTree($this->repoDir);
+    }
+
+    /**
+     * The bug this check exists for, reproduced: a sub-package importing the
+     * framework while declaring only the container. Inside the monorepo the
+     * root autoloader supplies it; installed alone it fatals.
+     */
+    public function test_an_import_the_manifest_never_mentions_is_reported(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', ['acme/container' => '^1.0'], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('acme/bridge', $findings[0]->package);
+        self::assertSame('Acme\Framework\Kernel', $findings[0]->import);
+        self::assertSame('acme/framework', $findings[0]->providedBy);
+    }
+
+    public function test_an_import_the_manifest_requires_is_not_reported(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', ['acme/framework' => '^1.0'], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        self::assertSame([], $this->check());
+    }
+
+    /**
+     * Every section counts, because a package shipped as a phar declares no
+     * autoload prefix and its classes get attributed to whichever sibling
+     * publishes the namespace -- so demanding a particular section would name
+     * the wrong package to add.
+     */
+    public function test_a_mention_in_require_dev_or_suggest_is_enough(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\', ['acme/framework' => '^1.0']);
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        self::assertSame([], $this->check());
+    }
+
+    public function test_a_package_importing_its_own_namespace_is_not_reported(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Bridge\Other']);
+
+        self::assertSame([], $this->check());
+    }
+
+    /**
+     * A monorepo root commonly autoloads its sub-packages so one install serves
+     * development. Holding the root to their imports would name a requirement
+     * in the wrong manifest.
+     */
+    public function test_a_nested_packages_files_are_not_charged_to_the_root(): void
+    {
+        // The shape a monorepo actually has: the root autoloads the sub-package
+        // too, so that one `composer install` serves development.
+        $this->writeManifest('composer.json', 'acme/root', [], [
+            'Acme\\' => 'src',
+            'Acme\Bridge\\' => 'bridge/src',
+        ]);
+        $this->writeClass('src/RootThing.php', 'Acme', []);
+        $this->writePackage('bridge', 'acme/bridge', ['acme/framework' => '^1.0'], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        // Both manifests declare `Acme\Bridge\`; the bridge owns it, and it
+        // already declares what those files import.
+        self::assertSame([], $this->check());
+    }
+
+    /**
+     * The same overlap, with the sub-package's manifest incomplete: the finding
+     * has to name the sub-package, because that is the manifest to fix and the
+     * one that gets published on its own.
+     */
+    public function test_an_overlapping_prefix_reports_the_deeper_package(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root', ['acme/framework' => '^1.0'], [
+            'Acme\\' => 'src',
+            'Acme\Bridge\\' => 'bridge/src',
+        ]);
+        $this->writeClass('src/RootThing.php', 'Acme', []);
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('acme/bridge', $findings[0]->package);
+    }
+
+    /**
+     * A self-import is skipped, not a reason to stop reading the file: the
+     * imports after it still have to be checked.
+     */
+    public function test_a_self_import_does_not_stop_the_rest_of_the_file(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', [
+            'Acme\Bridge\Other',
+            'Acme\Framework\Kernel',
+        ]);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('acme/framework', $findings[0]->providedBy);
+    }
+
+    /**
+     * A declared import is skipped, not a reason to stop reading the file.
+     */
+    public function test_a_declared_import_does_not_stop_the_rest_of_the_file(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', ['acme/container' => '^1.0'], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', [
+            'Acme\Container\Box',
+            'Acme\Framework\Kernel',
+        ]);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('acme/framework', $findings[0]->providedBy);
+    }
+
+    /**
+     * One finding per missing package, naming the first import that needed it.
+     */
+    public function test_one_missing_package_is_reported_once(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/A.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+        $this->writeClass('bridge/src/B.php', 'Acme\Bridge', ['Acme\Framework\Other']);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('Acme\Framework\Kernel', $findings[0]->import);
+    }
+
+    public function test_each_missing_package_gets_its_own_finding(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/A.php', 'Acme\Bridge', ['Acme\Framework\Kernel', 'Acme\Container\Box']);
+
+        // Declaration order, which is deterministic: files are walked sorted and
+        // imports keep the order the source wrote them.
+        self::assertSame(
+            ['acme/framework', 'acme/container'],
+            array_map(static fn (UndeclaredImport $f): string => $f->providedBy, $this->check()),
+        );
+    }
+
+    /**
+     * Two packages at the same depth declaring distinct prefixes each own
+     * theirs, so neither silences the other.
+     */
+    public function test_siblings_each_own_their_own_prefix(): void
+    {
+        $this->writePackage('bridge', 'acme/bridge', [], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/A.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+        $this->writePackage('extra', 'acme/extra', [], 'Acme\Extra\\');
+        $this->writeClass('extra/src/B.php', 'Acme\Extra', ['Acme\Container\Box']);
+
+        self::assertSame(
+            ['acme/bridge', 'acme/extra'],
+            array_map(static fn (UndeclaredImport $f): string => $f->package, $this->check()),
+        );
+    }
+
+    /**
+     * Two packages at the same depth declaring one prefix have a genuine
+     * conflict, and neither is the obvious owner. Both keep checking their own
+     * files, because disowning it on both sides would silently check nothing.
+     */
+    public function test_two_packages_at_the_same_depth_both_keep_their_prefix(): void
+    {
+        $this->writePackage('one', 'acme/one', [], 'Acme\Shared\\');
+        $this->writeClass('one/src/A.php', 'Acme\Shared', ['Acme\Framework\Kernel']);
+        $this->writePackage('two', 'acme/two', [], 'Acme\Shared\\');
+        $this->writeClass('two/src/B.php', 'Acme\Shared', ['Acme\Framework\Kernel']);
+
+        self::assertSame(
+            ['acme/one', 'acme/two'],
+            array_map(static fn (UndeclaredImport $f): string => $f->package, $this->check()),
+        );
+    }
+
+    /**
+     * A psr-4 directory may be written with a trailing separator; it names the
+     * same directory either way.
+     */
+    public function test_a_trailing_separator_on_the_autoload_directory_is_tolerated(): void
+    {
+        $this->writeManifest('bridge/composer.json', 'acme/bridge', [], ['Acme\Bridge\\' => 'src/']);
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('acme/framework', $findings[0]->providedBy);
+    }
+
+    /**
+     * A prefix another package owns is skipped, not a reason to stop: the
+     * prefixes listed after it still belong to this package.
+     */
+    public function test_a_disowned_prefix_does_not_stop_the_later_ones(): void
+    {
+        // The disowned prefix is declared first, so skipping it and stopping at
+        // it are different outcomes.
+        $this->writeManifest('composer.json', 'acme/root', [], [
+            'Acme\Bridge\\' => 'bridge/src',
+            'Acme\\' => 'src',
+        ]);
+        $this->writeClass('src/RootThing.php', 'Acme', ['Acme\Framework\Kernel']);
+        $this->writePackage('bridge', 'acme/bridge', ['acme/framework' => '^1.0'], 'Acme\Bridge\\');
+        $this->writeClass('bridge/src/Bootstrapper.php', 'Acme\Bridge', ['Acme\Framework\Kernel']);
+
+        $findings = $this->check();
+
+        self::assertCount(1, $findings);
+        self::assertSame('acme/root', $findings[0]->package);
+    }
+
+    /**
+     * Ownership is decided against every other package, not just up to the
+     * first one that shares no prefix.
+     */
+    public function test_ownership_considers_every_other_package(): void
+    {
+        $this->writeManifest('composer.json', 'acme/root', [], ['Acme\Deep\\' => 'zz-deep/src']);
+        // Sorted before the deep package, and sharing no prefix with the root,
+        // so stopping at it rather than skipping it is a different outcome.
+        $this->writePackage('aa-unrelated', 'acme/unrelated', [], 'Acme\Unrelated\\');
+        $this->writeClass('aa-unrelated/src/U.php', 'Acme\Unrelated', []);
+        $this->writePackage('zz-deep', 'acme/deep', ['acme/framework' => '^1.0'], 'Acme\Deep\\');
+        $this->writeClass('zz-deep/src/D.php', 'Acme\Deep', ['Acme\Framework\Kernel']);
+
+        // acme/deep is the deepest claimant of `Acme\Deep\` and declares what it
+        // imports, so nothing is reported against the root.
+        self::assertSame([], $this->check());
+    }
+
+    /**
+     * @return list<UndeclaredImport>
+     */
+    private function check(): array
+    {
+        $packages = (new ComposerPackageFinder())->findIn($this->repoDir);
+
+        $installed = [
+            ['name' => 'acme/framework', 'autoload' => ['psr-4' => ['Acme\Framework\\' => 'src']]],
+            ['name' => 'acme/container', 'autoload' => ['psr-4' => ['Acme\Container\\' => 'src']]],
+        ];
+
+        return (new PackageManifestChecker())->check($packages, NamespacePackageMap::from($packages, $installed));
+    }
+
+    /**
+     * @param array<string, string> $require
+     * @param array<string, string> $requireDev
+     */
+    private function writePackage(
+        string $relativeDir,
+        string $name,
+        array $require,
+        string $prefix,
+        array $requireDev = [],
+    ): void {
+        $this->writeManifest(
+            $relativeDir === '.' ? 'composer.json' : $relativeDir . '/composer.json',
+            $name,
+            $require,
+            [$prefix => 'src'],
+            $requireDev,
+        );
+    }
+
+    /**
+     * @param array<string, string> $require
+     * @param array<string, string> $psr4
+     * @param array<string, string> $requireDev
+     */
+    private function writeManifest(
+        string $relativePath,
+        string $name,
+        array $require,
+        array $psr4,
+        array $requireDev = [],
+    ): void {
+        $this->write($relativePath, (string)json_encode([
+            'name' => $name,
+            'require' => $require === [] ? new stdClass() : $require,
+            'require-dev' => $requireDev === [] ? new stdClass() : $requireDev,
+            'autoload' => ['psr-4' => $psr4],
+        ]));
+    }
+
+    /**
+     * @param list<string> $imports
+     */
+    private function writeClass(string $relativePath, string $namespace, array $imports): void
+    {
+        $useLines = implode("\n", array_map(static fn (string $i): string => 'use ' . $i . ';', $imports));
+
+        $this->write($relativePath, "<?php\n\nnamespace {$namespace};\n\n{$useLines}\n\nfinal class Generated {}\n");
+    }
+
+    private function write(string $relativePath, string $contents): void
+    {
+        $absolute = $this->repoDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+
+        if (!is_dir(dirname($absolute))) {
+            mkdir(dirname($absolute), 0777, true);
+        }
+
+        file_put_contents($absolute, $contents);
+        $this->createdFiles[] = $absolute;
+    }
+
+    private function removeEmptyTree(string $directory): void
+    {
+        self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $directory);
+
+        foreach ((array)glob($directory . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR) as $child) {
+            if (is_string($child)) {
+                $this->removeEmptyTree($child);
+            }
+        }
+
+        if (is_dir($directory)) {
+            rmdir($directory);
+        }
+    }
+}


### PR DESCRIPTION
## 📚 Description

A module directory that ships as its own composer package can import a namespace its `composer.json` never mentions. Inside the monorepo the root autoloader supplies it, so nothing fails. It fails the day someone installs that package alone.

This repository shipped exactly that bug in both bridges, and #670 fixed it by hand after the fact. No tool here would have caught it. Now `doctor` does.

Related to #677

## 🔖 How it decides

Each import is attributed to the package publishing its namespace, built from `vendor/composer/installed.json` plus the repository's own manifests. Read as manifests, never by executing an autoloader — the question is what a package *promises*, and loading a class only proves what happens to be on this machine today.

Two rules the naive version gets wrong, both found by running it on this repository:

- **Longest prefix wins, and every claimant is kept.** Laravel publishes `Illuminate\Support\` from *both* `illuminate/support` and `illuminate/collections`. First-wins picked the wrong one and reported a requirement as missing that the manifest already had. Declaring any one claimant is enough.
- **Where two manifests declare one prefix, the deeper one owns it.** This repository's root autoloads `Gacela\SymfonyBridge\` so that one `composer install` serves development. Without that rule the root is charged with every import of every package beneath it, and the requirement it asks for belongs in a different manifest.

## ⚠️ Deliberately weaker than the issue proposed, and why

The issue specifies an allow-list file with mandatory reasons and staleness detection, mirroring `CycleAllowList`. **There is no allow-list here, and none is needed** — composer already has the vocabulary. This repository's root manifest already carries `"symfony/console": "Allows to use vendor/bin/gacela script"` in `suggest`. A side file and a `suggest` entry say the same thing, but only one of them is read by composer, shown by `composer suggests`, and maintained by people who never heard of Gacela's graph tooling.

**Every manifest section counts as a mention, `require-dev` included.** That is weaker than "would a consumer receive it", and it is the strongest claim this check can make honestly: `phpstan/phpstan` ships a phar and declares **no** autoload prefix at all, so `PHPStan\Analyser\Scope` attributes to whichever sibling publishes `PHPStan\` — here `phpstan/phpstan-strict-rules`. Demanding a *specific* section would tell a reader to add a requirement on the wrong package. Total absence is unambiguous, and it is the failure #670 actually was.

**Only the undeclared direction.** A requirement nothing imports is frequently correct — a package requires a concrete implementation so the container can resolve it at runtime and never names the class. Telling those apart needs a reviewed exception per entry: a second declaration surface for a weaker finding.

## 🧭 Placed in `doctor`, not `debug:graph`

The issue proposes `debug:graph --check --composer`. `debug:graph`'s subject is the module graph; this asks about package manifests. `doctor` already owns a check registry, the rendering, and the `--strict` exit contract, so this needs no new command *and* no overloading of one whose subject is something else.

## ✅ Quality

- 49 new tests. The #670 bug is reproduced directly: a sub-package importing the framework while declaring only the container.
- **100% covered MSI.** Two rounds of mutation testing drove two real simplifications rather than more tests: `NamespacePackageMap` and `ComposerPackage` were each independently deciding what an autoload prefix is (the same "two liars" duplication #697 removed), and a path-nesting exclusion with separator arithmetic collapsed into one prefix-ownership comparison.
- Ten surviving mutants are documented ignores with reasons — accumulator key shapes, `sort()` over a directory listing, and a `>` whose `>=` twin cannot differ because two distinct prefixes of equal length cannot both prefix one class name.
- Green on PHP 8.3, 8.4 and 8.5 locally; `doctor --strict` exits 0 on this repository.

## 🔍 What it says here today

```
✓ package manifests
    3 package(s) declare everything they import
```

Clean, because #682 and #685 already fixed the two live findings the issue describes. Its value from here is as a regression gate: the next manifest that drifts is caught before release rather than after.
