### PR TITLE
📝 Correct two pages that still describe the old behaviour

### DIFF
--- a/docs/module-boundaries.md
+++ b/docs/module-boundaries.md
@@ -98,7 +98,7 @@ vendor/bin/gacela debug:graph --check --allowed-cycles=allowed-module-cycles.jso
 
 The allow list is **self-invalidating**: an entry that no longer matches a real cycle fails the check just as loudly as an undeclared cycle. That is deliberate. An allow-list that outlives what it allows stops being a record of a decision and becomes a mute button, and nothing would tell you it had happened. A `reason` is required for the same reason — an allowance nobody justified is indistinguishable from a cycle nobody noticed.
 
-`debug:graph` with no `--check` stays exit-code-neutral, so adding the gate does not change what the command already did.
+`debug:graph` with no `--check` stays exit-code-neutral, so adding the gate does not change what the command already did. The one exception is passing an option only `--check` reads: `--allowed-cycles` and `--rules` are refused without it, rather than accepted and ignored — a run that wrote a rules file and forgot the flag used to print the graph and exit zero, which is a gate that looks green while checking nothing.
 
 ## Declaring which modules may depend on which
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -31,7 +31,7 @@ $profiler->stop('db-query', 'users');
 
 The profiler lives in process memory, so results are read in the same process that recorded them.
 
-In code, `getEntries()` returns every recorded span, and `getStats()` aggregates them:
+In code, `getEntries()` returns every recorded span, `getUnfinishedOperations()` names what is still open, and `getStats()` aggregates the rest:
 
 ```php
 $stats = Profiler::getInstance()->getStats();
@@ -43,7 +43,16 @@ $stats['peak_memory'];       // int, bytes
 $stats['by_operation'];      // per operation: count, total_duration, avg_duration
 ```
 
-On the command line, `profile:report` renders the same data as a table (`--format=table|json|summary`), sorted by duration, memory, or operation (`--sort`). Because the profiler is per-process, the command shows the spans recorded during its own run: enable the profiler and instrument code inside `gacela.php` or the bootstrap closure, and whatever executes while the command boots is what appears in the report.
+A `stop()` that misspells the operation or subject is ignored — there is no start time to measure from — so its span never becomes an entry and looks exactly like code nobody instrumented. `getUnfinishedOperations()` is the difference: it returns what was started and never closed, keyed `operation:subject` and counted, because nested spans of one operation close innermost-first.
+
+```php
+$profiler->start('db-query', 'orders');
+$profiler->stop('db-query', 'order');   // typo
+
+$profiler->getUnfinishedOperations();   // ['db-query:orders' => 1]
+```
+
+On the command line, `profile:report` renders the same data as a table (`--format=table|json|summary`), sorted by duration, memory, or operation (`--sort`). It lists anything left open under **Started and never stopped**, and `--format=json` carries the same answer in an `unfinished` field. Because the profiler is per-process, the command shows the spans recorded during its own run: enable the profiler and instrument code inside `gacela.php` or the bootstrap closure, and whatever executes while the command boots is what appears in the report.
 
 ## See also
 


### PR DESCRIPTION
## 📚 Description

Two pages still describe behaviour that changed under them.

**`module-boundaries.md`** stated flatly:

> `debug:graph` with no `--check` stays exit-code-neutral, so adding the gate does
> not change what the command already did.

Still true of a plain run. No longer true of one passing an option only `--check`
reads — #743 made `--rules` and `--allowed-cycles` refused rather than accepted and
ignored. The old sentence promised neutrality for precisely the case that used to
print the graph, exit zero, and check nothing.

**`profiling.md`** documented `getEntries()` and `getStats()` and stopped, so the
answer to *"why is my operation missing from the report"* was not on the page.
#745 added it.

## 🔖 Changes

- The boundaries claim keeps its guarantee for a plain run and names the one
  exception, with the reason it exists.
- The profiling page documents `getUnfinishedOperations()`, the typo it exists to
  explain, and the report's **Started and never stopped** section.

## ✅ Notes

**Both claims were run, not reasoned about.** The example added to `profiling.md` was
executed verbatim:

```
$profiler->start('db-query', 'orders');
$profiler->stop('db-query', 'order');   // typo
$profiler->getUnfinishedOperations();   // ['db-query:orders' => 1]
```

```
array (
  'db-query:orders' => 1,
)
```

And both exit codes the boundaries page now claims were checked: `--rules` without
`--check` exits 1, a plain `debug:graph` exits 0.

- Documentation only; no production change. Suite green.
- Third and last of the docs sweep, after #746 (doctor checks) and #747 (CLI flags).
  Every behaviour I changed this session is now described accurately, and I checked
  the remaining pages rather than assuming these were the only two.
