### PR TITLE
✨ doctor reports an addAppConfig() path that matches no file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars and reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs are now sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`
 - Generate editor metadata for `getProvidedDependency()` with `ide:meta`, from the `#[Provides]` attributes. An id two providers type differently is listed rather than written, since one application-wide answer would be wrong in one of them
-- Report in `doctor` every `extendService()` id no Provider ever `set()`s, any package importing a namespace its own `composer.json` never mentions, editor metadata the attributes no longer produce, and a cache directory that cannot be written to — enabled caching that stores nothing runs correctly and pays the cold cost on every request, and the staleness check reads it as "nothing to check"
+- Report in `doctor` every `extendService()` id no Provider ever `set()`s, any package importing a namespace its own `composer.json` never mentions, editor metadata the attributes no longer produce, a cache directory that cannot be written to — enabled caching that stores nothing runs correctly and pays the cold cost on every request, and the staleness check reads it as "nothing to check" — and an `addAppConfig()` path matching no file, which loads nothing and surfaces later as a missing key somewhere else entirely. Only the base path is reported, since an environment file is meant to be absent where it does not apply
 
 ### Changed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,6 +65,8 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).
 
+*config sources* answers whether the paths you passed to `addAppConfig()` match a file. `conf/*.php` for a directory named `config` bootstraps perfectly — globbing a path that is not there yields no files, and an application with no configuration is a legitimate one — and then the first thing to read a key fails, with an error about the key rather than about the path that was meant to provide it. Only the base path is reported: `config/app-prod.php` is *meant* to be absent everywhere it does not apply.
+
 *cache directory* answers whether the cache you enabled can actually be written. Writing is best-effort by design — an application must not fail because an optimisation could not be stored — so a project that enabled caching and got a directory it has no permission on runs correctly and pays the cold cost on every request, with nothing said. Reported read-only: `doctor` never creates the directory to find out.
 
 Among the built-in checks, *service extensions* verifies every `extendService()` id against what the Providers actually `set()`: an extension on an id nothing ever stores — a typo, or an id registered only through `bind()`/`singleton()` — is accepted and applied nowhere at runtime, silently, so `doctor` is the surface that says so. Under `--strict` an unmatched id fails the run.

--- a/src/Console/Application/Doctor/Check/ConfigSourceCheck.php
+++ b/src/Console/Application/Doctor/Check/ConfigSourceCheck.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+
+use function count;
+use function sprintf;
+
+/**
+ * Whether the config paths a project declared actually match a file.
+ *
+ * `addAppConfig('conf/*.php')` for a directory named `config` bootstraps
+ * perfectly: globbing a path that is not there yields no files, no file yields
+ * no values, and an application with no configuration is a legitimate one. What
+ * fails is the first thing to read a key, with an error about the key rather
+ * than about the path that was supposed to provide it.
+ *
+ * {@see ConfigSchemaCheck} only sees this when the project declared a schema to
+ * check the values against. This one needs no schema: a path that matches
+ * nothing is worth saying out loud whatever the values were meant to be.
+ */
+final class ConfigSourceCheck implements HealthCheck
+{
+    /**
+     * @param list<string> $unmatchedPatterns declared config patterns that matched no file
+     * @param int $declaredCount how many config paths the project declared in total
+     */
+    public function __construct(
+        private readonly array $unmatchedPatterns,
+        private readonly int $declaredCount,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'config sources';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->declaredCount === 0) {
+            return CheckResult::ok($this->name(), 'no config paths declared — nothing to load');
+        }
+
+        if ($this->unmatchedPatterns === []) {
+            return CheckResult::ok(
+                $this->name(),
+                sprintf('%d declared config path(s) match files', $this->declaredCount),
+            );
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            array_map(
+                static fn (string $pattern): string => sprintf('%s matches no file', $pattern),
+                $this->unmatchedPatterns,
+            ),
+            sprintf(
+                '%d of %d declared config path(s) load nothing, so every value they were meant to provide is missing. Correct the path passed to addAppConfig(), or drop it.',
+                count($this->unmatchedPatterns),
+                $this->declaredCount,
+            ),
+        );
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -7,6 +7,7 @@ namespace Gacela\Console\Infrastructure\Command;
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
+use Gacela\Console\Application\Doctor\Check\ConfigSourceCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\IdeMetadataStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
@@ -33,6 +34,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function count;
 use function sprintf;
 
 /**
@@ -88,7 +90,9 @@ final class DoctorCommand extends Command
         $config = Config::getInstance();
         $modules = $this->getFacade()->findAllAppModules($filter);
         $configFactory = $config->getFactory();
-        $suffixTypes = $configFactory->createGacelaFileConfig()->getSuffixTypes();
+        $gacelaFileConfig = $configFactory->createGacelaFileConfig();
+        $configLoader = $configFactory->createConfigLoader();
+        $suffixTypes = $gacelaFileConfig->getSuffixTypes();
         $stubsDir = $this->getFacade()->stubsDir();
         $declaredKinds = ResolvableTypes::declaredKinds();
 
@@ -98,7 +102,7 @@ final class DoctorCommand extends Command
                 null,
                 $config->getAppRootDir(),
                 $config->mergedConfigCache(),
-                $configFactory->createConfigLoader()->sourceFiles(),
+                $configLoader->sourceFiles(),
                 ClassResolverCache::bootstrapFingerprint(),
             ),
             // Ahead of the staleness check on purpose: with nowhere to write,
@@ -110,6 +114,10 @@ final class DoctorCommand extends Command
             ),
             new SuffixMismatchCheck($modules, $suffixTypes),
             new FilenameMismatchCheck($modules, $suffixTypes),
+            new ConfigSourceCheck(
+                $configLoader->patternsMatchingNothing(),
+                count($configLoader->declaredPatterns()),
+            ),
             new ConfigSchemaCheck($config->configSchema(), $config->getAllValues()),
             new StubHealthCheck($stubsDir, StubHealthCheck::readPublished($stubsDir, $declaredKinds), $declaredKinds),
             new ServiceExtensionTargetCheck(

--- a/src/Framework/Config/ConfigLoader.php
+++ b/src/Framework/Config/ConfigLoader.php
@@ -73,6 +73,57 @@ final class ConfigLoader
     }
 
     /**
+     * The distinct base patterns this project declared.
+     *
+     * Distinct rather than one per config item: the same path declared twice is
+     * one claim about where configuration lives, and counting it twice would
+     * report "1 of 2 paths load nothing" for a project that wrote exactly one.
+     *
+     * @return list<string>
+     */
+    public function declaredPatterns(): array
+    {
+        $patterns = [];
+
+        foreach ($this->gacelaConfigFile->getConfigItems() as $configItem) {
+            $pattern = $this->pathNormalizer->normalizePathPattern($configItem);
+
+            if ($pattern !== '') {
+                $patterns[] = $pattern;
+            }
+        }
+
+        return array_values(array_unique($patterns));
+    }
+
+    /**
+     * The declared config paths that matched no file at all.
+     *
+     * Only the base pattern of each item, never the environment-and-dimensions
+     * chain: `config/app-prod.php` is meant to be absent everywhere it does not
+     * apply, so reporting it would fire on every correctly configured project.
+     * The base pattern is the one the project wrote out and expects to load,
+     * and a typo in it costs nothing at bootstrap -- the values are simply not
+     * there, and the first thing to read one fails somewhere else entirely.
+     *
+     * @return list<string>
+     */
+    public function patternsMatchingNothing(): array
+    {
+        $unmatched = [];
+
+        foreach ($this->gacelaConfigFile->getConfigItems() as $configItem) {
+            $pattern = $this->pathNormalizer->normalizePathPattern($configItem);
+
+            if ($pattern !== '' && $this->pathFinder->matchingPattern($pattern) === []) {
+                $unmatched[] = $pattern;
+            }
+        }
+
+        return array_values(array_unique($unmatched));
+    }
+
+    /**
      * @return list<string>
      */
     private function patternsOf(GacelaConfigItem $configItem): array

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -73,6 +73,7 @@ final class DoctorCommandTest extends TestCase
             '✓ cache directory',
             '✓ suffix configuration',
             '✓ class filenames',
+            '✓ config sources',
             '✓ config schema',
             '✓ published stubs',
             '✓ service extensions',

--- a/tests/Unit/Console/Application/Doctor/Check/ConfigSourceCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/ConfigSourceCheckTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\ConfigSourceCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigSourceCheckTest extends TestCase
+{
+    public function test_a_project_declaring_no_config_has_nothing_to_load(): void
+    {
+        $result = (new ConfigSourceCheck([], 0))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no config paths declared — nothing to load'], $result->details);
+    }
+
+    public function test_declared_paths_that_all_match_pass(): void
+    {
+        $result = (new ConfigSourceCheck([], 2))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['2 declared config path(s) match files'], $result->details);
+    }
+
+    /**
+     * The typo this exists for: `conf/` where the directory is `config/`.
+     */
+    public function test_a_path_matching_nothing_is_named(): void
+    {
+        $result = (new ConfigSourceCheck(['/app/conf/*.php'], 1))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['/app/conf/*.php matches no file'], $result->details);
+        self::assertStringContainsString('1 of 1', $result->remediation);
+        self::assertStringContainsString('addAppConfig()', $result->remediation);
+    }
+
+    public function test_every_unmatched_path_is_named_not_only_the_first(): void
+    {
+        $result = (new ConfigSourceCheck(['/app/conf/*.php', '/app/settings/*.php'], 3))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame([
+            '/app/conf/*.php matches no file',
+            '/app/settings/*.php matches no file',
+        ], $result->details);
+        self::assertStringContainsString('2 of 3', $result->remediation);
+    }
+}

--- a/tests/Unit/Framework/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Framework/Config/ConfigLoaderTest.php
@@ -90,6 +90,105 @@ final class ConfigLoaderTest extends TestCase
         self::assertSame([$default, $local], $loader->sourceFiles());
     }
 
+    /**
+     * Bootstrap reads `gacela.php` more than once, so the same path arrives as
+     * several config items. One path declared is one path to report on.
+     */
+    public function test_the_same_path_declared_by_several_items_counts_once(): void
+    {
+        $default = $this->writeFile('default.php');
+
+        $loader = $this->loaderFor(
+            local: $this->tempDir . '/local.php',
+            patternMatches: [$default],
+            envPatternMatches: [],
+            configItemCount: 3,
+        );
+
+        self::assertSame(['pattern'], $loader->declaredPatterns());
+    }
+
+    /**
+     * Several paths, one of them declared twice and one matching nothing: both
+     * answers have to come back as lists, numbered from zero, or the caller
+     * reporting "1 of 2" reads a gap where a pattern used to be.
+     */
+    public function test_distinct_paths_are_listed_in_order_with_the_duplicate_collapsed(): void
+    {
+        $present = $this->writeFile('default.php');
+
+        $normalizer = $this->createStub(PathNormalizerInterface::class);
+        $normalizer->method('normalizePathPattern')
+            ->willReturnCallback(static fn (GacelaConfigItem $item): string => 'pattern-' . $item->path());
+        $normalizer->method('normalizePathPatternsWithSuffixes')->willReturn([]);
+        $normalizer->method('normalizePathLocal')->willReturn($this->tempDir . '/local.php');
+
+        $pathFinder = $this->createStub(PathFinderInterface::class);
+        $pathFinder->method('matchingPattern')->willReturnMap([
+            ['pattern-a', [$present]],
+            ['pattern-b', []],
+            ['pattern-c', []],
+        ]);
+
+        $gacelaConfigFile = new GacelaConfigFile();
+        $gacelaConfigFile->setConfigItems([
+            new GacelaConfigItem('a', '', $this->createStub(ConfigReaderInterface::class)),
+            new GacelaConfigItem('a', '', $this->createStub(ConfigReaderInterface::class)),
+            new GacelaConfigItem('b', '', $this->createStub(ConfigReaderInterface::class)),
+            new GacelaConfigItem('b', '', $this->createStub(ConfigReaderInterface::class)),
+            new GacelaConfigItem('c', '', $this->createStub(ConfigReaderInterface::class)),
+        ]);
+
+        $loader = new ConfigLoader($gacelaConfigFile, $pathFinder, $normalizer);
+
+        self::assertSame(['pattern-a', 'pattern-b', 'pattern-c'], $loader->declaredPatterns());
+        self::assertSame(['pattern-b', 'pattern-c'], $loader->patternsMatchingNothing());
+    }
+
+    public function test_a_base_pattern_matching_files_is_not_reported(): void
+    {
+        $default = $this->writeFile('default.php');
+
+        $loader = $this->loaderFor(
+            local: $this->tempDir . '/local.php',
+            patternMatches: [$default],
+            envPatternMatches: [],
+        );
+
+        self::assertSame([], $loader->patternsMatchingNothing());
+    }
+
+    public function test_a_base_pattern_matching_nothing_is_reported(): void
+    {
+        $loader = $this->loaderFor(
+            local: $this->tempDir . '/local.php',
+            patternMatches: [],
+            envPatternMatches: [],
+        );
+
+        self::assertSame(['pattern'], $loader->patternsMatchingNothing());
+    }
+
+    /**
+     * The environment file is meant to be absent everywhere it does not apply,
+     * so reporting it would fire on every correctly configured project. Only
+     * the base pattern is a claim that something should be there.
+     */
+    public function test_an_absent_environment_pattern_is_not_reported(): void
+    {
+        $default = $this->writeFile('default.php');
+
+        $loader = $this->loaderFor(
+            local: $this->tempDir . '/local.php',
+            patternMatches: [$default],
+            envPatternMatches: [],
+        );
+
+        self::assertSame([], $loader->patternsMatchingNothing());
+        // ...and the environment pattern really was empty, so the case is real.
+        self::assertSame([$default], $loader->sourceFiles());
+    }
+
     public function test_load_all_skips_local_override_from_pattern_matches(): void
     {
         $reader = new class() implements ConfigReaderInterface {
@@ -137,8 +236,12 @@ final class ConfigLoaderTest extends TestCase
      * @param list<string> $patternMatches
      * @param list<string> $envPatternMatches
      */
-    private function loaderFor(string $local, array $patternMatches, array $envPatternMatches): ConfigLoader
-    {
+    private function loaderFor(
+        string $local,
+        array $patternMatches,
+        array $envPatternMatches,
+        int $configItemCount = 1,
+    ): ConfigLoader {
         $normalizer = $this->createStub(PathNormalizerInterface::class);
         $normalizer->method('normalizePathPattern')->willReturn('pattern');
         $normalizer->method('normalizePathPatternWithEnvironment')->willReturn('pattern-env');
@@ -151,10 +254,13 @@ final class ConfigLoaderTest extends TestCase
             ['pattern-env', $envPatternMatches],
         ]);
 
+        $configItems = [];
+        for ($i = 0; $i < $configItemCount; ++$i) {
+            $configItems[] = new GacelaConfigItem('', '', $this->createStub(ConfigReaderInterface::class));
+        }
+
         $gacelaConfigFile = new GacelaConfigFile();
-        $gacelaConfigFile->setConfigItems([
-            new GacelaConfigItem('', '', $this->createStub(ConfigReaderInterface::class)),
-        ]);
+        $gacelaConfigFile->setConfigItems($configItems);
 
         return new ConfigLoader($gacelaConfigFile, $pathFinder, $normalizer);
     }


### PR DESCRIPTION
## 📚 Description

`addAppConfig('conf/*.php')` for a directory named `config` bootstraps perfectly. Globbing a path that is not there yields no files, no file yields no values, and an application with no configuration is a legitimate one — so nothing objects. What fails is the first thing to read a key, with an error about *the key* rather than about the path that was supposed to provide it.

Reproduced before building:

```php
$config->addAppConfig('conf/*.php');   // the directory is config/
// bootstraps fine. Config::getAllValues() === []
```

`ConfigSchemaCheck` only catches this when the project declared a schema to check values against. This one needs no schema: a declared path that matches nothing is worth saying out loud whatever the values were meant to be.

## 🔖 Changes

- `ConfigSourceCheck`, warning and naming every path that loads nothing
- `ConfigLoader::patternsMatchingNothing()` and `declaredPatterns()`, alongside the existing `sourceFiles()`
- **Only the base pattern of each item is reported.** The environment-and-dimensions chain (`config/app-prod.php`, `config/app-prod-eu.php`) is *meant* to be absent wherever it does not apply, so including it would fire on every correctly configured project. That distinction is what makes this a signal rather than noise
- `DoctorCommand` now builds the config loader and file config once instead of calling the factory per check

## ⚠️ Something this turned up

While checking the numbers in the warning, I found that **`gacela.php` is executed twice on every bootstrap** — verified directly:

```
>>> gacela.php closure invoked
>>> gacela.php closure invoked
```

One `addAppConfig()` call therefore arrives as two identical config items, and the same glob is walked twice. Counting items raw would have told a project that declared one path that "1 of 2 paths load nothing", so the count here is of **distinct** patterns and is correct either way.

The double execution itself is not addressed here — it is a bootstrap-plumbing change that deserves its own PR and its own scrutiny, and it means every side effect a user puts in `gacela.php` happens twice. Filing separately.

## 🧪 Tests

- `ConfigSourceCheckTest` — declared-nothing, all-matching, one unmatched, several unmatched
- `ConfigLoaderTest` — base pattern matching and not matching, an absent environment pattern *not* reported, and the duplicate-collapsing case with three distinct paths

Mutation coverage 100% on both files, no ignores added. The multi-pattern test exists because the single-pattern stub could not observe `array_unique`/`array_values` at all — three mutants survived until the fixture had a duplicate and a gap to re-index.