### PR TITLE
📝 Warn about re-bootstrapping without GacelaTestCase

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,29 @@ $resolved = $this->recordedGacelaEventsOf(ServiceResolvedEvent::class); // one t
 
 If you only need the reset helpers inside an existing test hierarchy, use the [`ContainerFixture`](../src/Framework/Testing/ContainerFixture.php) trait directly — `GacelaTestCase` builds on it.
 
+### Bootstrapping twice without either of them
+
+Neither is required. But calling `Gacela::bootstrap()` a second time in one process on your own keeps the **previous** boot's services, and says nothing:
+
+```php
+Gacela::bootstrap($dir, static fn (GacelaConfig $c) => $c->addBinding(Clock::class, $frozenClock));
+Gacela::get(Clock::class);   // the frozen one, as expected
+
+Gacela::bootstrap($dir, static fn (GacelaConfig $c) => $c->addBinding(Clock::class, $realClock));
+Gacela::get(Clock::class);   // still the frozen one
+```
+
+The configuration *is* re-read, so the second boot leaves you with new config and old services. Add [`resetInMemoryCache()`](../src/Framework/Bootstrap/GacelaConfig.php) to the closure and both move together:
+
+```php
+Gacela::bootstrap($dir, static function (GacelaConfig $config): void {
+    $config->resetInMemoryCache();
+    // …
+});
+```
+
+`GacelaTestCase` and both framework bridges call it on every boot for exactly this reason. It is opt-in rather than automatic because a process that re-bootstraps with the *same* wiring pays to resolve everything again.
+
 ## Replacing another module
 
 Testing module A in isolation means replacing module B. A container binding only works when B's Facade arrives through a Provider, and a consumer that writes `new BlogFacade()` leaves nothing to bind — so the seam is the **Factory** every Facade resolves:


### PR DESCRIPTION
## 📚 Description

Reproduced against the current build:

```php
Gacela::bootstrap($dir, fn (GacelaConfig $c) => $c->addBinding(ArrayObject::class, new ArrayObject(['from' => 'A'])));
Gacela::get(ArrayObject::class);   // A

Gacela::bootstrap($dir, fn (GacelaConfig $c) => $c->addBinding(ArrayObject::class, new ArrayObject(['from' => 'B'])));
Gacela::get(ArrayObject::class);   // still A
```

A second `Gacela::bootstrap()` in one process keeps the previous boot's services, silently. What makes it hard to spot is the asymmetry — I checked, and the **configuration is re-read correctly**, so the second boot leaves you with new config and old services rather than obviously-stale everything.

This is known and deliberate. `resetInMemoryCache()`'s own docblock says *"anything that re-bootstraps inside one process wants this … or a re-bootstrap keeps serving the previous boot's services out of the stale locator (#666)"*, and `GacelaTestCase` plus both bridges call it on every boot.

The gap is discoverability. `docs/testing.md` says `GacelaTestCase` gives you "isolation for free" and never says what you owe if you skip it — and the explanation lives on a method you would only read having already guessed it exists.

## 🔖 Changes

A short section in `docs/testing.md`, next to the `ContainerFixture` note that already covers "you don't have to use the base class": the failing shape, the one-line fix, and why it is opt-in rather than automatic (a process re-bootstrapping with the *same* wiring pays to resolve everything again).

Both snippets are verified — the broken one reproduces, and adding `resetInMemoryCache()` makes the second boot return `B`.

## 🤔 What I did not do

Auto-resetting on a *detected* re-bootstrap would remove the footgun entirely, and the docblock's "anything that re-bootstraps wants this" is close to an argument for it.

I did not, because it reverses a decision this project already made deliberately in response to #666, and it has a real cost the docblock does not mention: a worker re-bootstrapping with identical wiring would re-resolve everything on every loop. That is a maintainer's call about defaults, not a gap to fill — so it is written down here rather than changed underneath.