### PR TITLE
🐛 Preload links the whole framework, not 32 named files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Declare `psr/container` in both bridge manifests and `symfony/console` in the Laravel bridge's, and demote their test-only requirements to `require-dev`, so each manifest states what its `src/` imports and only that
 - Key the on-disk class-name cache by the bootstrap's `projectNamespaces` and suffix types, so two bootstraps of one app sharing a cache dir no longer serve each other's classes
 - Point the "missing return type" exception at the namespace `ServiceMap` actually lives in: its recommended fix named one that does not exist, so following it left the attribute unmatched. Its docblock alternative is now marked as the deprecated path it is
+- Preload the framework instead of a hand-written list of 32 files, 13 of which never linked. `AbstractFacade`, `AbstractFactory`, `AbstractProvider`, `Config`, `ClassInfo`, all three resolvers and both containers were named without the parents, interfaces and traits they need, so opcache dropped every one of them and warned about it at each FPM start; a 33rd entry had been renamed away. The set is now discovered and linked through an autoloader of Gacela's runtime closure, which also keeps it from falling behind a rename
 
 ## [2.2.0](https://github.com/gacela-project/gacela/compare/2.1.0...2.2.0) - 2026-08-11
 

--- a/docs/opcache-preload.md
+++ b/docs/opcache-preload.md
@@ -20,7 +20,7 @@ Restart PHP-FPM:
 sudo systemctl restart php8.3-fpm
 ```
 
-Verify in the logs: `Gacela Opcache Preload: 176 classes linked, 0 skipped`.
+Verify in the logs: `Gacela Opcache Preload: <n> classes linked, 0 skipped`. The count tracks the framework's size; the `0` is the part to check.
 
 Anything Gacela could not link is named in that line, and PHP logs its own `Can't preload unlinked class ...` warning next to it. Both mean the class was dropped from the image and is being loaded per request as usual — a correctness problem for the preload only, not for your application.
 

--- a/docs/opcache-preload.md
+++ b/docs/opcache-preload.md
@@ -20,18 +20,20 @@ Restart PHP-FPM:
 sudo systemctl restart php8.3-fpm
 ```
 
-Verify in the logs: `Gacela Opcache Preload: 32 files preloaded successfully, 0 failed`.
+Verify in the logs: `Gacela Opcache Preload: 176 classes linked, 0 skipped`.
+
+Anything Gacela could not link is named in that line, and PHP logs its own `Can't preload unlinked class ...` warning next to it. Both mean the class was dropped from the image and is being loaded per request as usual — a correctness problem for the preload only, not for your application.
 
 ## Preload your own files
 
-Create `config/app-preload.php`:
+Create `config/app-preload.php`. Load the classes rather than compiling the files: a compiled class is only kept if everything it extends, implements and uses was preloaded too, and loading it is what pulls those in.
 
 ```php
 <?php
-$root = dirname(__DIR__);
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-opcache_compile_file($root . '/src/User/UserFacade.php');
-opcache_compile_file($root . '/src/Product/ProductFacade.php');
+class_exists(App\User\UserFacade::class);
+class_exists(App\Product\ProductFacade::class);
 ```
 
 Wire it via env var in your FPM pool:
@@ -60,6 +62,9 @@ sudo systemctl restart php8.3-fpm
 |-------------------------|------------------------------------------------------------------------|
 | Files not preloading    | `php -v` ≥ 8.3, `php -i \| grep opcache.enable`, preload file readable |
 | Permission denied       | `opcache.preload_user` must match the PHP-FPM user (`ps aux \| grep php-fpm`) |
+| `Can't preload unlinked class` | A parent, interface or trait was not preloaded. For your own files, load the class instead of compiling the file (above). |
+| Preload aborts on `fopen(php://stdout)` or similar | Some package runs I/O in a composer `files` autoload entry, which the preload context forbids. Install with `--no-dev`, or preload your classes without requiring the full autoloader. |
+| Nothing happens on Windows | `opcache.preload` is not supported there. |
 
 ## Docker
 

--- a/docs/production-performance.md
+++ b/docs/production-performance.md
@@ -36,7 +36,7 @@ Run `cache:warm` as a deploy step, after `composer install` and before traffic i
 
 ## 3. Preload the framework into opcache
 
-Point `opcache.preload` at `resources/gacela-preload.php` to load Gacela's core files into shared memory at PHP startup, removing their compilation cost from every request.
+Point `opcache.preload` at `resources/gacela-preload.php` to load the framework into shared memory at PHP startup, removing its compilation and linking cost from every request. The script discovers what to load, so it covers the whole framework and cannot fall behind a rename.
 
 Preloaded files are snapshotted at startup, so **restart PHP-FPM after every deploy**. The `php.ini` block, Docker recipe, `GACELA_PRELOAD_USER_FILES` and troubleshooting are in [Opcache preload](opcache-preload.md).
 

--- a/infection.json5
+++ b/infection.json5
@@ -67,6 +67,10 @@
             // removed -- the windows matrix is what enforces it, and did:
             // `/repo\\build/dto\\Order.php` failed all nine windows jobs on #700.
             '.*str_replace\\(\'/\', DIRECTORY_SEPARATOR.*',
+            // SplFileInfo reports backslashes on windows, which is also the
+            // namespace separator. Identity on POSIX, so only the windows
+            // matrix can see this one removed.
+            '.*str_replace\\(\'\\\\\\\\\', \'/\', \\$file->getPathname\\(\\)\\).*',
             // Windows-only PHP_OS/EOL handling: a no-op on POSIX where PHP_EOL is "\n".
             '.*strcasecmp\\(substr\\(PHP_OS.*',
             '.*str_replace\\("\\\\n", PHP_EOL.*',
@@ -110,6 +114,12 @@
         },
         MethodCallRemoval: {
             ignore: [
+                // Registering the preload autoloader only changes anything in a
+                // process that has no other one -- which a test suite, running
+                // under composer's, never is. What it guards is asserted by
+                // OpcachePreloadTest, which starts a real preloading process;
+                // that process loads the shipped file, so no mutant reaches it.
+                "Gacela\\Framework\\Preload\\Preloader::run",
                 "Gacela\\Framework\\Cache\\FileCache::writeContentsAtomically",
                 "Gacela\\Framework\\Cache\\FileCache::delete",
                 "Gacela\\Framework\\Testing\\ContainerFixture::registerContainerTempDirsCleanup",
@@ -295,6 +305,10 @@
         // that would tell them apart are the ones already pinned by name.
         ArrayOneItem: {
             ignore: [
+                // The early return happens only when the map holds exactly the
+                // framework's own prefix, so slicing it to one item returns it
+                // unchanged.
+                "Gacela\\Framework\\Preload\\Preloader::autoloadPrefixes",
                 "Gacela\\Console\\Domain\\PackageManifest\\ComposerPackage::keysOf",
                 "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
             ],
@@ -358,6 +372,16 @@
                 "Gacela\\Framework\\Cache\\FileCache::invalidateOpcacheFor",
                 "Gacela\\Framework\\Testing\\ContainerFixture::registerContainerTempDirsCleanup",
                 "Gacela\\Console\\Domain\\ModuleGraph\\ModuleCycleDetector::stronglyConnectedComponents",
+                // Body of the preload autoloader: it is only ever asked for a
+                // class no other autoloader has already found, and under
+                // composer's there is no such class. Same reason as
+                // Preloader::run in MethodCallRemoval above.
+                "Gacela\\Framework\\Preload\\Preloader::registerAutoloader",
+            ],
+        },
+        NotIdentical: {
+            ignore: [
+                "Gacela\\Framework\\Preload\\Preloader::registerAutoloader",
             ],
         },
         // foundPsr4() strips the trailing separator from a psr-4 key/value. Those

--- a/resources/gacela-preload.php
+++ b/resources/gacela-preload.php
@@ -3,126 +3,50 @@
 /**
  * Gacela Opcache Preload Script
  *
- * This script preloads Gacela framework files into opcache for maximum performance.
- * Use this in production environments with opcache enabled.
+ * Loads the Gacela framework into shared memory at PHP startup, so its classes
+ * are not read, compiled and linked again on every request.
  *
  * Configuration in php.ini or php-fpm config:
  *   opcache.preload=/path/to/your/project/vendor/gacela-project/gacela/resources/gacela-preload.php
  *   opcache.preload_user=www-data
  *
- * Benefits:
- *   - 20-30% performance improvement for Gacela applications
- *   - Reduced memory usage per request
- *   - Faster bootstrap time
+ * Preloaded classes are snapshotted at startup, so restart PHP-FPM after every
+ * deploy.
  *
  * Requirements:
  *   - PHP 8.3 or higher
- *   - Opcache enabled
- *   - Production environment (not recommended for development)
+ *   - Opcache enabled (opcache.preload is not supported on Windows)
+ *
+ * Which classes get loaded, and why they are discovered rather than listed, is
+ * documented on {@see Gacela\Framework\Preload\Preloader}.
  */
 
 declare(strict_types=1);
+
+use Gacela\Framework\Preload\Preloader;
 
 if (PHP_VERSION_ID < 80300) {
     throw new RuntimeException('Opcache preloading requires PHP 8.3 or higher');
 }
 
-if (!\function_exists('opcache_compile_file')) {
-    throw new RuntimeException('Opcache is not enabled or opcache_compile_file is not available');
-}
-
-// Get the Gacela root directory (vendor/gacela-project/gacela)
 $gacelaRoot = \dirname(__DIR__);
 
-// Core framework files that should be preloaded
-$coreFiles = [
-    // Bootstrap
-    '/src/Framework/Bootstrap/GacelaConfig.php',
-    '/src/Framework/Bootstrap/SetupGacela.php',
-    '/src/Framework/Gacela.php',
+// The one explicit require: it registers the autoloader every other class here
+// is then found through. Composer's autoloader is deliberately not used -- see
+// the Preloader docblock.
+require_once $gacelaRoot . '/src/Framework/Preload/Preloader.php';
 
-    // Config
-    '/src/Framework/Config/Config.php',
-    '/src/Framework/Config/ConfigFactory.php',
-    '/src/Framework/Config/ConfigLoader.php',
-    '/src/Framework/Config/PathFinder.php',
+$result = Preloader::run($gacelaRoot);
 
-    // Class Resolvers
-    '/src/Framework/ClassResolver/AbstractClassResolver.php',
-    '/src/Framework/ClassResolver/Facade/FacadeResolver.php',
-    '/src/Framework/ClassResolver/Factory/FactoryResolver.php',
-    '/src/Framework/ClassResolver/Config/ConfigResolver.php',
-    '/src/Framework/ClassResolver/Provider/ProviderResolver.php',
-    '/src/Framework/ClassResolver/ClassInfo.php',
-    '/src/Framework/ClassResolver/ClassNameFinder/ClassNameFinder.php',
-    '/src/Framework/ClassResolver/ClassResolverCache.php',
-
-    // Cache
-    '/src/Framework/ClassResolver/Cache/CacheInterface.php',
-    '/src/Framework/ClassResolver/Cache/AbstractPhpFileCache.php',
-    '/src/Framework/ClassResolver/Cache/ClassNamePhpCache.php',
-    '/src/Framework/ClassResolver/Cache/InMemoryCache.php',
-    '/src/Framework/ClassResolver/Cache/GacelaFileCache.php',
-
-    // Service Resolution
-    '/src/Framework/ServiceResolver/DocBlockResolver.php',
-    '/src/Framework/ServiceResolver/DocBlockResolverCache.php',
-    '/src/Framework/ServiceResolverAwareTrait.php',
-
-    // Base Classes
-    '/src/Framework/AbstractFacade.php',
-    '/src/Framework/AbstractFactory.php',
-    '/src/Framework/AbstractConfig.php',
-    '/src/Framework/AbstractProvider.php',
-
-    // Container
-    '/src/Framework/Container/Container.php',
-    '/src/Framework/Container/ContainerInterface.php',
-    '/src/Framework/Container/Locator.php',
-    '/src/Framework/Container/LocatorInterface.php',
-
-    // Event Dispatching
-    '/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php',
-];
-
-$preloadedCount = 0;
-$failedFiles = [];
-
-foreach ($coreFiles as $file) {
-    $fullPath = $gacelaRoot . $file;
-
-    if (!file_exists($fullPath)) {
-        $failedFiles[] = $file;
-        continue;
-    }
-
-    try {
-        opcache_compile_file($fullPath);
-        ++$preloadedCount;
-    } catch (Throwable $e) {
-        $failedFiles[] = $file . ' (' . $e->getMessage() . ')';
-    }
-}
-
-// Optional: Preload user's application files if configured
+// Optional: preload the application's own classes too.
 $userPreloadFile = getenv('GACELA_PRELOAD_USER_FILES');
-if ($userPreloadFile && file_exists($userPreloadFile)) {
+if (\is_string($userPreloadFile) && $userPreloadFile !== '' && file_exists($userPreloadFile)) {
     try {
         require_once $userPreloadFile;
-    } catch (Throwable $e) {
-        error_log('Failed to load user preload file: ' . $e->getMessage());
+    } catch (Throwable $exception) {
+        error_log('Gacela Opcache Preload: user file failed: ' . $exception->getMessage());
     }
 }
 
-// Log preloading statistics
-if (\function_exists('error_log')) {
-    error_log(\sprintf(
-        'Gacela Opcache Preload: %d files preloaded successfully, %d failed',
-        $preloadedCount,
-        \count($failedFiles),
-    ));
-
-    if ($failedFiles !== []) {
-        error_log('Failed files: ' . implode(', ', $failedFiles));
-    }
-}
+// STDERR does not exist during preload, so this is the only way to be heard.
+error_log($result->summary());

--- a/src/Framework/Preload/PreloadResult.php
+++ b/src/Framework/Preload/PreloadResult.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Preload;
+
+use function count;
+use function implode;
+use function sprintf;
+
+/**
+ * What a preload run managed to link, and what it could not.
+ *
+ * The skipped names are carried rather than counted: a class that fails to link
+ * is silently missing from the preload image, so the one chance to notice is
+ * the line written at startup.
+ */
+final class PreloadResult
+{
+    /**
+     * @param list<class-string> $linked
+     * @param list<string> $skipped
+     */
+    public function __construct(
+        private readonly array $linked,
+        private readonly array $skipped,
+    ) {
+    }
+
+    public function linkedCount(): int
+    {
+        return count($this->linked);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function skipped(): array
+    {
+        return $this->skipped;
+    }
+
+    /**
+     * The line an operator reads at startup. It names what was skipped rather
+     * than only counting it: a count says the image is incomplete, the names
+     * say which class is being loaded per request instead.
+     */
+    public function summary(): string
+    {
+        $summary = sprintf(
+            'Gacela Opcache Preload: %d classes linked, %d skipped',
+            count($this->linked),
+            count($this->skipped),
+        );
+
+        if ($this->skipped === []) {
+            return $summary;
+        }
+
+        return $summary . ' (' . implode(', ', $this->skipped) . ')';
+    }
+}

--- a/src/Framework/Preload/Preloader.php
+++ b/src/Framework/Preload/Preloader.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Preload;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Throwable;
+
+use function class_exists;
+use function dirname;
+use function interface_exists;
+use function is_dir;
+use function is_file;
+use function sort;
+use function spl_autoload_register;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function trait_exists;
+
+/**
+ * What `opcache.preload` loads, and how it manages to link.
+ *
+ * Preloading only pays off when a class is *linked*, not merely compiled. PHP
+ * links what was preloaded once the script finishes, and succeeds only if every
+ * parent, interface and trait came along too. Anything still missing a
+ * dependency is reported at startup and dropped from the image altogether.
+ *
+ * That is why the set is derived here instead of hand-listed. A list gets this
+ * wrong by construction: naming `AbstractFacade` without `CacheableTrait`, or
+ * `Container` without `ContainerInterface`, preloads neither of them -- and the
+ * list also rots, since a renamed file only ever shows up as a log line.
+ *
+ * Linking is driven through an autoloader rather than by compiling the files,
+ * because asking for a class pulls in whatever it extends, implements or uses
+ * *wherever that lives* -- including the packages outside this tree, which a
+ * directory scan would otherwise have to name for itself.
+ * Composer's autoloader is deliberately not the one used: it runs every
+ * installed package's `files` entries, and the preload context forbids the I/O
+ * some of them do at load time -- one `fopen('php://stdout')` in a stream
+ * library aborts the entire preload. Gacela's runtime closure is three
+ * packages, so those prefixes are named below instead.
+ */
+final class Preloader
+{
+    private const NAMESPACE_PREFIX = 'Gacela\\Framework\\';
+
+    /**
+     * Requires phpunit, which is a dev dependency and absent in production.
+     * Loading it would raise a fatal in a context that cannot report one
+     * usefully.
+     *
+     * Matched on the namespace rather than on the path, so it names exactly the
+     * one package it means and not any directory that happens to be called
+     * something similar.
+     */
+    private const EXCLUDED_NAMESPACE = 'Gacela\\Framework\\Testing\\';
+
+    /**
+     * Link every framework class into the preload image.
+     *
+     * @param string $gacelaRoot the package root: the directory holding `src/`
+     */
+    public static function run(string $gacelaRoot): PreloadResult
+    {
+        self::registerAutoloader(self::autoloadPrefixes($gacelaRoot));
+
+        $linked = [];
+        $skipped = [];
+
+        foreach (self::classNames($gacelaRoot) as $className) {
+            try {
+                if (class_exists($className) || interface_exists($className) || trait_exists($className)) {
+                    $linked[] = $className;
+                } else {
+                    $skipped[] = $className;
+                }
+            } catch (Throwable $throwable) {
+                // One class that cannot link must not cost the whole image.
+                // A dev-only dependency appearing under src/ later lands here
+                // and is reported, rather than aborting every other class.
+                $skipped[] = $className . ' (' . $throwable->getMessage() . ')';
+            }
+        }
+
+        return new PreloadResult($linked, $skipped);
+    }
+
+    /**
+     * Every framework class, in a stable order.
+     *
+     * @return list<class-string>
+     */
+    public static function classNames(string $gacelaRoot): array
+    {
+        $frameworkDir = $gacelaRoot . '/src/Framework';
+
+        if (!is_dir($frameworkDir)) {
+            return [];
+        }
+
+        $prefixLength = strlen($frameworkDir) + 1;
+
+        $classNames = [];
+
+        /** @var SplFileInfo $file */
+        foreach (self::phpFilesIn($frameworkDir) as $file) {
+            // Windows reports backslashes here, which are also the namespace
+            // separator: normalize before either meaning is read into it.
+            $path = str_replace('\\', '/', $file->getPathname());
+
+            /** @var class-string $className */
+            $className = self::NAMESPACE_PREFIX . str_replace('/', '\\', substr($path, $prefixLength, -4));
+
+            if (str_starts_with($className, self::EXCLUDED_NAMESPACE)) {
+                continue;
+            }
+
+            $classNames[] = $className;
+        }
+
+        sort($classNames);
+
+        return $classNames;
+    }
+
+    /**
+     * The psr-4 prefixes of Gacela's runtime closure, longest first so a lookup
+     * stops at the most specific one.
+     *
+     * @return array<string, string>
+     */
+    public static function autoloadPrefixes(string $gacelaRoot): array
+    {
+        $vendorDir = self::vendorDir($gacelaRoot);
+
+        $prefixes = [
+            'Gacela\\Framework\\' => $gacelaRoot . '/src/Framework/',
+        ];
+
+        if ($vendorDir === null) {
+            return $prefixes;
+        }
+
+        $prefixes['Gacela\\Container\\'] = $vendorDir . '/gacela-project/container/src/Container/';
+        $prefixes['Psr\\Container\\'] = $vendorDir . '/psr/container/src/';
+
+        return $prefixes;
+    }
+
+    /**
+     * The psr-4 rule: strip the prefix, the rest is the path below its
+     * directory. Kept out of the autoloader closure so it can be read on its
+     * own -- inside one it is only ever exercised by classes the surrounding
+     * application has not already loaded, which in a test suite is none of them.
+     *
+     * @param array<string, string> $prefixes
+     */
+    public static function fileFor(string $className, array $prefixes): ?string
+    {
+        foreach ($prefixes as $prefix => $directory) {
+            if (!str_starts_with($className, $prefix)) {
+                continue;
+            }
+
+            $file = $directory . str_replace('\\', '/', substr($className, strlen($prefix))) . '.php';
+
+            if (is_file($file)) {
+                return $file;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Gacela is either the installed package or the repository itself, so the
+     * vendor directory is above it in one layout and inside it in the other.
+     * Recognised by what it contains rather than by path shape.
+     */
+    private static function vendorDir(string $gacelaRoot): ?string
+    {
+        $candidates = [
+            dirname($gacelaRoot, 2),
+            $gacelaRoot . '/vendor',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_dir($candidate . '/psr/container/src')) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string> $prefixes
+     */
+    private static function registerAutoloader(array $prefixes): void
+    {
+        spl_autoload_register(static function (string $className) use ($prefixes): void {
+            $file = self::fileFor($className, $prefixes);
+
+            if ($file !== null) {
+                /** @psalm-suppress UnresolvableInclude the path comes from the prefix map, resolved by fileFor() */
+                require_once $file;
+            }
+        });
+    }
+
+    /**
+     * @return iterable<SplFileInfo>
+     */
+    private static function phpFilesIn(string $directory): iterable
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getExtension() === 'php') {
+                yield $file;
+            }
+        }
+    }
+}

--- a/tests/Feature/Framework/Preload/OpcachePreloadTest.php
+++ b/tests/Feature/Framework/Preload/OpcachePreloadTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\Preload;
+
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function dirname;
+use function escapeshellarg;
+use function extension_loaded;
+use function file_get_contents;
+use function is_file;
+use function random_bytes;
+use function shell_exec;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/**
+ * Runs the shipped preload script the way php-fpm does, in its own process.
+ *
+ * Nothing short of this catches the failure it guards against: a class whose
+ * parent, interface or trait was not preloaded compiles fine, is reported as
+ * loaded, and is then dropped from the image with a warning only PHP itself
+ * emits -- at startup, into a log, in production.
+ */
+final class OpcachePreloadTest extends TestCase
+{
+    private string $errorLog = '';
+
+    protected function setUp(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('opcache.preload is not supported on Windows');
+        }
+
+        if (!extension_loaded('Zend OPcache')) {
+            self::markTestSkipped('opcache is not available');
+        }
+
+        $this->errorLog = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-preload-' . bin2hex(random_bytes(4)) . '.log';
+    }
+
+    protected function tearDown(): void
+    {
+        self::assertNotSame('', $this->errorLog);
+        self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $this->errorLog);
+
+        if (is_file($this->errorLog)) {
+            unlink($this->errorLog);
+        }
+    }
+
+    public function test_the_whole_framework_preloads_and_links(): void
+    {
+        $output = $this->runWithPreload('echo "REQUEST OK";');
+
+        self::assertStringContainsString('REQUEST OK', $output, 'the request after preloading did not run');
+        self::assertStringNotContainsString("Can't preload unlinked class", $output);
+        self::assertStringContainsString('0 skipped', $output);
+    }
+
+    /**
+     * Preloading is only worth anything if the application still boots on top
+     * of it -- the image is shared, so a class linked wrongly breaks every
+     * request, not one.
+     */
+    public function test_gacela_bootstraps_on_top_of_the_preloaded_image(): void
+    {
+        $root = $this->projectRoot();
+
+        $output = $this->runWithPreload(sprintf(
+            'require %s; ' . \Gacela\Framework\Gacela::class . '::bootstrap(%s); echo "BOOTSTRAP OK";',
+            escapeshellarg($root . '/vendor/autoload.php'),
+            escapeshellarg($root),
+        ));
+
+        self::assertStringContainsString('BOOTSTRAP OK', $output);
+        self::assertStringNotContainsString("Can't preload unlinked class", $output);
+    }
+
+    private function runWithPreload(string $code): string
+    {
+        $command = sprintf(
+            '%s -d opcache.enable_cli=1 -d opcache.preload=%s -d log_errors=1 -d error_log=%s -r %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($this->projectRoot() . '/resources/gacela-preload.php'),
+            escapeshellarg($this->errorLog),
+            escapeshellarg($code),
+        );
+
+        $stdout = (string)shell_exec($command);
+        $logged = is_file($this->errorLog) ? (string)file_get_contents($this->errorLog) : '';
+
+        return $stdout . "\n" . $logged;
+    }
+
+    private function projectRoot(): string
+    {
+        return dirname(__DIR__, 4);
+    }
+}

--- a/tests/Feature/Framework/Preload/OpcachePreloadTest.php
+++ b/tests/Feature/Framework/Preload/OpcachePreloadTest.php
@@ -44,7 +44,12 @@ final class OpcachePreloadTest extends TestCase
 
     protected function tearDown(): void
     {
-        self::assertNotSame('', $this->errorLog);
+        // tearDown still runs when setUp skipped, so there is nothing named yet
+        // on the platforms that skip -- and nothing to remove either.
+        if ($this->errorLog === '') {
+            return;
+        }
+
         self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $this->errorLog);
 
         if (is_file($this->errorLog)) {

--- a/tests/Unit/Framework/Preload/PreloaderTest.php
+++ b/tests/Unit/Framework/Preload/PreloaderTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Preload;
+
+use Gacela\Framework\ClassResolver\ClassInfo;
+use Gacela\Framework\Preload\Preloader;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function bin2hex;
+use function count;
+use function dirname;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sort;
+use function str_replace;
+use function strlen;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class PreloaderTest extends TestCase
+{
+    private string $fixtureRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->fixtureRoot = sys_get_temp_dir() . '/gacela-preload-fixture-' . bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        $root = $this->fixtureRoot;
+
+        // Removing a tree, so the root it walks is asserted to be the one this
+        // test built and nothing above it, before anything is unlinked.
+        self::assertNotSame('', $root);
+        self::assertStringStartsWith(sys_get_temp_dir() . '/gacela-preload-fixture-', $root);
+        self::assertStringStartsWith(sys_get_temp_dir(), $root);
+
+        $this->fixtureRoot = '';
+
+        if (!is_dir($root)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+        }
+
+        rmdir($root);
+    }
+
+    public function test_a_root_without_a_framework_directory_yields_nothing(): void
+    {
+        self::assertSame([], Preloader::classNames(__DIR__ . '/does-not-exist'));
+    }
+
+    public function test_the_framework_classes_are_discovered(): void
+    {
+        $classNames = Preloader::classNames($this->gacelaRoot());
+
+        self::assertGreaterThan(100, count($classNames));
+    }
+
+    /**
+     * The pillars, their resolvers and the container: the classes the feature
+     * exists for. A hand-written list once named these while omitting the
+     * parents, interfaces and traits they need, so none of them linked.
+     */
+    public function test_the_classes_the_framework_is_built_from_are_included(): void
+    {
+        $classNames = Preloader::classNames($this->gacelaRoot());
+
+        foreach ([
+            \Gacela\Framework\AbstractFacade::class,
+            \Gacela\Framework\AbstractFactory::class,
+            \Gacela\Framework\AbstractConfig::class,
+            \Gacela\Framework\AbstractProvider::class,
+            \Gacela\Framework\Gacela::class,
+            \Gacela\Framework\ClassResolver\ClassInfo::class,
+            \Gacela\Framework\Container\Container::class,
+        ] as $expected) {
+            self::assertContains($expected, $classNames);
+        }
+    }
+
+    /**
+     * The whole point of deriving the list: a class name that no longer has a
+     * file behind it can never be produced.
+     */
+    public function test_every_discovered_class_has_a_file(): void
+    {
+        $root = $this->gacelaRoot();
+
+        foreach (Preloader::classNames($root) as $className) {
+            $relative = str_replace('\\', '/', substr($className, strlen('Gacela\\Framework\\')));
+
+            self::assertFileExists($root . '/src/Framework/' . $relative . '.php');
+        }
+    }
+
+    /**
+     * Testing/ needs phpunit, which is a dev dependency. Loading it during a
+     * production preload is a fatal in a context that cannot report one.
+     */
+    public function test_the_testing_helpers_are_excluded(): void
+    {
+        foreach (Preloader::classNames($this->gacelaRoot()) as $className) {
+            self::assertStringNotContainsString('\Testing\\', $className);
+        }
+    }
+
+    /**
+     * A preload image built in filesystem order differs between machines for no
+     * reason; sorting is what makes the logged count reproducible.
+     */
+    public function test_the_order_is_sorted(): void
+    {
+        $classNames = Preloader::classNames($this->gacelaRoot());
+
+        $sorted = $classNames;
+        sort($sorted);
+
+        self::assertSame($sorted, $classNames);
+        self::assertNotSame([], $classNames);
+    }
+
+    /**
+     * Linking needs the packages a framework class extends or implements, not
+     * only the framework itself.
+     */
+    public function test_the_runtime_closure_is_covered_by_the_prefixes(): void
+    {
+        $prefixes = Preloader::autoloadPrefixes($this->gacelaRoot());
+
+        self::assertArrayHasKey('Gacela\\Framework\\', $prefixes);
+        self::assertArrayHasKey('Gacela\\Container\\', $prefixes);
+        self::assertArrayHasKey('Psr\\Container\\', $prefixes);
+    }
+
+    public function test_every_prefix_points_at_a_directory_that_exists(): void
+    {
+        foreach (Preloader::autoloadPrefixes($this->gacelaRoot()) as $directory) {
+            self::assertDirectoryExists($directory);
+        }
+    }
+
+    /**
+     * Spelled out rather than checked for existence: every one of these
+     * directories has an existing ancestor, so "it is a directory" passes for a
+     * path truncated to the wrong depth.
+     */
+    public function test_each_prefix_points_at_the_directory_that_holds_it(): void
+    {
+        $root = $this->gacelaRoot();
+
+        self::assertSame([
+            'Gacela\\Framework\\' => $root . '/src/Framework/',
+            'Gacela\\Container\\' => $root . '/vendor/gacela-project/container/src/Container/',
+            'Psr\\Container\\' => $root . '/vendor/psr/container/src/',
+        ], Preloader::autoloadPrefixes($root));
+    }
+
+    /**
+     * The layout every user actually runs: gacela installed under
+     * `vendor/gacela-project/gacela`, with its siblings two levels up. Built as
+     * a fixture because this repository is only ever the other layout.
+     */
+    public function test_the_vendor_directory_is_found_when_gacela_is_an_installed_package(): void
+    {
+        $vendor = $this->fixtureRoot . '/vendor';
+        $installed = $vendor . '/gacela-project/gacela';
+
+        mkdir($installed . '/src/Framework', 0o777, true);
+        mkdir($vendor . '/psr/container/src', 0o777, true);
+        mkdir($vendor . '/gacela-project/container/src/Container', 0o777, true);
+
+        self::assertSame([
+            'Gacela\\Framework\\' => $installed . '/src/Framework/',
+            'Gacela\\Container\\' => $vendor . '/gacela-project/container/src/Container/',
+            'Psr\\Container\\' => $vendor . '/psr/container/src/',
+        ], Preloader::autoloadPrefixes($installed));
+    }
+
+    public function test_a_class_no_prefix_covers_resolves_to_no_file(): void
+    {
+        self::assertNull(Preloader::fileFor('Acme\Thing', Preloader::autoloadPrefixes($this->gacelaRoot())));
+    }
+
+    public function test_a_prefixed_class_resolves_to_the_file_below_its_directory(): void
+    {
+        $root = $this->gacelaRoot();
+
+        self::assertSame(
+            $root . '/src/Framework/ClassResolver/ClassInfo.php',
+            Preloader::fileFor(ClassInfo::class, Preloader::autoloadPrefixes($root)),
+        );
+    }
+
+    /**
+     * The dependency that a framework class extends lives in another package,
+     * which is the whole reason the prefixes are not just Gacela's own.
+     */
+    public function test_a_class_from_another_package_resolves_through_its_own_prefix(): void
+    {
+        $root = $this->gacelaRoot();
+
+        self::assertSame(
+            $root . '/vendor/psr/container/src/ContainerInterface.php',
+            Preloader::fileFor(PsrContainerInterface::class, Preloader::autoloadPrefixes($root)),
+        );
+    }
+
+    public function test_a_class_whose_prefix_matches_but_has_no_file_resolves_to_nothing(): void
+    {
+        self::assertNull(
+            Preloader::fileFor('Gacela\Framework\NotAThing', Preloader::autoloadPrefixes($this->gacelaRoot())),
+        );
+    }
+
+    /**
+     * Without a vendor directory only the framework's own prefix can be known.
+     */
+    public function test_a_root_with_no_vendor_directory_maps_only_the_framework(): void
+    {
+        $prefixes = Preloader::autoloadPrefixes(__DIR__ . '/nowhere');
+
+        self::assertSame(['Gacela\\Framework\\'], array_keys($prefixes));
+    }
+
+    public function test_running_it_links_every_discovered_class(): void
+    {
+        $root = $this->gacelaRoot();
+
+        $result = Preloader::run($root);
+
+        self::assertSame([], $result->skipped());
+        self::assertSame(count(Preloader::classNames($root)), $result->linkedCount());
+        self::assertStringEndsWith('0 skipped', $result->summary());
+    }
+
+    /**
+     * A php file under `src/` that declares no class is reported rather than
+     * counted: preloading it achieves nothing, and a silent success would say
+     * the image holds something it does not.
+     */
+    public function test_a_file_declaring_no_class_is_reported_as_skipped(): void
+    {
+        $frameworkDir = $this->fixtureRoot . '/src/Framework';
+        mkdir($frameworkDir, 0o777, true);
+        file_put_contents($frameworkDir . '/NotAClass.php', "<?php\n// nothing declared here\n");
+
+        $result = Preloader::run($this->fixtureRoot);
+
+        self::assertSame(0, $result->linkedCount());
+        self::assertSame(['Gacela\Framework\NotAClass'], $result->skipped());
+        self::assertSame(
+            'Gacela Opcache Preload: 0 classes linked, 1 skipped (Gacela\Framework\NotAClass)',
+            $result->summary(),
+        );
+    }
+
+    private function gacelaRoot(): string
+    {
+        return dirname(__DIR__, 4);
+    }
+}


### PR DESCRIPTION
## 📚 Description

The shipped `resources/gacela-preload.php` — the documented production performance feature — preloads almost nothing.

It names 32 files by hand. Preloaded classes are only kept if **everything they extend, implement or use was preloaded too**, and the list omits those, so PHP drops them and warns at every FPM start:

```
Can't preload unlinked class Gacela\Framework\AbstractFacade: Unknown trait Gacela\Framework\Attribute\CacheableTrait
Can't preload unlinked class Gacela\Framework\Container\Container: Unknown interface Gacela\Framework\Container\ContainerInterface
```

Thirteen classes are affected — `AbstractFacade`, `AbstractFactory`, `AbstractProvider`, `Config`, `PathFinder`, `SetupGacela`, `ClassInfo`, `ClassNameFinder`, all three resolvers, and both containers. That is essentially every class the feature exists to preload. A 33rd entry, `DocBlockResolverCache.php`, was renamed away and had been reported only as an `error_log` line nobody reads.

## 🔖 Changes

- Discover the framework rather than listing it, so the set cannot fall behind a rename
- Link through an autoloader over Gacela's runtime closure (`Gacela\Framework\`, `Gacela\Container\`, `Psr\Container\`): asking for a class pulls in whatever it extends, implements or uses, wherever that lives
- Deliberately **not** composer's autoloader — it executes every installed package's `files` entries, and the preload context forbids the I/O some do at load time (`fopen('php://stdout')` in `amphp/byte-stream` aborts the whole preload)
- Exclude `Gacela\Framework\Testing\`, which needs phpunit and is absent in production; anything else that cannot link is reported by name instead of aborting the run
- Drop `linked()`/`skippedCount()` from the result — unused surface

Before: `31 files preloaded successfully, 1 failed` + 13 unlinked warnings.
After: `Gacela Opcache Preload: 176 classes linked, 0 skipped`, no warnings.

## ✅ Verification

`OpcachePreloadTest` starts a **real preloading process** (`opcache.preload`, skipped on Windows where it is unsupported, and when opcache is absent) and asserts no class went unlinked. It was confirmed to fail against the previous script, naming all thirteen — a test that cannot fail would have been worthless here.

Mutation coverage is 100% on both new files. Three mutants are ignored with reasons: the autoloader body is only reachable in a process that has no other autoloader, which a suite running under composer's never is.

On timing I have **no defensible number to report**. Preload looks dramatic against a cold opcache (7.0 ms → 1.8 ms bootstrap) and vanishes into noise against a warm one, and CLI models neither FPM steady state. So the unverified "20-30% performance improvement" claim is removed rather than replaced with another one. The correctness finding stands on its own: thirteen classes were not being preloaded at all.

## 🧪 Tests

- `tests/Unit/Framework/Preload/PreloaderTest.php` — discovery, exclusion, sorting, psr-4 resolution, and the installed (`vendor/gacela-project/gacela`) layout, which had no coverage
- `tests/Feature/Framework/Preload/OpcachePreloadTest.php` — a real preload, plus bootstrapping on top of the resulting image