### PR TITLE
fix: normalize the cache directory on every call, not only the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+- Normalize the cache directory on every `getCacheDir()` call, not only the first. The trailing separator was stripped from the returned value but the raw one was memoized, so the first caller got `/var/cache` and everyone after it got `/var/cache/` — which they concatenated onto, building `/var/cache//file.php`. Both spellings open the same file, so nothing failed; the paths the console reports and the empty-directory branch the `doctor` cache checks take now agree regardless of who asked first
 - Never write or delete the scoped cache's dependency graph at the filesystem root. `ScopedCache` built its graph path by concatenating onto the underlying `FileCache` directory, which is empty for `''`, `'/'` and whitespace — so a cache with nowhere to write persisted the graph to `/` on every `dependsOn()` and unlinked it on `clear()`. It now reads the same `CacheFilePath` rule the values do, and keeps the graph in memory when there is nowhere to put it
 
 - Refuse `debug:graph --rules` and `--allowed-cycles` when `--check` is absent, instead of ignoring them. Both files are read only by `--check`, so a CI job that wrote a rules file and ran the command without it printed the graph and exited zero — a gate that looks green while checking nothing

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -371,9 +371,16 @@ final class Config implements ConfigInterface
             return $this->cacheDir;
         }
 
-        $this->cacheDir = getenv('GACELA_CACHE_DIR') ?: $this->getDefaultCacheDir();
+        // Trimmed before it is stored, not on the way out: the memoized field is
+        // what every call after the first returns, so trimming the return value
+        // normalized the path for exactly one caller and left the rest with the
+        // raw one -- which they then concatenated onto, producing `dir//file`.
+        $this->cacheDir = rtrim(
+            getenv('GACELA_CACHE_DIR') ?: $this->getDefaultCacheDir(),
+            '/\\',
+        );
 
-        return rtrim($this->cacheDir, '/\\');
+        return $this->cacheDir;
     }
 
     /**

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -152,6 +152,32 @@ final class ConfigTest extends TestCase
         }
     }
 
+    /**
+     * The memoization test above passes with a fixture that has no trailing
+     * separator, so `rtrim()` is a no-op there and the two calls agree by
+     * accident. With one, they did not: the trimmed value was returned but the
+     * *un*-trimmed one was stored, so only the first caller saw a normalized
+     * path and everyone after it got the raw one.
+     *
+     * Callers concatenate onto this, so the later ones built `dir//file`. Both
+     * spellings open the same file, which is why nothing failed -- but they are
+     * not the same string, and the doctor checks that branch on an empty cache
+     * dir see a different value depending on who asked first.
+     */
+    public function test_get_cache_dir_is_normalized_on_every_call_not_only_the_first(): void
+    {
+        Config::resetInstance();
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->setFileCache(true, '/trailing-sep-cache/'),
+        );
+        $config = Config::createWithSetup($setup);
+        $config->setAppRootDir('/apps');
+
+        self::assertSame('/apps/trailing-sep-cache', $config->getCacheDir());
+        self::assertSame('/apps/trailing-sep-cache', $config->getCacheDir());
+        self::assertSame('/apps/trailing-sep-cache', $config->getCacheDir());
+    }
+
     public function test_get_cache_dir_returns_windows_style_absolute_path_unchanged(): void
     {
         Config::resetInstance();


### PR DESCRIPTION
## 📚 Description

`Config::getCacheDir()` returned a different string on the first call than on
every call after it.

The value is memoized, but the trailing separator was stripped from the
*returned* value rather than from the one stored:

```php
$this->cacheDir = getenv('GACELA_CACHE_DIR') ?: $this->getDefaultCacheDir();

return rtrim($this->cacheDir, '/\\');   // trims for exactly one caller
```

So with `GACELA_CACHE_DIR=/var/cache/`:

| call | returns |
|------|---------|
| 1st  | `/var/cache`  |
| 2nd+ | `/var/cache/` |

Callers concatenate onto it — `AbstractPhpFileCache::absoluteFilename()` and
`MergedConfigCache` both do — so the later ones built `/var/cache//file.php`.
Both spellings open the same file, which is why no test caught it and nothing
broke at runtime. What it does affect is every place the path is compared or
shown rather than opened: the paths `cache:clear` and `doctor` report, and the
`$cacheDir === ''` branch the two cache checks take, which is reached for
`GACELA_CACHE_DIR=/` on the first call and not on the second.

`test_get_cache_dir_is_resolved_once_and_memoized` already asserts exactly this
property. It passes because its fixture is `/memoized-cache` — no trailing
separator, so `rtrim()` is a no-op and the two calls agree by accident.

## 🔖 Changes

- `Config::getCacheDir()` trims before storing, so the memoized value is the
  normalized one and every call returns it
- A regression test with a trailing separator in the fixture, asserting three
  consecutive calls agree — the shape the existing memoization test cannot see
