### PR TITLE
✅ Guard what the distributed package contains

### DIFF
--- a/tests/Integration/Architecture/DistributedPackageTest.php
+++ b/tests/Integration/Architecture/DistributedPackageTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function exec;
+use function implode;
+use function sprintf;
+use function trim;
+
+/**
+ * What a consumer receives when they `composer require` this package.
+ *
+ * The dist is the working tree minus everything `.gitattributes` marks
+ * `export-ignore`, so that file decides what ships -- and getting it wrong is
+ * silent in both directions. Export-ignoring `resources/` would publish a
+ * package whose documented `opcache.preload` target does not exist; forgetting
+ * to ignore a dev config would ship this repository's own `phpstan.neon` into
+ * everyone else's analysis.
+ *
+ * Asked of git rather than of a built tarball: `git ls-files` plus
+ * `check-attr export-ignore` is exactly the pair that decides membership, and
+ * it needs no archive to be created to answer.
+ */
+final class DistributedPackageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if ($this->git('rev-parse --is-inside-work-tree') !== 'true') {
+            self::markTestSkipped('not a git checkout, so there is no dist to reason about');
+        }
+    }
+
+    /**
+     * Files a consumer's tooling loads by name. Each is referenced from
+     * somewhere outside this repository -- composer's `extra.phpstan.includes`,
+     * an XInclude, or a php.ini `opcache.preload`.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function shippedPaths(): iterable
+    {
+        yield 'phpstan extension' => ['phpstan-gacela.neon'];
+        yield 'psalm fallback config' => ['psalm-gacela.xml'];
+        yield 'opcache preload script' => ['resources/gacela-preload.php'];
+        yield 'the framework itself' => ['src/Framework/Gacela.php'];
+        yield 'the console binary' => ['bin/gacela'];
+    }
+
+    /**
+     * This repository's own tooling. Shipping any of it means a consumer's
+     * analysis or test run picks up configuration written for Gacela's source
+     * tree, not theirs.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function withheldPaths(): iterable
+    {
+        yield 'dev phpstan config' => ['phpstan.neon'];
+        yield 'dev psalm config' => ['psalm.xml'];
+        yield 'phpunit config' => ['phpunit.xml'];
+        yield 'infection config' => ['infection.json5'];
+        yield 'the test suite' => ['tests'];
+    }
+
+    #[DataProvider('shippedPaths')]
+    public function test_a_path_consumers_load_is_in_the_dist(string $path): void
+    {
+        self::assertTrue($this->isTracked($path), sprintf('%s is not tracked, so it cannot ship', $path));
+        self::assertTrue(
+            $this->shipped($path),
+            sprintf('%s is missing from the dist, so consumers never receive it', $path),
+        );
+    }
+
+    #[DataProvider('withheldPaths')]
+    public function test_this_repositorys_own_tooling_stays_here(string $path): void
+    {
+        self::assertTrue($this->isTracked($path), sprintf('%s is not tracked -- fix the fixture, not the rule', $path));
+        self::assertFalse(
+            $this->shipped($path),
+            sprintf("%s ships, and it is written for this source tree rather than a consumer's", $path),
+        );
+    }
+
+    private function isTracked(string $path): bool
+    {
+        return $this->git(sprintf('ls-files -- %s', escapeshellarg($path))) !== '';
+    }
+
+    /**
+     * Asked of the archive itself, not of `check-attr`.
+     *
+     * `check-attr` answers for the path handed to it, and export-ignore is
+     * normally written on a directory -- `/tests`, `/resources`. Exclusion
+     * cascades to the contents; the attribute lookup on a child does not. A
+     * guard built on `check-attr` therefore passes while the file it names is
+     * absent from the dist, which is the one case it exists to catch.
+     */
+    private function shipped(string $path): bool
+    {
+        static $entries = null;
+
+        if ($entries === null) {
+            $output = [];
+            exec(sprintf(
+                'git -C %s archive --format=tar HEAD | tar -t 2>/dev/null',
+                escapeshellarg(dirname(__DIR__, 3)),
+            ), $output);
+
+            $entries = $output;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === $path || str_starts_with($entry, rtrim($path, '/') . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function git(string $arguments): string
+    {
+        $output = [];
+        exec(sprintf('git -C %s %s 2>/dev/null', escapeshellarg(dirname(__DIR__, 3)), $arguments), $output);
+
+        return trim(implode("\n", $output));
+    }
+}


### PR DESCRIPTION
## 📚 Description

`.gitattributes` decides what a consumer receives when they `composer require` this package, and getting it wrong is silent **in both directions**:

- export-ignoring `resources/` publishes a package whose documented `opcache.preload` target does not exist — after #702 and #709 made that script the difference between preloading working and not
- forgetting to ignore a dev config ships *this* repository's `phpstan.neon` into everyone else's analysis

Nothing checked either. I verified the current dist by hand first — 496 files, `phpstan-gacela.neon`, `psalm-gacela.xml` and `resources/` present, `tests/`, `phpstan.neon`, `psalm.xml` absent — so this PR adds the guard, not a fix.

## ⚠️ The first version of this test did not work

It used `git check-attr export-ignore <path>`, which looked obviously right and is not:

```
/resources export-ignore          # committed slip
check-attr resources/gacela-preload.php  ->  unspecified   # test passes
git archive                              ->  file absent   # consumer gets nothing
```

`export-ignore` is written on directories, exclusion **cascades to their contents**, and the attribute lookup on a child does not. So the guard passed while the file it named was missing from the dist — vacuous in precisely the case it exists for.

It now asks `git archive --format=tar HEAD | tar -t`, which is the artifact itself rather than a proxy for it.

## 🧪 Verification

Both directions, by committing a slip on a throwaway branch — editing the working tree proves nothing here, because `git archive HEAD` reads `.gitattributes` from the committed tree:

| committed slip | result |
|---|---|
| `/resources export-ignore` | `resources/gacela-preload.php is missing from the dist, so consumers never receive it` |
| remove `/phpunit.xml export-ignore` | `phpunit.xml ships, and it is written for this source tree rather than a consumer's` |

Each withheld path is also asserted **tracked**, so a renamed fixture fails loudly instead of passing because the path stopped existing.

## 🔍 How it surfaced

`composer archive` fails outright in this working tree:

```
Entry \\ar/folders/.../*.php cannot be created: phar error: invalid path ... contains back-slash
```

That is a known, gitignored fossil — a mutant-mangled `/var/folders/…` path, already documented in `.gitattributes` as having *"broken every Windows job once already"*. It does not affect what ships: Packagist builds dists from `git archive`, which only sees tracked files, and I confirmed that path produces a correct package. Worth knowing that `composer archive` is not the way to inspect the dist here; `git archive` is.