### PR TITLE
✨ doctor reports a specific listener that can never fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars and reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs are now sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`
 - Generate editor metadata for `getProvidedDependency()` with `ide:meta`, from the `#[Provides]` attributes. An id two providers type differently is listed rather than written, since one application-wide answer would be wrong in one of them
+- Report in `doctor` every `registerSpecificListener()` target that can never fire — an interface, an abstract class or a typo — since the dispatcher matches `$event::class` exactly and such a listener is accepted and simply never runs
 - Report in `doctor` every `extendService()` id no Provider ever `set()`s, any package importing a namespace its own `composer.json` never mentions, editor metadata the attributes no longer produce, a cache directory that cannot be written to — enabled caching that stores nothing runs correctly and pays the cold cost on every request, and the staleness check reads it as "nothing to check" — and an `addAppConfig()` path matching no file, which loads nothing and surfaces later as a missing key somewhere else entirely. Only the base path is reported, since an environment file is meant to be absent where it does not apply
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,6 +65,8 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).
 
+*event listeners* answers whether a `registerSpecificListener()` target can ever match. The dispatcher compares `$event::class`, so a listener registered against an interface never fires — not even for events that implement it — and neither does one naming an abstract class or a typo. `Container::afterResolving()` matches by `instanceof`, which is exactly why registering against a contract looks like it should work. A concrete class nothing dispatches is left alone: that listener is waiting, not broken.
+
 *config sources* answers whether the paths you passed to `addAppConfig()` match a file. `conf/*.php` for a directory named `config` bootstraps perfectly — globbing a path that is not there yields no files, and an application with no configuration is a legitimate one — and then the first thing to read a key fails, with an error about the key rather than about the path that was meant to provide it. Only the base path is reported: `config/app-prod.php` is *meant* to be absent everywhere it does not apply.
 
 *cache directory* answers whether the cache you enabled can actually be written. Writing is best-effort by design — an application must not fail because an optimisation could not be stored — so a project that enabled caching and got a directory it has no permission on runs correctly and pays the cold cost on every request, with nothing said. Reported read-only: `doctor` never creates the directory to find out.

--- a/src/Console/Application/Doctor/Check/EventListenerTargetCheck.php
+++ b/src/Console/Application/Doctor/Check/EventListenerTargetCheck.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use ReflectionClass;
+
+use function class_exists;
+use function count;
+use function interface_exists;
+use function sprintf;
+
+/**
+ * Every `registerSpecificListener()` target, checked against something an event
+ * can actually be.
+ *
+ * The dispatcher matches on `$event::class` -- the exact, concrete class. So a
+ * listener registered for an interface never fires, even for events that
+ * implement it, and neither does one registered for an abstract class or a name
+ * with a typo in it. All three are accepted at bootstrap and simply never run.
+ *
+ * The interface case is the one worth catching. `Container::afterResolving()`
+ * in this same framework matches by `instanceof`, so registering against a
+ * contract is a reasonable thing to expect to work, and nothing says otherwise
+ * until an event that should have been handled quietly is not.
+ *
+ * Only names that can never equal `$event::class` are reported. A concrete
+ * class that exists is left alone whether or not it is ever dispatched: a
+ * listener for an event this deployment happens not to raise is waiting, not
+ * broken.
+ */
+final class EventListenerTargetCheck implements HealthCheck
+{
+    /**
+     * @param list<string> $listenerTargets the event names passed to registerSpecificListener()
+     */
+    public function __construct(
+        private readonly array $listenerTargets,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'event listeners';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->listenerTargets === []) {
+            return CheckResult::ok($this->name(), 'no specific listeners registered');
+        }
+
+        $warnings = [];
+
+        foreach ($this->listenerTargets as $target) {
+            $reason = $this->whyItCanNeverFire($target);
+
+            if ($reason !== null) {
+                $warnings[] = sprintf('%s %s', $target, $reason);
+            }
+        }
+
+        if ($warnings !== []) {
+            return CheckResult::warn(
+                $this->name(),
+                $warnings,
+                'a specific listener runs only when the dispatched event is exactly that class -- register the concrete event, or use registerGenericListener() and filter inside it',
+            );
+        }
+
+        return CheckResult::ok(
+            $this->name(),
+            sprintf('%d listener target(s) name a concrete event', count($this->listenerTargets)),
+        );
+    }
+
+    private function whyItCanNeverFire(string $target): ?string
+    {
+        if (interface_exists($target)) {
+            return 'is an interface, and events are matched by exact class';
+        }
+
+        if (!class_exists($target)) {
+            return 'names no class';
+        }
+
+        /** @var ReflectionClass<object> $reflection */
+        $reflection = new ReflectionClass($target);
+
+        if ($reflection->isAbstract()) {
+            return 'is abstract, so no dispatched event can be exactly it';
+        }
+
+        return null;
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -8,6 +8,7 @@ use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSourceCheck;
+use Gacela\Console\Application\Doctor\Check\EventListenerTargetCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
 use Gacela\Console\Application\Doctor\Check\IdeMetadataStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
@@ -20,6 +21,7 @@ use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\IdeMeta\IdeMetadataResult;
+use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\ClassResolverCache;
 use Gacela\Framework\ClassResolver\ResolvableTypes;
 use Gacela\Framework\Config\Config;
@@ -120,6 +122,7 @@ final class DoctorCommand extends Command
             ),
             new ConfigSchemaCheck($config->configSchema(), $config->getAllValues()),
             new StubHealthCheck($stubsDir, StubHealthCheck::readPublished($stubsDir, $declaredKinds), $declaredKinds),
+            new EventListenerTargetCheck($this->specificListenerTargets()),
             new ServiceExtensionTargetCheck(
                 $modules,
                 array_keys($config->getSetupGacela()->getServicesToExtend()),
@@ -141,6 +144,28 @@ final class DoctorCommand extends Command
         }
 
         return $checks;
+    }
+
+    /**
+     * Read off the concrete setup: the listener map is not part of
+     * SetupGacelaInterface, and widening a public contract to reach a
+     * diagnostic would be the tail wagging the dog. An implementation that is
+     * not Gacela's own simply reports nothing here.
+     *
+     * @return list<class-string>
+     */
+    private function specificListenerTargets(): array
+    {
+        $setup = Config::getInstance()->getSetupGacela();
+
+        if (!$setup instanceof SetupGacela) {
+            return [];
+        }
+
+        /** @var list<class-string> $targets */
+        $targets = array_keys($setup->getSpecificListeners() ?? []);
+
+        return $targets;
     }
 
     private function renderResult(CheckResult $result, OutputInterface $output): void

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -76,6 +76,7 @@ final class DoctorCommandTest extends TestCase
             '✓ config sources',
             '✓ config schema',
             '✓ published stubs',
+            '✓ event listeners',
             '✓ service extensions',
             '✓ package manifests',
             '✓ IDE metadata',

--- a/tests/Unit/Console/Application/Doctor/Check/EventListenerTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/EventListenerTargetCheckTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\EventListenerTargetCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapStartedEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EventListenerTargetCheckTest extends TestCase
+{
+    public function test_a_project_registering_no_specific_listener_has_nothing_to_check(): void
+    {
+        $result = (new EventListenerTargetCheck([]))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no specific listeners registered'], $result->details);
+    }
+
+    public function test_a_concrete_event_class_passes(): void
+    {
+        $result = (new EventListenerTargetCheck([GacelaBootstrapStartedEvent::class]))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['1 listener target(s) name a concrete event'], $result->details);
+    }
+
+    /**
+     * The case this exists for. `Container::afterResolving()` matches by
+     * instanceof, so registering against a contract looks reasonable -- and the
+     * dispatcher matches `$event::class`, so it never runs.
+     */
+    public function test_an_interface_is_reported_even_though_events_implement_it(): void
+    {
+        $result = (new EventListenerTargetCheck([GacelaEventInterface::class]))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            [GacelaEventInterface::class . ' is an interface, and events are matched by exact class'],
+            $result->details,
+        );
+        self::assertStringContainsString('registerGenericListener()', $result->remediation);
+    }
+
+    public function test_a_name_that_is_no_class_at_all_is_reported(): void
+    {
+        $result = (new EventListenerTargetCheck(['App\Event\Mispelled']))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['App\Event\Mispelled names no class'], $result->details);
+    }
+
+    public function test_an_abstract_class_is_reported(): void
+    {
+        $result = (new EventListenerTargetCheck([AbstractFixtureEvent::class]))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            [AbstractFixtureEvent::class . ' is abstract, so no dispatched event can be exactly it'],
+            $result->details,
+        );
+    }
+
+    /**
+     * A concrete event nothing dispatches is waiting, not broken: only names
+     * that can never equal `$event::class` are reported.
+     */
+    public function test_every_unfireable_target_is_named_and_the_valid_one_is_not(): void
+    {
+        $result = (new EventListenerTargetCheck([
+            GacelaBootstrapStartedEvent::class,
+            GacelaEventInterface::class,
+            'App\Event\Mispelled',
+        ]))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertCount(2, $result->details);
+        self::assertStringNotContainsString(GacelaBootstrapStartedEvent::class, implode('|', $result->details));
+    }
+}
+
+abstract class AbstractFixtureEvent
+{
+}


### PR DESCRIPTION
## 📚 Description

`ConfigurableEventDispatcher` matches on `$event::class` — the exact, concrete class:

```php
foreach ($this->specificListeners[$event::class] ?? [] as $listener) {
```

So a listener registered against an **interface never runs**, not even for events that implement it. Verified before writing anything:

```php
$config->registerSpecificListener(GacelaBootstrapStartedEvent::class, ...);  // fired: 1
$config->registerSpecificListener(GacelaEventInterface::class, ...);         // fired: 0
```

That second listener is dead, and the event it wanted **does** implement that interface. Nothing at bootstrap objects. A name with a typo behaves the same way — I checked that too, and `registerSpecificListener('Totally\Misspelled', …)` bootstraps happily and never fires.

The interface case is the one worth catching, because it is a reasonable thing to expect to work: **`Container::afterResolving()` in this same framework matches by `instanceof`**, deliberately, so that "after anything implementing LoggerAwareInterface is built" is one registration rather than one per implementation. Someone who learned that behaviour will write the event listener the same way and get silence.

## 🔖 Changes

`EventListenerTargetCheck`, reporting three shapes that can never equal `$event::class`:

```
⚠ event listeners
    Gacela\Framework\Event\GacelaEventInterface is an interface, and events are matched by exact class
    App\Event\Mispelled names no class
    → a specific listener runs only when the dispatched event is exactly that class -- register the
      concrete event, or use registerGenericListener() and filter inside it
```

Also reports an abstract class, for the same reason. `--strict` exits 1, so CI can hold the line.

**A concrete class nothing dispatches is deliberately not reported.** That listener is waiting, not broken — an optional module may raise its event only in some deployments, and flagging it would make the check noise.

## 🔧 One design note

The listener map is not on `SetupGacelaInterface`, only on the concrete `SetupGacela`. I narrowed with `instanceof` rather than widening a public interface to reach a diagnostic — same precedent as `wasBuiltFrom()` in #705. An implementation that is not Gacela's own reports nothing here rather than forcing every implementor to grow a method.

PHPStan caught my first annotation being *wider* than the truth (`list<string>` where the keys are `list<class-string>`), with the apt message "do not widen parameter or return types just to make the error go away". Corrected rather than suppressed.

## 🧪 Tests

Six cases: nothing registered, a concrete class, an interface, a non-existent name, an abstract class, and a mixed list asserting the valid target is *not* named. 100% MSI, no ignores. Verified end to end against a scaffolded project, including `--strict` exiting 1.