### PR TITLE
📝 Say why these two parameters are mixed

### DIFF
--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -296,6 +296,14 @@ final class ConsoleFactory extends AbstractFactory
         return preg_match('~^(?:[a-zA-Z]:[\\\\/]|[\\\\/])~', $path) === 1;
     }
 
+    /**
+     * `mixed` on purpose, and narrower than it looks only from one caller.
+     * Bindings are `string|object|callable`, but a *contextual* binding is
+     * whatever `->give()` was handed -- typed `mixed` upstream, and an `int`
+     * is a normal thing to inject. Psalm sees only the first caller and offers
+     * to narrow this to `string|callable|object`, which would fatal on the
+     * second. Do not apply that fix.
+     */
     private function stringifyBoundConcrete(mixed $concrete): string
     {
         return is_string($concrete) ? $concrete : get_debug_type($concrete);

--- a/src/Framework/Container/Container.php
+++ b/src/Framework/Container/Container.php
@@ -230,6 +230,15 @@ final class Container implements ContainerInterface
         $this->inner->singletonIf($abstract, $concrete);
     }
 
+    /**
+     * Store anything under an id: a Closure is resolved on first read, and
+     * every other value is handed back as it was given.
+     *
+     * `mixed` on purpose. Psalm infers `Closure` from the call sites it can
+     * see and offers to narrow the signature to it -- which would reject
+     * `$container->set(Pool::class, new Pool())`, the form the documentation
+     * uses. Do not apply that fix.
+     */
     public function set(string $id, mixed $instance): void
     {
         $this->inner->set($id, $instance);


### PR DESCRIPTION
## 📚 Description

Every `composer quality` run ends with:

```
Psalm can automatically fix 5 of these issues.
Run Psalm again with --alter --issues=MissingParamType --dry-run
```

**Both signatures it offers to narrow are wrong**, and applying the fix breaks working code. Nothing warns you before you run it.

### `Container::set()` → `Closure $instance`

```php
$c = new Container();
$c->set('plain',  new ArrayObject(['x' => 1]));   // works today
$c->set('scalar', 'just-a-string');               // works today
```

`docs/container-configuration.md` documents `$container->set(Pool::class, new Pool())`. Psalm infers `Closure` because that is all the call sites it can see happen to pass — the narrowed signature would reject the documented form.

### `stringifyBoundConcrete()` → `string|callable|object`

True for one caller and not the other. `getContainerBindings()` really is `string|object|callable` — `addBinding()` enforces it, and I confirmed a scalar throws. But `getContainerContextualBindings()` passes whatever `->give()` was handed, which is `mixed` upstream:

```php
$config->when(Consumer::class)->needs('$retries')->give(42);   // => int
```

Narrowing would fatal on that path.

## 🔖 Changes

A docblock on each saying `mixed` is deliberate, what the narrowed version would break, and not to apply the fix.

## 🤔 Why not suppress instead

`@psalm-suppress MissingParamType` would remove the count and the advertisement. I did not, because Psalm is not *reporting* these as issues — the run is clean and it only offers them as fixable. A suppression for an unreported issue risks becoming an `UnusedPsalmSuppress` of its own, and it would hide the reasoning rather than record it. The advertisement is cosmetic; the trap is a contributor applying it without checking, and a comment at the call site is what actually prevents that.

Both claims verified against a running container before writing them down, not inferred from the signatures.