### PR TITLE
📝 Note what an infection run leaves behind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Source code lives in `src/` under the `Gacela\` namespace, grouped by module-res
 - `composer quality` — quick guardrail: php-cs-fixer dry run, Psalm, then PHPStan.
 - `composer csfix` / `composer csrun` — auto-fix or check formatting with php-cs-fixer config.
 - `composer phpbench` — execute aggregate performance benchmarks.
-- `composer infection` — mutation testing; requires Xdebug enabled.
+- `composer infection` — mutation testing; requires Xdebug enabled. It runs mutated code, which writes files into fixture directories and, when a mutant mangles a path, into a directory named after the mangled root (`\\ar/...`, from `/var/...`). All of it is gitignored and rector is configured to skip it, so a run leaves the suite green — but it does break `composer archive`, which filters by `.gitattributes` rather than `.gitignore` and refuses the back-slashed name. Use `git archive HEAD` to inspect what ships; that is also what Packagist builds from.
 
 ## Coding Style & Naming Conventions
 


### PR DESCRIPTION
## 📚 Description

`composer infection` runs mutated code. That code writes files — into the bridges' fixture directories, and when a mutant mangles a path separator, into a directory named after the mangled root: `\\ar/folders/...`, from `/var/folders/...`.

Everything about that is already handled *except* discoverability:

- `.gitignore` stops it being committed (and explains the `\\ar` case in a comment)
- `rector.php` skips the generated caches, so `composer test` stays green (#706)
- so nothing points at it at all — until `composer archive` fails:

```
Entry \\ar/folders/.../*.php cannot be created:
phar error: invalid path ... contains back-slash
```

`composer archive` filters by `.gitattributes`, not `.gitignore`, so an untracked artifact is enough to stop it. Working that out from the error alone took me about twenty minutes, and the answer — use `git archive HEAD`, which is what Packagist builds from anyway — is not written anywhere.

One line in the `composer infection` entry of `AGENTS.md`, where someone reading about the command will already be.

## 🔍 Context

This is the last loose end from #706 and #720. #706 fixed the part that broke the suite; #720 verified what actually ships and guards it. Neither wrote down the part that only bites a maintainer inspecting the dist.

No behaviour change; `AGENTS.md` is export-ignored, so this does not affect consumers.