### PR TITLE
📝 Store the benchmark baseline twice before believing it

### DIFF
--- a/tests/Benchmark/README.md
+++ b/tests/Benchmark/README.md
@@ -28,7 +28,14 @@ vendor/bin/phpbench run <path> --tag=selfbase --store --progress=none
 vendor/bin/phpbench run <path> --ref=selfbase --report=aggregate --progress=none
 ```
 
-If unchanged code drifts near the threshold, the subject belongs in `informational`, not in `gate` with a widened tolerance. `ScopedCacheBench` is the worked example: gated at ±10%, widened to ±30%, and it still produced +48.96% on a PR that changed no runtime code. Widening again would have left a "gate" that only catches a >1.6x regression. A gate that fails on PRs which never touched the code does not get fixed — it gets bypassed, which costs more than not having it.
+**Store the baseline twice before believing it.** The stored run is one sample too, and an unusually fast one makes every later run look like a regression. Measured here: against one baseline, `bench_resolve_with_inject_attribute` reported `+10.38%` and then `+10.66%` on untouched code -- enough to condemn the subject -- and against a baseline stored minutes later, `-0.04%` and `-5.08%`. The tell was that *every* subject in the file had moved the same direction, which says something about the baseline rather than about any one of them.
+
+```bash
+vendor/bin/phpbench run <path> --tag=selfbase2 --store --progress=none
+vendor/bin/phpbench run <path> --ref=selfbase2 --report=aggregate --progress=none
+```
+
+If unchanged code drifts near the threshold **against both baselines**, the subject belongs in `informational`, not in `gate` with a widened tolerance. `ScopedCacheBench` is the worked example: gated at ±10%, widened to ±30%, and it still produced +48.96% on a PR that changed no runtime code. Widening again would have left a "gate" that only catches a >1.6x regression. A gate that fails on PRs which never touched the code does not get fixed — it gets bypassed, which costs more than not having it.
 
 Prefer moving the subject to `informational` over widening a gate past ~30%.
 


### PR DESCRIPTION
## 📚 Description

The perf gate failed on #723 — a **one-line docs change to `AGENTS.md`** — with `bench_resolve_with_bindings` at `+10.46%`. It passed on rerun, as an identical flake did on #702 earlier.

Rather than only rerunning, I followed the procedure this file prescribes for a suspect subject: store a self-baseline, re-measure unchanged code against it.

```
bench_resolve_with_inject_attribute   +10.38%   then  +10.66%     # unchanged code
```

Over the ±10% gate, twice, with `rstdev` at ±1.5–2.6% — exactly the "rstdev is not sufficient on its own" case this file describes. By its own guidance the subject belongs in `informational`, and **that is the change I was about to propose**.

Then I noticed *every* subject in the file had moved the same direction (`+1.94`, `+10.38`, `+6.09`, `+1.42`), which fits "the baseline was fast" as well as "the subject is unstable". Storing a second baseline separated them:

```
bench_resolve_with_inject_attribute    -0.04%   then   -5.08%     # same code, new baseline
bench_resolve_with_bindings            -0.75%   then   -6.36%
```

The subjects are fine. **The first baseline was the anomaly.**

## 🔖 Changes

The missing step, and the tell that catches it: a uniform direction across every subject in a file is evidence about the baseline, not about any one subject. The verdict now requires drift against *both* baselines.

## 🚫 What this PR deliberately does not do

**No gate configuration changes.** Two false positives this session on changes that cannot affect runtime is real, but the corrected measurement shows natural drift spanning roughly −6% to +10% depending on which run becomes the baseline — the ±10% threshold simply sits near that band. That explains both flakes without implicating a subject, and weakening a blocking gate on the strength of one misread baseline is exactly what this file warns leads to a gate nobody trusts.