### PR TITLE
🐛 Never write the scoped graph at the filesystem root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Fixed
 
+- Never write or delete the scoped cache's dependency graph at the filesystem root. `ScopedCache` built its graph path by concatenating onto the underlying `FileCache` directory, which is empty for `''`, `'/'` and whitespace — so a cache with nowhere to write persisted the graph to `/` on every `dependsOn()` and unlinked it on `clear()`. It now reads the same `CacheFilePath` rule the values do, and keeps the graph in memory when there is nowhere to put it
+
 - Refuse `debug:graph --rules` and `--allowed-cycles` when `--check` is absent, instead of ignoring them. Both files are read only by `--check`, so a CI job that wrote a rules file and ran the command without it printed the graph and exited zero — a gate that looks green while checking nothing
 - Refuse `make:module --with-tests` on a template that scaffolds no test, instead of ignoring it. Only the service template writes a facade test; on the others the flag was accepted, four files were written and "created successfully" reported — so a reader who asked for a test believed they had one
 

--- a/src/Framework/Cache/ScopedCache.php
+++ b/src/Framework/Cache/ScopedCache.php
@@ -11,8 +11,6 @@ use function is_array;
 use function is_file;
 use function is_string;
 
-use const DIRECTORY_SEPARATOR;
-
 /**
  * Dependency-aware decorator over {@see FileCache}.
  *
@@ -80,7 +78,12 @@ final class ScopedCache
         $this->dependencies = [];
         $this->dependents = [];
 
-        FileCache::delete($this->graphPath());
+        $path = $this->graphPath();
+        if ($path === null) {
+            return;
+        }
+
+        FileCache::delete($path);
     }
 
     /**
@@ -249,9 +252,23 @@ final class ScopedCache
         return false;
     }
 
-    private function graphPath(): string
+    /**
+     * Null when the underlying cache has nowhere to write.
+     *
+     * {@see FileCache::normalizeDirectory()} reduces `''`, `'/'` and whitespace
+     * to an empty string, and concatenating onto that gave
+     * `'/.gacela-scoped-cache-graph.php'` -- the filesystem root. The graph is
+     * written on every `dependsOn()` and deleted by `clear()`, so a cache with
+     * no usable directory wrote and unlinked at the root while holding nothing
+     * on disk of its own.
+     *
+     * The same rule {@see FileCache} reads, through the same helper, rather
+     * than a second path builder that has to be remembered separately -- which
+     * is exactly how this one was missed when the other was fixed.
+     */
+    private function graphPath(): ?string
     {
-        return $this->cache->directory . DIRECTORY_SEPARATOR . self::GRAPH_FILENAME;
+        return CacheFilePath::inDirectory($this->cache->directory, self::GRAPH_FILENAME);
     }
 
     /**
@@ -262,11 +279,18 @@ final class ScopedCache
     private function loadGraph(): void
     {
         $path = $this->graphPath();
-        if (!is_file($path)) {
+        if ($path === null || !is_file($path)) {
             return;
         }
 
-        /** @var mixed $payload */
+        /**
+         * The path is built rather than written inline, so Psalm can no longer
+         * partially resolve it -- the file is a graph this class wrote.
+         *
+         * @psalm-suppress UnresolvableInclude
+         *
+         * @var mixed $payload
+         */
         $payload = require $path;
         if (!is_array($payload)) {
             return;
@@ -295,6 +319,14 @@ final class ScopedCache
 
     private function persistGraph(): void
     {
-        FileCache::writeAtomically($this->graphPath(), $this->dependencies);
+        $path = $this->graphPath();
+
+        // A cache with nowhere to write keeps its graph in memory, as the
+        // values it decorates already do.
+        if ($path === null) {
+            return;
+        }
+
+        FileCache::writeAtomically($path, $this->dependencies);
     }
 }

--- a/tests/Feature/Framework/ScopedCache/ScopedCacheFeatureTest.php
+++ b/tests/Feature/Framework/ScopedCache/ScopedCacheFeatureTest.php
@@ -8,6 +8,7 @@ use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\ScopedCache;
 use GacelaTest\Feature\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 use function count;
 use function glob;
@@ -34,6 +35,64 @@ final class ScopedCacheFeatureTest extends TestCase
     protected function tearDown(): void
     {
         DirectoryUtil::removeDir($this->cacheDir);
+    }
+
+    /**
+     * The graph is written on every `dependsOn()`, `invalidate()` and
+     * `clear()`, and its path was the cache directory concatenated with the
+     * filename. {@see FileCache} reduces `''`, `'/'` and whitespace to an
+     * empty directory, so that concatenation named the filesystem root: a
+     * cache with nowhere to write wrote and unlinked at `/` while holding
+     * nothing on disk of its own.
+     *
+     * The values it decorates already degrade to memory; the graph now does
+     * the same, through the helper {@see FileCache} reads.
+     */
+    public function test_a_cache_with_nowhere_to_write_keeps_its_graph_in_memory(): void
+    {
+        $scoped = new ScopedCache(new FileCache(''));
+
+        $scoped->put('parent', 'p');
+        $scoped->put('child', 'c');
+        $scoped->dependsOn('child', 'parent');
+
+        self::assertSame(['child'], $scoped->dependents('parent'));
+        self::assertFileDoesNotExist(DIRECTORY_SEPARATOR . self::GRAPH_FILE);
+        // Asked of the path, not only of the filesystem: a write to `/` fails
+        // silently for an unprivileged process, so the file is absent whether
+        // or not the bug is present. The path is the thing that differs.
+        self::assertNull($this->graphPathOf($scoped));
+    }
+
+    /**
+     * And a real directory still resolves to a path under it, so the guard
+     * above cannot pass by answering null for everything.
+     */
+    public function test_a_real_directory_still_resolves_to_a_graph_path(): void
+    {
+        $scoped = new ScopedCache(new FileCache($this->cacheDir));
+
+        self::assertSame(
+            $this->cacheDir . DIRECTORY_SEPARATOR . self::GRAPH_FILE,
+            $this->graphPathOf($scoped),
+        );
+    }
+
+    /**
+     * Every write path, because each persists: an invalidate and a clear would
+     * each have reached the root on their own.
+     */
+    public function test_invalidating_and_clearing_with_nowhere_to_write_touch_no_disk(): void
+    {
+        $scoped = new ScopedCache(new FileCache(''));
+        $scoped->put('parent', 'p');
+        $scoped->dependsOn('child', 'parent');
+
+        $scoped->invalidate('parent');
+        $scoped->clear();
+
+        self::assertNull($scoped->get('parent'));
+        self::assertFileDoesNotExist(DIRECTORY_SEPARATOR . self::GRAPH_FILE);
     }
 
     /**
@@ -149,5 +208,21 @@ final class ScopedCacheFeatureTest extends TestCase
     private function countCacheFiles(): int
     {
         return count(glob($this->cacheDir . '/*.php') ?: []);
+    }
+
+    /**
+     * The graph's path, read off the object.
+     *
+     * Private because nothing outside needs it, and pinned here because the
+     * difference between a correct and an incorrect one is invisible in
+     * behaviour: both keep working, and both leave `/` untouched on a machine
+     * that cannot write there.
+     */
+    private function graphPathOf(ScopedCache $scoped): ?string
+    {
+        $method = new ReflectionMethod($scoped, 'graphPath');
+
+        /** @var ?string */
+        return $method->invoke($scoped);
     }
 }

--- a/tests/Feature/Framework/ScopedCache/ScopedCacheFeatureTest.php
+++ b/tests/Feature/Framework/ScopedCache/ScopedCacheFeatureTest.php
@@ -12,6 +12,7 @@ use ReflectionMethod;
 
 use function count;
 use function glob;
+use function rtrim;
 use function sys_get_temp_dir;
 use function uniqid;
 
@@ -29,7 +30,11 @@ final class ScopedCacheFeatureTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->cacheDir = sys_get_temp_dir() . '/gacela-scoped-cache-feature-' . uniqid('', true);
+        // DIRECTORY_SEPARATOR, not '/': FileCache normalizes separators, so a
+        // fixture joined with a literal slash is not the string the cache holds
+        // on Windows -- where sys_get_temp_dir() is already back-slashed.
+        $this->cacheDir = rtrim(sys_get_temp_dir(), '/\\')
+            . DIRECTORY_SEPARATOR . 'gacela-scoped-cache-feature-' . uniqid('', true);
     }
 
     protected function tearDown(): void
@@ -163,7 +168,7 @@ final class ScopedCacheFeatureTest extends TestCase
         $cache = $this->openCache();
         $this->seedPipeline($cache);
 
-        $graphPath = $this->cacheDir . '/' . self::GRAPH_FILE;
+        $graphPath = $this->cacheDir . DIRECTORY_SEPARATOR . self::GRAPH_FILE;
         self::assertFileExists($graphPath);
         self::assertGreaterThan(0, $this->countCacheFiles());
 


### PR DESCRIPTION
## 📚 Description

**This is the defect #730 fixed, in the decorator #730 missed.**

`ScopedCache` built its graph path independently:

```php
return $this->cache->directory . DIRECTORY_SEPARATOR . self::GRAPH_FILENAME;
```

`FileCache` reduces `''`, `'/'` and whitespace to an empty directory, so that
becomes `/.gacela-scoped-cache-graph.php`. The graph is written on **every**
`dependsOn()`, `invalidate()` and `clear()` — so a cache with nowhere to write
persisted to the filesystem root and unlinked there, while holding nothing on disk
of its own.

Computed rather than executed, since running it is the bug:

```
empty       FileCache::directory=''   graphPath()='/.gacela-scoped-cache-graph.php'
root        FileCache::directory=''   graphPath()='/.gacela-scoped-cache-graph.php'
whitespace  FileCache::directory=''   graphPath()='/.gacela-scoped-cache-graph.php'

CacheFilePath::inDirectory('', ...) → NULL      ← what #730 already answers
```

#730 introduced `CacheFilePath` and routed `FileCache` through it. This path builder
was left behind — a second place that had to be remembered separately, which is
exactly how it survived.

## 🔖 Changes

- `graphPath()` returns `?string` from the shared helper; read, write and delete all
  honour it. The graph stays in memory when there is nowhere to put it, as the values
  it decorates already do.

## ✅ Notes

**My first tests did not catch this, and I nearly kept them.** They asserted
`assertFileDoesNotExist('/.gacela-scoped-cache-graph.php')` — which passes with the
fix reverted, because a write to `/` fails silently for an unprivileged process. The
file is absent either way; only the **path** differs. The tests now assert the path,
with a real directory alongside so the guard cannot pass by answering null for
everything. Reverting the fix now fails 1 test; before, it failed none.

- **Cycle rejection was checked and is correct.** An early probe suggested cycles
  were *not* rejected — that probe was invalid, because the `invalidate()` before it
  had already cleared the edges. On a clean graph both transitive and self-cycles
  raise `CycleDetectedException`.
- Psalm needed the same `UnresolvableInclude` suppression as #730, for the same
  reason: the path is built rather than written inline. It is load-bearing, so
  #750's `findUnusedPsalmSuppress` stays satisfied.
- Full gate green: 1775 unit / 337 integration / 437 feature, quality clean,
  12 mutants on changed lines with **0 escaped, 100% MSI**.
