### PR TITLE
docs: show a module double that works on a final Factory

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,7 +66,7 @@ Gacela::bootstrap($dir, static function (GacelaConfig $config): void {
 Testing module A in isolation means replacing module B. A container binding only works when B's Facade arrives through a Provider, and a consumer that writes `new BlogFacade()` leaves nothing to bind — so the seam is the **Factory** every Facade resolves:
 
 ```php
-$this->swapModuleFactory(BlogFacade::class, new class() extends BlogFactory {
+$this->swapModuleFactory(BlogFacade::class, new class() extends AbstractFactory {
     public function createPostReader(): PostReader
     {
         return new InMemoryPostReader(['a post']);
@@ -76,8 +76,23 @@ $this->swapModuleFactory(BlogFacade::class, new class() extends BlogFactory {
 (new CheckoutFacade())->summary();  // reaches the double, not the real Blog
 ```
 
+The double extends `AbstractFactory`, not `BlogFactory`. It only has to carry the methods the Facade under test actually calls — `swapModuleFactory()` takes an `AbstractFactory`, so what it *is* does not have to be Blog's own.
+
+**If `BlogFactory` is `final`, that is the only form available.** A `final` class cannot be subclassed (PHP raises a fatal error) and cannot be doubled by PHPUnit either (`ClassIsFinalException`), so neither `new class() extends BlogFactory` nor `$this->createStub(BlogFactory::class)` compiles or runs. `make:module` generates `final` pillars, and this codebase prefers them, so assume that is the case unless you know otherwise.
+
+Extending the real Factory is worth it when it is *not* final and you want to keep its other `create*()` methods and override one:
+
+```php
+$this->swapModuleFactory(BlogFacade::class, new class() extends BlogFactory {   // BlogFactory must not be final
+    public function createPostReader(): PostReader
+    {
+        return new InMemoryPostReader(['a post']);
+    }
+});
+```
+
 - `swapModuleFactory()`, `swapModuleConfig()` and `swapModuleProvider()` all take the **Facade** class: that is the name a consumer already knows, and the one the resolver derives a module's pillars from.
-- Any object of the right pillar type works — an anonymous subclass, or a PHPUnit stub (`$this->createStub(BlogFactory::class)`).
+- Any object of the right pillar type works: a standalone `AbstractFactory`, an anonymous subclass of the real one, or a PHPUnit stub — the last two only where the class is not `final`.
 - The swap survives repeated resolutions, and applies to a module that was already resolved earlier in the same test.
 - Swapping the same module twice keeps the last double.
 - Every swap is dropped in `tearDown()`, so the next test sees the real module again whatever order the suite runs in.

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Sealed/Domain/SealedGreeter.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Sealed/Domain/SealedGreeter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Sealed\Domain;
+
+final class SealedGreeter
+{
+    public function __construct(
+        private readonly string $greeting = 'hello',
+    ) {
+    }
+
+    public function greet(): string
+    {
+        return $this->greeting;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Sealed/SealedFacade.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Sealed/SealedFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Sealed;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<SealedFactory>
+ */
+final class SealedFacade extends AbstractFacade
+{
+    public function greet(): string
+    {
+        return $this->getFactory()->createGreeter()->greet();
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoubleFixture/Sealed/SealedFactory.php
+++ b/tests/Integration/Framework/Testing/ModuleDoubleFixture/Sealed/SealedFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Sealed;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Sealed\Domain\SealedGreeter;
+
+/**
+ * `final`, which is what `make:module` generates and what the rest of this
+ * codebase prefers. Nothing can extend it, so the double for this module has to
+ * be a standalone `AbstractFactory` -- which is the point of the test that uses
+ * it. The neighbouring `GreetingFactory` is deliberately not final, so both
+ * shapes are covered.
+ */
+final class SealedFactory extends AbstractFactory
+{
+    public function createGreeter(): SealedGreeter
+    {
+        return new SealedGreeter();
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleDoublesTest.php
+++ b/tests/Integration/Framework/Testing/ModuleDoublesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Integration\Framework\Testing;
 
+use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Testing\GacelaTestCase;
 use Gacela\Framework\Testing\ModuleDoubleException;
@@ -12,6 +13,8 @@ use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\Greeti
 use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingFacade;
 use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingFactory;
 use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\GreetingProvider;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Sealed\Domain\SealedGreeter;
+use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Sealed\SealedFacade;
 
 /**
  * Replacing another module is the most common thing a test of a modular
@@ -20,6 +23,33 @@ use GacelaTest\Integration\Framework\Testing\ModuleDoubleFixture\Greeting\Greeti
 final class ModuleDoublesTest extends GacelaTestCase
 {
     private const FIXTURE_DIR = __DIR__ . '/ModuleDoubleFixture';
+
+    /**
+     * A `final` Factory -- which is what `make:module` generates, and what the
+     * rest of this codebase prefers -- cannot be subclassed, so neither the
+     * anonymous subclass this file uses elsewhere nor `createStub()` can double
+     * it: PHP raises a fatal error, PHPUnit a `ClassIsFinalException`.
+     *
+     * `swapModuleFactory()` takes an `AbstractFactory`, not the module's own
+     * one, so the double is a standalone factory carrying the methods the Facade
+     * calls. Every other fixture here is deliberately non-final, which is how a
+     * shape the scaffolder always produces went untested.
+     */
+    public function test_a_final_factory_is_doubled_by_a_standalone_one(): void
+    {
+        $this->bootstrapGacela(self::FIXTURE_DIR);
+
+        self::assertSame('hello', (new SealedFacade())->greet(), 'precondition: the real module answers');
+
+        $this->swapModuleFactory(SealedFacade::class, new class() extends AbstractFactory {
+            public function createGreeter(): SealedGreeter
+            {
+                return new SealedGreeter('swapped');
+            }
+        });
+
+        self::assertSame('swapped', (new SealedFacade())->greet());
+    }
 
     public function test_a_swapped_factory_is_what_the_facade_uses(): void
     {


### PR DESCRIPTION
## 📚 Description

Scaffold a module the way the docs tell you to, then double it the way the docs
tell you to:

```bash
vendor/bin/gacela make:module App/Greeting --template=service --with-tests
```

```php
$this->swapModuleFactory(GreetingFacade::class, new class() extends GreetingFactory {
});
```

```
PHP Fatal error: Class App\Greeting\GreetingFactory@anonymous cannot extend
final class App\Greeting\GreetingFactory
```

The scaffolder generates `final class $CLASS_NAME$ extends AbstractFactory` — in
both the plain and the `service` template — and `testing.md` led with an
anonymous subclass of the real Factory. The documented fallback fails too:

```
PHPUnit\Framework\MockObject\Generator\ClassIsFinalException:
Class "App\Greeting\GreetingFactory" is declared "final" and cannot be doubled
```

So **both** documented ways to double a module were impossible for any module
Gacela itself scaffolds — including the `--with-tests` template, which exists to
produce a module that is ready to test.

### Why it went unnoticed

`swapModuleFactory()` takes an `AbstractFactory`, not the module's own one, so a
standalone factory has always worked. The suite only ever exercised the subclass
form, against a fixture `GreetingFactory` that is deliberately **not** final —
a shape the scaffolder never produces.

## 🔖 Changes

- `testing.md` leads with the double that always works: an `AbstractFactory`
  carrying the methods the Facade under test calls. It states plainly that a
  `final` Factory rules out both the subclass and the stub, and that
  `make:module` generates `final` pillars
- The subclass form is kept, for the non-final case where it earns its keep —
  inheriting the other `create*()` methods and overriding one
- A `Sealed` fixture module whose Factory **is** `final`, and a test that doubles
  it. That is the guard that keeps the new documentation true; the neighbouring
  non-final fixture keeps covering the subclass form

Verified end to end in a scratch project: scaffolded with
`--template=service --with-tests`, the generated test passes as shipped, the two
documented doubles fail as described, and the new one passes.

## 🔖 Not changed

Making the generated Factory non-final would let the old example work verbatim,
but it weakens a good default for every user to serve one testing shape, and
`final` is what this codebase prefers. Say the word if you would rather have it
the other way — the stubs are two lines.
