### PR TITLE
✅ Run the module-cycle check in the local gate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,6 +131,7 @@
             "@test-all-suites",
             "XDEBUG_MODE=off ./vendor/bin/phpmetrics --config=phpmetrics-config.json --junit=data/log-junit.xml"
         ],
+        "module-cycles": "php bin/gacela debug:graph --check --allowed-cycles=allowed-module-cycles.json",
         "phpbench": "XDEBUG_MODE=off ./vendor/bin/phpbench run --report=aggregate --ansi",
         "phpbench-base": "XDEBUG_MODE=off ./vendor/bin/phpbench run --tag=baseline --report=aggregate --progress=plain --ansi",
         "phpbench-ref": "XDEBUG_MODE=off ./vendor/bin/phpbench run --ref=baseline --report=aggregate --progress=plain --ansi",
@@ -147,7 +148,8 @@
             "@rectorrun",
             "@psalm",
             "@phpstan",
-            "@phpstan-tests"
+            "@phpstan-tests",
+            "@module-cycles"
         ],
         "rector": "XDEBUG_MODE=off ./vendor-bin/rector/vendor/bin/rector",
         "rectorrun": "XDEBUG_MODE=off ./vendor-bin/rector/vendor/bin/rector --dry-run",


### PR DESCRIPTION
## 📚 Description

CI enforces a module-cycle check in its own workflow:

```
php bin/gacela debug:graph --check --allowed-cycles=allowed-module-cycles.json
```

`composer quality` did not run it. So a contributor could run `composer test`, see
green, push, and have `module-cycles` fail on a check they had no local way to
reach — the slowest possible way to learn about a cycle.

It costs **0.15s**, which is nothing beside the analysers it now sits with. There is
no reason for the local gate to be the smaller one.

## 🔖 Changes

- A `module-cycles` script, and `quality` runs it after the analysers — so it is
  reached by `composer quality`, `composer test` and the pre-commit hook alike.

## ✅ Notes

**Verified on the path that matters.** `allowed-module-cycles.json` is empty, so any
cycle fails. I built a throwaway two-module project that genuinely cycles:

```
✗ Dependency cycle: App\A -> App\B      exit 1
```

My first attempt at that proof was weaker and I nearly kept it: emptying the
allow-list to `{"cycles":[]}` gave exit 1, but from *schema* validation
(`Allowed-cycle entry #0 must list at least two "modules"`) — a different failure
that would have overstated what was tested.

- `composer.json` re-normalized; `composer normalize --dry-run` reports it already
  normalized, so the CI style job stays green.
- Full gate green with the check included: 1775 unit / 337 integration / 434
  feature, and `quality` reports `✓ No undeclared module dependency cycles`.

## 🔭 Checked, no change needed

`module-graph` is the other cheap-looking workflow, but it diffs the graph against
the base branch — meaningless locally, so it stays CI-only. `infection` and
`phpbench` are correctly excluded from the local gate: both are far too slow to run
on every commit, and both already gate in CI.
