### PR TITLE
✨ Name what the profiler never saw finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Name what `profile:report` never saw finish. A `stop()` that misspells the operation or subject is ignored — there is no start time to measure from — so the entry vanishes and looks exactly like code nobody instrumented. The report now lists what is still open, counted where several spans of one operation are, and `--format=json` carries the same answer in an `unfinished` field
+
 - Report in `doctor` a tagged id nothing can answer. `Container::tagged()` resolves each id in turn and gives back `null` for one naming nothing, so the group a module iterates silently carries a hole and the failure lands on the consumer as "Call to a member function … on null" — pointing at the loop rather than the registration. An id is answerable when a Provider `set()`s it or it names a class the container can construct, so a tag grouping plain service ids is untouched
 - Report a `#[Cacheable]` key that never mentions the arguments, on a method that has them, through both PHPStan (`gacela.cacheableKeyIgnoresArguments`) and Psalm (`GacelaCacheableKeyIgnoresArguments`). The key decides what the entry is filed under, so one without a `{N}` placeholder is the same string for every call and `getUser(2)` is answered with user 1's row — nothing fails, the wrong record is simply served. A key built at runtime is not judged, and a method without arguments is left alone
 

--- a/src/Console/Infrastructure/Command/ProfileReportCommand.php
+++ b/src/Console/Infrastructure/Command/ProfileReportCommand.php
@@ -50,9 +50,11 @@ final class ProfileReportCommand extends Command
         }
 
         $entries = $profiler->getEntries();
+        $unfinished = $profiler->getUnfinishedOperations();
 
         if ($entries === []) {
             $output->writeln('<info>No profiling data available</info>');
+            $this->writeUnfinished($unfinished, $output);
             $output->writeln('');
 
             return self::SUCCESS;
@@ -69,7 +71,42 @@ final class ProfileReportCommand extends Command
             default => $this->outputTable($entries, $profiler, $output),
         };
 
+        // Not for `json`, whose consumer parses a document rather than reading
+        // prose, and which already carries the same list in a field of its own.
+        if ($format !== 'json') {
+            $this->writeUnfinished($unfinished, $output);
+        }
+
         return self::SUCCESS;
+    }
+
+    /**
+     * The operations still open when the report ran.
+     *
+     * An operation missing from the report because its `stop()` misspelled the
+     * subject looks exactly like one that was never instrumented. This is the
+     * difference, and it is the reason a reader would look here at all.
+     *
+     * @param array<string, int> $unfinished
+     */
+    private function writeUnfinished(array $unfinished, OutputInterface $output): void
+    {
+        if ($unfinished === []) {
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln('<comment>Started and never stopped:</comment>');
+
+        foreach ($unfinished as $key => $openCount) {
+            $output->writeln(sprintf(
+                '  %s%s',
+                $key,
+                $openCount > 1 ? sprintf(' (%d open)', $openCount) : '',
+            ));
+        }
+
+        $output->writeln('<comment>A stop() must match its start() on both operation and subject.</comment>');
     }
 
     /**
@@ -122,6 +159,9 @@ final class ProfileReportCommand extends Command
         $data = [
             'entries' => [],
             'stats' => $profiler->getStats(),
+            // A field of its own rather than prose: the same answer the text
+            // report gives, for a consumer that parses rather than reads.
+            'unfinished' => $profiler->getUnfinishedOperations(),
         ];
 
         foreach ($entries as $entry) {

--- a/src/Framework/Profiler/Profiler.php
+++ b/src/Framework/Profiler/Profiler.php
@@ -111,6 +111,34 @@ final class Profiler
     }
 
     /**
+     * Operations started and never stopped, with how many of each are still
+     * open.
+     *
+     * A `stop()` whose operation or subject does not match its `start()` is
+     * ignored -- there is no start time to measure from -- so a typo in either
+     * costs the entry *and* says nothing, in the one tool whose job is telling
+     * a reader what happened. The unmatched start is still here, and naming it
+     * is what turns "my operation is missing from the report" into the typo
+     * that caused it.
+     *
+     * Keyed `operation:subject`, the same shape the report reads.
+     *
+     * @return array<string, int>
+     */
+    public function getUnfinishedOperations(): array
+    {
+        $unfinished = [];
+
+        // No emptiness check: popStartTime() unsets the key when its last span
+        // closes, so a key that is here has spans still open.
+        foreach ($this->activeOperations as $key => $startTimes) {
+            $unfinished[$key] = count($startTimes);
+        }
+
+        return $unfinished;
+    }
+
+    /**
      * @return list<TProfileEntry>
      */
     public function getEntries(): array

--- a/tests/Feature/Console/ProfileReport/ProfileReportCommandTest.php
+++ b/tests/Feature/Console/ProfileReport/ProfileReportCommandTest.php
@@ -121,10 +121,10 @@ final class ProfileReportCommandTest extends TestCase
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
-        /** @var array{entries: list<array<string, mixed>>, stats: array<string, mixed>} $decoded */
+        /** @var array{entries: list<array<string, mixed>>, stats: array<string, mixed>, unfinished: array<string, int>} $decoded */
         $decoded = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
 
-        self::assertSame(['entries', 'stats'], array_keys($decoded));
+        self::assertSame(['entries', 'stats', 'unfinished'], array_keys($decoded));
         self::assertSame($this->profiler->getStats(), $decoded['stats']);
 
         $expected = array_map(
@@ -179,6 +179,78 @@ final class ProfileReportCommandTest extends TestCase
     /**
      * @param array<string, string> $input
      */
+    /**
+     * An operation missing from the report because its `stop()` misspelled the
+     * subject looks exactly like one that was never instrumented. This is the
+     * difference.
+     */
+    public function test_the_report_names_what_was_started_and_never_stopped(): void
+    {
+        $this->profiler->start('db-query', 'users');
+        $this->profiler->stop('db-query', 'users');
+        $this->profiler->start('db-query', 'orders');
+        $this->profiler->stop('db-query', 'order');
+
+        $display = $this->runCommand([])->getDisplay();
+
+        self::assertStringContainsString('Started and never stopped:', $display);
+        self::assertStringContainsString('db-query:orders', $display);
+        self::assertStringContainsString('must match its start()', $display);
+    }
+
+    public function test_a_report_with_nothing_open_says_nothing_about_it(): void
+    {
+        $this->profiler->start('db-query', 'users');
+        $this->profiler->stop('db-query', 'users');
+
+        self::assertStringNotContainsString('Started and never stopped', $this->runCommand([])->getDisplay());
+    }
+
+    /**
+     * Reached even when nothing completed: an unmatched pair is the likeliest
+     * reason there is no data to report, and the run that most needs the answer
+     * is the one that produced nothing.
+     */
+    public function test_it_is_reported_even_when_no_entry_completed(): void
+    {
+        $this->profiler->start('render', 'page');
+
+        $display = $this->runCommand([])->getDisplay();
+
+        self::assertStringContainsString('No profiling data available', $display);
+        self::assertStringContainsString('render:page', $display);
+    }
+
+    /**
+     * Several spans of one operation open at once are counted, because naming
+     * it once would understate what is still outstanding.
+     */
+    public function test_several_open_spans_of_one_operation_are_counted(): void
+    {
+        $this->profiler->start('render', 'page');
+        $this->profiler->start('render', 'page');
+
+        self::assertStringContainsString('render:page (2 open)', $this->runCommand([])->getDisplay());
+    }
+
+    /**
+     * A consumer that parses gets a field rather than prose.
+     */
+    public function test_json_carries_the_unfinished_operations_in_a_field(): void
+    {
+        $this->profiler->start('db-query', 'users');
+        $this->profiler->stop('db-query', 'users');
+        $this->profiler->start('render', 'page');
+
+        $display = $this->runCommand(['--format' => 'json'])->getDisplay();
+
+        /** @var array{unfinished: array<string, int>} $decoded */
+        $decoded = json_decode($display, true);
+
+        self::assertSame(['render:page' => 1], $decoded['unfinished']);
+        self::assertStringNotContainsString('Started and never stopped', $display);
+    }
+
     private function runCommand(array $input): CommandTester
     {
         $tester = new CommandTester(new ProfileReportCommand());

--- a/tests/Unit/Framework/Profiler/ProfilerTest.php
+++ b/tests/Unit/Framework/Profiler/ProfilerTest.php
@@ -73,6 +73,75 @@ final class ProfilerTest extends TestCase
         self::assertCount(2, $entries);
     }
 
+    /**
+     * A `stop()` whose subject does not match its `start()` is ignored -- there
+     * is no start time to measure from -- so the entry is lost and nothing says
+     * why. The unmatched start is still open, and naming it is what turns "my
+     * operation is missing from the report" into the typo that caused it.
+     */
+    public function test_a_start_whose_stop_never_matched_is_reported_as_unfinished(): void
+    {
+        $this->profiler->enable();
+        $this->profiler->start('db-query', 'orders');
+        $this->profiler->stop('db-query', 'order');
+
+        self::assertSame([], $this->profiler->getEntries());
+        self::assertSame(['db-query:orders' => 1], $this->profiler->getUnfinishedOperations());
+    }
+
+    /**
+     * Every open operation, not the first one found: a report naming one of
+     * three sends its reader to fix that one and rerun into the same silence.
+     */
+    public function test_every_open_operation_is_reported(): void
+    {
+        $this->profiler->enable();
+        $this->profiler->start('db-query', 'orders');
+        $this->profiler->start('render', 'page');
+        $this->profiler->start('http', 'upstream');
+
+        self::assertSame(
+            ['db-query:orders' => 1, 'render:page' => 1, 'http:upstream' => 1],
+            $this->profiler->getUnfinishedOperations(),
+        );
+    }
+
+    public function test_a_matched_pair_leaves_nothing_unfinished(): void
+    {
+        $this->profiler->enable();
+        $this->profiler->start('db-query', 'users');
+        $this->profiler->stop('db-query', 'users');
+
+        self::assertSame([], $this->profiler->getUnfinishedOperations());
+    }
+
+    /**
+     * Nested spans of one operation close innermost-first, so a report of what
+     * is still open has to count them rather than merely name them.
+     */
+    public function test_nested_starts_are_counted_while_they_remain_open(): void
+    {
+        $this->profiler->enable();
+        $this->profiler->start('render', 'page');
+        $this->profiler->start('render', 'page');
+
+        self::assertSame(['render:page' => 2], $this->profiler->getUnfinishedOperations());
+
+        $this->profiler->stop('render', 'page');
+
+        self::assertSame(['render:page' => 1], $this->profiler->getUnfinishedOperations());
+    }
+
+    public function test_reset_clears_what_was_left_open(): void
+    {
+        $this->profiler->enable();
+        $this->profiler->start('render', 'page');
+
+        $this->profiler->reset();
+
+        self::assertSame([], $this->profiler->getUnfinishedOperations());
+    }
+
     public function test_profiler_generates_statistics(): void
     {
         $this->profiler->start('operation1', 'subject1');


### PR DESCRIPTION
## 📚 Description

`Profiler::stop()` ignores a call whose operation or subject does not match its
`start()` — there is no start time to measure from, which is correct. But the entry
is then simply absent, and absent looks exactly like code nobody instrumented:

```php
$profiler->start('db-query', 'orders');
$profiler->stop('db-query', 'order');   // typo
```

```
$ gacela profile:report
No profiling data available          ← and nothing about why
```

That is a poor answer from the one tool whose job is telling a reader what
happened. The unmatched start was already sitting in `activeOperations`; this names
it.

```
Started and never stopped:
  db-query:orders
  render:page
A stop() must match its start() on both operation and subject.
```

## 🔖 Changes

- `Profiler::getUnfinishedOperations()` returns what is still open, keyed
  `operation:subject`.
- `profile:report` lists them, and `--format=json` carries the same answer in an
  `unfinished` field rather than as prose a parser would have to read.

## ✅ Notes

**Counted, not merely listed.** Nested spans of one operation close
innermost-first, so `render:page (2 open)` is a different fact from `render:page`.

**Reported even when nothing completed** — the "No profiling data available" run is
precisely the one that most needs the explanation, and it was the case with no
answer at all.

- An existing test pins the JSON document's top-level keys, so adding a field broke
  it by design. Updated deliberately rather than worked around: `['entries',
  'stats', 'unfinished']` is a contract worth stating.
- Psalm caught a redundant emptiness check I had added — `popStartTime()` unsets the
  key when its last span closes, so a key that is present always has spans open.
  Removed rather than annotated, with a comment saying why it is safe.
- The mutation gate found that no test had **two distinct** open operations, so
  returning only the first would have passed. 3 mutants, **0 escaped, 100% MSI**.
- Full gate green: 1775 unit / 337 integration / 434 feature.

## 🔭 Also probed, no change

The profiler is documented as manual instrumentation, not automatic tracking — its
own help says so — so recording nothing after a bootstrap is correct, not a dead
feature. Both `--dry-run` flags (`dto:generate`, `ide:meta`) were verified to write
nothing while reporting what they would do.
