### PR TITLE
📝 List every check that reports dead configuration

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,12 +65,13 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 `doctor` also runs any check you registered with `GacelaConfig::addHealthCheck()` — see [module health checks](module-health-checks.md).
 
-Four of the built-in checks report the same kind of fault: **configuration a project declared that nothing acts on**. Each is accepted at bootstrap, costs nothing at runtime, and does exactly nothing — which is why a command has to be the one to say so. Under `--strict` any of them fails the run.
+Five of the built-in checks report the same kind of fault: **configuration a project declared that nothing acts on**. Each is accepted at bootstrap, costs nothing at runtime, and does exactly nothing — which is why a command has to be the one to say so. Under `--strict` any of them fails the run.
 
 - **event listeners** — a `registerSpecificListener()` target no dispatched event can be. The dispatcher compares `$event::class`, so a listener registered against an interface never fires, not even for events implementing it; nor does one naming an abstract class or a typo. `Container::afterResolving()` matches by `instanceof`, which is exactly why registering against a contract looks like it should work. A concrete class nothing dispatches is left alone — that listener is waiting, not broken.
 - **config sources** — an `addAppConfig()` path matching no file. `conf/*.php` for a directory named `config` bootstraps perfectly, and then the first read of a key fails with an error about the key rather than the path meant to provide it. Only the base path is reported: `config/app-prod.php` is *meant* to be absent where it does not apply.
 - **cache directory** — caching enabled onto a directory that cannot be written. Writing is best-effort by design, so the application runs correctly and pays the cold cost on every request instead. Reported read-only: `doctor` never creates the directory to find out.
-- **service extensions** — an `extendService()` id no Provider ever `set()`s. A typo, or an id registered only through `bind()`/`singleton()`, which do not drain the extension queue.
+- **service extensions** — an `extendService()` id no Provider ever `set()`s. A typo, or an id registered only through `bind()`/`singleton()`, which do not drain the extension queue. An `extendProviderService()` id is held against the Provider it names, which is the sharper miss: not "nobody set this id" but "the Provider you named does not", so an id some *other* Provider registers is still reported.
+- **tagged services** — a `tag()` id nothing can answer. `Container::tagged()` resolves each id in turn and gives back `null` for one naming nothing, so the group a module iterates carries a hole and the failure lands on the consumer as "Call to a member function … on null", pointing at the loop rather than the registration. An id is answerable when a Provider `set()`s it or it names a class the container can construct, so a tag grouping plain service ids is left alone.
 
 ## Production
 


### PR DESCRIPTION
## 📚 Description

`docs/cli.md` has a themed list: *"Four of the built-in checks report the same kind
of fault: **configuration a project declared that nothing acts on**."*

Two changes since then belong in it, and neither was added — so the count was wrong
and the list incomplete:

- **#740** added a check for a `tag()` id nothing can answer.
- **#741** extended the service-extensions check to hold an `extendProviderService()`
  id against the Provider it names.

Both are exactly what the section is for: accepted at bootstrap, free at runtime,
doing nothing.

## 🔖 Changes

- The count reads five, and the new check has a bullet of its own.
- The service-extensions bullet covers the provider-scoped half, including the case
  the app-wide check cannot express: an id some *other* Provider registers.

## ✅ Notes

**I deliberately did not add a guard for this.** The static-analysis rules table has
one — `StaticAnalysisDocsTest` caught exactly this drift for #742, which is why I
went looking here. But that table lists *every* rule, whereas this section documents
a **theme**: only 6 of the 13 checks `doctor` runs are named in `cli.md`, and the
other 7 are deliberately absent. A guard demanding all of them appear would be wrong
about seven checks, and one demanding only these five would encode a list nobody
maintains.

So this is drift a reader has to catch, and the honest thing is to say so rather
than ship a guard that would fire on correct documentation.

- Documentation only; no production change. Suite green: 1770 unit / 337
  integration / 429 feature.
