### PR TITLE
✨ Refuse to overwrite an existing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Changed
 
+- Refuse to overwrite in `make:module` and `make:file`, and add `--force` for when replacing is the intent. Generating over an existing module replaced every pillar with a stub and reported "created successfully" for each one, with no prompt and no flag — the only record that hand-written code had been there was the file it had just been written over. Every target is now checked before the first is written, so a run that would replace something writes nothing and names what is in the way. **This changes existing behaviour**: a script that regenerates a module in place now needs `--force`
 - Resolve a class name to its kind through the configured suffixes rather than the four literal pillar names. A project on `addSuffixTypeFacade('PublicApi')` now normalizes `App\Foo\FooPublicApi` to the `Facade` key the resolver looks up, so an `overrideExistingResolvedClass()` call on such a name takes effect where it was inert before
 
 ### Fixed

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -52,19 +52,22 @@ final class ConsoleFacade extends AbstractFacade
     /**
      * Which of the files a `make:*` run would write already exist.
      *
+     * A target path is built from the module arguments alone -- the stubs a
+     * template would fill in never reach it -- so which template is in play
+     * makes no difference here, and asking would be a distinction nothing
+     * could observe.
+     *
      * @param list<array{string, string}> $files [filename, subDirectory] pairs
-     * @param bool $service whether the service template's generator is the one that would write them
      *
      * @return list<string>
      */
     public function existingGeneratedFiles(
         CommandArguments $commandArguments,
         array $files,
-        bool $withShortName = false,
-        bool $service = false,
+        bool $withShortName,
     ): array {
         return $this->getFactory()
-            ->createFileContentGeneratorFor($service)
+            ->createFileContentGenerator()
             ->existingTargets($commandArguments, $files, $withShortName);
     }
 

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -49,6 +49,25 @@ final class ConsoleFacade extends AbstractFacade
      *
      * @param string $subDirectory optional sub-directory (relative to the module dir) to place the file in
      */
+    /**
+     * Which of the files a `make:*` run would write already exist.
+     *
+     * @param list<array{string, string}> $files [filename, subDirectory] pairs
+     * @param bool $service whether the service template's generator is the one that would write them
+     *
+     * @return list<string>
+     */
+    public function existingGeneratedFiles(
+        CommandArguments $commandArguments,
+        array $files,
+        bool $withShortName = false,
+        bool $service = false,
+    ): array {
+        return $this->getFactory()
+            ->createFileContentGeneratorFor($service)
+            ->existingTargets($commandArguments, $files, $withShortName);
+    }
+
     public function generateServiceFileContent(
         CommandArguments $commandArguments,
         string $filename,

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -112,6 +112,20 @@ final class ConsoleFactory extends AbstractFactory
         );
     }
 
+    /**
+     * The generator a `make:*` run would use, picked by template.
+     *
+     * Here rather than in the Facade so the two paths that must agree on a
+     * target path -- checking what exists and writing it -- resolve the same
+     * generator.
+     */
+    public function createFileContentGeneratorFor(bool $service): FileContentGeneratorInterface
+    {
+        return $service
+            ? $this->createServiceFileContentGenerator()
+            : $this->createFileContentGenerator();
+    }
+
     public function createServiceFileContentGenerator(): FileContentGeneratorInterface
     {
         return new FileContentGenerator(

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -112,20 +112,6 @@ final class ConsoleFactory extends AbstractFactory
         );
     }
 
-    /**
-     * The generator a `make:*` run would use, picked by template.
-     *
-     * Here rather than in the Facade so the two paths that must agree on a
-     * target path -- checking what exists and writing it -- resolve the same
-     * generator.
-     */
-    public function createFileContentGeneratorFor(bool $service): FileContentGeneratorInterface
-    {
-        return $service
-            ? $this->createServiceFileContentGenerator()
-            : $this->createFileContentGenerator();
-    }
-
     public function createServiceFileContentGenerator(): FileContentGeneratorInterface
     {
         return new FileContentGenerator(

--- a/src/Console/Domain/FileContent/FileContentGenerator.php
+++ b/src/Console/Domain/FileContent/FileContentGenerator.php
@@ -26,7 +26,7 @@ final class FileContentGenerator implements FileContentGeneratorInterface
      * directory on the way -- so a command can find out what it is about to
      * replace while it is still able to refuse.
      */
-    public function targetPath(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string
+    public function targetPath(CommandArguments $commandArguments, string $filename, bool $withShortName, string $subDirectory): string
     {
         $targetDirectory = $commandArguments->directory();
         if ($subDirectory !== '') {
@@ -43,7 +43,7 @@ final class FileContentGenerator implements FileContentGeneratorInterface
      *
      * @return list<string>
      */
-    public function existingTargets(CommandArguments $commandArguments, array $files, bool $withShortName = false): array
+    public function existingTargets(CommandArguments $commandArguments, array $files, bool $withShortName): array
     {
         $existing = [];
 

--- a/src/Console/Domain/FileContent/FileContentGenerator.php
+++ b/src/Console/Domain/FileContent/FileContentGenerator.php
@@ -21,6 +21,43 @@ final class FileContentGenerator implements FileContentGeneratorInterface
      *
      * @return string path result where the file was generated
      */
+    /**
+     * Where {@see generate()} would write, without writing it or creating any
+     * directory on the way -- so a command can find out what it is about to
+     * replace while it is still able to refuse.
+     */
+    public function targetPath(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string
+    {
+        $targetDirectory = $commandArguments->directory();
+        if ($subDirectory !== '') {
+            $targetDirectory .= '/' . $subDirectory;
+        }
+
+        $moduleName = $withShortName ? '' : $commandArguments->basename();
+
+        return sprintf('%s/%s%s.php', $targetDirectory, $moduleName, $filename);
+    }
+
+    /**
+     * @param list<array{string, string}> $files [filename, subDirectory] pairs
+     *
+     * @return list<string>
+     */
+    public function existingTargets(CommandArguments $commandArguments, array $files, bool $withShortName = false): array
+    {
+        $existing = [];
+
+        foreach ($files as [$filename, $subDirectory]) {
+            $path = $this->targetPath($commandArguments, $filename, $withShortName, $subDirectory);
+
+            if ($this->fileContentIo->existsFile($path)) {
+                $existing[] = $path;
+            }
+        }
+
+        return $existing;
+    }
+
     public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string
     {
         $targetDirectory = $commandArguments->directory();
@@ -33,7 +70,7 @@ final class FileContentGenerator implements FileContentGeneratorInterface
         $moduleName = $withShortName ? '' : $commandArguments->basename();
         $className = $moduleName . $filename;
 
-        $path = sprintf('%s/%s.php', $targetDirectory, $className);
+        $path = $this->targetPath($commandArguments, $filename, $withShortName, $subDirectory);
         $search = ['$NAMESPACE$', '$MODULE_NAME$', '$CLASS_NAME$'];
         $replace = [$commandArguments->namespace(), $moduleName, $className];
 

--- a/src/Console/Domain/FileContent/FileContentGeneratorInterface.php
+++ b/src/Console/Domain/FileContent/FileContentGeneratorInterface.php
@@ -14,4 +14,22 @@ interface FileContentGeneratorInterface
      * @return string path result where the file was generated
      */
     public function generate(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string;
+
+    /**
+     * Where `generate()` would write, without writing it.
+     */
+    public function targetPath(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string;
+
+    /**
+     * Which of the given targets already exist on disk.
+     *
+     * Asked of every file a command is about to write before it writes any of
+     * them: a module half replaced is worse than one refused, the same reason
+     * an unusable path is rejected before generation rather than during it.
+     *
+     * @param list<array{string, string}> $files [filename, subDirectory] pairs
+     *
+     * @return list<string> the paths that exist, in the order given
+     */
+    public function existingTargets(CommandArguments $commandArguments, array $files, bool $withShortName = false): array;
 }

--- a/src/Console/Domain/FileContent/FileContentGeneratorInterface.php
+++ b/src/Console/Domain/FileContent/FileContentGeneratorInterface.php
@@ -18,7 +18,7 @@ interface FileContentGeneratorInterface
     /**
      * Where `generate()` would write, without writing it.
      */
-    public function targetPath(CommandArguments $commandArguments, string $filename, bool $withShortName = false, string $subDirectory = ''): string;
+    public function targetPath(CommandArguments $commandArguments, string $filename, bool $withShortName, string $subDirectory): string;
 
     /**
      * Which of the given targets already exist on disk.
@@ -31,5 +31,5 @@ interface FileContentGeneratorInterface
      *
      * @return list<string> the paths that exist, in the order given
      */
-    public function existingTargets(CommandArguments $commandArguments, array $files, bool $withShortName = false): array;
+    public function existingTargets(CommandArguments $commandArguments, array $files, bool $withShortName): array;
 }

--- a/src/Console/Domain/FileContent/FileContentIoInterface.php
+++ b/src/Console/Domain/FileContent/FileContentIoInterface.php
@@ -9,4 +9,6 @@ interface FileContentIoInterface
     public function mkdir(string $directory): void;
 
     public function filePutContents(string $path, string $fileContent): void;
+
+    public function existsFile(string $path): bool;
 }

--- a/src/Console/Infrastructure/Command/ConsoleSection.php
+++ b/src/Console/Infrastructure/Command/ConsoleSection.php
@@ -6,6 +6,8 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function count;
+use function implode;
 use function sprintf;
 use function str_repeat;
 
@@ -28,5 +30,24 @@ final class ConsoleSection
     public static function separator(OutputInterface $output): void
     {
         $output->writeln(sprintf('<info>%s</info>', str_repeat('=', self::WIDTH)));
+    }
+
+    /**
+     * Why a `make:*` run wrote nothing, in one place so both makers refuse in
+     * the same words.
+     *
+     * @param list<string> $paths
+     */
+    public static function refusedToOverwrite(OutputInterface $output, array $paths): void
+    {
+        $output->writeln(sprintf(
+            '<error>%s already %s.</error>',
+            implode(', ', $paths),
+            count($paths) === 1 ? 'exists' : 'exist',
+        ));
+        $output->writeln(sprintf(
+            'Nothing was written. Pass <comment>--force</comment> to replace %s.',
+            count($paths) === 1 ? 'it' : 'them',
+        ));
     }
 }

--- a/src/Console/Infrastructure/Command/MakeFileCommand.php
+++ b/src/Console/Infrastructure/Command/MakeFileCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_map;
 use function sprintf;
 
 /**
@@ -38,7 +39,8 @@ final class MakeFileCommand extends Command
             ->setDescription('Generate a ' . $filenames)
             ->addArgument('path', InputArgument::REQUIRED, 'The file path. For example "App/TestModule/TestSubModule"')
             ->addArgument('filenames', InputArgument::REQUIRED | InputArgument::IS_ARRAY, $filenames)
-            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name');
+            ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Replace files that already exist');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -71,6 +73,20 @@ final class MakeFileCommand extends Command
 
         $commandArguments = $this->getFacade()->parseArguments($path);
         $shortName = $input->getOption('short-name') === true;
+
+        $files = array_map(static fn (string $filename): array => [$filename, ''], $filenames);
+
+        // Same rule as make:module: check every target before writing any of
+        // them, so a run that would replace hand-written code refuses instead.
+        if ($input->getOption('force') !== true) {
+            $existing = $this->getFacade()->existingGeneratedFiles($commandArguments, $files, $shortName);
+
+            if ($existing !== []) {
+                ConsoleSection::refusedToOverwrite($output, $existing);
+
+                return self::FAILURE;
+            }
+        }
 
         foreach ($filenames as $filename) {
             $absolutePath = $this->getFacade()->generateFileContent(

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -88,7 +88,7 @@ final class MakeModuleCommand extends Command
         // no way back from -- the same reason an unusable path is refused
         // before generation rather than during it.
         if ($input->getOption('force') !== true) {
-            $existing = $this->getFacade()->existingGeneratedFiles($commandArguments, $files, $shortName, $isService);
+            $existing = $this->getFacade()->existingGeneratedFiles($commandArguments, $files, $shortName);
 
             if ($existing !== []) {
                 ConsoleSection::refusedToOverwrite($output, $existing);

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\ConsoleFacade;
-use Gacela\Console\Domain\CommandArguments\CommandArguments;
 use Gacela\Console\Domain\CommandArguments\ModulePath;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Framework\ServiceResolver\ServiceMap;
@@ -17,6 +16,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function implode;
 use function in_array;
 use function sprintf;
 
@@ -38,7 +38,8 @@ final class MakeModuleCommand extends Command
             ->addOption('short-name', 's', InputOption::VALUE_NONE, 'Remove module prefix to the class name')
             ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Module template: basic, service (Facade wired to a Domain service), or minimal (Facade + Factory only)', 'basic')
             ->addOption('minimal', null, InputOption::VALUE_NONE, 'Scaffold only the Facade and Factory pillars (shorthand for --template=minimal)')
-            ->addOption('with-tests', null, InputOption::VALUE_NONE, 'Also scaffold a facade test (service template only)');
+            ->addOption('with-tests', null, InputOption::VALUE_NONE, 'Also scaffold a facade test (service template only)')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Replace files that already exist');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -78,20 +79,30 @@ final class MakeModuleCommand extends Command
 
         $commandArguments = $this->getFacade()->parseArguments($path);
         $shortName = $input->getOption('short-name') === true;
+        $isService = $template === 'service';
+        $files = $this->filesFor($template, $input->getOption('with-tests') === true);
 
-        if ($template === 'service') {
-            $this->generateServiceModule($commandArguments, $shortName, $input->getOption('with-tests') === true, $output);
-        } elseif ($template === 'minimal') {
-            $this->generateMinimalModule($commandArguments, $shortName, $output);
-        } else {
-            foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
-                $fullPath = $this->getFacade()->generateFileContent(
-                    $commandArguments,
-                    $filename,
-                    $shortName,
-                );
-                $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
+        // Every target, before the first one is written. Generating over a
+        // module replaces hand-written code with a stub and reports it as
+        // "created", so a partly-replaced module is the one outcome there is
+        // no way back from -- the same reason an unusable path is refused
+        // before generation rather than during it.
+        if ($input->getOption('force') !== true) {
+            $existing = $this->getFacade()->existingGeneratedFiles($commandArguments, $files, $shortName, $isService);
+
+            if ($existing !== []) {
+                ConsoleSection::refusedToOverwrite($output, $existing);
+
+                return self::FAILURE;
             }
+        }
+
+        foreach ($files as [$filename, $subDirectory]) {
+            $fullPath = $isService
+                ? $this->getFacade()->generateServiceFileContent($commandArguments, $filename, $shortName, $subDirectory)
+                : $this->getFacade()->generateFileContent($commandArguments, $filename, $shortName);
+
+            $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
         }
 
         $pieces = explode('/', $commandArguments->directory());
@@ -101,15 +112,30 @@ final class MakeModuleCommand extends Command
         return self::SUCCESS;
     }
 
-    private function generateServiceModule(
-        CommandArguments $commandArguments,
-        bool $shortName,
-        bool $withTests,
-        OutputInterface $output,
-    ): void {
+    /**
+     * Which files a template scaffolds, as [filename, subDirectory] pairs.
+     *
+     * One list per template, read once to check what exists and again to
+     * write: two lists would let the check and the writing disagree, which is
+     * precisely the disagreement that loses a file.
+     *
+     * @return list<array{string, string}>
+     */
+    private function filesFor(string $template, bool $withTests): array
+    {
+        if ($template === 'minimal') {
+            // Config and Provider are optional: add them when the module
+            // actually reads config or wires external dependencies.
+            return [[FilenameSanitizer::FACADE, ''], [FilenameSanitizer::FACTORY, '']];
+        }
+
         $files = [];
         foreach (FilenameSanitizer::EXPECTED_FILENAMES as $filename) {
             $files[] = [$filename, ''];
+        }
+
+        if ($template !== 'service') {
+            return $files;
         }
 
         $files[] = ['Service', 'Domain'];
@@ -117,35 +143,6 @@ final class MakeModuleCommand extends Command
             $files[] = ['FacadeTest', 'Tests'];
         }
 
-        foreach ($files as [$filename, $subDirectory]) {
-            $fullPath = $this->getFacade()->generateServiceFileContent(
-                $commandArguments,
-                $filename,
-                $shortName,
-                $subDirectory,
-            );
-            $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
-        }
+        return $files;
     }
-
-    /**
-     * The `minimal` template scaffolds only the Facade and Factory pillars.
-     * Config and Provider are optional: add them when the module actually
-     * reads config or wires external dependencies.
-     */
-    private function generateMinimalModule(
-        CommandArguments $commandArguments,
-        bool $shortName,
-        OutputInterface $output,
-    ): void {
-        foreach ([FilenameSanitizer::FACADE, FilenameSanitizer::FACTORY] as $filename) {
-            $fullPath = $this->getFacade()->generateFileContent(
-                $commandArguments,
-                $filename,
-                $shortName,
-            );
-            $output->writeln(sprintf("> Path '%s' created successfully", $fullPath));
-        }
-    }
-
 }

--- a/src/Console/Infrastructure/FileContentIo.php
+++ b/src/Console/Infrastructure/FileContentIo.php
@@ -7,6 +7,7 @@ namespace Gacela\Console\Infrastructure;
 use Gacela\Console\Domain\FileContent\FileContentIoInterface;
 use RuntimeException;
 
+use function file_exists;
 use function sprintf;
 
 final class FileContentIo implements FileContentIoInterface
@@ -28,6 +29,11 @@ final class FileContentIo implements FileContentIoInterface
         }
 
         throw new RuntimeException(sprintf('Directory "%s" was not created', $directory));
+    }
+
+    public function existsFile(string $path): bool
+    {
+        return file_exists($path);
     }
 
     public function filePutContents(string $path, string $fileContent): void

--- a/tests/Feature/Console/CodeGenerator/MakeRefusesToOverwriteTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeRefusesToOverwriteTest.php
@@ -152,6 +152,23 @@ final class MakeRefusesToOverwriteTest extends TestCase
         self::assertFileExists(self::FACADE);
     }
 
+    /**
+     * The service template puts files in sub-directories (`Domain/`, `Tests/`),
+     * and the check resolves them through the plain generator -- a target path
+     * is built from the module arguments alone, never from the stubs a template
+     * would fill in. This is what says those two agree.
+     */
+    public function test_the_service_template_sub_directories_are_checked_too(): void
+    {
+        $this->runCommand('make:module ' . self::MODULE_ARG . ' --template=service --with-tests');
+
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG . ' --template=service --with-tests');
+
+        self::assertStringContainsString('Domain/OverwriteModuleService.php', $output);
+        self::assertStringContainsString('Tests/OverwriteModuleFacadeTest.php', $output);
+        self::assertStringContainsString('Nothing was written.', $output);
+    }
+
     private function generateModule(): void
     {
         $this->runCommand('make:module ' . self::MODULE_ARG);

--- a/tests/Feature/Console/CodeGenerator/MakeRefusesToOverwriteTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeRefusesToOverwriteTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\CodeGenerator;
+
+use Gacela\Console\Infrastructure\ConsoleBootstrap;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Util\DirectoryUtil;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function file_get_contents;
+use function file_put_contents;
+use function unlink;
+
+/**
+ * Generating over a module that already exists.
+ *
+ * `make:module App/Wallet` on an existing module replaced all four pillars with
+ * stubs and reported "created successfully" for each one. No prompt, no flag, no
+ * mention that anything had been there -- and the only record that it had was
+ * the file that was just overwritten.
+ *
+ * The rule is the one the unusable-path check already follows: decide before
+ * writing anything. A module half replaced is worse than one refused.
+ */
+final class MakeRefusesToOverwriteTest extends TestCase
+{
+    private const MODULE_ARG = 'Psr4CodeGeneratorData/OverwriteModule';
+
+    private const MODULE_DIR = '.' . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'OverwriteModule';
+
+    private const FACADE = self::MODULE_DIR . DIRECTORY_SEPARATOR . 'OverwriteModuleFacade.php';
+
+    private const HAND_WRITTEN = '<?php // hand written, not a stub';
+
+    public static function tearDownAfterClass(): void
+    {
+        DirectoryUtil::removeDir(self::MODULE_DIR);
+    }
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+        DirectoryUtil::removeDir(self::MODULE_DIR);
+    }
+
+    public function test_a_second_run_refuses_and_leaves_the_files_alone(): void
+    {
+        $this->generateModule();
+        file_put_contents(self::FACADE, self::HAND_WRITTEN);
+
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG);
+
+        self::assertStringContainsString('already exist.', $output);
+        self::assertStringContainsString('Nothing was written.', $output);
+        self::assertSame(self::HAND_WRITTEN, file_get_contents(self::FACADE));
+    }
+
+    /**
+     * The refusal names the files, because "it already exists" without saying
+     * which leaves the reader to guess what a `--force` would cost them.
+     */
+    public function test_the_refusal_names_every_file_that_blocks_it(): void
+    {
+        $this->generateModule();
+
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG);
+
+        foreach (['Facade', 'Factory', 'Config', 'Provider'] as $pillar) {
+            self::assertStringContainsString('OverwriteModule' . $pillar . '.php', $output);
+        }
+    }
+
+    public function test_force_replaces_them(): void
+    {
+        $this->generateModule();
+        file_put_contents(self::FACADE, self::HAND_WRITTEN);
+
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG . ' --force');
+
+        self::assertStringContainsString('created successfully', $output);
+        self::assertNotSame(self::HAND_WRITTEN, file_get_contents(self::FACADE));
+    }
+
+    /**
+     * Only the files that are actually in the way. A module missing one pillar
+     * still reports the three that are there, so the reader knows a `--force`
+     * would not be free.
+     */
+    public function test_only_the_files_that_exist_are_reported(): void
+    {
+        $this->generateModule();
+        unlink(self::MODULE_DIR . DIRECTORY_SEPARATOR . 'OverwriteModuleConfig.php');
+
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG);
+
+        self::assertStringContainsString('OverwriteModuleFacade.php', $output);
+        self::assertStringNotContainsString('OverwriteModuleConfig.php', $output);
+    }
+
+    public function test_make_file_refuses_the_same_way(): void
+    {
+        $this->generateModule();
+        file_put_contents(self::FACADE, self::HAND_WRITTEN);
+
+        $output = $this->runCommand('make:file ' . self::MODULE_ARG . ' Facade');
+
+        self::assertStringContainsString('already exists.', $output);
+        self::assertSame(self::HAND_WRITTEN, file_get_contents(self::FACADE));
+    }
+
+    /**
+     * One file reads as one file. The plural form on a single path is the kind
+     * of seam that says nobody ran it.
+     */
+    public function test_one_file_is_reported_in_the_singular(): void
+    {
+        $this->generateModule();
+
+        $output = $this->runCommand('make:file ' . self::MODULE_ARG . ' Facade');
+
+        self::assertStringContainsString('already exists.', $output);
+        self::assertStringContainsString('to replace it.', $output);
+    }
+
+    public function test_many_files_are_reported_in_the_plural(): void
+    {
+        $this->generateModule();
+
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG);
+
+        self::assertStringContainsString('already exist.', $output);
+        self::assertStringContainsString('to replace them.', $output);
+    }
+
+    /**
+     * The check must not cost the first run anything: a module that does not
+     * exist yet is still generated in full.
+     */
+    public function test_a_first_run_is_unaffected(): void
+    {
+        $output = $this->runCommand('make:module ' . self::MODULE_ARG);
+
+        self::assertStringContainsString('created successfully', $output);
+        self::assertStringNotContainsString('Nothing was written', $output);
+        self::assertFileExists(self::FACADE);
+    }
+
+    private function generateModule(): void
+    {
+        $this->runCommand('make:module ' . self::MODULE_ARG);
+    }
+
+    private function runCommand(string $command): string
+    {
+        $output = new BufferedOutput();
+
+        $bootstrap = new ConsoleBootstrap();
+        $bootstrap->setAutoExit(false);
+        $bootstrap->run(new StringInput($command), $output);
+
+        return $output->fetch();
+    }
+}

--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -10,6 +10,7 @@ use Gacela\Console\Domain\FileContent\FileContentIoInterface;
 use Gacela\Console\Domain\FileContent\StubFiles;
 use Gacela\Console\Domain\FileContent\StubLocator;
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class FileContentGeneratorTest extends TestCase
@@ -24,6 +25,63 @@ final class FileContentGeneratorTest extends TestCase
             new CommandArguments('Namespace', 'Dir'),
             'unknown_template',
         );
+    }
+
+    /**
+     * The path the overwrite check reports, spelled out for every shape that
+     * changes it.
+     *
+     * Deliberately literal rather than compared against what `generate()`
+     * writes: `generate()` builds its path by calling this method, so asserting
+     * the two agree asserts nothing. Agreement is a property of the design --
+     * one path builder, used by both -- and what remains worth pinning is that
+     * the builder is right.
+     *
+     * @param list<string> $expected
+     */
+    #[DataProvider('pathShapes')]
+    public function test_the_reported_target_covers_every_path_shape(bool $shortName, string $subDirectory, string $expected): void
+    {
+        $generator = new FileContentGenerator(
+            $this->createStub(FileContentIoInterface::class),
+            new StubLocator('', ['Facade' => 'template-result'], StubFiles::basic()),
+        );
+
+        $actual = $generator->targetPath(
+            new CommandArguments('Namespace', 'Dir'),
+            FilenameSanitizer::FACADE,
+            $shortName,
+            $subDirectory,
+        );
+
+        self::assertSame($expected, $actual);
+    }
+
+    /**
+     * @return iterable<string, array{bool, string, string}>
+     */
+    public static function pathShapes(): iterable
+    {
+        yield 'plain' => [false, '', 'Dir/DirFacade.php'];
+        yield 'short name' => [true, '', 'Dir/Facade.php'];
+        yield 'sub-directory' => [false, 'Domain', 'Dir/Domain/DirFacade.php'];
+        yield 'short name in a sub-directory' => [true, 'Domain', 'Dir/Domain/Facade.php'];
+    }
+
+    /**
+     * Naming a target must not create the directory for it: a command asks this
+     * before deciding whether to refuse, and a refused run that left an empty
+     * module directory behind would be writing after saying it wrote nothing.
+     */
+    public function test_naming_a_target_creates_nothing(): void
+    {
+        $fileContentIo = $this->createMock(FileContentIoInterface::class);
+        $fileContentIo->expects(self::never())->method('mkdir');
+        $fileContentIo->expects(self::never())->method('filePutContents');
+
+        $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [], StubFiles::basic()));
+
+        $generator->targetPath(new CommandArguments('Namespace', 'Dir'), FilenameSanitizer::FACADE);
     }
 
     public function test_facade_maker_template(): void

--- a/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
+++ b/tests/Unit/Console/Domain/FileContent/FileContentGeneratorTest.php
@@ -81,7 +81,7 @@ final class FileContentGeneratorTest extends TestCase
 
         $generator = new FileContentGenerator($fileContentIo, new StubLocator('', [], StubFiles::basic()));
 
-        $generator->targetPath(new CommandArguments('Namespace', 'Dir'), FilenameSanitizer::FACADE);
+        $generator->targetPath(new CommandArguments('Namespace', 'Dir'), FilenameSanitizer::FACADE, false, '');
     }
 
     public function test_facade_maker_template(): void

--- a/tests/Unit/Console/Domain/FileContent/StubPublisherTest.php
+++ b/tests/Unit/Console/Domain/FileContent/StubPublisherTest.php
@@ -134,6 +134,15 @@ final class StubPublisherTest extends TestCase
             {
                 $this->written[$path] = $fileContent;
             }
+
+            /**
+             * What this double recorded, so a caller asking whether it already
+             * wrote a path gets an answer consistent with the writes above.
+             */
+            public function existsFile(string $path): bool
+            {
+                return isset($this->written[$path]);
+            }
         };
     }
 


### PR DESCRIPTION
## 📚 Description

`make:module App/Wallet` on a module that already exists replaced all four
pillars with stubs and reported this:

```
> Path 'src/Wallet/WalletFacade.php' created successfully
> Path 'src/Wallet/WalletFactory.php' created successfully
> Path 'src/Wallet/WalletConfig.php' created successfully
> Path 'src/Wallet/WalletProvider.php' created successfully
Module 'Wallet' created successfully
```

No prompt, no flag, no mention that anything had been there. "created" is not
even what happened. `make:file` did the same. The only record that hand-written
code had been there was the file that had just been written over.

`MakeModuleCommand` already states the right rule, for the unusable-path check
directly above this one:

> *a half-written module is worse than a refusal*

Now:

```
src/Wallet/WalletFacade.php, src/Wallet/WalletFactory.php, ... already exist.
Nothing was written. Pass --force to replace them.
```

## 🔖 Changes

- Every target is checked before the first one is written, so a run that would
  replace something writes nothing. `--force` (`-f`) opts in.
- The refusal names the files in the way — including the partial case, where a
  module missing one pillar reports the three that are there — so `--force` is an
  informed choice rather than a retry.
- `FileContentGenerator::targetPath()` names where `generate()` would write
  without writing it, and without creating the directory on the way (pinned by a
  test: a refused run must not leave an empty module directory behind).
- The three template branches in `MakeModuleCommand` collapse into one list of
  `[filename, subDirectory]` pairs, read once to check and again to write.
- Singular/plural wording lives in `ConsoleSection` so both makers refuse in the
  same words.

## ⚠️ Behaviour change

A script that regenerates a module in place now needs `--force`. Called out in the
changelog under `### Changed`.

## ✅ Notes

**I wrote a vacuous test and caught it by breaking the code.** My first invariant
test asserted that `targetPath()` agrees with where `generate()` writes — but
`generate()` builds its path *by calling* `targetPath()`, so they cannot disagree
and the assertion was a tautology. It passed with `targetPath()` deliberately
broken. Agreement is a property of the design, not something a test can add;
what is worth pinning is that the builder is right, so it now asserts the literal
path for each shape (short name, sub-directory, both). Verified it fails on the
same deliberate break: 2 of 4.

- Gacela's own `GacelaFacadeOnlyDelegates` rule caught my first version putting
  generator selection inline in the Facade. Moved to the Factory.
- Verified by hand end-to-end: refuse (exit 1, file byte-identical), `--force`
  (exit 0, replaced), fresh module unaffected, service template with `--with-tests`
  unaffected, partial module lists only what blocks it.
- Full gate green: 1700 unit / 335 integration / 418 feature, psalm + phpstan +
  cs-fixer + rector clean. Infection on the changed domain and IO files: 32
  mutants, **0 escaped, 100% MSI** (the `Command` classes are globally ignored as
  presentation code).
