### PR TITLE
✅ Pin the shapes Psalm's rules must not report

### DIFF
--- a/tests/Integration/Psalm/ArchitectureRulesTest.php
+++ b/tests/Integration/Psalm/ArchitectureRulesTest.php
@@ -110,6 +110,24 @@ final class ArchitectureRulesTest extends PsalmFixtureTestCase
     }
 
     /**
+     * Nor is a class that already has a parent: PHP has single inheritance, so
+     * it cannot extend the pillar too. Outside Gacela the shape is ordinary --
+     * a Laravel `ServiceProvider`, an OAuth `GoogleAuthProvider` -- and these
+     * rules run inside every consumer's build.
+     *
+     * Its own file, because the assertion is that Psalm reports *nothing* here
+     * and a shared file would let another rule's silence stand in for this one.
+     */
+    public function test_a_class_that_already_extends_something_is_not_told_to_extend_a_pillar(): void
+    {
+        $errors = $this->analyseFixture();
+        $this->skipIfPsalmCannotRun($errors);
+
+        self::assertStringContainsString('GacelaSuffixExtends', $errors, 'precondition: the rule ran at all');
+        self::assertSame('', $this->errorsIn('InheritedNameFacade.php'));
+    }
+
+    /**
      * Psalm has no separate channel for a tip, so the correction rides along in
      * the message rather than being dropped.
      */

--- a/tests/Integration/Psalm/RulesFixture/CleanFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/CleanFacade.php
@@ -5,14 +5,44 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Psalm\RulesFixture;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\DeclaredTypeResolverAwareTrait;
 
 /**
+ * The shapes the rules must leave alone, through Psalm's own front end.
+ *
+ * The analyser has host-free unit tests, and PHPStan drives the same shapes in
+ * its fixture set. What is unpinned without this is Psalm's half: its storage
+ * seam answers `extendsClass()` from a different source, and the static and
+ * declared-kind guards read the parsed method Psalm hands over rather than
+ * PHPStan's.
+ *
  * @extends AbstractFacade<CleanFactory>
  */
 final class CleanFacade extends AbstractFacade
 {
+    use DeclaredTypeResolverAwareTrait;
+
     public function doThing(): string
     {
         return $this->getFactory()->createThing();
+    }
+
+    /**
+     * Delegating to a kind declared with `addResolvableType()`, which is
+     * reached through `getResolvedType()` rather than a pillar accessor.
+     */
+    public function viaDeclaredKind(): ?object
+    {
+        return $this->getResolvedType('Exporter');
+    }
+
+    /**
+     * A static method has no `$this` to delegate through, so no body it could
+     * hold would satisfy the rule -- a named constructor is an ordinary shape
+     * on any class.
+     */
+    public static function make(): self
+    {
+        return new self();
     }
 }

--- a/tests/Integration/Psalm/RulesFixture/InheritedNameFacade.php
+++ b/tests/Integration/Psalm/RulesFixture/InheritedNameFacade.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Psalm\RulesFixture;
+
+abstract class SomeHostBase
+{
+}
+
+/**
+ * Named after a pillar but already extending something else.
+ *
+ * PHP has single inheritance, so "should extend AbstractFacade" is advice this
+ * class cannot take. Outside Gacela the shape is ordinary -- a Laravel
+ * `ServiceProvider`, an OAuth `GoogleAuthProvider` -- and these rules run
+ * inside every consumer's build.
+ */
+final class InheritedNameFacade extends SomeHostBase
+{
+}


### PR DESCRIPTION
## 📚 Description

Three fixes landed in the shared analyser: delegating to a declared kind (#733), a
class that already extends something (#734), and a static Facade method (#735).

In each of those PRs I wrote that Psalm was fixed too, since both front ends run the
same analyser. That was true, but I had verified it by reading the code. This is the
verification, done for real and kept.

It is not redundant with the existing tests. The analyser has host-free unit tests
and PHPStan drives the same shapes in its fixture set — what neither covers is
Psalm's half: `StorageAnalysedClass` answers `extendsClass()` from Psalm's storage
rather than PHPStan's reflection, and the static and declared-kind guards read the
method node Psalm parses.

## 🔖 Changes

- `CleanFacade` — the fixture asserted to produce **no** findings — gains the two
  delegation shapes: `getResolvedType()` and a `public static function make(): self`.
- `InheritedNameFacade` is new: named after a pillar, already extending something
  else. Its own file, because the assertion is that Psalm reports nothing there and
  a shared file would let another rule's silence stand in for this one.

## ✅ Notes

**Verified these tests can fail.** Reverting all three fixes makes them fail, each
naming its own shape:

```
CleanFacade::viaDeclaredKind() must only delegate to ...
CleanFacade::make() must only delegate to ...
Class InheritedNameFacade should extend Gacela\Framework\AbstractFacade
```

**One fixture detail worth knowing.** `viaDeclaredKind()` returns the resolved type
rather than calling a method through it. `getResolvedType()` gives back `?object`,
so `?->run()` is a `MixedMethodCall` — a *generic* Psalm finding, in a fixture whose
whole assertion is that it produces nothing. It would have stood in for the rule's
silence and made the test pass for the wrong reason. The rule judges the delegation
root, not what is called on it, so returning it directly exercises the same path.

- Pure testing, no production change: 1734 unit / 336 integration / 423 feature,
  psalm + phpstan + cs-fixer + rector clean.
