### PR TITLE
📝 Say what module count does not cost

### DIFF
--- a/docs/production-performance.md
+++ b/docs/production-performance.md
@@ -75,6 +75,14 @@ GACELA_CACHE_DIR=/var/cache/gacela-prod
 
 `GACELA_CACHE_DIR` overrides the directory at runtime and takes precedence over the bootstrap value.
 
+## What none of this has to pay for
+
+**Module count.** Bootstrapping does not walk your modules — it reads the configuration and builds the container, and costs the same in a project with five modules as in one with five hundred. Measured flat from 10 to 500.
+
+Resolution is charged per module you actually **touch**, not per module you have: a pillar is resolved on first use and memoized, so a request that reaches two modules pays for two. This is why the levers above are about *bootstrap* and *class loading* — the parts every request pays — rather than about the size of the codebase.
+
+If a request in a large application feels slow, the module count is not the first place to look. `debug:module` shows what one module actually resolves, and the [profiler](profiling.md) attributes time to the operations that ran.
+
 ## Checklist
 
 | Step | Lever | Reference |


### PR DESCRIPTION
## 📚 Description

"Will this scale for a large monolith?" is an adoption question `production-performance.md` never answered. I measured it rather than reasoning about it — generated projects of 10, 50, 100 and 500 modules (four pillars each) and timed bootstrap plus resolving every facade:

| modules | bootstrap | resolve all | per module |
|---|---|---|---|
| 10 | 3.8 ms | 0.72 ms | 0.072 ms |
| 50 | 3.8 ms | 1.40 ms | 0.028 ms |
| 100 | 3.5 ms | 2.39 ms | 0.024 ms |
| 500 | 3.4 ms | 9.75 ms | **0.020 ms** |

**Bootstrap is flat** — it reads configuration and builds the container, and never walks modules. **Per-module resolution falls** as the count grows, because the first resolution pays one-time costs that later ones amortise. Nothing is superlinear.

The page now says that as a design property: you pay per module a request *touches*, not per module you have — which is why every lever on that page is about bootstrap and class loading rather than codebase size.

## 🔢 No numbers in the page

The table above is the evidence for the PR, not content for the docs. These are cold-opcache CLI runs; they describe the shape reliably and nobody's production absolutely. Same reason the unverified "20-30%" claim came out in #702.

## 🤔 Why no benchmark

I considered adding a module-scaling bench so a future O(n²) regression could not hide — every existing subject uses one or two modules, so they genuinely would not see it.

`tests/Benchmark/README.md` argues against it convincingly. Such a subject is disk-bound and slow, which makes it a poor `gate` candidate, and the README's own worked example (`ScopedCacheBench`, +48.96% on a PR that changed no runtime code) ends with: *"A gate that fails on PRs which never touched the code does not get fixed — it gets bypassed."* Guarding a hypothetical regression with ~400 committed fixture files, or with per-iteration file generation, is worse than not guarding it.

Also checked before proposing anything: `BenchmarkGroupsTest` already prevents the related rot — a bench with no gating group being silently unmeasured.