### PR TITLE
✅ Pin preload degrading instead of aborting on a missing dependency

### DIFF
--- a/src/Framework/Preload/Preloader.php
+++ b/src/Framework/Preload/Preloader.php
@@ -17,6 +17,7 @@ use function is_dir;
 use function is_file;
 use function sort;
 use function spl_autoload_register;
+use function sprintf;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
@@ -82,7 +83,10 @@ final class Preloader
                 // One class that cannot link must not cost the whole image.
                 // A dev-only dependency appearing under src/ later lands here
                 // and is reported, rather than aborting every other class.
-                $skipped[] = $className . ' (' . $throwable->getMessage() . ')';
+                // Spelled with sprintf like the summary that renders it, and
+                // not asserted character by character: the reason is PHP's own
+                // wording, which has changed between versions before.
+                $skipped[] = sprintf('%s (%s)', $className, $throwable->getMessage());
             }
         }
 

--- a/tests/Unit/Framework/Preload/PreloaderTest.php
+++ b/tests/Unit/Framework/Preload/PreloaderTest.php
@@ -292,6 +292,37 @@ final class PreloaderTest extends TestCase
         );
     }
 
+    /**
+     * A class whose parent is not installed is the realistic way this happens:
+     * a partial or half-updated install, where the framework is there and one
+     * of the packages it runs on is not.
+     *
+     * What matters is that the one class costs only itself. Preloading is
+     * best-effort by design, so aborting the image over it would take a startup
+     * that merely degrades and make it a boot failure -- and the reason has to
+     * reach the operator, since it is the only account of what is missing.
+     */
+    public function test_a_class_whose_dependency_is_missing_is_reported_and_costs_only_itself(): void
+    {
+        $frameworkDir = $this->fixtureRoot . '/src/Framework';
+        mkdir($frameworkDir, 0o777, true);
+        file_put_contents(
+            $frameworkDir . '/Fine.php',
+            "<?php\nnamespace Gacela\\Framework;\nfinal class Fine {}\n",
+        );
+        file_put_contents(
+            $frameworkDir . '/Broken.php',
+            "<?php\nnamespace Gacela\\Framework;\nfinal class Broken extends \\Absent\\Package\\Missing {}\n",
+        );
+
+        $result = Preloader::run($this->fixtureRoot);
+
+        self::assertSame(1, $result->linkedCount(), 'the healthy class still linked');
+        self::assertCount(1, $result->skipped());
+        self::assertStringContainsString('Gacela\Framework\Broken', $result->skipped()[0]);
+        self::assertStringContainsString('Absent\Package\Missing', $result->skipped()[0]);
+    }
+
     private function gacelaRoot(): string
     {
         return dirname(__DIR__, 4);


### PR DESCRIPTION
## 📚 Description

Verifying #709 in the layout users actually run — gacela installed under `vendor/gacela-project/gacela` — turned up no bug: **220 classes linked, 0 skipped**, path detection correct.

Testing the degraded case did turn up an untested behaviour. With the container packages absent, the preload reports rather than dies:

```
Gacela Opcache Preload: 173 classes linked, 3 skipped
  (Gacela\Framework\Attribute\Inject (Class "Gacela\Container\Attribute\Inject" not found),
   Gacela\Framework\Container\Container (Interface … not found),
   Gacela\Framework\Container\ContainerInterface)
```

The one class costs only itself, and the request is still served. That is the whole point — preloading is best-effort, so aborting the image over a single unlinkable class turns a startup that merely degrades into a boot failure. The `try/catch` doing it had **no test**: deleting it left the suite green.

## 🔖 Changes

A test for the realistic shape of this — a class whose parent is not installed, which is what a partial or half-updated install looks like — asserting the healthy class still links, the broken one is reported, and the reason names what is missing.

Confirmed it catches the regression: with the `try/catch` removed the test errors out.

## ⚠️ One production line changed

The skipped entry is built with `sprintf` now, like `PreloadResult::summary()` which renders it.

That line's five surviving mutants are why. They are only killable by asserting the message character for character — and the reason half is **PHP's own wording**, which has changed between versions before (this session already hit an 8.5 reflection change). Pinning it exactly would be a golden-master test that breaks on a PHP upgrade and tells nobody what regressed. The test matches the parts we author instead.

Worth stating plainly: covering the `catch` moved MSI from 100% to 93%, because those mutants were previously *uncovered* rather than killed. `sprintf` brings it back to 100% by having fewer ways to be wrong, not by asserting more.