### PR TITLE
✨ doctor reports a cache directory that cannot be written to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars and reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs are now sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`
 - Generate editor metadata for `getProvidedDependency()` with `ide:meta`, from the `#[Provides]` attributes. An id two providers type differently is listed rather than written, since one application-wide answer would be wrong in one of them
-- Report in `doctor` every `extendService()` id no Provider ever `set()`s, any package importing a namespace its own `composer.json` never mentions, and editor metadata the attributes no longer produce
+- Report in `doctor` every `extendService()` id no Provider ever `set()`s, any package importing a namespace its own `composer.json` never mentions, editor metadata the attributes no longer produce, and a cache directory that cannot be written to — enabled caching that stores nothing runs correctly and pays the cold cost on every request, and the staleness check reads it as "nothing to check"
 
 ### Changed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,6 +65,8 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).
 
+*cache directory* answers whether the cache you enabled can actually be written. Writing is best-effort by design — an application must not fail because an optimisation could not be stored — so a project that enabled caching and got a directory it has no permission on runs correctly and pays the cold cost on every request, with nothing said. Reported read-only: `doctor` never creates the directory to find out.
+
 Among the built-in checks, *service extensions* verifies every `extendService()` id against what the Providers actually `set()`: an extension on an id nothing ever stores — a typo, or an id registered only through `bind()`/`singleton()` — is accepted and applied nowhere at runtime, silently, so `doctor` is the surface that says so. Under `--strict` an unmatched id fails the run.
 
 ## Production

--- a/src/Console/Application/Doctor/Check/CacheWritabilityCheck.php
+++ b/src/Console/Application/Doctor/Check/CacheWritabilityCheck.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Closure;
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+
+use function dirname;
+use function is_dir;
+use function is_writable;
+use function sprintf;
+
+/**
+ * Whether the cache Gacela was told to keep can actually be written.
+ *
+ * A cache directory that cannot be written to costs nothing at runtime and
+ * everything in production: writing is best-effort by design -- an application
+ * must not fail because an optimisation could not be stored -- so a project
+ * that enabled caching, deployed, and got a directory it has no permission on
+ * runs correctly and pays the cold cost on every request, with nothing said.
+ *
+ * {@see CacheStalenessCheck} cannot report it either: with no directory there
+ * are no cache files to compare against their sources, so it answers "nothing
+ * to check" and the run looks healthy.
+ *
+ * Deliberately read-only, unlike {@see \Gacela\Framework\Cache\WritableDirectory},
+ * which creates the directory to find out. A command whose job is to report the
+ * state of things should not be the reason that state changed.
+ */
+final class CacheWritabilityCheck implements HealthCheck
+{
+    /** @var Closure(string):bool */
+    private readonly Closure $isWritable;
+
+    /**
+     * @param null|Closure(string):bool $isWritable answers whether a directory that exists can be written to
+     */
+    public function __construct(
+        private readonly bool $fileCacheEnabled,
+        private readonly string $cacheDir,
+        ?Closure $isWritable = null,
+    ) {
+        $this->isWritable = $isWritable ?? is_writable(...);
+    }
+
+    public function name(): string
+    {
+        return 'cache directory';
+    }
+
+    public function run(): CheckResult
+    {
+        if (!$this->fileCacheEnabled) {
+            return CheckResult::ok($this->name(), 'file cache disabled — nothing is written');
+        }
+
+        if ($this->cacheDir === '') {
+            return CheckResult::ok($this->name(), 'no cache directory resolved — nothing is written');
+        }
+
+        if (is_dir($this->cacheDir)) {
+            return ($this->isWritable)($this->cacheDir)
+                ? CheckResult::ok($this->name(), sprintf('writable: %s', $this->cacheDir))
+                : $this->unwritable(sprintf('%s exists but cannot be written to', $this->cacheDir));
+        }
+
+        // Not yet created is normal -- the first write makes it. What matters is
+        // whether that write can succeed, which is the parent's business.
+        $parent = dirname($this->cacheDir);
+
+        if (is_dir($parent) && ($this->isWritable)($parent)) {
+            return CheckResult::ok($this->name(), sprintf('will be created on first write: %s', $this->cacheDir));
+        }
+
+        return $this->unwritable(sprintf('%s does not exist and cannot be created', $this->cacheDir));
+    }
+
+    private function unwritable(string $detail): CheckResult
+    {
+        return CheckResult::warn(
+            $this->name(),
+            [$detail],
+            'Caching is enabled but nothing can be stored, so every request pays the cold cost. Grant write permission, or point enableFileCache() at a directory the application user owns.',
+        );
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
+use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\IdeMetadataStalenessCheck;
@@ -99,6 +100,13 @@ final class DoctorCommand extends Command
                 $config->mergedConfigCache(),
                 $configFactory->createConfigLoader()->sourceFiles(),
                 ClassResolverCache::bootstrapFingerprint(),
+            ),
+            // Ahead of the staleness check on purpose: with nowhere to write,
+            // there are no cache files to be stale and that check reports
+            // "nothing to check" -- which is the symptom, not the cause.
+            new CacheWritabilityCheck(
+                $config->getSetupGacela()->isFileCacheEnabled(),
+                $config->getCacheDir(),
             ),
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules, $suffixTypes),

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -70,6 +70,7 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
         self::assertSame([
             '✓ cache staleness',
+            '✓ cache directory',
             '✓ suffix configuration',
             '✓ class filenames',
             '✓ config schema',
@@ -127,8 +128,14 @@ final class DoctorCommandTest extends TestCase
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
-        // The registered check runs after the built-in ones, and its detail is shown.
-        self::assertSame('✓ module health: FakeModule', $this->statusLinesOf($tester)[8]);
+        // The registered check runs after the built-in ones, and its detail is
+        // shown. Located from the end rather than by index: which position that
+        // is changes whenever a built-in check is added, and the claim here is
+        // about the order, not the count.
+        $lines = $this->statusLinesOf($tester);
+
+        self::assertSame('✓ All checks passed', array_pop($lines));
+        self::assertSame('✓ module health: FakeModule', array_pop($lines));
         self::assertStringContainsString('FakeHealthCheck ran', $tester->getDisplay());
     }
 

--- a/tests/Unit/Console/Application/Doctor/Check/CacheWritabilityCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/CacheWritabilityCheckTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+
+final class CacheWritabilityCheckTest extends TestCase
+{
+    private string $dir = '';
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/gacela-cache-writable-' . bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        self::assertStringStartsWith(sys_get_temp_dir() . '/gacela-cache-writable-', $this->dir);
+
+        if (is_dir($this->dir)) {
+            rmdir($this->dir);
+        }
+    }
+
+    public function test_a_disabled_file_cache_has_nothing_to_write(): void
+    {
+        $result = (new CacheWritabilityCheck(false, $this->dir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['file cache disabled — nothing is written'], $result->details);
+    }
+
+    /**
+     * A disabled cache is reported before the directory is looked at, so an
+     * unwritable path nobody writes to is not an ailment.
+     */
+    public function test_a_disabled_file_cache_is_fine_even_where_nothing_could_be_written(): void
+    {
+        $result = (new CacheWritabilityCheck(false, $this->dir, static fn (): bool => false))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+    }
+
+    public function test_no_resolved_directory_has_nothing_to_write(): void
+    {
+        $result = (new CacheWritabilityCheck(true, ''))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no cache directory resolved — nothing is written'], $result->details);
+    }
+
+    public function test_an_existing_writable_directory_passes(): void
+    {
+        mkdir($this->dir);
+
+        $result = (new CacheWritabilityCheck(true, $this->dir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['writable: ' . $this->dir], $result->details);
+    }
+
+    /**
+     * The failure this exists for. Probing is injected rather than done with
+     * chmod: a suite running as root can write to a mode-555 directory anyway,
+     * and windows ignores the bits entirely, so the real thing would pass on
+     * exactly the machines it is meant to warn.
+     */
+    public function test_an_existing_unwritable_directory_warns(): void
+    {
+        mkdir($this->dir);
+
+        $result = (new CacheWritabilityCheck(true, $this->dir, static fn (): bool => false))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame([$this->dir . ' exists but cannot be written to'], $result->details);
+        self::assertStringContainsString('every request pays the cold cost', $result->remediation);
+        self::assertStringContainsString('enableFileCache()', $result->remediation);
+    }
+
+    /**
+     * Missing is the normal state before anything has been cached, so it is
+     * only a problem when it could not be created either.
+     */
+    public function test_a_missing_directory_under_a_writable_parent_passes(): void
+    {
+        $result = (new CacheWritabilityCheck(true, $this->dir))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['will be created on first write: ' . $this->dir], $result->details);
+    }
+
+    public function test_a_missing_directory_under_an_unwritable_parent_warns(): void
+    {
+        $result = (new CacheWritabilityCheck(true, $this->dir, static fn (): bool => false))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame([$this->dir . ' does not exist and cannot be created'], $result->details);
+    }
+
+    public function test_a_missing_directory_whose_parent_is_absent_warns(): void
+    {
+        $result = (new CacheWritabilityCheck(true, $this->dir . '/nested/deeper'))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            [$this->dir . '/nested/deeper does not exist and cannot be created'],
+            $result->details,
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Description

Writing the cache is best-effort by design — an application must not fail because an optimisation could not be stored. The cost of that is silence: a project that called `enableFileCache()` and deployed onto a directory it has no permission on **runs correctly and pays the cold cost on every request**, with nothing said anywhere.

`doctor` could not report it either. `CacheStalenessCheck` compares cache files against their sources, so with no directory there are no files to be stale and it answers `no cache directory — nothing to check`. The run looks healthy. That message is the symptom, not the cause.

Verified against a real read-only directory before and after:

```
before: ✓ cache staleness — no cache directory — nothing to check
after:  ⚠ cache directory — /path/.gacela-cache exists but cannot be written to
```

## 🔖 Changes

- `CacheWritabilityCheck`, ordered ahead of the staleness check so the cause is reported before the symptom
- Warns rather than errors: the application is degraded, not broken, and that distinction is the whole reason the failure is silent to begin with
- A missing directory is **not** a fault — that is the normal state before the first write. It is only reported when the parent could not be written either, i.e. when creating it would fail too
- **Read-only on purpose**, unlike `WritableDirectory`, which creates the directory to find out. A command whose job is to report the state of things should not be the reason that state changed

## 🧪 Tests

`tests/Unit/Console/Application/Doctor/Check/CacheWritabilityCheckTest.php` — 8 cases: disabled, unresolved, existing-writable, existing-unwritable, missing-under-writable-parent, missing-under-unwritable-parent, missing-parent.

The writability probe is injected rather than driven by `chmod`, and that is deliberate: a suite running as root writes to a mode-`555` directory anyway and Windows ignores the bits entirely, so a `chmod`-based test would pass on exactly the machines it is meant to warn about. The production path (real `is_writable`) was verified separately against a genuine read-only directory as a non-root user.

Mutation coverage 100%, no ignores added.

## 🔧 Also

`DoctorCommandTest` asserted the registered health check sat at index `[8]` of the output — brittle by construction, and it broke the moment a built-in check was added. It now locates the line from the end, which is what the test actually means: the registered check runs *after* the built-in ones. The next check to be added will not touch it.