### PR TITLE
🐛 Run benchmarks where deprecations are displayed

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -19,5 +19,8 @@
         "aggregate"
       ]
     }
+  },
+  "runner.php_config": {
+    "error_reporting": "8191"
   }
 }


### PR DESCRIPTION
## 📚 Description

`composer phpbench` fails locally for any contributor whose CLI has
`display_errors` on:

```
bench_phpdoc_based_resolution ERROR
  Benchmark made some noise:
  Deprecated: Gacela: ...::getFactory() was resolved from the file's use statements.
```

phpbench treats any output from a subject as noise. Two `DocBlockResolverBench`
subjects exercise the phpdoc fallback **on purpose**, which triggers the 3.0
deprecation — so the notice lands in the child process's stdout and both subjects
error, exit 1.

CI does not see it, because GitHub's PHP has `display_errors` off. So the suite is
green there and broken on a common developer setup, which is the worst place for a
divergence to live.

`runner.php_config` pins the child processes' `error_reporting` rather than
inheriting whatever the contributor's ini happens to say.

## ✅ Notes

**Deprecations only — checked, not assumed.** I added a throwaway benchmark that
raises a real `E_USER_WARNING` and confirmed it still errors the run:

```
with a real warning exit=1
  Benchmark made some noise:
  Warning: a real warning in tests/Benchmark/NoisyBench.php on line 5
```

**Numeric on purpose.** The value reaches a shell as `-d error_reporting=...`, where
`E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED` is mangled into `sh: ~E_DEPRECATED:
command not found`. `8191` is that expression.

- Verified the whole `gate` group now runs locally: exit 0, 22 subjects, 0 errors.
- Pre-existing: the same two subjects error identically at `22911e50`, so this is
  not fallout from recent work.

## 🔭 What this was found while doing

Measuring whether 23 merged PRs had cost anything cumulatively — the CI guard
re-baselines against the base branch each run, so sub-threshold drift would not
show. The answer is **no detectable regression**, and the measurement is worth
reporting mainly for its uselessness: three consecutive readings of
`FileCacheBench::bench_without_cache` against a fixed baseline gave

```
+13.60%   +2.75%   +8.17%
```

An 11-point spread on one subject, against a 10% threshold. Local FileCache
benchmarks do real filesystem I/O and cannot resolve a change of this size on a
working laptop. The first reading alone would have read as a clear regression in
`FileCache` — which #730 touched — and reporting it would have been wrong. This is
what `tests/Benchmark/README.md` already says; it earned its place again.
