### PR TITLE
test: declare the psalm handler statics that outlive a cache reset

### DIFF
--- a/tests/Integration/Architecture/StaticStateCoverageTest.php
+++ b/tests/Integration/Architecture/StaticStateCoverageTest.php
@@ -108,6 +108,8 @@ final class StaticStateCoverageTest extends TestCase
         'ClassRules::$cacheableKeys' => 'pure memoization, as above: the second rule that judges a method rather than a class, this one reading the #[Cacheable] attribute on it',
         'CrossModuleRules::$analyser' => "configuration: the boundary check psalm was asked to run, read from the consumer's <crossModule> element at plugin registration. Nothing re-establishes it, so clearing it would silently turn the rule off",
         'CrossModuleCallRules::$analyser' => 'configuration: the other half of the same check, registered from the same element',
+        'ServiceMapMissingRules::$analyser' => "configuration: the 3.0-readiness check psalm was asked to run, read from the consumer's <serviceMapMissing> element at plugin registration. Same lifetime as the cross-module handlers above, and nothing re-establishes it",
+        'DeclaredModuleDependencyRules::$analyser' => "configuration: the module-rules check, read from the consumer's <moduleRules> element and holding the rule set parsed from the file it names",
     ];
 
     protected function tearDown(): void


### PR DESCRIPTION
## 📚 Description

`StaticStateCoverageTest` failed on an unrelated branch:

```
These statics still hold state after Gacela::resetCache():
ServiceMapMissingRules::$analyser.
Either clear them from Gacela::resetCache(), or add them to
OUTLIVES_RESET with the reason their lifetime is not cache lifetime.
```

#758 added that handler and missed the entry. Its lifetime is plugin
registration, not cache lifetime — it holds the check Psalm was asked to run,
read from the consumer's `<serviceMapMissing>` element, and nothing
re-establishes it. That is the same reason `CrossModuleRules::$analyser` and
`CrossModuleCallRules::$analyser` are already declared, and those are set by the
same test class in the same way.

It is **order-dependent**, which is why it appeared on someone else's branch: the
guard sees it only when a plugin invocation that turns the check on happens to be
the last one in the process. Local seeds did not reproduce it — CI's run is
coverage-narrowed by `--only-covering-test-cases`, so it runs a different set —
so the fix was verified directly instead: with `configure(true)` left set, the
guard passes with the entry and trips without it.

`DeclaredModuleDependencyRules::$analyser` is the same construct with the same
gap. It has not failed yet because every plugin invocation without a
`<moduleRules>` element reconfigures it back to null — which is luck, not
design. Declared here before a seed finds it.

## 🔖 Changes

- Two `OUTLIVES_RESET` entries, each with the reason its lifetime is not cache
  lifetime, in the "configuration" category the list already distinguishes
- No production change: both statics are correct as they are, and clearing them
  on a cache reset would silently turn the checks off
