### PR TITLE
✨ Refuse a make:file kind Gacela does not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Changed
 
+- Refuse a `make:file` kind Gacela does not have, instead of generating the closest pillar. `make:file App/Wallet Repository` wrote a `Factory` and reported it created; `Controller`, `Service` and `Middleware` wrote a `Provider`, and `Migration` a `Factory`. Matching is now the letters typed, in order, somewhere in the kind's name — so `cade`, `tory`, `fig` and `de-pr` still reach their pillars — and a word that reaches nothing is refused with the `addResolvableType()` call that would make it real. **This changes existing behaviour**: an undeclared kind used to resolve to a pillar
 - Refuse to overwrite in `make:module` and `make:file`, and add `--force` for when replacing is the intent. Generating over an existing module replaced every pillar with a stub and reported "created successfully" for each one, with no prompt and no flag — the only record that hand-written code had been there was the file it had just been written over. Every target is now checked before the first is written, so a run that would replace something writes nothing and names what is in the way. **This changes existing behaviour**: a script that regenerates a module in place now needs `--force`
 - Resolve a class name to its kind through the configured suffixes rather than the four literal pillar names. A project on `addSuffixTypeFacade('PublicApi')` now normalizes `App\Foo\FooPublicApi` to the `Facade` key the resolver looks up, so an `overrideExistingResolvedClass()` call on such a name takes effect where it was inert before
 

--- a/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
+++ b/src/Console/Domain/FilenameSanitizer/FilenameSanitizer.php
@@ -7,7 +7,11 @@ namespace Gacela\Console\Domain\FilenameSanitizer;
 use RuntimeException;
 
 use function count;
+use function implode;
 use function sprintf;
+use function str_contains;
+use function strlen;
+use function strtolower;
 
 /**
  * Which file `make:file` was asked for, from whatever the user typed.
@@ -27,15 +31,24 @@ final class FilenameSanitizer implements FilenameSanitizerInterface
 
     public const PROVIDER = 'Provider';
 
-    /**
-     * The pillars, which every project has. `make:module` scaffolds exactly
-     * these; a declared kind is generated one file at a time by `make:file`.
-     */
     public const EXPECTED_FILENAMES = [
         self::FACADE,
         self::FACTORY,
         self::CONFIG,
         self::PROVIDER,
+    ];
+
+    /**
+     * The pillars, which every project has. `make:module` scaffolds exactly
+     * these; a declared kind is generated one file at a time by `make:file`.
+     */
+    /**
+     * Names a kind answers to besides its own, lowercased.
+     *
+     * @var array<string, list<string>>
+     */
+    private const ALIASES = [
+        self::PROVIDER => ['dependency-provider'],
     ];
 
     /**
@@ -66,24 +79,90 @@ final class FilenameSanitizer implements FilenameSanitizerInterface
 
     public function sanitize(string $filename): string
     {
-        $percents = [];
+        $matches = $this->matching($filename);
 
-        foreach ($this->getExpectedFilenames() as $expected) {
-            $percents[$expected] = similar_text($expected, $filename);
-        }
-
-        $maxVal = max($percents);
-        $maxValKeys = array_keys($percents, $maxVal, true);
-
-        if (count($maxValKeys) > 1) {
+        if ($matches === []) {
             throw new RuntimeException(sprintf(
-                'When using "%s", which filename do you mean [%s]?',
+                "\"%s\" is not one of the filenames make:file can generate: %s.\n"
+                . "Declare it with addResolvableType('%s') in gacela.php to generate it as a kind of its own.",
                 $filename,
-                implode(' or ', $maxValKeys),
+                implode(', ', $this->getExpectedFilenames()),
+                $filename,
             ));
         }
 
-        /** @psalm-suppress RedundantCast */
-        return (string)reset($maxValKeys);
+        if (count($matches) > 1) {
+            throw new RuntimeException(sprintf(
+                'When using "%s", which filename do you mean [%s]?',
+                $filename,
+                implode(' or ', $matches),
+            ));
+        }
+
+        return $matches[0];
+    }
+
+    /**
+     * The kinds the typed word can mean.
+     *
+     * The letters typed, in order, somewhere in the kind's name -- so `cade`
+     * and `tory` reach `Facade` and `Factory`, and `fig` reaches `Config`.
+     * A word that spells a kind out in full reaches it too, which is how
+     * `dependency-provider` finds `Provider`.
+     *
+     * Not a similarity score, because no threshold separates the words that
+     * should match from the words that should not. `de-pr` scores 36% against
+     * `Provider` and `Service` scores 53%, so any cutoff keeping the first
+     * keeps the second -- and `Service` silently produced a `Provider` file.
+     * Asking whether the letters are there answers every case exactly.
+     *
+     * @return list<string>
+     */
+    private function matching(string $filename): array
+    {
+        $needle = strtolower($filename);
+        $matches = [];
+
+        foreach ($this->getExpectedFilenames() as $expected) {
+            foreach ($this->namesFor($expected) as $name) {
+                if ($this->spellsOut($needle, $name) || str_contains($needle, $name)) {
+                    $matches[] = $expected;
+                    break;
+                }
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Every name a kind answers to, lowercased.
+     *
+     * `Provider` carries the name it had before it was renamed, so the
+     * abbreviations built on it -- `de-pr` for `dependency-provider` -- keep
+     * working.
+     *
+     * @return list<string>
+     */
+    private function namesFor(string $kind): array
+    {
+        return [strtolower($kind), ...self::ALIASES[$kind] ?? []];
+    }
+
+    /**
+     * Whether every character of the needle appears in the haystack, in order.
+     */
+    private function spellsOut(string $needle, string $haystack): bool
+    {
+        $at = 0;
+        $length = strlen($needle);
+
+        for ($i = 0, $end = strlen($haystack); $i < $end && $at < $length; ++$i) {
+            if ($haystack[$i] === $needle[$at]) {
+                ++$at;
+            }
+        }
+
+        return $at === $length;
     }
 }

--- a/src/Console/Infrastructure/Command/MakeFileCommand.php
+++ b/src/Console/Infrastructure/Command/MakeFileCommand.php
@@ -10,6 +10,7 @@ use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use Gacela\Framework\ClassResolver\ResolvableTypes;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,10 +49,19 @@ final class MakeFileCommand extends Command
         /** @var list<string> $inputFileNames */
         $inputFileNames = $input->getArgument('filenames');
 
-        $filenames = array_map(
-            fn (string $raw): string => $this->getFacade()->sanitizeFilename($raw),
-            $inputFileNames,
-        );
+        // A word naming no kind is the user's input, not a fault in the
+        // framework -- rendered as an error rather than left to surface as an
+        // uncaught exception attributed to a file inside Gacela.
+        try {
+            $filenames = array_map(
+                fn (string $raw): string => $this->getFacade()->sanitizeFilename($raw),
+                $inputFileNames,
+            );
+        } catch (RuntimeException $runtimeException) {
+            $output->writeln(sprintf('<error>%s</error>', $runtimeException->getMessage()));
+
+            return self::FAILURE;
+        }
 
         /** @var string $path */
         $path = $input->getArgument('path');

--- a/tests/Feature/Console/CodeGenerator/MakeFileDeclaredKindTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeFileDeclaredKindTest.php
@@ -103,20 +103,36 @@ final class MakeFileDeclaredKindTest extends TestCase
     }
 
     /**
-     * Undeclared, `Exporter` is just another string to fuzzy-match, and it
-     * matches whatever it matched before declared kinds existed. Pinned so that
-     * teaching the sanitizer new kinds cannot quietly re-route the old ones.
+     * Undeclared, `Exporter` reaches nothing and no file is written.
+     *
+     * It used to reach the closest pillar, so this same command wrote a
+     * `Provider` and reported it created. Asked of the files as well as the
+     * status: the whole failure was that something appeared on disk.
      */
-    public function test_an_undeclared_kind_still_resolves_to_the_closest_pillar(): void
+    public function test_an_undeclared_kind_writes_nothing(): void
     {
         $this->bootstrapWithoutDeclarations();
         $this->publishStub('exporter-maker.txt', 'namespace $NAMESPACE$; class $CLASS_NAME$ {}');
 
         $tester = $this->makeFile('Exporter');
 
-        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertFileExists(self::GENERATED_DIR . '/DeclaredKindModuleProvider.php');
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('is not one of the filenames', $tester->getDisplay());
+        self::assertFileDoesNotExist(self::GENERATED_DIR . '/DeclaredKindModuleProvider.php');
         self::assertFileDoesNotExist(self::GENERATED_DIR . '/DeclaredKindModuleExporter.php');
+    }
+
+    /**
+     * And the message names the way out, which for a project that wants an
+     * `Exporter` is to declare one.
+     */
+    public function test_the_refusal_names_the_declaration_that_would_allow_it(): void
+    {
+        $this->bootstrapWithoutDeclarations();
+
+        $tester = $this->makeFile('Exporter');
+
+        self::assertStringContainsString("addResolvableType('Exporter')", $tester->getDisplay());
     }
 
     public function test_the_help_text_lists_the_declared_kind_next_to_the_pillars(): void

--- a/tests/Unit/Console/Domain/FilenameSanitizer/FilenameSanitizerTest.php
+++ b/tests/Unit/Console/Domain/FilenameSanitizer/FilenameSanitizerTest.php
@@ -8,6 +8,8 @@ use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+use function sprintf;
+
 final class FilenameSanitizerTest extends TestCase
 {
     private FilenameSanitizer $filenameSanitizer;
@@ -62,12 +64,71 @@ final class FilenameSanitizerTest extends TestCase
     }
 
     /**
-     * Undeclared, the word is just another string to fuzzy-match, and it
-     * matches what it matched before declared kinds existed.
+     * Undeclared, the word reaches nothing.
+     *
+     * It used to fall back to the closest pillar, so `make:file App/Wallet
+     * Exporter` wrote a `Provider` and reported it as created. The words that
+     * land here are the ones people actually type -- `Repository`, `Controller`,
+     * `Service`, `Migration` -- and every one of them produced a file of a kind
+     * nobody asked for.
      */
-    public function test_an_undeclared_kind_falls_back_to_the_closest_pillar(): void
+    public function test_an_undeclared_kind_reaches_nothing(): void
     {
-        self::assertSame(FilenameSanitizer::PROVIDER, $this->filenameSanitizer->sanitize('Exporter'));
+        $this->expectExceptionMessage('"Exporter" is not one of the filenames make:file can generate');
+
+        $this->filenameSanitizer->sanitize('Exporter');
+    }
+
+    /**
+     * Naming the way out: Gacela has a feature for exactly this, and a reader
+     * who typed `Repository` almost certainly wants it.
+     */
+    public function test_the_refusal_points_at_declaring_the_kind(): void
+    {
+        $this->expectExceptionMessage("addResolvableType('Repository')");
+
+        $this->filenameSanitizer->sanitize('Repository');
+    }
+
+    /**
+     * The kinds every other PHP framework has, which Gacela does not. Each one
+     * silently produced a pillar: `Repository` and `Migration` a `Factory`,
+     * `Controller`, `Service` and `Middleware` a `Provider`.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function kindsGacelaDoesNotHave(): iterable
+    {
+        yield 'repository' => ['Repository'];
+        yield 'controller' => ['Controller'];
+        yield 'service' => ['Service'];
+        yield 'middleware' => ['Middleware'];
+        yield 'migration' => ['Migration'];
+        yield 'model' => ['Model'];
+        yield 'entity' => ['Entity'];
+        yield 'listener' => ['Listener'];
+        yield 'command' => ['Command'];
+        yield 'handler' => ['Handler'];
+    }
+
+    #[DataProvider('kindsGacelaDoesNotHave')]
+    public function test_a_kind_gacela_does_not_have_is_refused(string $filename): void
+    {
+        $this->expectExceptionMessage(sprintf('"%s" is not one of the filenames make:file can generate', $filename));
+
+        $this->filenameSanitizer->sanitize($filename);
+    }
+
+    /**
+     * `dependency-provider` is what `Provider` used to be called, and `de-pr`
+     * abbreviates that rather than `Provider` -- so the old name is carried as
+     * an alias instead of being left to a similarity score that cannot tell it
+     * from `Service`.
+     */
+    public function test_the_provider_still_answers_to_its_former_name(): void
+    {
+        self::assertSame(FilenameSanitizer::PROVIDER, $this->filenameSanitizer->sanitize('dependency-provider'));
+        self::assertSame(FilenameSanitizer::PROVIDER, $this->filenameSanitizer->sanitize('de-pr'));
     }
 
     public function test_facade_or_factory_problem(): void


### PR DESCRIPTION
## 📚 Description

`FilenameSanitizer::sanitize()` picked the highest `similar_text()` score with no
floor, so **every** word resolved to something:

| typed | generated | reported |
|---|---|---|
| `Repository` | `Factory` | created successfully |
| `Controller` | `Provider` | created successfully |
| `Service` | `Provider` | created successfully |
| `Middleware` | `Provider` | created successfully |
| `Migration` | `Factory` | created successfully |
| `Banana` | `Facade` | created successfully |

These are the kinds people are most likely to type. Each produced a file of a kind
nobody asked for. It refused only on a *tie* — so `zzz` was rejected while `Banana`
quietly became a Facade.

Now:

```
"Repository" is not one of the filenames make:file can generate: Facade, Factory, Config, Provider.
Declare it with addResolvableType('Repository') in gacela.php to generate it as a kind of its own.
```

## 🔖 Changes

- Matching is the letters typed, in order, somewhere in the kind's name — so
  `cade`, `tory`, `fig` and `pro` still reach their pillars — plus a word that
  spells a kind out in full, which is how `dependency-provider` reaches `Provider`.
- `Provider` carries `dependency-provider` as an alias, because `de-pr` abbreviates
  the old name rather than the new one.
- The refusal renders as an error and returns `FAILURE`, rather than surfacing as an
  uncaught exception attributed to a file inside Gacela.

## ⚠️ Behaviour change

An undeclared kind used to resolve to the closest pillar. That was pinned in two
tests, both of which described it as intentional — I have rewritten them to
document the new rule and said so plainly here, because this is a judgement call
about intended behaviour rather than a plain bug fix. Happy to drop it if the
fallback is wanted.

## ✅ Notes

**No threshold can fix this, and I only established that by extracting the whole
pinned corpus.** My first attempt was a 0.6 similarity floor, chosen from a corpus
I had assembled by hand. It was wrong twice over:

- Measured **case-sensitively** — as the code actually compares — `expo`→`Exporter`
  and `prov`→`Provider` score 50%, *below* the bogus `Service`→`Provider` at 53%.
- After switching to case-insensitive, `dependency-provider` came in at 59.3%,
  below the 0.6 line, and it is a pinned legacy input.

Extracting every `yield` and `sanitize()` literal from the test files instead of
sampling them produced `de-pr` at **36.4%** against `Provider`, versus `Service` at
**53.3%** — so the two groups genuinely overlap and no cutoff separates them. A
containment rule failed on `de-pr` too. The subsequence rule classifies all 23
pinned inputs, 13 wrong words, both declared-kind cases and the ambiguous `fac`
with **zero misclassifications** — an exact rule rather than a tuned constant.

- Full gate green: 1712 unit / 335 integration / 420 feature, psalm + phpstan +
  cs-fixer + rector clean. 37 mutants on changed lines, **0 escaped, 100% MSI**.
