### PR TITLE
✨ doctor --only-problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Declare a class kind of your own with `addResolvableType()`, resolved by suffix like the four pillars and reached through `DeclaredTypeResolverAwareTrait`; the `addSuffixType*()` verbs are now sugar over it
 - Generate a declared kind with `make:file App/Wallet Exporter`, from the stub the project publishes for it at `stubs/gacela/exporter-maker.txt`
 - Generate editor metadata for `getProvidedDependency()` with `ide:meta`, from the `#[Provides]` attributes. An id two providers type differently is listed rather than written, since one application-wide answer would be wrong in one of them
+- Print only the checks that found something with `doctor --only-problems`. Twelve checks is a lot of "✓" to read to find the one "⚠", and `-q` is not the answer: it suppresses everything, so `--strict -q` fails a build without saying what failed
 - Report in `doctor` what a project declared and nothing acts on: an `extendService()` id no Provider `set()`s, a `registerSpecificListener()` target no dispatched event can be, an `addAppConfig()` path matching no file, a cache directory that cannot be written to, a package importing a namespace its own `composer.json` never mentions, and editor metadata the attributes no longer produce. Each of these is accepted today and simply does nothing
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,7 +60,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 | Command | What it does |
 |---|---|
-| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md) and each package's `composer.json` against what it imports. Takes an optional namespace to restrict module-scoped checks, and `--strict` to exit non-zero on warnings too |
+| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md) and each package's `composer.json` against what it imports. Takes an optional namespace to restrict module-scoped checks, `--strict` to exit non-zero on warnings too, and `--only-problems` to print just the checks that found something |
 | `validate:config` | Checks the configuration for errors and best-practice violations, and against the [declared schema](config-schema.md) |
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -52,7 +52,8 @@ final class DoctorCommand extends Command
         $this->setName('doctor')
             ->setDescription('Run environmental & wiring health checks for the current Gacela setup')
             ->addArgument('filter', InputArgument::OPTIONAL, 'Restrict module-scoped checks to this namespace', '')
-            ->addOption('strict', null, InputOption::VALUE_NONE, 'Exit with a failure code on warnings too, for CI');
+            ->addOption('strict', null, InputOption::VALUE_NONE, 'Exit with a failure code on warnings too, for CI')
+            ->addOption('only-problems', null, InputOption::VALUE_NONE, 'Report only the checks that found something');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -61,16 +62,32 @@ final class DoctorCommand extends Command
 
         $filter = ConsoleInput::argument($input, 'filter');
         $strict = $input->getOption('strict') === true;
+        $onlyProblems = $input->getOption('only-problems') === true;
         $checks = $this->buildChecks($filter);
         $worst = CheckStatus::Ok;
+        $rendered = false;
 
         foreach ($checks as $check) {
             $result = $check->run();
-            $this->renderResult($result, $output);
+
+            // A passing check is the bulk of the output and none of the news.
+            // The summary below still reports, so a clean run says so rather
+            // than printing nothing and leaving "did it run?" open.
+            if (!$onlyProblems || $result->status !== CheckStatus::Ok) {
+                $this->renderResult($result, $output);
+                $rendered = true;
+            }
+
             $worst = $this->worseOf($worst, $result->status);
         }
 
-        $output->writeln('');
+        // renderResult() already ends each block with a blank line, so this one
+        // only separates the summary from *something*. With --only-problems and
+        // nothing to report there is nothing to separate it from.
+        if ($rendered) {
+            $output->writeln('');
+        }
+
         ConsoleSection::separator($output);
 
         return match ($worst) {

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -124,6 +124,55 @@ final class DoctorCommandTest extends TestCase
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
     }
 
+    /**
+     * Twelve checks is a lot of "✓" to read to find the one "⚠". `-q` is not
+     * the answer: it suppresses everything, so `--strict -q` fails a build with
+     * no indication of what failed.
+     */
+    public function test_only_problems_hides_the_passing_checks(): void
+    {
+        $tester = $this->doctor([UnhealthyHealthCheck::class], ['--only-problems' => true]);
+
+        $lines = $this->statusLinesOf($tester);
+
+        self::assertContains('✗ module health: UnhealthyModule', $lines);
+        self::assertNotContains('✓ cache staleness', $lines);
+        self::assertNotContains('✓ event listeners', $lines);
+    }
+
+    /**
+     * The remediation is the reason to read the line at all, so hiding the
+     * passing checks must not hide it.
+     */
+    public function test_only_problems_keeps_the_detail_of_what_it_reports(): void
+    {
+        $tester = $this->doctor([DegradedWithMetadataHealthCheck::class], ['--only-problems' => true]);
+
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('Cache is stale', $display);
+        self::assertStringContainsString('stale-entries: 42', $display);
+    }
+
+    /**
+     * A clean run still says so. Printing nothing would leave "did it even
+     * run?" open -- which is what `-q` already does.
+     */
+    public function test_only_problems_still_reports_a_clean_run(): void
+    {
+        $tester = $this->doctor([], ['--only-problems' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertContains('✓ All checks passed', $this->statusLinesOf($tester));
+    }
+
+    public function test_only_problems_does_not_change_the_exit_code(): void
+    {
+        $strict = $this->doctor([DegradedWithoutMetadataHealthCheck::class], ['--only-problems' => true, '--strict' => true]);
+
+        self::assertSame(Command::FAILURE, $strict->getStatusCode(), 'a warning still fails --strict');
+    }
+
     public function test_a_registered_health_check_is_appended_to_the_built_in_ones(): void
     {
         $tester = $this->doctor([FakeHealthCheck::class]);


### PR DESCRIPTION
## 📚 Description

`doctor` runs twelve checks now. On a healthy project that is **41 lines of `✓`**; on one with a single warning, 43 lines to find the one that matters.

`-q` is not the answer — it suppresses *everything*:

```
$ gacela doctor -q            # project HAS warnings
                              # (no output at all)
$ gacela doctor --strict -q; echo $?
1                             # a build fails and says nothing about why
```

Redefining `-q` to mean "problems only" would also break the convention every other Symfony command follows, so this is its own flag.

```
$ gacela doctor --only-problems

Gacela Doctor
============================================================

⚠ event listeners
    Gacela\Framework\Event\GacelaEventInterface is an interface, and events are matched by exact class
    App\Event\Mispelled names no class
    → a specific listener runs only when the dispatched event is exactly that class -- register the
      concrete event, or use registerGenericListener() and filter inside it

============================================================
⚠ Doctor finished with warnings
```

43 lines → 13.

## 🔖 Behaviour worth stating

- **The detail and remediation survive.** Hiding the passing checks must not hide the reason to read the line at all.
- **A clean run still reports** (41 lines → 8, ending in `✓ All checks passed`). Printing nothing would leave *"did it even run?"* open — which is exactly `-q`'s failure mode.
- **The exit code is unchanged.** `--only-problems --strict` still fails on a warning; this flag decides what is printed, not what counts.

## 🧪 Tests

Four cases on `DoctorCommandTest`: passing checks hidden, the reported check keeps its detail and metadata, a clean run still prints the summary, and the exit code is untouched under `--strict`.

Asserted directly rather than via mutation coverage: `Gacela\Console\Infrastructure\Command\*` is excluded from the gate by design as presentation code, and `infection.json5` says the behaviour worth pinning there — *"exit codes, which check reported what, whether a flag changes what gets written"* — belongs in targeted assertions. That is precisely this flag.

Also removed a stray blank line: `renderResult()` already ends each block with one, so the pre-summary blank only separates the summary from *something*. With nothing reported there was nothing to separate it from, and the clean output had two blanks stacked before the rule.