### PR TITLE
🐛 Refuse graph rules given without --check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Fixed
 
+- Refuse `debug:graph --rules` and `--allowed-cycles` when `--check` is absent, instead of ignoring them. Both files are read only by `--check`, so a CI job that wrote a rules file and ran the command without it printed the graph and exited zero — a gate that looks green while checking nothing
+
 - Report in `doctor` an `extendProviderService()` id the named Provider never `set()`s. Its own docblock promised this, and only app-wide `extendService()` ids were ever passed to the check — so a typo, or the wrong Provider named, applied nowhere and said nothing. The provider-scoped miss is the sharper one: not "nobody set this id" but "the Provider you named does not"
 
 - Answer a mistyped Laravel bridge config key with the one that was meant. `config/gacela.php` listing all eight allowed keys is a list to scan rather than an answer; Symfony's own config tree replies "Did you mean ...?" to the same mistake, and Gacela already reads the same helper for a mistyped key in `gacela.php`

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function count;
 use function implode;
 use function in_array;
 use function is_array;
@@ -72,6 +73,23 @@ final class DebugGraphCommand extends Command
 
         if ($input->getOption('check') === true) {
             return $this->check($graph, $filter, $format, $input, $output);
+        }
+
+        // Both files are only read by --check, and a CI job that passes one
+        // without it gets a printed graph and a zero exit: a gate that looks
+        // green while checking nothing. Refused rather than implied, because
+        // --check also decides cycles, and turning it on for someone who asked
+        // for neither is a different command than the one they wrote.
+        $ignored = $this->optionsNeedingCheck($input);
+        if ($ignored !== []) {
+            $output->writeln(sprintf(
+                '<error>%s only %s with --check, and this run would report nothing.</error>',
+                implode(' and ', $ignored),
+                count($ignored) === 1 ? 'applies' : 'apply',
+            ));
+            $output->writeln(sprintf('Add <comment>--check</comment>: <comment>debug:graph --check %s=...</comment>', $ignored[0]));
+
+            return self::FAILURE;
         }
 
         if ($graph === []) {
@@ -157,6 +175,24 @@ final class DebugGraphCommand extends Command
         }
 
         return $cycleResult->isClean() && $ruleResult->isClean() ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * The options `check()` alone reads, when it is not going to run.
+     *
+     * @return list<string>
+     */
+    private function optionsNeedingCheck(InputInterface $input): array
+    {
+        $ignored = [];
+
+        foreach (['--rules' => 'rules', '--allowed-cycles' => 'allowed-cycles'] as $flag => $option) {
+            if (ConsoleInput::option($input, $option) !== '') {
+                $ignored[] = $flag;
+            }
+        }
+
+        return $ignored;
     }
 
     /**

--- a/tests/Feature/Console/DebugGraphRules/DebugGraphRulesTest.php
+++ b/tests/Feature/Console/DebugGraphRules/DebugGraphRulesTest.php
@@ -125,6 +125,58 @@ final class DebugGraphRulesTest extends TestCase
         self::assertStringContainsString('--rules cannot be combined with a filter', $this->command->getDisplay());
     }
 
+    /**
+     * Both files are read only by `--check`. Passing one without it printed the
+     * graph and exited zero: a CI job that writes a rules file, wires the
+     * command in, and is guarded by nothing.
+     */
+    public function test_rules_without_check_is_refused_rather_than_ignored(): void
+    {
+        $rules = $this->writeRules([
+            ['from' => self::PAYMENT, 'deny' => [self::ADMIN], 'reason' => 'reviewed'],
+        ]);
+
+        $exitCode = $this->command->execute(['--rules' => $rules]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('--rules only applies with --check', $this->command->getDisplay());
+        self::assertStringContainsString('--check --rules=', $this->command->getDisplay());
+    }
+
+    public function test_an_allow_list_without_check_is_refused_too(): void
+    {
+        $exitCode = $this->command->execute(['--allowed-cycles' => '/some/file.json']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('--allowed-cycles only applies with --check', $this->command->getDisplay());
+    }
+
+    /**
+     * One file reads as one file, and the plural form on a single flag is the
+     * seam that says nobody ran it.
+     */
+    public function test_both_together_are_named_in_the_plural(): void
+    {
+        $exitCode = $this->command->execute([
+            '--rules' => '/some/rules.json',
+            '--allowed-cycles' => '/some/cycles.json',
+        ]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('--rules and --allowed-cycles only apply with --check', $this->command->getDisplay());
+    }
+
+    /**
+     * The plain graph is the command's ordinary use and must stay unaffected.
+     */
+    public function test_a_plain_graph_run_is_unaffected(): void
+    {
+        $exitCode = $this->command->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringNotContainsString('only applies with --check', $this->command->getDisplay());
+    }
+
     public function test_check_fails_when_the_rules_file_is_missing(): void
     {
         $exitCode = $this->command->execute(['--check' => true, '--rules' => '/does/not/exist.json']);


### PR DESCRIPTION
## 📚 Description

`--rules` and `--allowed-cycles` are read inside `check()`, which only runs when
`--check` is passed. Without it, both were accepted and **ignored**:

```
$ gacela debug:graph --rules=rules.json
App\Shop (0)
App\Ware (0)
$ echo $?
0
```

Malformed JSON, a missing file, a rule denying an edge that exists — all of it
passes, because none of it is read. A CI job that writes a rules file and wires
this command in is guarded by nothing, and looks green for it.

With `--check`, the same inputs behave correctly, which is what makes the silent
case easy to miss:

```
$ gacela debug:graph --check --rules=rules.json
"rules.json" is not valid JSON: Syntax error   → exit 1
```

Now:

```
--rules only applies with --check, and this run would report nothing.
Add --check: debug:graph --check --rules=...
```

## 🔖 Changes

- Either option without `--check` is refused, naming the flag and the command to
  run instead.

## ✅ Notes

**Refused rather than implied.** `--check` also decides cycles, so turning it on
for someone who asked for neither runs a different command than the one they
wrote. The same method already refuses `--rules` combined with a filter rather
than guessing, so this follows the precedent beside it.

**Why it was reachable at all:** the help text describes what each option is *for*
and never that it needs `--check`, while `--check`'s own text mentions only cycles.
Nothing in the interface hinted at the dependency.

- Singular and plural both pinned — `--rules only applies` versus `--rules and
  --allowed-cycles only apply`. Getting that wrong is the seam that says nobody
  ran it.
- A plain `debug:graph` run is pinned as unaffected, and `--compare-to` is
  untouched.
- Full gate green: 1770 unit / 337 integration / 427 feature. Infection reports 0
  mutants on the changed lines: `Console\Infrastructure\Command\*` is globally
  ignored as presentation code, and the gate passes (exit 0) rather than failing
  at 0%.
