### PR TITLE
📝 Say what the ServiceMap deprecation does not tell you

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -222,13 +222,17 @@ Not blocking this upgrade, but the notices start now.
 
 **Resolving a pillar from a `@method` docblock, or by scanning the caller's `use` statements**, raises `E_USER_DEPRECATED`. Declare it with `#[ServiceMap(method: ..., className: ...)]` — the attribute is checked first, so adding it silences the notice.
 
+The generic form counts too. `@extends AbstractFacade<MyFactory>` names the factory by its short name, which is resolved through the file's `use` statements — the second deprecated strategy. Typing a pillar generically is still worth doing for the analysers; it is not a substitute for the attribute.
+
+**Static analysis will not find these for you.** PHPStan reads `@method` and `@extends` natively, so a class carrying either is a class it considers correct — with or without the attribute. A green analysis run says nothing about whether you are ready for 3.0.
+
 The notice fires on a **cold resolve only**, because the answer is memoized per caller-and-method. To surface every occurrence:
 
 ```bash
 vendor/bin/gacela cache:clear
 ```
 
-or develop with the file cache off.
+or develop with the file cache off. Even then you only see the accessors your run actually calls, so the list is as complete as the code paths you exercise — a suite that never touches a module never reports it.
 
 ---
 


### PR DESCRIPTION
## 📚 Description

Three things a migrator cannot learn from the deprecation notice, all found while investigating whether tooling could produce a complete migration list.

**1. The generic form deprecates too.** `@extends AbstractFacade<MyFactory>` names the factory by its *short* name, so `DocBlockParser` hands back something `class_exists()` rejects and resolution falls through to the file's `use` statements — the second deprecated strategy. This repo's own `FakeFacade` carries only that annotation and reports exactly that:

```
FakeFacade::getFactory() was resolved from the file's use statements.
```

Typing a pillar generically is still worth doing for the analysers. It is not a substitute for the attribute, and reading the old text you would think it was untouched.

**2. PHPStan will not find these.** It reads `@method` and `@extends` natively, so a class carrying either is one it considers correct — with or without `#[ServiceMap]`. The shipped extension *types* accessors that have the attribute; nothing flags the ones that do not. This repository is the proof: `composer quality` is green while twelve deprecations fire in its own suite.

**3. Clearing the cache is not exhaustive.** The notice fires once per caller-and-method on a cold resolve, and only when that accessor is actually called — so the list is as complete as the code paths you exercise, not as complete as your codebase.

## 🔖 Changes

Documentation only, in the `Deprecated in 2.0, removed in 3.0` section where the migration instructions already live.

## 🧪 Why no tooling instead

I looked at building a `doctor` check or a PHPStan rule to produce the complete list, and did not:

- A **doctor check** would have to reflect arbitrary project classes to follow trait use and inheritance — loading a user's code to diagnose it — or fall back to a textual scan that silently misses inherited cases. A migration list that is quietly partial is the failure mode this section is about.
- A **PHPStan rule** is the right vehicle technically, but it would fire on every fixture in this repository that exercises the fallback deliberately, and the friction of baselining those is real design work rather than a quick addition.

Neither is ruled out; both need a design decision rather than an afternoon. What is certain today is that the notice under-reports, and readers should know that before they trust it.