### PR TITLE
🐛 Check extendProviderService ids against the Provider named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- Report in `doctor` an `extendProviderService()` id the named Provider never `set()`s. Its own docblock promised this, and only app-wide `extendService()` ids were ever passed to the check — so a typo, or the wrong Provider named, applied nowhere and said nothing. The provider-scoped miss is the sharper one: not "nobody set this id" but "the Provider you named does not"
+
 - Answer a mistyped Laravel bridge config key with the one that was meant. `config/gacela.php` listing all eight allowed keys is a list to scan rather than an answer; Symfony's own config tree replies "Did you mean ...?" to the same mistake, and Gacela already reads the same helper for a mistyped key in `gacela.php`
 - Say so when a plugin's class does not exist. A name registered with `addPluginStack()` is a string until something loads it, and the container answers `null` for one that resolves to nothing — so a typo was reported as a class that "does not implement" the contract, sending the reader to inspect an `implements` clause on a file that is not there
 - Never touch the filesystem root from `FileCache` when there is no cache directory. `''`, `'/'` and whitespace all normalize to an empty directory, and every path was concatenated onto it directly — so the entry path became `'/<sha1>.php'` and the glob `'/*.php'`. A cache with no usable directory wrote entries to the root, read them back, and `clear()` would have unlinked every PHP file it found there; on Windows, where the drive root is writable, the entries really did land there. `CacheFilePath` now answers "nowhere" rather than "the root", and reads, writes, deletes and batch commits all honour it

--- a/src/Console/Application/Doctor/Check/ServiceExtensionTargetCheck.php
+++ b/src/Console/Application/Doctor/Check/ServiceExtensionTargetCheck.php
@@ -38,11 +38,13 @@ final class ServiceExtensionTargetCheck implements HealthCheck
      * @param list<AppModule> $modules
      * @param list<string> $extensionIds ids passed to extendService()
      * @param list<string> $appContainerServiceIds ids the app container itself stores
+     * @param array<class-string, list<string>> $providerScopedIds ids passed to extendProviderService(), by provider
      */
     public function __construct(
         private readonly array $modules,
         private readonly array $extensionIds,
         private readonly array $appContainerServiceIds,
+        private readonly array $providerScopedIds = [],
     ) {
     }
 
@@ -53,7 +55,7 @@ final class ServiceExtensionTargetCheck implements HealthCheck
 
     public function run(): CheckResult
     {
-        if ($this->extensionIds === []) {
+        if ($this->extensionIds === [] && $this->providerScopedIds === []) {
             return CheckResult::ok($this->name(), 'no service extensions registered');
         }
 
@@ -75,6 +77,25 @@ final class ServiceExtensionTargetCheck implements HealthCheck
             }
         }
 
+        $scopedCount = 0;
+        foreach ($this->providerScopedIds as $providerClass => $ids) {
+            $registered = array_flip($this->registeredBy($providerClass, $warnings));
+
+            foreach ($ids as $id) {
+                ++$scopedCount;
+
+                if (isset($registered[$id])) {
+                    continue;
+                }
+
+                $warnings[] = sprintf(
+                    "'%s' is extended on %s, which never set()s it -- the extension will never apply",
+                    $id,
+                    $providerClass,
+                );
+            }
+        }
+
         if ($warnings !== []) {
             return CheckResult::warn(
                 $this->name(),
@@ -83,7 +104,10 @@ final class ServiceExtensionTargetCheck implements HealthCheck
             );
         }
 
-        return CheckResult::ok($this->name(), sprintf('%d extension id(s) matched', count($this->extensionIds)));
+        return CheckResult::ok(
+            $this->name(),
+            sprintf('%d extension id(s) matched', count($this->extensionIds) + $scopedCount),
+        );
     }
 
     /**
@@ -98,7 +122,28 @@ final class ServiceExtensionTargetCheck implements HealthCheck
     private function providedIds(AppModule $module, array &$warnings): array
     {
         $providerClass = $module->providerClass();
-        if ($providerClass === null || !is_subclass_of($providerClass, AbstractProvider::class)) {
+        if ($providerClass === null) {
+            return [];
+        }
+
+        return $this->registeredBy($providerClass, $warnings);
+    }
+
+    /**
+     * What one Provider stores, read off a throwaway scope.
+     *
+     * Named directly by `extendProviderService()`, so the miss is sharper than
+     * the app-wide one: not "nobody set this" but "the Provider you named does
+     * not". A slot holding a class that is not a Provider is skipped rather
+     * than instantiated and run.
+     *
+     * @param list<string> $warnings
+     *
+     * @return list<string>
+     */
+    private function registeredBy(string $providerClass, array &$warnings): array
+    {
+        if (!is_subclass_of($providerClass, AbstractProvider::class)) {
             return [];
         }
 

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -144,6 +144,7 @@ final class DoctorCommand extends Command
                 $modules,
                 array_keys($config->getSetupGacela()->getServicesToExtend()),
                 Gacela::container()->getRegisteredServices(),
+                $this->providerScopedExtensionIds(),
             ),
             // Regenerated unfiltered, and lazily: the metadata file describes
             // the whole application, so comparing it against the modules a
@@ -183,6 +184,32 @@ final class DoctorCommand extends Command
         $targets = array_keys($setup->getSpecificListeners() ?? []);
 
         return $targets;
+    }
+
+    /**
+     * Ids passed to `extendProviderService()`, grouped by the Provider each
+     * names.
+     *
+     * Read off the concrete setup for the same reason as the listener map
+     * above: it is not part of SetupGacelaInterface.
+     *
+     * @return array<class-string, list<string>>
+     */
+    private function providerScopedExtensionIds(): array
+    {
+        $setup = Config::getInstance()->getSetupGacela();
+
+        if (!$setup instanceof SetupGacela) {
+            return [];
+        }
+
+        $byProvider = [];
+
+        foreach ($setup->getProviderServicesToExtend() as $providerClass => $byId) {
+            $byProvider[$providerClass] = array_keys($byId);
+        }
+
+        return $byProvider;
     }
 
     private function renderResult(CheckResult $result, OutputInterface $output): void

--- a/tests/Unit/Console/Application/Doctor/Check/ServiceExtensionTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/ServiceExtensionTargetCheckTest.php
@@ -130,6 +130,97 @@ final class ServiceExtensionTargetCheckTest extends TestCase
     /**
      * @param class-string|null $providerClass
      */
+    /**
+     * `extendProviderService()` names the Provider, so the miss is sharper
+     * than the app-wide one: not "nobody set this id" but "the Provider you
+     * named does not". Its own docblock promised `doctor` reported this, and
+     * only app-wide ids were ever passed to this check.
+     */
+    public function test_a_provider_scoped_id_the_named_provider_sets_is_matched(): void
+    {
+        $check = new ServiceExtensionTargetCheck([], [], [], [SetProvider::class => [SetProvider::ID]]);
+
+        self::assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    /**
+     * The matched id comes first on purpose: skipping it must not abandon the
+     * ids after it, and with the unmatched one first the skip's `continue` and
+     * `break` are indistinguishable.
+     */
+    public function test_a_matched_provider_scoped_id_does_not_end_the_walk(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [],
+            [],
+            [],
+            [SetProvider::class => [SetProvider::ID, 'knwon.id']],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('knwon.id', $result->details[0]);
+    }
+
+    public function test_a_provider_scoped_id_the_named_provider_never_sets_warns(): void
+    {
+        $check = new ServiceExtensionTargetCheck([], [], [], [SetProvider::class => ['knwon.id']]);
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('knwon.id', $result->details[0]);
+        self::assertStringContainsString(SetProvider::class, $result->details[0]);
+    }
+
+    /**
+     * The case the app-wide check cannot express: the id is real and some
+     * other Provider registers it, but not the one named -- so the extension
+     * still never applies.
+     */
+    public function test_an_id_registered_only_by_another_provider_warns(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [$this->module(SetProvider::class)],
+            [],
+            [],
+            [BindOnlyProvider::class => [SetProvider::ID]],
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString(BindOnlyProvider::class, $result->details[0]);
+    }
+
+    /**
+     * A provider slot holding a class that is not a Provider is skipped rather
+     * than instantiated and run.
+     */
+    public function test_a_provider_scoped_id_on_a_non_provider_class_is_skipped(): void
+    {
+        $check = new ServiceExtensionTargetCheck([], [], [], [StubFacade::class => ['some.id']]);
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        // Exactly the unmatched id: the class is skipped, not run and crashed.
+        self::assertCount(1, $result->details);
+    }
+
+    public function test_the_passing_message_counts_both_kinds_of_extension(): void
+    {
+        $check = new ServiceExtensionTargetCheck(
+            [],
+            ['app.id'],
+            ['app.id'],
+            [SetProvider::class => [SetProvider::ID]],
+        );
+
+        self::assertContains('2 extension id(s) matched', $check->run()->details);
+    }
+
     private function module(?string $providerClass): AppModule
     {
         return new AppModule(


### PR DESCRIPTION
## 📚 Description

`extendProviderService()`'s own docblock says:

> An id the named Provider never registers is reported by `doctor`, where an
> app-wide extension on a mistyped id is only reported as unmatched anywhere.

It was not. Only app-wide `extendService()` ids ever reached
`ServiceExtensionTargetCheck`, so a typo was scheduled, applied nowhere, and said
nothing — at runtime *or* in diagnosis:

```php
$config->extendProviderService(ShopProvider::class, 'labell', $wrap);  // 'label'
```

```
Shop=Shop-base        ← unwrapped, silently
⚠ doctor              ← nothing
```

Now:

```
⚠ service extensions
    'labell' is extended on App\Shop\ShopProvider, which never set()s it --
    the extension will never apply
```

## 🔖 Changes

- Provider-scoped ids are checked against the Provider each one names.
- Folded into the existing check rather than added as a thirteenth doctor line:
  both answer the same question about the same verb, and the count now covers both.

## ✅ Notes

**The provider-scoped miss is sharper than the app-wide one**, which is the whole
point of naming the Provider. An id that is real but registered by a *different*
Provider still never applies — the app-wide check cannot express that, and this one
reports it:

```
'shop.only' is extended on App\Ware\WareProvider, which never set()s it
```

Pinned by its own test, and verified consumer-side.

- **I damaged a neighbouring docblock and static analysis caught it.** My helper
  was inserted between `specificListenerTargets()`'s docblock and its signature,
  orphaning it — Psalm reported the resulting `array<array-key, mixed>`. Restored,
  and the displaced comment turned out to document the right pattern, so the new
  helper follows it: read off the concrete setup and narrow with `instanceof`,
  because the map is not part of `SetupGacelaInterface`.
- **Third time this session for one mutant.** `continue` → `break` survives whenever
  the matched entry sits last in its fixture, so a skip that abandoned everything
  after it would pass. Same fix as #737 and #740: order the fixture so it can fail.
  14 mutants, **0 escaped, 100% MSI**.
- Full gate green: 1745 unit / 336 integration / 423 feature.
