### PR TITLE
📝 Say what the quality gate actually runs

### DIFF
--- a/.claude/rules/php.md
+++ b/.claude/rules/php.md
@@ -23,7 +23,7 @@ globs: src/**/*.php,tests/**/*.php
 ## Quality Gates
 
 ```bash
-composer quality     # cs-fixer (dry-run) + psalm + phpstan
+composer quality     # normalize + cs-fixer + rector (dry-run) + psalm + phpstan (src and tests) + module cycles
 composer fix         # normalize + cs-fixer + rector (auto-fix)
 composer infection   # Mutation testing (requires Xdebug)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Source code lives in `src/` under the `Gacela\` namespace, grouped by module-res
 
 - `composer install` — install PHP 8.3+ dependencies and trigger repo git hooks.
 - `composer test` — run linting, static analysis, and the full PHPUnit matrix (`unit`, `integration`, `feature`).
-- `composer quality` — quick guardrail: php-cs-fixer dry run, Psalm, then PHPStan.
+- `composer quality` — every check CI enforces that is fast enough to run per-commit: composer-normalize, php-cs-fixer and rector dry runs, Psalm, PHPStan over `src/` and again over the tests, then the module-cycle check. `module-graph` stays CI-only because it diffs against the base branch, and `infection` and `phpbench` because they are too slow for a per-commit gate.
 - `composer csfix` / `composer csrun` — auto-fix or check formatting with php-cs-fixer config.
 - `composer phpbench` — execute aggregate performance benchmarks.
 - `composer infection` — mutation testing; requires Xdebug enabled. It runs mutated code, which writes files into fixture directories and, when a mutant mangles a path, into a directory named after the mangled root (`\\ar/...`, from `/var/...`). All of it is gitignored and rector is configured to skip it, so a run leaves the suite green — but it does break `composer archive`, which filters by `.gitattributes` rather than `.gitignore` and refuses the back-slashed name. Use `git archive HEAD` to inspect what ships; that is also what Packagist builds from.


### PR DESCRIPTION
## 📚 Description

Two checked-in files described the local gate as it was several checks ago:

| File | Said | Actually runs |
|---|---|---|
| `AGENTS.md` | "php-cs-fixer dry run, Psalm, then PHPStan" | seven checks |
| `.claude/rules/php.md` | "cs-fixer (dry-run) + psalm + phpstan" | seven checks |

Rector and the tests' own PHPStan pass were **already** missing before this session;
#752 (module cycles) and #753 (composer-normalize) widened the gap.

Both now list what `composer quality` runs, and say why `module-graph`, `infection`
and `phpbench` stay CI-only — the first diffs against the base branch, the other two
are too slow for a per-commit gate.

## ✅ Notes

**Written from `composer.json`, not from memory.** The list is the seven script names
in the order `quality` invokes them:

```
actual : normalizerun csrun rectorrun psalm phpstan phpstan-tests module-cycles
```

and the gate was run to confirm each step reports: `already normalized`, rector
`[OK]`, psalm `No errors`, phpstan `No errors` ×2, `✓ No undeclared module
dependency cycles`.

**Timing mattered here.** I wrote this while #753 was still open, so the description
mentioned a check that was not yet on `main`. Rebasing onto it before opening was the
difference between a doc that is true on merge and one that is aspirational.

- Documentation only; no production change.
- Third docs correction of the session, and the first written *with* the change
  rather than after it — the lesson from #746–#748 applied forward instead of
  backward.
