### PR TITLE
🐛 Suggest the config key that was meant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Name the config key that was meant when one is not found. `ConfigException::keyNotFound()` has always accepted the available keys and always been handed none, leaving `Did you mean?` unreachable for config while the identical helper worked for services; all six typed getters now supply them. Since the config is flat, a nested reach like `database.host` is answered with `database`
 - Declare `psr/container` in both bridge manifests and `symfony/console` in the Laravel bridge's, and demote their test-only requirements to `require-dev`, so each manifest states what its `src/` imports and only that
 - Key the on-disk class-name cache by the bootstrap's `projectNamespaces` and suffix types, so two bootstraps of one app sharing a cache dir no longer serve each other's classes
 - Point the "missing return type" exception at the namespace `ServiceMap` actually lives in: its recommended fix named one that does not exist, so following it left the attribute unmatched. Its docblock alternative is now marked as the deprecated path it is

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -17,6 +17,7 @@ use Gacela\Framework\Exception\ConfigException;
 use RuntimeException;
 
 use function array_key_exists;
+use function array_keys;
 use function count;
 use function is_array;
 use function is_bool;
@@ -103,7 +104,7 @@ final class Config implements ConfigInterface
         if (!$this->hasKey($key)) {
             $this->notifyKeyNotFound($key);
 
-            throw ConfigException::keyNotFound($key, self::class);
+            throw $this->keyNotFound($key);
         }
 
         return $this->config[$key];
@@ -123,7 +124,7 @@ final class Config implements ConfigInterface
                 return $default;
             }
 
-            throw ConfigException::keyNotFound($key, self::class);
+            throw $this->keyNotFound($key);
         }
 
         $value = $this->config[$key];
@@ -148,7 +149,7 @@ final class Config implements ConfigInterface
                 return $default;
             }
 
-            throw ConfigException::keyNotFound($key, self::class);
+            throw $this->keyNotFound($key);
         }
 
         $value = $this->config[$key];
@@ -175,7 +176,7 @@ final class Config implements ConfigInterface
                 return $default;
             }
 
-            throw ConfigException::keyNotFound($key, self::class);
+            throw $this->keyNotFound($key);
         }
 
         $value = $this->config[$key];
@@ -204,7 +205,7 @@ final class Config implements ConfigInterface
                 return $default;
             }
 
-            throw ConfigException::keyNotFound($key, self::class);
+            throw $this->keyNotFound($key);
         }
 
         $value = $this->config[$key];
@@ -233,7 +234,7 @@ final class Config implements ConfigInterface
                 return $default;
             }
 
-            throw ConfigException::keyNotFound($key, self::class);
+            throw $this->keyNotFound($key);
         }
 
         $value = $this->config[$key];
@@ -415,6 +416,22 @@ final class Config implements ConfigInterface
     public function mergedConfigCache(): MergedConfigCache
     {
         return $this->createMergedConfigCache();
+    }
+
+    /**
+     * Every "key not found" carries the keys that do exist, so a typo can be
+     * answered with the name that was meant.
+     *
+     * Routed through one method because the six typed getters each raise this
+     * independently, and the suggestion was previously absent from all of them:
+     * `ConfigException::keyNotFound()` has always taken the available keys and
+     * has always been handed none, leaving `Did you mean?` unreachable for
+     * config while the identical machinery worked for services. A seventh
+     * getter cannot now forget them.
+     */
+    private function keyNotFound(string $key): ConfigException
+    {
+        return ConfigException::keyNotFound($key, self::class, array_keys($this->config));
     }
 
     /**

--- a/tests/Unit/Framework/Config/ConfigKeySuggestionTest.php
+++ b/tests/Unit/Framework/Config/ConfigKeySuggestionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Config;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Exception\ConfigException;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A mistyped config key answered with the key that was meant.
+ *
+ * `ConfigException::keyNotFound()` has always accepted the available keys and
+ * always been handed none, so `Did you mean?` was unreachable for config while
+ * the identical helper worked for services through {@see \Gacela\Framework\Container\Locator}.
+ * Nothing failed -- the suggestion simply never appeared.
+ */
+final class ConfigKeySuggestionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::resetInstance();
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+            $config->addAppConfigKeyValues([
+                'database' => ['host' => 'localhost'],
+                'api-token' => 'super-secret-value',
+                'retries' => 3,
+            ]);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Config::resetInstance();
+    }
+
+    /**
+     * Every typed getter raises this independently, and the suggestion was
+     * missing from all six. Asked of each one so a getter added later cannot
+     * quietly go back to the bare message.
+     *
+     * @return iterable<string, array{callable(Config, string): mixed}>
+     */
+    public static function getters(): iterable
+    {
+        yield 'get' => [static fn (Config $c, string $k): mixed => $c->get($k)];
+        yield 'getString' => [static fn (Config $c, string $k): string => $c->getString($k)];
+        yield 'getInt' => [static fn (Config $c, string $k): int => $c->getInt($k)];
+        yield 'getFloat' => [static fn (Config $c, string $k): float => $c->getFloat($k)];
+        yield 'getBool' => [static fn (Config $c, string $k): bool => $c->getBool($k)];
+        yield 'getArray' => [static fn (Config $c, string $k): array => $c->getArray($k)];
+    }
+
+    /**
+     * @param callable(Config, string): mixed $read
+     */
+    #[DataProvider('getters')]
+    public function test_every_getter_suggests_the_key_that_was_meant(callable $read): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage("Did you mean?\n  - database");
+
+        $read(Config::getInstance(), 'databse');
+    }
+
+    /**
+     * Gacela's config is flat -- `hasKey()` is a plain `array_key_exists`, with
+     * no traversal into nested values. Reaching for `database.host` is a
+     * reasonable habit from elsewhere, and naming `database` is how that reader
+     * finds out the nesting is theirs to walk.
+     */
+    public function test_a_dotted_key_points_at_the_top_level_key_that_holds_it(): void
+    {
+        $this->expectExceptionMessage("Did you mean?\n  - database");
+
+        Config::getInstance()->get('database.host');
+    }
+
+    /**
+     * Suggestions are similar keys, not a listing. A key resembling nothing
+     * gets the plain message rather than the whole config surface.
+     */
+    public function test_a_key_resembling_nothing_is_not_offered_alternatives(): void
+    {
+        try {
+            Config::getInstance()->get('zzzzzzzzzz');
+            self::fail('Expected ConfigException');
+        } catch (ConfigException $configException) {
+            self::assertStringContainsString('Could not find config key "zzzzzzzzzz"', $configException->getMessage());
+            self::assertStringNotContainsString('Did you mean?', $configException->getMessage());
+        }
+    }
+
+    /**
+     * Key names travel; values do not. This message reaches logs and error
+     * pages, and a config holds credentials -- so the suggestion is built from
+     * `array_keys()` alone.
+     */
+    public function test_the_suggestion_never_carries_a_config_value(): void
+    {
+        try {
+            Config::getInstance()->getString('api-toke');
+            self::fail('Expected ConfigException');
+        } catch (ConfigException $configException) {
+            self::assertStringContainsString('api-token', $configException->getMessage());
+            self::assertStringNotContainsString('super-secret-value', $configException->getMessage());
+        }
+    }
+
+    /**
+     * A default is the caller saying the key is optional, so a miss is not a
+     * mistake to be corrected.
+     */
+    public function test_a_getter_given_a_default_still_returns_it(): void
+    {
+        self::assertSame('fallback', Config::getInstance()->getString('databse', 'fallback'));
+    }
+}


### PR DESCRIPTION
## 📚 Description

A mistyped config key now answers with the key that was meant.

`ConfigException::keyNotFound()` has always taken `$availableKeys` and has always
called `ErrorSuggestionHelper::suggestSimilar()` with them. All six call sites
passed none, so the parameter sat at its `[]` default and `Did you mean?` was
unreachable for config — while the identical helper has been live and tested for
services, where `Locator` passes `knownServiceNames()`.

Nothing failed. The suggestion simply never appeared.

Before:

```
Could not find config key "databse" in "Gacela\Framework\Config\Config"
```

After:

```
Could not find config key "databse" in "Gacela\Framework\Config\Config"

Did you mean?
  - database
```

## 🔖 Changes

- `Config` supplies `array_keys($this->config)` on every "key not found", through
  one private `keyNotFound()` method rather than six repetitions — six sites each
  passing this independently is why it went stale, and a seventh getter cannot
  now forget.
- A nested reach like `database.host` is answered with `database`. Gacela's config
  is flat (`hasKey()` is a plain `array_key_exists`, no traversal), so dotted
  access is a reasonable habit from elsewhere that silently misses; naming the
  top-level key is how that reader finds out the nesting is theirs to walk.

## ✅ Notes

- **Only key names travel, never values.** Suggestions are built from
  `array_keys()` alone, and the helper already caps at 3 entries over a 0.4
  similarity threshold — so a miss discloses at most three key names, not the
  config surface. Pinned by a test, since these messages reach logs.
- Tests are asked of **each of the six getters** via a data provider, because
  "six sites, none wired" is precisely what regressed.
- Verified the tests fail without the fix: **8 of 10 fail**, the 2 that pass
  being the negative cases (nothing similar → no suggestion; default given →
  returned), which the change correctly leaves alone.
- Full gate green: 1690 unit / 333 integration / 410 feature, psalm + phpstan +
  cs-fixer clean. Infection on `Config.php`: 156 killed, 100% mutation code
  coverage; the 2 escaped mutants are pre-existing and untouched here (the
  eager-assembly call on line 280 and the `configSchema` memoization).
