### PR TITLE
✨ Report a tagged id nothing can answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Report in `doctor` a tagged id nothing can answer. `Container::tagged()` resolves each id in turn and gives back `null` for one naming nothing, so the group a module iterates silently carries a hole and the failure lands on the consumer as "Call to a member function … on null" — pointing at the loop rather than the registration. An id is answerable when a Provider `set()`s it or it names a class the container can construct, so a tag grouping plain service ids is untouched
+
 - Select configuration by more than `APP_ENV` with `addConfigDimension()`: each declared variable adds a link to the chain, so `config/app-prod-eu.php` refines `config/app-prod.php` refines `config/app.php`. The merged-config cache is keyed by the whole tuple, so two regions sharing a cache directory never read each other's file
 - Declare a data shape with `declareDtoSchema()` and generate the immutable class from it with `dto:generate`: typed getters, `with*()` copies, `toArray()` and `fromArray()`. Declarations of one shape union, so a project adds a property to a packaged shape without forking it, and redefining one is refused at bootstrap. The file is written where the project's own composer `autoload` already looks
 - Declare an extension point with `addPluginStack()`: every implementation of one interface, in declaration order, resolved lazily and read back typed through `getPluginStack()`. Calling it again appends, so another config source contributes to a stack it did not declare

--- a/src/Console/Application/Doctor/Check/TaggedServiceTargetCheck.php
+++ b/src/Console/Application/Doctor/Check/TaggedServiceTargetCheck.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+use Throwable;
+
+use function array_flip;
+use function class_exists;
+use function interface_exists;
+use function is_subclass_of;
+use function sprintf;
+
+/**
+ * Every id given to `tag()`, checked against something that could answer it.
+ *
+ * `Container::tagged()` resolves each id in turn, and an id naming nothing
+ * comes back as `null` -- so the group a module iterates silently contains a
+ * hole, and the failure lands on the consumer as "Call to a member function
+ * ... on null", pointing at the loop rather than at the registration.
+ *
+ * An id is answerable two ways: a Provider `set()`s it, or it names a class the
+ * container can construct. Only an id that is neither can never resolve, which
+ * is why this cannot be a `class_exists()` check at bootstrap -- a tag may
+ * legitimately group plain service ids that no class name backs.
+ *
+ * The same eager, throwaway-scope trick {@see ServiceExtensionTargetCheck}
+ * uses, and for the same reason: no runtime moment can prove the miss, because
+ * a tag is only resolved when some module asks for it.
+ */
+final class TaggedServiceTargetCheck implements HealthCheck
+{
+    /**
+     * @param list<AppModule> $modules
+     * @param array<string, list<string>> $tags ids grouped by tag name
+     * @param list<string> $appContainerServiceIds ids the app container itself stores
+     */
+    public function __construct(
+        private readonly array $modules,
+        private readonly array $tags,
+        private readonly array $appContainerServiceIds,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'tagged services';
+    }
+
+    public function run(): CheckResult
+    {
+        if ($this->tags === []) {
+            return CheckResult::ok($this->name(), 'no tagged services registered');
+        }
+
+        $warnings = [];
+        $provided = array_flip($this->appContainerServiceIds);
+
+        foreach ($this->modules as $module) {
+            foreach ($this->providedIds($module, $warnings) as $id) {
+                $provided[$id] = true;
+            }
+        }
+
+        $tagged = 0;
+        foreach ($this->tags as $tag => $ids) {
+            foreach ($ids as $id) {
+                ++$tagged;
+                if (isset($provided[$id])) {
+                    continue;
+                }
+
+                if (class_exists($id)) {
+                    continue;
+                }
+
+                if (interface_exists($id)) {
+                    continue;
+                }
+
+                $warnings[] = sprintf(
+                    "'%s' is tagged '%s', and nothing answers it -- no Provider registers it and no such class exists",
+                    $id,
+                    $tag,
+                );
+            }
+        }
+
+        if ($warnings !== []) {
+            return CheckResult::warn(
+                $this->name(),
+                $warnings,
+                'check the id for a typo; an id nothing answers resolves to null, and the group carrying it fails wherever it is iterated',
+            );
+        }
+
+        return CheckResult::ok($this->name(), sprintf('%d tagged id(s) answered', $tagged));
+    }
+
+    /**
+     * What one module's Provider stores, read off a throwaway scope. A
+     * Provider that cannot run outside its deployment is reported instead of
+     * crashing the diagnosis of every other one.
+     *
+     * @param list<string> $warnings
+     *
+     * @return list<string>
+     */
+    private function providedIds(AppModule $module, array &$warnings): array
+    {
+        $providerClass = $module->providerClass();
+        if ($providerClass === null || !is_subclass_of($providerClass, AbstractProvider::class)) {
+            return [];
+        }
+
+        try {
+            $provider = new $providerClass();
+
+            $container = new Container();
+            $provider->register($container);
+
+            return $container->getRegisteredServices();
+        } catch (Throwable $throwable) {
+            $warnings[] = sprintf('%s failed to run: %s', $providerClass, $throwable->getMessage());
+
+            return [];
+        }
+    }
+}

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -16,6 +16,7 @@ use Gacela\Console\Application\Doctor\Check\PackageManifestCheck;
 use Gacela\Console\Application\Doctor\Check\ServiceExtensionTargetCheck;
 use Gacela\Console\Application\Doctor\Check\StubHealthCheck;
 use Gacela\Console\Application\Doctor\Check\SuffixMismatchCheck;
+use Gacela\Console\Application\Doctor\Check\TaggedServiceTargetCheck;
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Application\Doctor\HealthCheck;
@@ -143,6 +144,11 @@ final class DoctorCommand extends Command
             new ServiceExtensionTargetCheck(
                 $modules,
                 array_keys($config->getSetupGacela()->getServicesToExtend()),
+                Gacela::container()->getRegisteredServices(),
+            ),
+            new TaggedServiceTargetCheck(
+                $modules,
+                $config->getSetupGacela()->getTags(),
                 Gacela::container()->getRegisteredServices(),
             ),
             // Regenerated unfiltered, and lazily: the metadata file describes

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -78,6 +78,7 @@ final class DoctorCommandTest extends TestCase
             '✓ published stubs',
             '✓ event listeners',
             '✓ service extensions',
+            '✓ tagged services',
             '✓ package manifests',
             '✓ IDE metadata',
             '✓ All checks passed',

--- a/tests/Unit/Console/Application/Doctor/Check/TaggedServiceTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/TaggedServiceTargetCheckTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\TaggedServiceTargetCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\SetProvider;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\StubFacade;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\ThrowingProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Container::tagged()` resolves each id in turn and answers `null` for one
+ * naming nothing, so the group a module iterates silently carries a hole and
+ * the failure lands on the consumer as "Call to a member function ... on
+ * null" -- pointing at the loop, not at the registration.
+ */
+final class TaggedServiceTargetCheckTest extends TestCase
+{
+    public function test_no_tags_is_ok(): void
+    {
+        $result = (new TaggedServiceTargetCheck([], [], []))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertContains('no tagged services registered', $result->details);
+    }
+
+    /**
+     * The reason this cannot be a `class_exists()` check at bootstrap: a tag
+     * may group plain service ids that no class name backs, and those are
+     * answered by whichever Provider registers them.
+     */
+    public function test_a_plain_id_a_provider_registers_is_answered(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [$this->module(SetProvider::class)],
+            ['validators' => [SetProvider::ID]],
+            [],
+        );
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function test_a_class_the_container_can_construct_is_answered(): void
+    {
+        $check = new TaggedServiceTargetCheck([], ['validators' => [StubFacade::class]], []);
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    /**
+     * The count is the whole of what a passing run reports, so it is asserted
+     * rather than left to read as "some".
+     */
+    public function test_the_passing_message_counts_every_id_across_every_tag(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [],
+            ['validators' => [StubFacade::class, 'app.id'], 'renderers' => ['other.id']],
+            ['app.id', 'other.id'],
+        );
+
+        self::assertContains('3 tagged id(s) answered', $check->run()->details);
+    }
+
+    public function test_an_id_the_app_container_provides_is_answered(): void
+    {
+        $check = new TaggedServiceTargetCheck([], ['validators' => ['app.id']], ['app.id']);
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    /**
+     * The answered id comes first on purpose: skipping it must not abandon the
+     * ids after it, and with the unanswered one first the skip's `continue`
+     * and `break` are indistinguishable.
+     */
+    public function test_an_answered_id_does_not_end_the_walk_of_its_group(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [$this->module(SetProvider::class)],
+            ['validators' => [SetProvider::ID, 'App\\Shop\\Ghost']],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('Ghost', $result->details[0]);
+    }
+
+    /**
+     * The slot holds a class name, and nothing guarantees it is a Provider.
+     * It is skipped rather than instantiated and run.
+     */
+    public function test_a_provider_slot_holding_a_non_provider_class_is_skipped(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [$this->module(StubFacade::class)],
+            ['validators' => ['App\\Shop\\Ghost']],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        // Exactly the unanswered id: the class is skipped, not run and crashed.
+        self::assertCount(1, $result->details);
+    }
+
+    public function test_an_id_nothing_answers_warns_naming_the_id_and_the_tag(): void
+    {
+        $check = new TaggedServiceTargetCheck([], ['validators' => ['App\Shop\Ghost']], []);
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('App\Shop\Ghost', $result->details[0]);
+        self::assertStringContainsString('validators', $result->details[0]);
+    }
+
+    /**
+     * Only the unanswered one: a tag is a group, and reporting the whole group
+     * because one member is wrong buries the member that is.
+     */
+    public function test_only_the_unanswered_id_of_a_group_is_reported(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [],
+            ['validators' => [StubFacade::class, 'App\Shop\Ghost']],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertCount(1, $result->details);
+        self::assertStringContainsString('Ghost', $result->details[0]);
+    }
+
+    /**
+     * A Provider that cannot run outside its deployment is reported instead of
+     * crashing the diagnosis of every other one.
+     */
+    public function test_a_provider_that_throws_is_reported_rather_than_fatal(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [$this->module(ThrowingProvider::class)],
+            ['validators' => [StubFacade::class]],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('failed to run', $result->details[0]);
+    }
+
+    public function test_a_module_without_a_provider_is_skipped(): void
+    {
+        $check = new TaggedServiceTargetCheck(
+            [$this->module(null)],
+            ['validators' => ['App\Shop\Ghost']],
+            [],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        // Exactly the unanswered id: a skipped module must not add a
+        // provider-failure line of its own.
+        self::assertCount(1, $result->details);
+    }
+
+    private function module(?string $providerClass): AppModule
+    {
+        return new AppModule(
+            'App\TestModule',
+            'TestModule',
+            StubFacade::class,
+            null,
+            null,
+            $providerClass,
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Description

Same failure shape as #739, one feature over.

`Container::tagged()` resolves each id in turn and answers **`null`** for one that
names nothing. So a tag with a typo in it:

```php
$config->tag([EmailValidator::class, 'App\Shop\Ghost'], 'validators');
```

fails nowhere near the registration:

```
Call to a member function name() on null
  in src/Shop/ShopFactory.php:9
```

The consumer's loop is blamed. Nothing names the tag, the id, or the fact that a
class is missing.

## 🔖 Changes

- `doctor` gains a `tagged services` check: every id given to `tag()`, held against
  something that could answer it.

```
⚠ tagged services
    'App\Shop\Ghost' is tagged 'validators', and nothing answers it -- no Provider
    registers it and no such class exists
    → check the id for a typo; an id nothing answers resolves to null, and the
      group carrying it fails wherever it is iterated
```

## ✅ Notes

**Why this is not a `class_exists()` check at bootstrap** — which is how #739 fixed
the equivalent for plugin stacks. A plugin is contractually a class implementing an
interface; a **tagged id is not**. The documented pattern groups plain service ids
that no class name backs:

```php
$container->set('validators', static fn (Container $c) => $c->tagged('validators'));
```

So an id is answerable two ways — a Provider `set()`s it, or it names a class the
container can construct — and only an id that is neither can never resolve. Pinned
by a test using a plain, Provider-registered id.

**Why a diagnostic and not a runtime error**: a tag resolves only when some module
asks for it, so no runtime moment can prove the miss. Same eager, throwaway-scope
approach as `ServiceExtensionTargetCheck`, whose docblock argues exactly this.

- **The mutation gate found four gaps in my tests**, all real: the count in the
  passing message was unasserted (two mutants), an answered id sat last in its
  group so `continue`/`break` were indistinguishable, and I had not covered a
  provider slot holding a non-Provider class. 24 mutants, **0 escaped, 100% MSI**.
- Verified consumer-side end to end, including that a tag of plain Provider ids and
  a project with no tags both stay silent.
- Full gate green: 1750 unit / 336 integration / 423 feature.
