### PR TITLE
🐛 Make a local infection run survivable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,11 @@ vendor/
 *.cache
 *.tmp
 .gacela-cache-*
-cachegacela-*
+# Written when a mutant drops the separator between the cache directory and the
+# filename, so the name carries the directory's own prefix: `warmer-cache` +
+# `gacela-merged-config-...`. Anchored at the start this matched none of them,
+# and two got committed.
+*cachegacela-*
 tests/**/Users/
 gacela-local.php
 gacela-custom-services*.php

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
             "@csfix"
         ],
         "infection": [
-            "XDEBUG_MODE=coverage ./vendor/bin/infection --show-mutations --threads=max",
+            "XDEBUG_MODE=coverage php -d memory_limit=-1 ./vendor/bin/infection --show-mutations --threads=max",
             "@static-clear-cache"
         ],
         "metrics-report": [

--- a/rector.php
+++ b/rector.php
@@ -40,6 +40,17 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/tests/**/gacela-class-names*.php',
         __DIR__ . '/tests/**/gacela-custom-services*.php',
         __DIR__ . '/tests/**/gacela-merged-config*.php',
+        // The bridges write the same caches into their own fixtures, and their
+        // tests are scanned too -- so leaving them out only moved the failure.
+        // Spelled out per name rather than `gacela-*.php`: the env-specific
+        // `gacela-dev.php` and `gacela-prod.php` fixtures are real files that
+        // have to keep being checked.
+        __DIR__ . '/symfony-bridge/tests/**/gacela-class-names*.php',
+        __DIR__ . '/symfony-bridge/tests/**/gacela-custom-services*.php',
+        __DIR__ . '/symfony-bridge/tests/**/gacela-merged-config*.php',
+        __DIR__ . '/laravel-bridge/tests/**/gacela-class-names*.php',
+        __DIR__ . '/laravel-bridge/tests/**/gacela-custom-services*.php',
+        __DIR__ . '/laravel-bridge/tests/**/gacela-merged-config*.php',
         __DIR__ . '/tests/Unit/PHPStan/Rules/Fixture',
         // assert() inside an anonymous class extending a non-TestCase parent
         // must not be rewritten to $this->assertSame().

--- a/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config-f51331f0083f.php
+++ b/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config-f51331f0083f.php
@@ -1,6 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-return [
-];

--- a/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config/-f51331f0083f.php
+++ b/symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config/-f51331f0083f.php
@@ -1,6 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-return [
-];


### PR DESCRIPTION
## 📚 Description

Two problems, both only visible off CI, found by running `composer infection` on this branch.

**1. It runs out of memory and says nothing.** At a default 128M it exhausts memory parsing coverage, reports **no MSI at all**, and still **exits 0** — a run that looks like it passed and measured nothing:

```
before:  2× "Allowed memory size of 134217728 bytes exhausted"   MSI: (never printed)   exit 0
after:   0                                                        Covered Code MSI: 98%  exit 0
```

CI never saw this: `setup-php` sets `memory_limit=-1`.

**2. Running it then leaves `composer test` failing.** Mutants that drop a path separator write real files into the bridges' fixture directories. `.gitignore` and cs-fixer (`ignoreVCSIgnored(true)`) both handle those — **rector reads neither**. Its skip list already exists for exactly this reason, with a comment saying so, but only covers `tests/`; it was never extended to `symfony-bridge/tests` or `laravel-bridge/tests`, so the failure had only moved.

## 🔖 Changes

- `composer infection` pins `memory_limit=-1`, matching what CI already has
- Rector's existing skip patterns extended to both bridges. Spelled out per cache name rather than `gacela-*.php`, because `gacela-dev.php` and `gacela-prod.php` are **real fixtures** that must keep being checked — I grepped before widening it
- Deleted two artifacts that were committed in #696:
  - `symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config-f51331f0083f.php`
  - `symfony-bridge/tests/Fixtures/warmer-cachegacela-merged-config/-f51331f0083f.php`

  Both contain `return [];`. The names are the artifact: `warmer-cache` + `gacela-merged-config-…` with the separator missing, and a file called `-f51331f0083f.php` where that separator should have been.
- The ignore rule meant to prevent that, `cachegacela-*`, is anchored at the start of the basename while every real artifact carries its cache directory's prefix, so it matched none of them. Now `*cachegacela-*`:

  | basename | before | after |
  |---|---|---|
  | `warmer-cachegacela-merged-config-….php` | **not ignored** | ignored |
  | `bootstrapper-cachegacela-class-names-….php` | **not ignored** | ignored |
  | `cachegacela-merged-config-x.php` | ignored | ignored |

## 🧪 Verification

No new tests — this is build tooling, and the check is the tooling itself. `composer test` passes **with the leftover artifact directories still on disk**, which is the thing that was broken; before this it failed on them. The full `composer infection` run now completes and reports 98%.

No changelog entry: nothing here is user-facing.