### PR TITLE
♻️ Drop the suppressions psalm no longer needs

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,8 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+
+    findUnusedPsalmSuppress="true"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Console/ConsoleConfig.php
+++ b/src/Console/ConsoleConfig.php
@@ -60,8 +60,6 @@ final class ConsoleConfig extends AbstractConfig
     }
 
     /**
-     * @psalm-suppress MixedReturnTypeCoercion
-     *
      * @throws ConsoleException|JsonException
      *
      * @return ComposerJsonContent

--- a/src/Framework/Cache/FileCache.php
+++ b/src/Framework/Cache/FileCache.php
@@ -400,7 +400,6 @@ final class FileCache
     private static function invalidateOpcacheFor(string $file): void
     {
         if (function_exists('opcache_invalidate')) {
-            /** @psalm-suppress UndefinedFunction */
             opcache_invalidate($file, true);
         }
     }

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -281,7 +281,6 @@ final class Config implements ConfigInterface
 
         // Declared defaults come first: a key a source provides is that
         // source's, and a key nobody provides is the declaration's.
-        /** @psalm-suppress DuplicateArrayKey */
         $this->config = [
             ...$this->configSchema()->defaults(),
             ...$this->loadMergedConfigValues(),

--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -82,7 +82,6 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
     {
         $new = clone $this;
         $new->configItems = [...$this->configItems, ...$other->getConfigItems()];
-        /** @psalm-suppress DuplicateArrayKey */
         $new->bindings = [...$this->bindings, ...$other->getBindings()];
         // Every kind either side declared, not the four that used to be the
         // only ones: a project-declared kind pushed in through setSuffixTypes()

--- a/src/Framework/ServiceResolverAwareTrait.php
+++ b/src/Framework/ServiceResolverAwareTrait.php
@@ -25,8 +25,6 @@ trait ServiceResolverAwareTrait
     private static array $docBlockServiceResolvers = [];
 
     /**
-     * @psalm-suppress LessSpecificImplementedReturnType
-     *
      * @param list<mixed> $parameters
      *
      * @return mixed

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -307,7 +307,6 @@ trait ContainerFixture
 
         $this->containerTempDirsCleanupRegistered = true;
 
-        /** @psalm-suppress UnusedFunctionCall */
         register_shutdown_function(function (): void {
             $this->cleanupContainerTempDirs();
         });

--- a/src/Framework/Testing/ContainerSnapshot.php
+++ b/src/Framework/Testing/ContainerSnapshot.php
@@ -62,15 +62,10 @@ final class ContainerSnapshot
      */
     public function __unserialize(array $data): void
     {
-        /** @psalm-suppress InaccessibleProperty */
         $this->inMemoryCache = $data['inMemoryCache'] ?? [];
-        /** @psalm-suppress InaccessibleProperty */
         $this->config = $data['config'] ?? [];
-        /** @psalm-suppress InaccessibleProperty */
         $this->appRootDir = $data['appRootDir'] ?? null;
-        /** @psalm-suppress InaccessibleProperty */
         $this->cacheDir = $data['cacheDir'] ?? null;
-        /** @psalm-suppress InaccessibleProperty */
         $this->extras = $data['extras'] ?? [];
     }
 


### PR DESCRIPTION
## 📚 Description

Eleven `@psalm-suppress` annotations across seven files suppress issues psalm no
longer reports:

| File | Suppressed | Why it is dead |
|---|---|---|
| `FileCache` | `UndefinedFunction` | the `opcache_invalidate` call is already guarded by `function_exists` |
| `Config`, `GacelaConfigFile` | `DuplicateArrayKey` | on spreads psalm now understands |
| `ContainerSnapshot` ×5 | `InaccessibleProperty` | readonly writes psalm now allows where they happen |
| `ConsoleConfig`, `ServiceResolverAwareTrait`, `ContainerFixture` | three others | no longer raised |

A suppression that outlives its issue is not inert. It silences that issue if it
comes back — on the exact line most likely to reintroduce it.

## 🔖 Changes

- The eleven dead annotations are removed. The **fourteen that remain are
  load-bearing**: psalm reports none of them unused.
- `findUnusedPsalmSuppress="true"` in `psalm.xml`, so they cannot accumulate again.

## ✅ Notes

**Why these built up at all.** PHPStan reports unmatched ignores *by default* — that
is how a stale `phpstan.neon` entry surfaced in #734, the moment the rule stopped
firing. Psalm has to be asked, was never asked, and eleven accumulated silently.
Turning it on closes that asymmetry.

**The guard is checked, not assumed.** Reintroducing one dead suppression:

```
psalm exit=2
1 × UnusedPsalmSuppress
```

My first attempt at that check was **vacuous** — the injection failed on an
indentation mismatch, nothing was added, and psalm "passed". A guard proven by a
no-op test is worse than no guard, so it is worth saying that the second attempt
is the one that counts.

- Deterministic across CI runners: psalm reports *"Target PHP version: 8.3 (inferred
  from composer.json)"*, so the analysis does not vary with the PHP running it.
- Full gate green: 1775 unit / 337 integration / 434 feature, psalm + phpstan +
  phpstan-tests + cs-fixer + rector clean, mutation gate on changed lines passes.
