### PR TITLE
ref(console): state the psr-4 and json-reading rules once

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -373,8 +373,7 @@
             ignore: [
                 // Two distinct prefixes of equal length cannot both prefix one class name,
                 // so > and >= select the same longest match for every possible input.
-                "Gacela\\Console\\Domain\\PackageManifest\\NamespacePackageMap::packagesProviding",
-                "Gacela\\Console\\Domain\\DtoGenerate\\GeneratedClassPath::fileFor",
+                "Gacela\\Console\\Domain\\PackageManifest\\Psr4Prefixes::longestMatching",
                 "Gacela\\Framework\\Cache\\FileCache::stats",
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
                 "Gacela\\Framework\\Exception\\ErrorSuggestionHelper::findSimilar",
@@ -401,6 +400,7 @@
                 // declares. Every consumer foreaches the result, so the key shape is
                 // not observable.
                 "Gacela\\Console\\Application\\Doctor\\Check\\PackageManifestCheck::installedPackages",
+                "Gacela\\Console\\Domain\\PackageManifest\\NamespacePackageMap::from",
                 "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::undeclaredImportsOf",
                 "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
                 "Gacela\\Console\\Domain\\ModuleGraph\\GraphDiffMarkdownFormatter::affectedModules",
@@ -529,6 +529,11 @@
         // return as behaviour. These two are allocation guards, not behaviour.
         ReturnRemoval: {
             ignore: [
+                // Same shape one level up: with no installed.json the guard
+                // returns null, and falling through reads an offset off null,
+                // which is null, which fails the is_array() below and returns
+                // null anyway. The guard is what keeps a php warning out of it.
+                "Gacela\\Console\\Application\\Doctor\\Check\\PackageManifestCheck::installedPackages",
                 // The early return for a non-object `autoload` is a guard, not a branch:
                 // falling through leaves the accumulator empty and returns the same [].
                 "Gacela\\Console\\Domain\\PackageManifest\\ComposerPackage::prefixesOf",

--- a/src/Console/Application/Doctor/Check/PackageManifestCheck.php
+++ b/src/Console/Application/Doctor/Check/PackageManifestCheck.php
@@ -6,6 +6,7 @@ namespace Gacela\Console\Application\Doctor\Check;
 
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\Domain\FileContent\JsonFile;
 use Gacela\Console\Domain\PackageManifest\ComposerPackageFinder;
 use Gacela\Console\Domain\PackageManifest\NamespacePackageMap;
 use Gacela\Console\Domain\PackageManifest\PackageManifestChecker;
@@ -86,20 +87,9 @@ final class PackageManifestCheck implements HealthCheck
         $path = $this->appRootDir . DIRECTORY_SEPARATOR . 'vendor'
             . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json';
 
-        if (!is_file($path)) {
-            return null;
-        }
+        $decoded = JsonFile::decode($path);
 
-        $contents = file_get_contents($path);
-
-        if ($contents === false) {
-            return null;
-        }
-
-        /** @var mixed $decoded */
-        $decoded = json_decode($contents, true);
-
-        if (!is_array($decoded)) {
+        if ($decoded === null) {
             return null;
         }
 

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -19,6 +19,7 @@ use Gacela\Console\Domain\DtoGenerate\GeneratedClassPath;
 use Gacela\Console\Domain\FileContent\FileContentGenerator;
 use Gacela\Console\Domain\FileContent\FileContentGeneratorInterface;
 use Gacela\Console\Domain\FileContent\FileContentIoInterface;
+use Gacela\Console\Domain\FileContent\JsonFile;
 use Gacela\Console\Domain\FileContent\StubFiles;
 use Gacela\Console\Domain\FileContent\StubLocator;
 use Gacela\Console\Domain\FileContent\StubPublisher;
@@ -54,7 +55,6 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 use Symfony\Component\Console\Command\Command;
 
-use function is_array;
 use function is_dir;
 use function is_string;
 use function preg_match;
@@ -391,26 +391,9 @@ final class ConsoleFactory extends AbstractFactory
     private function rootPsr4Prefixes(): array
     {
         $rootDir = Config::getInstance()->getAppRootDir();
-        $manifest = $rootDir . DIRECTORY_SEPARATOR . 'composer.json';
+        $decoded = JsonFile::decode($rootDir . DIRECTORY_SEPARATOR . 'composer.json');
 
-        if (!is_file($manifest)) {
-            return [];
-        }
-
-        $contents = file_get_contents($manifest);
-
-        if ($contents === false) {
-            return [];
-        }
-
-        /** @var mixed $decoded */
-        $decoded = json_decode($contents, true);
-
-        if (!is_array($decoded)) {
-            return [];
-        }
-
-        return ComposerPackage::autoloadPrefixesOf($decoded);
+        return $decoded === null ? [] : ComposerPackage::autoloadPrefixesOf($decoded);
     }
 
     private function createFileContentIo(): FileContentIoInterface

--- a/src/Console/Domain/DtoGenerate/GeneratedClassPath.php
+++ b/src/Console/Domain/DtoGenerate/GeneratedClassPath.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Domain\DtoGenerate;
 
+use Gacela\Console\Domain\PackageManifest\Psr4Prefixes;
+
 use function str_replace;
-use function str_starts_with;
 use function strlen;
 use function substr;
 use function trim;
@@ -41,31 +42,18 @@ final class GeneratedClassPath
      */
     public function fileFor(string $className): ?string
     {
-        $bestPrefix = '';
-        $bestDirectory = null;
+        // Longest prefix wins, the way composer resolves it: a project with both
+        // `App\` and `App\Generated\` means the second for a class under it.
+        $prefix = Psr4Prefixes::longestMatching($this->psr4Prefixes, $className);
 
-        foreach ($this->psr4Prefixes as $prefix => $directory) {
-            if (!str_starts_with($className, $prefix)) {
-                continue;
-            }
-
-            // Longest prefix wins, the way composer resolves it: a project with
-            // both `App\` and `App\Generated\` means the second for a class
-            // under it.
-            if (strlen($prefix) > strlen($bestPrefix)) {
-                $bestPrefix = $prefix;
-                $bestDirectory = $directory;
-            }
-        }
-
-        if ($bestDirectory === null) {
+        if ($prefix === null) {
             return null;
         }
 
-        $relative = str_replace('\\', DIRECTORY_SEPARATOR, substr($className, strlen($bestPrefix)));
+        $relative = str_replace('\\', DIRECTORY_SEPARATOR, substr($className, strlen($prefix)));
 
         return $this->rootDir
-            . DIRECTORY_SEPARATOR . $this->normalized($bestDirectory)
+            . DIRECTORY_SEPARATOR . $this->normalized($this->psr4Prefixes[$prefix])
             . DIRECTORY_SEPARATOR . $relative . '.php';
     }
 

--- a/src/Console/Domain/FileContent/JsonFile.php
+++ b/src/Console/Domain/FileContent/JsonFile.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\FileContent;
+
+use function file_get_contents;
+use function is_array;
+use function is_file;
+use function json_decode;
+
+/**
+ * Reads a json file, or answers that it could not.
+ *
+ * Absent, unreadable and malformed all collapse to null on purpose. Every
+ * caller here is inspecting a manifest it does not own, where the three are the
+ * same outcome -- there is nothing to read -- and telling them apart would only
+ * grow branches that end in the same place.
+ */
+final class JsonFile
+{
+    /**
+     * @return array<array-key, mixed>|null
+     */
+    public static function decode(string $path): ?array
+    {
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($contents, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/src/Console/Domain/PackageManifest/ComposerPackageFinder.php
+++ b/src/Console/Domain/PackageManifest/ComposerPackageFinder.php
@@ -6,13 +6,13 @@ namespace Gacela\Console\Domain\PackageManifest;
 
 use FilesystemIterator;
 use Gacela\Console\Domain\AllAppModules\ExcludedDirectories;
+use Gacela\Console\Domain\FileContent\JsonFile;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
 use function dirname;
-use function is_array;
 
 /**
  * Every `composer.json` the repository owns.
@@ -90,15 +90,6 @@ final class ComposerPackageFinder
      */
     private function decode(string $manifestPath): ?array
     {
-        $contents = file_get_contents($manifestPath);
-
-        if ($contents === false) {
-            return null;
-        }
-
-        /** @var mixed $decoded */
-        $decoded = json_decode($contents, true);
-
-        return is_array($decoded) ? $decoded : null;
+        return JsonFile::decode($manifestPath);
     }
 }

--- a/src/Console/Domain/PackageManifest/NamespacePackageMap.php
+++ b/src/Console/Domain/PackageManifest/NamespacePackageMap.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Console\Domain\PackageManifest;
 
 use function is_array;
-use function str_starts_with;
-use function strlen;
 
 /**
  * Which package provides a namespace.
@@ -84,23 +82,16 @@ final class NamespacePackageMap
      */
     public function packagesProviding(string $className): array
     {
-        $bestPrefix = '';
-        $best = [];
+        $prefix = Psr4Prefixes::longestMatching($this->prefixToPackages, $className);
 
-        foreach ($this->prefixToPackages as $prefix => $packages) {
-            if (!str_starts_with($className, $prefix)) {
-                continue;
-            }
-
-            if (strlen($prefix) > strlen($bestPrefix)) {
-                $bestPrefix = $prefix;
-                $best = $packages;
-            }
+        if ($prefix === null) {
+            return [];
         }
 
-        sort($best);
+        $packages = $this->prefixToPackages[$prefix];
+        sort($packages);
 
-        return $best;
+        return $packages;
     }
 
 }

--- a/src/Console/Domain/PackageManifest/Psr4Prefixes.php
+++ b/src/Console/Domain/PackageManifest/Psr4Prefixes.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\PackageManifest;
+
+use function str_starts_with;
+use function strlen;
+
+/**
+ * How composer picks the psr-4 prefix that owns a class name.
+ *
+ * Longest match wins. Stated once because it is a decision, not a loop: a
+ * project publishing both `Gacela\` and `Gacela\LaravelBridge\` gets a
+ * different answer under first-match, and the two readers of this rule -- which
+ * package provides a namespace, and where a generated class belongs -- would
+ * disagree about the same class while both looking correct.
+ *
+ * First-match is not hypothetical: it is what attributed `Illuminate\Support\`
+ * to the wrong package before #699 fixed it.
+ */
+final class Psr4Prefixes
+{
+    /**
+     * The longest declared prefix this class name starts with, or null when
+     * nothing claims it.
+     *
+     * Returns the prefix rather than the value behind it, so each caller reads
+     * its own map -- one holds directories, the other holds package names.
+     *
+     * @param array<string, mixed> $byPrefix
+     */
+    public static function longestMatching(array $byPrefix, string $className): ?string
+    {
+        $best = null;
+
+        foreach ($byPrefix as $prefix => $_value) {
+            if (!str_starts_with($className, $prefix)) {
+                continue;
+            }
+
+            if ($best === null || strlen($prefix) > strlen($best)) {
+                $best = $prefix;
+            }
+        }
+
+        return $best;
+    }
+}

--- a/tests/Unit/Console/Domain/FileContent/JsonFileTest.php
+++ b/tests/Unit/Console/Domain/FileContent/JsonFileTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\FileContent;
+
+use Gacela\Console\Domain\FileContent\JsonFile;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function is_file;
+use function random_bytes;
+use function sys_get_temp_dir;
+
+final class JsonFileTest extends TestCase
+{
+    private string $file = '';
+
+    protected function setUp(): void
+    {
+        $this->file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-json-' . bin2hex(random_bytes(4)) . '.json';
+    }
+
+    protected function tearDown(): void
+    {
+        self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $this->file);
+
+        if (is_file($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    public function test_a_file_that_is_not_there_reads_as_nothing(): void
+    {
+        self::assertNull(JsonFile::decode($this->file));
+    }
+
+    public function test_malformed_json_reads_as_nothing(): void
+    {
+        file_put_contents($this->file, '{not json');
+
+        self::assertNull(JsonFile::decode($this->file));
+    }
+
+    /**
+     * A manifest is an object. A bare scalar is valid json and still not
+     * something a caller here can read.
+     */
+    public function test_json_that_is_not_an_array_reads_as_nothing(): void
+    {
+        file_put_contents($this->file, '"just a string"');
+
+        self::assertNull(JsonFile::decode($this->file));
+    }
+
+    public function test_an_object_is_decoded(): void
+    {
+        file_put_contents($this->file, '{"name":"acme/thing","require":{"php":">=8.3"}}');
+
+        self::assertSame(
+            ['name' => 'acme/thing', 'require' => ['php' => '>=8.3']],
+            JsonFile::decode($this->file),
+        );
+    }
+
+    public function test_an_empty_object_decodes_to_an_empty_array(): void
+    {
+        file_put_contents($this->file, '{}');
+
+        self::assertSame([], JsonFile::decode($this->file));
+    }
+}

--- a/tests/Unit/Console/Domain/PackageManifest/Psr4PrefixesTest.php
+++ b/tests/Unit/Console/Domain/PackageManifest/Psr4PrefixesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\PackageManifest;
+
+use Gacela\Console\Domain\PackageManifest\Psr4Prefixes;
+use PHPUnit\Framework\TestCase;
+
+final class Psr4PrefixesTest extends TestCase
+{
+    public function test_nothing_matches_an_empty_map(): void
+    {
+        self::assertNull(Psr4Prefixes::longestMatching([], 'App\Order'));
+    }
+
+    public function test_a_class_no_prefix_covers_matches_nothing(): void
+    {
+        self::assertNull(Psr4Prefixes::longestMatching(['App\\' => 1], 'Other\Order'));
+    }
+
+    public function test_the_matching_prefix_is_returned(): void
+    {
+        self::assertSame('App\\', Psr4Prefixes::longestMatching(['App\\' => 1], 'App\Order'));
+    }
+
+    /**
+     * The decision this exists for. Under first-match a project publishing both
+     * `Gacela\` and `Gacela\LaravelBridge\` gets the wrong answer, whichever
+     * order the map happens to be in.
+     */
+    public function test_the_longest_prefix_wins_whichever_order_they_are_declared(): void
+    {
+        $shortFirst = ['Gacela\\' => 1, 'Gacela\LaravelBridge\\' => 2];
+        $longFirst = ['Gacela\LaravelBridge\\' => 2, 'Gacela\\' => 1];
+
+        self::assertSame('Gacela\LaravelBridge\\', Psr4Prefixes::longestMatching($shortFirst, 'Gacela\LaravelBridge\Thing'));
+        self::assertSame('Gacela\LaravelBridge\\', Psr4Prefixes::longestMatching($longFirst, 'Gacela\LaravelBridge\Thing'));
+    }
+
+    public function test_a_sibling_namespace_falls_back_to_the_shorter_prefix(): void
+    {
+        $prefixes = ['Gacela\\' => 1, 'Gacela\LaravelBridge\\' => 2];
+
+        self::assertSame('Gacela\\', Psr4Prefixes::longestMatching($prefixes, 'Gacela\Framework\Thing'));
+    }
+
+    /**
+     * An empty prefix claims everything, which is what composer's fallback
+     * directory means -- it must still lose to any prefix that matches.
+     */
+    public function test_an_empty_prefix_matches_but_never_beats_a_real_one(): void
+    {
+        self::assertSame('', Psr4Prefixes::longestMatching(['' => 1], 'Anything\At\All'));
+        self::assertSame('App\\', Psr4Prefixes::longestMatching(['' => 1, 'App\\' => 2], 'App\Order'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

A pass over the features in `## Unreleased`, looking for code that grew twice. Two things had.

No behaviour changes. Every file touched is at **100% covered MSI**, green on PHP 8.3, 8.4 and 8.5, and `doctor --strict` is clean.

## 🔖 Longest-prefix psr-4 resolution, written twice

`NamespacePackageMap::packagesProviding()` answers *which package provides this namespace*. `GeneratedClassPath::fileFor()` answers *where does this generated class belong*. Different questions — but both were resolving the class name against a psr-4 prefix map with the same loop, and the same tie-break.

That is composer's rule, and **a rule duplicated is a rule that can disagree with itself**. It is not hypothetical here: first-match instead of longest-match is exactly what attributed `Illuminate\Support\` to `illuminate/collections` and reported a requirement as missing that the manifest already had, before #699 fixed it. With two copies, fixing one and not the other looks correct on both sides.

`Psr4Prefixes::longestMatching()` states it once and returns the matched *prefix*, so each caller still reads its own map — one holds directories, the other holds package names.

A side benefit worth noting: that comparison carries an equivalent mutant (`>` and `>=` cannot differ, because two distinct prefixes of equal length cannot both prefix one class name). It needed a documented ignore in **both** copies. Now it needs one.

## 🔖 Reading a json manifest, written three times

`ComposerPackageFinder::decode()`, `PackageManifestCheck::installedPackages()` and `ConsoleFactory::rootPsr4Prefixes()` each did read → `false` check → `json_decode` → `is_array` check, then diverged.

`JsonFile::decode()` answers it once. Absent, unreadable and malformed all collapse to `null` deliberately: every caller is inspecting a manifest it does not own, where the three are the same outcome — there is nothing to read — and separating them only grows branches that end in the same place.

## 🔍 Considered and deliberately left alone

- **`DtoType` and `ConfigType` are near-identical.** They are not the same thing: one is read to *check* a value, the other to *write* a class, which is why one has `accepts()` and the other `phpType()`. Merging them would couple config validation to code generation for the sake of a shared shape.
- **`IdeMetadataGenerator` and `DtoGenerator` share a render → compare → write-if-changed flow.** One writes a single file, the other writes N and reports per-class outcomes. The identical part is a five-line read-or-null; the rest is not the same shape, and an abstraction over both would be fitted to two callers that have already diverged.

## ✅ Tests

New unit tests for both extractions, including the case that motivated the first: the longest prefix wins **whichever order the map declares them in**, since a first-match implementation passes one ordering and fails the other.
