### PR TITLE
docs: say what a binding's lifetime actually is

### DIFF
--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -65,10 +65,32 @@ return static function (GacelaConfig $config): void {
     $config->addAlias('logger', LoggerInterface::class);
 };
 
-// Both resolve to the same instance:
+// Both resolve to the same service -- same class, same wiring:
 $container->get(LoggerInterface::class);
 $container->get('logger');
 ```
+
+Not to the same *object*: a binding is wiring, and the container builds it per resolution. See [what is cached and what is not](#what-is-cached-and-what-is-not) for the shapes that do share an instance.
+
+## What is cached and what is not
+
+A binding says *how* to build something, not *what* was built, so the container builds it again on each resolution — through `get()` and through `getProvidedDependency()` in a module Factory alike:
+
+```php
+$config->addBinding(LoggerInterface::class, FileLogger::class);
+
+$container->get(LoggerInterface::class) === $container->get(LoggerInterface::class);   // false
+```
+
+Three things do hand back one instance:
+
+| | |
+|---|---|
+| `#[Singleton]` on the class | cached per container, and each module Factory keeps one |
+| `$container->set($id, ...)` in a Provider | the resolved value is kept under that id |
+| `addBinding($id, $object)` with an already-built object | there is nothing left to build |
+
+This is the opt-in caching described under [class attributes](#class-attributes-singleton-factory-and-lazy): reach for `#[Singleton]` when a service must be shared, rather than assuming a binding shares it. It matters most for a service that builds something internally on first use — a connection, a warmed lookup table — which is rebuilt with the object every time.
 
 ## Conditional Bindings
 
@@ -410,7 +432,7 @@ $config->loadDefinitions(Yaml::parseFile(__DIR__ . '/services.yaml'));
 
 | Type | Behavior | Use Case |
 |------|----------|----------|
-| Regular (binding) | Singleton | Stateless services, repositories |
+| Regular (binding) | New instance each resolution | Stateless services, repositories |
 | Conditional (`addBindingIf`) | Binds only if unbound | Plugin defaults that apps can override |
 | Factory | New instance each call | Stateful services, request-scoped |
 | Protected | Returns closure as-is | Lazy initialization, callable configs |

--- a/tests/Integration/Framework/Container/BindingLifetimeTest.php
+++ b/tests/Integration/Framework/Container/BindingLifetimeTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Container;
+
+use Gacela\Container\Attribute\Singleton;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * What a binding's lifetime actually is.
+ *
+ * `docs/container-configuration.md` used to answer "Singleton" in its quick
+ * reference, and illustrated an alias with "both resolve to the same instance".
+ * Neither holds for the two shapes that construct something: a binding is
+ * wiring, not an instance, and the container builds it per resolution. Its own
+ * prose says as much -- "an unregistered class is autowired fresh on each
+ * `get()`, `#[Singleton]` is the opt-in for caching" -- so the table contradicted
+ * the page it was on.
+ *
+ * Pinned here because it is a lifetime decision a reader makes from that table:
+ * a repository holding a lazily built cache is rebuilt on every call.
+ */
+final class BindingLifetimeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+    }
+
+    public function test_a_class_string_binding_is_built_on_every_resolution(): void
+    {
+        $container = $this->containerWith(static function (GacelaConfig $config): void {
+            $config->addBinding(BindingLifetimeContract::class, BindingLifetimeImplementation::class);
+        });
+
+        self::assertNotSame(
+            $container->get(BindingLifetimeContract::class),
+            $container->get(BindingLifetimeContract::class),
+        );
+    }
+
+    public function test_a_closure_binding_runs_the_closure_on_every_resolution(): void
+    {
+        $built = 0;
+
+        $container = $this->containerWith(static function (GacelaConfig $config) use (&$built): void {
+            $config->addBinding('built.per.call', static function () use (&$built): stdClass {
+                ++$built;
+
+                return new stdClass();
+            });
+        });
+
+        $container->get('built.per.call');
+        $container->get('built.per.call');
+
+        self::assertSame(2, $built);
+    }
+
+    /**
+     * An already-constructed object is the one shape that is shared, and only
+     * because there is nothing left to build.
+     */
+    public function test_binding_an_object_hands_that_object_back(): void
+    {
+        $instance = new stdClass();
+
+        $container = $this->containerWith(static function (GacelaConfig $config) use ($instance): void {
+            $config->addBinding('the.instance', $instance);
+        });
+
+        self::assertSame($instance, $container->get('the.instance'));
+        self::assertSame($instance, $container->get('the.instance'));
+    }
+
+    /**
+     * The alias reaches the same *service* -- same class, same wiring -- which is
+     * not the same as the same object.
+     */
+    public function test_an_alias_resolves_the_same_service_but_not_the_same_instance(): void
+    {
+        $container = $this->containerWith(static function (GacelaConfig $config): void {
+            $config->addBinding(BindingLifetimeContract::class, BindingLifetimeImplementation::class);
+            $config->addAlias('the.alias', BindingLifetimeContract::class);
+        });
+
+        $viaAlias = $container->get('the.alias');
+
+        self::assertInstanceOf(BindingLifetimeImplementation::class, $viaAlias);
+        self::assertNotSame($container->get(BindingLifetimeContract::class), $viaAlias);
+    }
+
+    /**
+     * The documented opt-in, so the correction has something to point at.
+     */
+    public function test_a_singleton_attribute_is_what_caches_an_instance(): void
+    {
+        $container = $this->containerWith(static function (GacelaConfig $config): void {
+        });
+
+        self::assertSame(
+            $container->get(BindingLifetimeCachedService::class),
+            $container->get(BindingLifetimeCachedService::class),
+        );
+    }
+
+    private function containerWith(callable $configFn): Container
+    {
+        Gacela::bootstrap(__DIR__, $configFn(...));
+
+        return Container::withConfig(Config::getInstance());
+    }
+}
+
+interface BindingLifetimeContract
+{
+}
+
+final class BindingLifetimeImplementation implements BindingLifetimeContract
+{
+}
+
+#[Singleton]
+final class BindingLifetimeCachedService
+{
+}


### PR DESCRIPTION
## 📚 Description

`container-configuration.md` answers the lifetime question twice, and both
answers were wrong.

**Quick reference:**

| Type | Behavior | Use Case |
|------|----------|----------|
| Regular (binding) | ~~Singleton~~ | Stateless services, repositories |

**Alias example:**

```php
// Both resolve to the same instance:      <- they do not
$container->get(LoggerInterface::class);
$container->get('logger');
```

Measured in a scratch project:

```
addBinding(iface => class-string)      New instance each call
addBinding(id => closure)              New instance each call   (closure ran twice for two gets)
addBinding(id => instance)             Same instance
#[Singleton] class                     Same instance
```

The same through the path consumers actually use — `getProvidedDependency()`
twice inside one module Factory returns two instances.

The page already said this in prose, three sections down:

> Without any attribute, an unregistered class is autowired fresh on each
> `get()` — `#[Singleton]` is the opt-in for caching

So the table contradicted the page it was on. It is a lifetime decision a reader
makes *from that table*, and the row even suggests "repositories": a repository
that builds a connection or a warmed lookup on first use is rebuilt with the
object on every call.

## 🔖 Changes

- The quick-reference row says "New instance each resolution"
- The alias comment says "the same service — same class, same wiring", with a
  pointer to the new section, since the alias is not what makes it fresh
- A **What is cached and what is not** section naming the three shapes that do
  hand back one instance: `#[Singleton]`, `$container->set()` in a Provider, and
  binding an already-built object
- `BindingLifetimeTest` pins each claim — class-string and closure bindings
  build per resolution, an object binding does not, an alias resolves the same
  service but not the same instance, and `#[Singleton]` is what caches

No behaviour change: the container is doing the right thing, and the existing
`AliasServicesTest` already asserted `assertNotSame` for an alias to a *factory*.
Bindings simply had no test pinning their lifetime, which is how the table drifted.

## 🔎 The rest of the page checks out

Verified end to end while finding this: `addFactory` returns a new instance per
resolution, `addProtected` hands back the closure itself, `afterResolving` fires
**once per resolution rather than once per instance**, it does **not** fire for a
nested autowired constructor dependency, and `#[Singleton]` caches per container.
