### PR TITLE
📝 Correct the CLI flags this session changed

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,8 +14,8 @@ Every command except `init` needs a bootstrappable project — a `gacela.php` in
 | Command | What it does |
 |---|---|
 | `init` | Creates the `gacela.php` a project needs before anything else works, plus the `config/app.php` it declares. `--force` regenerates `gacela.php` and never touches your config |
-| `make:module App/Blog` | Generates a module. `--template=basic\|service\|minimal`, `--minimal`, `--with-tests`, `--short-name` |
-| `make:file App/Blog Facade Factory` | Generates named files into an existing module — the four pillars, plus any kind the project declared |
+| `make:module App/Blog` | Generates a module. `--template=basic\|service\|minimal`, `--minimal`, `--with-tests` (service template only — refused on the others rather than ignored), `--short-name`, `--force` to replace files that already exist |
+| `make:file App/Blog Facade Factory` | Generates named files into an existing module — the four pillars, plus any kind the project declared. `--short-name`, `--force` to replace files that already exist |
 | `stubs:publish` | Copies the scaffolder's templates into the project so `make:*` generates your house style. `--template=basic\|service`, `--force` |
 
 ### Your own stubs
@@ -52,7 +52,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 | `debug:config` | The effective merged configuration, after every source and override, each key marked `declared`, `undeclared` or `missing` against the [schema](config-schema.md) |
 | `debug:container` | Container contents — user bindings and plugins only |
 | `debug:dependencies Foo::class` | A class's constructor parameters and whether the container can supply each. `--tree` walks the whole graph and marks every node `binding`, `instance`, `autowired` or `unresolvable` |
-| `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--allowed-cycles`, `--rules` to fail on dependencies your rules file forbids, `--compare-to` |
+| `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--compare-to`. `--allowed-cycles` and `--rules` are read only by `--check`, and are refused without it |
 
 `debug:graph --check` is the one built for CI; see [module boundaries](module-boundaries.md) for wiring it into a workflow.
 


### PR DESCRIPTION
## 📚 Description

Three rows in `docs/cli.md` had drifted from the commands they describe — all three
because of changes made this session, and none caught by a test.

| Row | Was | Now |
|---|---|---|
| `make:module` | no `--force` | `--force`, and `--with-tests` marked service-only *and* refused elsewhere |
| `make:file` | no flags at all | `--short-name`, `--force` |
| `debug:graph` | `--rules` read as standalone | `--allowed-cycles` and `--rules` are read only by `--check`, and refused without it |

The `debug:graph` row is the one that mattered most: it listed `--rules` beside
`--check` as though either would do, and the combination it implied — `--rules`
alone — was exactly the one that silently checked nothing until #743.

## ✅ Notes

**Every flag in these three rows was diffed against the command's own `--help`**,
not just the ones I changed:

```
make:module  real: --force --minimal --short-name --template --with-tests
             docs: --force --minimal --short-name --template --with-tests
make:file    real: --force --short-name
             docs: --force --short-name
debug:graph  real: --allowed-cycles --check --compare-to --format --rules
             docs: --allowed-cycles --check --compare-to --format --rules
```

That is what makes the rows correct rather than merely plausible — and it is how I
found that `make:file` documented no flags at all, which predates this session.

- Documentation only; no production change. Suite green: 1775 unit / 337
  integration / 434 feature.
- Follows #746, which fixed the same class of drift in the doctor-checks section.
  Between them, every CLI behaviour I changed this session is now described
  accurately.
