### PR TITLE
🐛 Advise on the kind that failed to resolve, not always the Facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Fixed
 
+- Advise on the kind that failed to resolve. A missing `Provider` named `Provider` four times and then closed with "Ensure your Facade extends AbstractFacade" — the fixed tip text was the only thing in the message not derived from the kind, and the two exceptions carrying it are raised for a `Provider` and for a kind declared through `addResolvableType()`, never for a Facade. A declared kind is no longer offered an `Abstract*` base the framework does not ship
+- Name the module-prefixed class in the resolver's `E.g.` line, matching what `make:module` writes and the first candidate the finder tries; the unprefixed `\App\Wallet\Provider` it named resolves too, but is not the spelling anything else in the message uses
 - Name the config key that was meant when one is not found. `ConfigException::keyNotFound()` has always accepted the available keys and always been handed none, leaving `Did you mean?` unreachable for config while the identical helper worked for services; all six typed getters now supply them. Since the config is flat, a nested reach like `database.host` is answered with `database`
 - Declare `psr/container` in both bridge manifests and `symfony/console` in the Laravel bridge's, and demote their test-only requirements to `require-dev`, so each manifest states what its `src/` imports and only that
 - Key the on-disk class-name cache by the bootstrap's `projectNamespaces` and suffix types, so two bootstraps of one app sharing a cache dir no longer serve each other's classes

--- a/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
+++ b/src/Framework/ClassResolver/ClassResolverExceptionTrait.php
@@ -48,7 +48,7 @@ trait ClassResolverExceptionTrait
             }
         }
 
-        return $message . ErrorSuggestionHelper::addHelpfulTip('facade_not_found');
+        return $message . ErrorSuggestionHelper::addResolvableTypeTip($resolvableType);
     }
 
     /**
@@ -83,11 +83,26 @@ trait ClassResolverExceptionTrait
         return array_values(array_unique($candidates));
     }
 
+    /**
+     * The module-prefixed name, which is the convention `make:module` writes
+     * and the first candidate the finder tries.
+     *
+     * The unprefixed `\App\Wallet\Provider` this used to name resolves too, so
+     * nothing was broken -- it simply pointed away from the spelling every
+     * generated module, and the candidate list directly below it, already uses.
+     *
+     * Built from the module's own namespace rather than read off the head of
+     * the candidate list: candidates are ordered by configured project
+     * namespace, so the first is `\App\Wallet\WalletProvider` for a project
+     * whose first namespace is `App` even when the module lives elsewhere
+     * entirely.
+     */
     private function findClassNameExample(ClassInfo $classInfo, string $resolvableType): string
     {
         return sprintf(
-            '\\%s\\%s\\%s',
+            '\\%s\\%s\\%s%s',
             $classInfo->getModuleNamespace(),
+            $classInfo->getModuleName(),
             $classInfo->getModuleName(),
             $resolvableType,
         );

--- a/src/Framework/Exception/ErrorSuggestionHelper.php
+++ b/src/Framework/Exception/ErrorSuggestionHelper.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Exception;
 
+use function array_map;
 use function array_slice;
+use function class_exists;
 use function implode;
 use function similar_text;
 use function sprintf;
@@ -37,6 +39,38 @@ final class ErrorSuggestionHelper
         );
     }
 
+    /**
+     * Tips for a class the resolver could not find, phrased in terms of the
+     * kind it was actually looking for.
+     *
+     * These replace a fixed `facade_not_found` text that named `Facade` in
+     * every message. The two exceptions carrying these tips are raised for a
+     * `Provider` and for a docblock-declared kind, and a Facade is constructed
+     * rather than resolved -- so the advice named the one kind it could never
+     * be, directly under a message naming the right one.
+     *
+     * The base-class line is offered only where that base exists: the four
+     * pillars have an `Abstract*`, a kind declared through
+     * `addResolvableType()` has none, and inventing `AbstractExporter` sends
+     * the reader looking for a class Gacela does not ship.
+     */
+    public static function addResolvableTypeTip(string $resolvableType): string
+    {
+        $tips = [];
+
+        if (class_exists('Gacela\\Framework\\Abstract' . $resolvableType)) {
+            $tips[] = sprintf('Ensure your %s extends Abstract%s', $resolvableType, $resolvableType);
+        }
+
+        $tips[] = 'Check the module namespace matches the directory structure';
+        $tips[] = sprintf('Verify the %s file name matches the class name', $resolvableType);
+
+        return sprintf(
+            "\n\nTips:\n%s",
+            implode("\n", array_map(static fn (string $t): string => '  • ' . $t, $tips)),
+        );
+    }
+
     public static function addHelpfulTip(string $context): string
     {
         return match ($context) {
@@ -50,11 +84,6 @@ final class ErrorSuggestionHelper
                 "  • Check if the service is registered in a Provider\n" .
                 "  • Verify the service binding in gacela.php\n" .
                 '  • Ensure the service class exists and is autoloadable',
-
-            'facade_not_found' => "\n\nTips:\n" .
-                "  • Ensure your Facade extends AbstractFacade\n" .
-                "  • Check the module namespace matches the directory structure\n" .
-                '  • Verify the Facade file name matches the class name',
 
             'config_error' => "\n\nTips:\n" .
                 "  • Check your gacela.php configuration file\n" .

--- a/tests/Feature/Framework/ClassResolver/ResolutionCandidatesTest.php
+++ b/tests/Feature/Framework/ClassResolver/ResolutionCandidatesTest.php
@@ -34,9 +34,24 @@ final class ResolutionCandidatesTest extends TestCase
         $message = $exception->getMessage();
 
         self::assertStringContainsString('Tried resolving the following class names:', $message);
+
+        // Asked of the bulleted list rather than the whole message: the `E.g.`
+        // line names the module-prefixed class too, so a message-wide search
+        // for it passes even with the prefix finder rule removed -- which is
+        // the one thing this test is here to notice.
+        $candidates = $this->candidateLines($message);
+
         // The two finder rules produce a module-prefixed and a bare candidate.
-        self::assertStringContainsString('\\ClassResolver\\ClassResolverProvider', $message);
-        self::assertStringContainsString('\\ClassResolver\\Provider', $message);
+        self::assertContains(
+            'ClassResolverProvider',
+            $this->shortNames($candidates),
+            'the module-prefixed candidate is missing from the list',
+        );
+        self::assertContains(
+            'Provider',
+            $this->shortNames($candidates),
+            'the bare candidate is missing from the list',
+        );
     }
 
     public function test_candidates_are_rendered_as_a_bulleted_block(): void
@@ -66,5 +81,31 @@ final class ResolutionCandidatesTest extends TestCase
         preg_match_all('/^ {2}- (\S+)$/m', $message, $matches);
         self::assertNotSame([], $matches[1]);
         self::assertSame(array_values(array_unique($matches[1])), $matches[1]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateLines(string $message): array
+    {
+        preg_match_all('/^ {2}- (\S+)$/m', $message, $matches);
+
+        /** @var list<string> $candidates */
+        $candidates = $matches[1];
+
+        return $candidates;
+    }
+
+    /**
+     * @param list<string> $candidates
+     *
+     * @return list<string>
+     */
+    private function shortNames(array $candidates): array
+    {
+        return array_values(array_map(
+            static fn (string $c): string => substr((string)strrchr($c, '\\'), 1),
+            $candidates,
+        ));
     }
 }

--- a/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockServiceNotFoundExceptionTest.php
+++ b/tests/Unit/Framework/ClassResolver/DocBlockService/DocBlockServiceNotFoundExceptionTest.php
@@ -29,13 +29,12 @@ final class DocBlockServiceNotFoundExceptionTest extends TestCase
 ClassResolver Exception
 Cannot resolve the `ResolvableType` for your module `FakeModule`
 You can fix this by adding the missing `ResolvableType` to your module.
-E.g. `\GacelaTest\Unit\FakeModule\ResolvableType`
+E.g. `\GacelaTest\Unit\FakeModule\FakeModuleResolvableType`
 
 
 Tips:
-  • Ensure your Facade extends AbstractFacade
   • Check the module namespace matches the directory structure
-  • Verify the Facade file name matches the class name
+  • Verify the ResolvableType file name matches the class name
 EOT;
 
         self::assertSame($expected, $exception->getMessage());

--- a/tests/Unit/Framework/ClassResolver/Provider/ProviderNotFoundExceptionTest.php
+++ b/tests/Unit/Framework/ClassResolver/Provider/ProviderNotFoundExceptionTest.php
@@ -20,9 +20,23 @@ final class ProviderNotFoundExceptionTest extends TestCase
 ClassResolver Exception
 Cannot resolve the `Provider` for your module `FakeModule`
 You can fix this by adding the missing `Provider` to your module.
-E.g. `\GacelaTest\Unit\FakeModule\Provider`
+E.g. `\GacelaTest\Unit\FakeModule\FakeModuleProvider`
 EOT;
 
         self::assertStringStartsWith($expectedStart, $exception->getMessage());
+    }
+
+    /**
+     * The tips used to be a fixed `facade_not_found` text, so this message named
+     * `Provider` four times and then advised on a `Facade` -- and this exception
+     * is never raised for a Facade, which is constructed rather than resolved.
+     */
+    public function test_the_tips_advise_on_the_kind_the_message_names(): void
+    {
+        $message = (new ProviderNotFoundException(new FakeFacade()))->getMessage();
+
+        self::assertStringContainsString('Ensure your Provider extends AbstractProvider', $message);
+        self::assertStringContainsString('Verify the Provider file name matches the class name', $message);
+        self::assertStringNotContainsString('Facade', $message);
     }
 }

--- a/tests/Unit/Framework/Exception/ErrorSuggestionHelperTest.php
+++ b/tests/Unit/Framework/Exception/ErrorSuggestionHelperTest.php
@@ -7,6 +7,8 @@ namespace GacelaTest\Unit\Framework\Exception;
 use Gacela\Framework\Exception\ErrorSuggestionHelper;
 use PHPUnit\Framework\TestCase;
 
+use function sprintf;
+
 final class ErrorSuggestionHelperTest extends TestCase
 {
     public function test_suggest_similar_returns_empty_string_when_no_options_available(): void
@@ -129,14 +131,45 @@ final class ErrorSuggestionHelperTest extends TestCase
         self::assertSame($expected, ErrorSuggestionHelper::addHelpfulTip('service_not_found'));
     }
 
-    public function test_add_helpful_tip_for_facade_not_found(): void
+    /**
+     * A pillar has an `Abstract*` to extend, so the advice names it.
+     */
+    public function test_tips_for_a_pillar_name_that_pillar(): void
     {
         $expected = "\n\nTips:\n"
-            . "  • Ensure your Facade extends AbstractFacade\n"
+            . "  • Ensure your Provider extends AbstractProvider\n"
             . "  • Check the module namespace matches the directory structure\n"
-            . '  • Verify the Facade file name matches the class name';
+            . '  • Verify the Provider file name matches the class name';
 
-        self::assertSame($expected, ErrorSuggestionHelper::addHelpfulTip('facade_not_found'));
+        self::assertSame($expected, ErrorSuggestionHelper::addResolvableTypeTip('Provider'));
+    }
+
+    /**
+     * A kind declared through `addResolvableType()` has no base class in the
+     * framework, so the line offering one is left out rather than pointing at
+     * an `AbstractExporter` that does not exist.
+     */
+    public function test_tips_for_a_declared_kind_omit_a_base_class_it_has_none_of(): void
+    {
+        $expected = "\n\nTips:\n"
+            . "  • Check the module namespace matches the directory structure\n"
+            . '  • Verify the Exporter file name matches the class name';
+
+        self::assertSame($expected, ErrorSuggestionHelper::addResolvableTypeTip('Exporter'));
+    }
+
+    /**
+     * All four pillars, because the tip is derived from the kind rather than
+     * written out per kind.
+     */
+    public function test_every_pillar_is_offered_its_own_base_class(): void
+    {
+        foreach (['Facade', 'Factory', 'Config', 'Provider'] as $pillar) {
+            self::assertStringContainsString(
+                sprintf('Ensure your %s extends Abstract%s', $pillar, $pillar),
+                ErrorSuggestionHelper::addResolvableTypeTip($pillar),
+            );
+        }
     }
 
     public function test_add_helpful_tip_for_config_error(): void


### PR DESCRIPTION
## 📚 Description

`buildMessage()` derives every line of a resolver failure from `$resolvableType`
— except the tips, which were a fixed `facade_not_found` text. So a missing
`Provider` named `Provider` four times and then advised on a Facade:

```
Cannot resolve the `Provider` for your module `Wallet`
You can fix this by adding the missing `Provider` to your module.
E.g. `\App\Wallet\Provider`
Tried resolving the following class names:
  - \App\Wallet\WalletProvider
  - \App\Wallet\Provider

Tips:
  • Ensure your Facade extends AbstractFacade          ← not a Facade
  • Check the module namespace matches the directory structure
  • Verify the Facade file name matches the class name  ← not a Facade
```

The two exceptions carrying these tips are raised for a `Provider` and for a kind
declared through `addResolvableType()`. Neither is ever a Facade — a Facade is
constructed, not resolved — so that advice named the one kind it could not be.

After:

```
E.g. `\App\Wallet\WalletProvider`
...
Tips:
  • Ensure your Provider extends AbstractProvider
  • Check the module namespace matches the directory structure
  • Verify the Provider file name matches the class name
```

## 🔖 Changes

- `ErrorSuggestionHelper::addResolvableTypeTip()` phrases the tips in terms of the
  kind being resolved. The `Abstract*` line is offered only where that base class
  exists, so a kind from `addResolvableType()` is not sent looking for an
  `AbstractExporter` Gacela does not ship.
- The `E.g.` line names the module-prefixed class — what `make:module` writes, and
  the first candidate the finder tries. It is built from the module's own
  namespace rather than read off the head of the candidate list, because that list
  is ordered by configured project namespace: for a project whose first namespace
  is `App`, the head is `\App\FakeModule\FakeModuleProvider` even when the module
  lives elsewhere entirely. I tried the candidate-list approach first and measured
  it producing a worse example than the one it replaced.
- Removed the now-orphaned `facade_not_found` arm of `addHelpfulTip()`.

## ✅ Notes

- **This change silently weakened an existing test, and infection caught it.**
  `test_not_found_exception_lists_the_candidates_tried` asserted
  `\ClassResolver\ClassResolverProvider` appeared *anywhere* in the message — and
  the new `E.g.` line contains that exact string, so the assertion passed even
  with `FinderRuleWithModulePrefix` deleted from the rules array. Now asked of the
  bulleted candidate list specifically. The escaping `ArrayItemRemoval` mutant is
  killed again: 94 mutants, **0 escaped, 100% MSI** on both changed files.
- Full gate green: 1693 unit / 333 integration / 410 feature, psalm + phpstan +
  cs-fixer clean. Rebased onto current `main` (post-#726) and re-measured.

## 🔭 Out of scope

`addHelpfulTip('class_not_found')` is dead — reachable only from its own unit test,
never passed by `src/`. It predates this change and I left it alone rather than
fold an unrelated removal into this diff. Happy to drop it in a follow-up.
