### PR TITLE
ref: merge each declared kind once

### DIFF
--- a/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
+++ b/src/Framework/Config/GacelaFileConfig/GacelaConfigFile.php
@@ -87,9 +87,16 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
         // only ones: a project-declared kind pushed in through setSuffixTypes()
         // did not survive a merge, which made it unusable in a gacela.php that
         // is merged with another.
+        // Keyed union rather than concatenated key lists: a kind both sides
+        // declare appeared twice, so filterList ran a second time over the same
+        // two inputs and overwrote its own answer with an identical one. `+`
+        // keeps this side's order and appends the kinds only the other declares,
+        // which is the order the concatenation produced.
+        $otherSuffixTypes = $other->getSuffixTypes();
+
         $merged = [];
-        foreach ([...array_keys($this->suffixTypes), ...array_keys($other->getSuffixTypes())] as $kind) {
-            $merged[$kind] = $this->filterList($other, $kind);
+        foreach ($this->suffixTypes + $otherSuffixTypes as $kind => $_) {
+            $merged[$kind] = $this->filterList($otherSuffixTypes, $kind);
         }
 
         $new->suffixTypes = $merged;
@@ -98,13 +105,15 @@ final class GacelaConfigFile implements GacelaConfigFileInterface
     }
 
     /**
+     * @param SuffixTypes $otherSuffixTypes
+     *
      * @return list<string>
      */
-    private function filterList(GacelaConfigFileInterface $other, string $key): array
+    private function filterList(array $otherSuffixTypes, string $key): array
     {
         $merged = array_merge(
             $this->suffixTypes[$key] ?? [],
-            $other->getSuffixTypes()[$key] ?? [],
+            $otherSuffixTypes[$key] ?? [],
         );
         $filtered = array_filter(array_unique($merged), static fn (string $str): bool => $str !== '');
         /** @var list<non-empty-string> $values */


### PR DESCRIPTION
## 📚 Description

`GacelaConfigFile::merge()` walked both sides' kind lists concatenated:

```php
foreach ([...array_keys($this->suffixTypes), ...array_keys($other->getSuffixTypes())] as $kind) {
    $merged[$kind] = $this->filterList($other, $kind);
}
```

A kind declared on **both** sides — which `Facade`, `Factory`, `Config` and
`Provider` always are — appears twice in that list, so `filterList()` ran a
second time over the same two inputs and overwrote its own answer with an
identical one. A keyed union visits each kind once, and `+` keeps this side's
order and appends the kinds only the other declares, which is the order the
concatenation produced.

`filterList()` now takes the other side's suffix types instead of the config
file, so `getSuffixTypes()` is called once per merge rather than once per kind
(measured at ~18 calls per bootstrap before).

## 🔖 Changes

- Keyed union over the two kind sets, so each kind is filtered once
- `filterList()` takes the array it needs, hoisting `getSuffixTypes()` out of
  the loop

## ⚠️ Not a speedup

I went looking for a bootstrap win and this is what the profile pointed at, but
it does not move the number. Interleaved A/B, best-of-7 × 400 bootstraps each:

| round | baseline | patched |
|---|---|---|
| 1 | 69.43 µs | 73.63 µs |
| 2 | 71.75 µs | 68.70 µs |

That is noise in both directions — an earlier non-interleaved pair suggested
−5%, and interleaving showed that was machine drift. The arrays involved hold a
handful of short strings, against a ~69 µs bootstrap.

So this is duplicate work removed and a clearer expression of "each kind once",
not a performance claim. Behaviour is unchanged: **100% covered-code MSI on the
file, no escaped mutants**, so the merge semantics are pinned by the existing
tests.

For the record, where bootstrap time actually goes (Xdebug, 60 bootstraps):
`Config::init()` is ~86% of it, and inside that `createGacelaFileConfig()` is
~39 µs of ~63 µs. The cost is spread thinly across building and merging ~3.7
`SetupGacela` objects per bootstrap — ~112 tracked property writes — with no
single hotspot that can be removed safely. A real win there means restructuring
that pipeline, which is not this PR.
