### PR TITLE
✅ Lock the declarations merged out of gacela.php

### DIFF
--- a/tests/Feature/Framework/MergingDeclarationsAcrossConfigSources/FeatureTest.php
+++ b/tests/Feature/Framework/MergingDeclarationsAcrossConfigSources/FeatureTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\MergingDeclarationsAcrossConfigSources;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+use function array_keys;
+
+/**
+ * A bootstrap closure and `gacela.php` are two config sources, and the closure's
+ * setup is the one the application ends up with -- so whatever the file declares
+ * has to be merged onto it, or it is silently absent.
+ *
+ * Each of these was carried by a `SetupMerger` line that could be deleted with
+ * the whole suite still green: the declarations survived by luck of nobody
+ * looking, on three features whose entire point is being declared in the file
+ * the merge reads.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_a_config_dimension_declared_in_the_file_survives_the_merge(): void
+    {
+        self::assertSame(
+            ['GACELA_TEST_REGION'],
+            Config::getInstance()->getSetupGacela()->getConfigDimensions(),
+        );
+    }
+
+    public function test_a_dto_shape_declared_in_the_file_survives_the_merge(): void
+    {
+        self::assertSame(
+            ['AcmeMerge\Order'],
+            array_keys(Config::getInstance()->getSetupGacela()->getDtoSchema()),
+        );
+    }
+
+    public function test_a_config_schema_declared_in_the_file_survives_the_merge(): void
+    {
+        self::assertSame(
+            ['shop.currency'],
+            array_keys(Config::getInstance()->getSetupGacela()->getConfigSchema()),
+        );
+    }
+
+    /**
+     * The values the schema describes still load: a schema that survived while
+     * the configuration it validates did not would pass the assertions above
+     * and mean nothing.
+     */
+    public function test_the_configuration_the_schema_describes_is_loaded(): void
+    {
+        self::assertSame('EUR', Config::getInstance()->get('shop')['currency']);
+    }
+}

--- a/tests/Feature/Framework/MergingDeclarationsAcrossConfigSources/config/app.php
+++ b/tests/Feature/Framework/MergingDeclarationsAcrossConfigSources/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return ['shop' => ['currency' => 'EUR']];

--- a/tests/Feature/Framework/MergingDeclarationsAcrossConfigSources/gacela.php
+++ b/tests/Feature/Framework/MergingDeclarationsAcrossConfigSources/gacela.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Schema\ConfigType;
+
+return static function (GacelaConfig $config): void {
+    $config->setFileCache(false);
+    $config->addAppConfig('config/*.php');
+    $config->addConfigDimension('GACELA_TEST_REGION');
+    $config->declareConfigSchema(['shop.currency' => ConfigType::string()->required()]);
+    $config->declareDtoSchema('AcmeMerge\Order', ['id' => 'int']);
+};


### PR DESCRIPTION
## 📚 Description

Three lines in `SetupMerger` could be **deleted with the whole suite still green**:

```php
$this->whenChanged($other, SetupGacela::configDimensions, fn () => $this->original->mergeConfigDimensions(...));
$this->whenChanged($other, SetupGacela::configSchema,     fn () => $this->original->mergeConfigSchema(...));
$this->whenChanged($other, SetupGacela::dtoSchema,        fn () => $this->original->mergeDtoSchema(...));
```

They carry what `gacela.php` declares onto a bootstrap closure's setup — which is the setup the application ends up with. Without them the declarations are silently absent, and nothing said so.

All three work today; I checked before writing anything. They survived by nobody looking, on three features whose entire point is being declared in the file the merge reads (`addConfigDimension()`, `declareConfigSchema()`, `declareDtoSchema()`).

Found by mining a full `infection` run — which only became possible once #706 stopped it running out of memory and reporting nothing.

## 🔖 Changes

A feature test bootstrapping **with a closure**, since that is the form that merges: a `gacela.php` declaring a config dimension, a config schema and a DTO shape, asserting each survives, plus that the configuration the schema describes still loads — a schema that survived while its values did not would pass the other three assertions and mean nothing.

## 🧪 Verification

Each merge call was deleted in turn and the suite re-run, to confirm these tests actually catch it:

| removed | result |
|---|---|
| `mergeConfigDimensions` | test fails |
| `mergeConfigSchema` | test fails |
| `mergeDtoSchema` | test fails |

`SetupMerger` is untouched by this PR — tests only, no production change.