### PR TITLE
✅ Verify composer.json normalization in the local gate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,6 +132,7 @@
             "XDEBUG_MODE=off ./vendor/bin/phpmetrics --config=phpmetrics-config.json --junit=data/log-junit.xml"
         ],
         "module-cycles": "php bin/gacela debug:graph --check --allowed-cycles=allowed-module-cycles.json",
+        "normalizerun": "@composer normalize --dry-run",
         "phpbench": "XDEBUG_MODE=off ./vendor/bin/phpbench run --report=aggregate --ansi",
         "phpbench-base": "XDEBUG_MODE=off ./vendor/bin/phpbench run --tag=baseline --report=aggregate --progress=plain --ansi",
         "phpbench-ref": "XDEBUG_MODE=off ./vendor/bin/phpbench run --ref=baseline --report=aggregate --progress=plain --ansi",
@@ -144,6 +145,7 @@
         ],
         "psalm": "XDEBUG_MODE=off ./vendor/bin/psalm",
         "quality": [
+            "@normalizerun",
             "@csrun",
             "@rectorrun",
             "@psalm",


### PR DESCRIPTION
## 📚 Description

Every tool in this repo is a pair — `csfix`/`csrun`, `rector`/`rectorrun` — one half
wired into `fix`, the other into `quality`. **`normalize` had only the fix half.**

So `composer fix` normalized `composer.json`, nothing local checked it had stayed
that way, and CI's code-style job failed on `composer normalize --dry-run`. Same
shape as #752: a contributor goes green locally and is told by CI about a file their
own fix script maintains.

## 🔖 Changes

- A `normalizerun` script, and `quality` runs it first — restoring the pair.

```
fix     : @static-clear-cache ; @composer normalize ; @rector ; @csfix
quality : @normalizerun ; @csrun ; @rectorrun ; @psalm ; @phpstan ; @phpstan-tests ; @module-cycles
```

## ✅ Notes

**Checked in both directions.** `quality` reports *"./composer.json is already
normalized."*, and a `composer.json` with `require` moved out of order gives:

```
denormalized exit=1
./composer.json is not normalized.
```

**php-cs-fixer's CI flags were compared too, and need nothing.** CI runs it with
`--allow-risky=yes --using-cache=no` while local `csrun` uses neither. Neither is a
gap: `.php-cs-fixer.dist.php` already sets `setRiskyAllowed(true)`, and an uncached
risky run finds the same **0 of 1370** files as the cached one. Worth stating,
because the flag difference looks like a gap until it is measured.

- Full gate green: 1775 unit / 337 integration / 434 feature.

## 🔭 The local gate now matches CI for everything cheap

`composer quality` covers normalization, code style, rector, psalm, phpstan,
phpstan-tests and module cycles — every check CI enforces that is fast enough to run
per-commit. What remains CI-only is deliberate: `module-graph` diffs against the base
branch (meaningless locally), and `infection` and `phpbench` are too slow for a
per-commit gate.
