### PR TITLE
✅ Fail on the warnings and notices already being reported

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,11 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnPhpunitWarning="true"
+         failOnPhpunitNotice="true"
+         failOnPhpunitDeprecation="true"
 >
   <php>
     <ini name="error_reporting" value="-1"/>


### PR DESCRIPTION
## 📚 Description

`phpunit.xml` carried **no `failOn*` policy at all**, so warnings, notices and
PHPUnit's own issues were printed and passed. All three suites already report zero
of them — this makes that a property rather than a coincidence.

The PHPUnit notices are the ones that earn their keep. While adding the doctor
check in #740, *"No expectations were configured for the mock object … consider
using a test stub instead"* caught a `createMock` that should have been a
`createStub`. Nothing would have failed if I had scrolled past it.

## 🔖 Changes

Four gates, all currently satisfied:

| Attribute | Catches |
|---|---|
| `failOnWarning`, `failOnNotice` | PHP-level warnings and notices |
| `failOnPhpunitWarning`, `failOnPhpunitNotice` | PHPUnit's own, e.g. a mock with no expectations |
| `failOnPhpunitDeprecation` | deprecated PHPUnit APIs, before an upgrade turns them into errors |

## ⚠️ `failOnDeprecation` stays off, deliberately

The twelve deprecations every run reports are **Gacela's own** 3.0
docblock-fallback notice, triggered by fixtures that exercise that path on
purpose. Failing on them would break the tests written to cover the deprecated
behaviour. They are intentional debt with a scheduled end, not drift.

## ✅ Notes

**The two pairs are not interchangeable, which I found by testing rather than
reading.** My first attempt set only `failOnWarning`/`failOnNotice`, and a mock
with no expectations still passed — `Notices: 1`, exit `0`. The PHPUnit-specific
attributes are what catch PHPUnit's own issues. Both pairs are now verified with a
throwaway test that triggers one of each:

```
guards exit=1
Tests: 2, Assertions: 2, Warnings: 1, PHPUnit Notices: 1
```

- `failOnSkipped` deliberately not enabled: one test skips by design when the
  checkout is not a git repository.
- Full gate green: 1775 unit / 337 integration / 434 feature, quality clean.
