### PR TITLE
🐛 Refuse --with-tests on a template that scaffolds none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Fixed
 
 - Refuse `debug:graph --rules` and `--allowed-cycles` when `--check` is absent, instead of ignoring them. Both files are read only by `--check`, so a CI job that wrote a rules file and ran the command without it printed the graph and exited zero — a gate that looks green while checking nothing
+- Refuse `make:module --with-tests` on a template that scaffolds no test, instead of ignoring it. Only the service template writes a facade test; on the others the flag was accepted, four files were written and "created successfully" reported — so a reader who asked for a test believed they had one
 
 - Report in `doctor` an `extendProviderService()` id the named Provider never `set()`s. Its own docblock promised this, and only app-wide `extendService()` ids were ever passed to the check — so a typo, or the wrong Provider named, applied nowhere and said nothing. The provider-scoped miss is the sharper one: not "nobody set this id" but "the Provider you named does not"
 

--- a/src/Console/Infrastructure/Command/MakeModuleCommand.php
+++ b/src/Console/Infrastructure/Command/MakeModuleCommand.php
@@ -80,7 +80,24 @@ final class MakeModuleCommand extends Command
         $commandArguments = $this->getFacade()->parseArguments($path);
         $shortName = $input->getOption('short-name') === true;
         $isService = $template === 'service';
-        $files = $this->filesFor($template, $input->getOption('with-tests') === true);
+        $withTests = $input->getOption('with-tests') === true;
+
+        // Only the service template scaffolds a facade test, and accepting the
+        // flag on the others wrote four files, reported "created successfully"
+        // and produced no test -- so a reader who asked for one believes they
+        // have it. Refused rather than ignored, the same way an unusable path
+        // is.
+        if ($withTests && !$isService) {
+            $output->writeln(sprintf(
+                '<error>--with-tests only applies to the service template, and the "%s" template scaffolds no test.</error>',
+                $template,
+            ));
+            $output->writeln('Add <comment>--template=service</comment>, or drop <comment>--with-tests</comment>.');
+
+            return self::FAILURE;
+        }
+
+        $files = $this->filesFor($template, $withTests);
 
         // Every target, before the first one is written. Generating over a
         // module replaces hand-written code with a stub and reports it as

--- a/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
+++ b/tests/Feature/Console/CodeGenerator/MakeModuleCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\Console\CodeGenerator;
 
+use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
 use Gacela\Console\Infrastructure\ConsoleBootstrap;
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Bootstrap\GacelaConfig;
@@ -11,8 +12,10 @@ use Gacela\Framework\Gacela;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Tester\CommandTester;
 
 use function sprintf;
 
@@ -89,6 +92,38 @@ OUT;
     {
         yield 'module' => ['TestModule', false];
         yield 'module -s' => ['', true];
+    }
+
+    /**
+     * Only the service template scaffolds a facade test. Accepting the flag on
+     * the others wrote four files, reported "created successfully" and produced
+     * no test -- so a reader who asked for one believes they have it.
+     */
+    public function test_with_tests_on_a_template_that_scaffolds_none_is_refused(): void
+    {
+        $tester = new CommandTester(new MakeModuleCommand());
+        $exitCode = $tester->execute(['path' => 'Psr4CodeGeneratorData/NotGenerated', '--with-tests' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('--with-tests only applies to the service template', $tester->getDisplay());
+        self::assertStringContainsString('--template=service', $tester->getDisplay());
+        self::assertDirectoryDoesNotExist(getcwd() . '/data/NotGenerated');
+    }
+
+    /**
+     * `--minimal` is shorthand for a template, so the refusal names the
+     * template it resolved to rather than the flag that chose it.
+     */
+    public function test_the_refusal_names_the_template_the_shorthand_resolved_to(): void
+    {
+        $tester = new CommandTester(new MakeModuleCommand());
+        $tester->execute([
+            'path' => 'Psr4CodeGeneratorData/NotGeneratedEither',
+            '--with-tests' => true,
+            '--minimal' => true,
+        ]);
+
+        self::assertStringContainsString('the "minimal" template scaffolds no test', $tester->getDisplay());
     }
 
     public function test_make_module_with_service_template_generates_a_working_module(): void


### PR DESCRIPTION
## 📚 Description

Found by sweeping for the shape #743 fixed: an option accepted without the thing
that reads it.

Only the service template scaffolds a facade test. On the others `--with-tests` was
accepted and ignored:

```
$ gacela make:module App/Tested --with-tests
> Path 'src/Tested/TestedFacade.php' created successfully
> Path 'src/Tested/TestedFactory.php' created successfully
> Path 'src/Tested/TestedConfig.php' created successfully
> Path 'src/Tested/TestedProvider.php' created successfully
Module 'Tested' created successfully          ← exit 0, and no test anywhere
```

A reader who asked for a test is told the module was created and believes they have
one.

Now:

```
--with-tests only applies to the service template, and the "basic" template scaffolds no test.
Add --template=service, or drop --with-tests.
```

## 🔖 Changes

- `--with-tests` on a template that scaffolds no test is refused, and nothing is
  written.

## ✅ Notes

**Documented and still silent.** The option's own help says *"(service template
only)"* — unlike #743, where nothing hinted at the dependency. That makes this the
weaker of the two cases, and I still think refusing beats ignoring: the cost of the
silence is a developer believing a test exists.

**The message names the template the run resolved to**, not the flag that chose it —
`--minimal` reports `the "minimal" template`, because that is the thing that
scaffolds no test. Pinned by its own test.

- The refusal writes nothing: asserted with `assertDirectoryDoesNotExist`, since
  "refused" and "refused after writing four files" read identically in a console.
- `--template=service --with-tests` still generates the test, and plain runs are
  untouched — both already pinned by existing tests, which pass unchanged.
- Full gate green: 1770 unit / 337 integration / 429 feature. Infection reports no
  mutants on the changed lines: `Console\Infrastructure\Command\*` is globally
  ignored as presentation code.
