### PR TITLE
test: pin the guarantee that bootstrap does not walk your modules

### DIFF
--- a/tests/Integration/Framework/Bootstrap/BootstrapDoesNotWalkModulesTest.php
+++ b/tests/Integration/Framework/Bootstrap/BootstrapDoesNotWalkModulesTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+use function array_filter;
+use function array_values;
+use function get_declared_classes;
+use function str_starts_with;
+
+/**
+ * The guarantee `docs/production-performance.md` rests on:
+ *
+ * > Bootstrapping does not walk your modules -- it reads the configuration and
+ * > builds the container, and costs the same in a project with five modules as
+ * > in one with five hundred.
+ * >
+ * > Resolution is charged per module you actually **touch**, not per module you
+ * > have.
+ *
+ * It is the reason the page tells you to tune bootstrap and class loading
+ * rather than the size of the codebase, so it is worth more than a sentence.
+ *
+ * Asserted structurally rather than by timing: a stopwatch on a sub-100µs
+ * bootstrap is noise, while "which classes did this load" is exact and cannot
+ * go flaky. Measured at the time of writing, for the record: bootstrap was
+ * 45.08 / 44.83 / 44.90 µs with 10 / 100 / 500 modules on disk.
+ *
+ * Every class name here is a string literal on purpose. Writing `AlphaFacade::class`
+ * would autoload it and make the test pass or fail on its own reference.
+ */
+final class BootstrapDoesNotWalkModulesTest extends TestCase
+{
+    private const string FIXTURE_DIR = __DIR__ . '/ModuleCountFixture';
+
+    private const string FIXTURE_NAMESPACE = 'GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\\';
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    /**
+     * Asserted about Alpha and Gamma, the two modules no test here touches:
+     * `get_declared_classes()` is process-global and this suite runs in random
+     * order, so asking "nothing at all is loaded" would fail whenever the test
+     * below happened to run first and load Beta.
+     */
+    public function test_bootstrapping_loads_none_of_the_projects_modules(): void
+    {
+        $this->bootstrapFixture();
+
+        $loaded = $this->loadedFixtureClasses();
+
+        self::assertNotContains(self::FIXTURE_NAMESPACE . 'Alpha\AlphaFacade', $loaded);
+        self::assertNotContains(self::FIXTURE_NAMESPACE . 'Alpha\AlphaFactory', $loaded);
+        self::assertNotContains(self::FIXTURE_NAMESPACE . 'Gamma\GammaFacade', $loaded);
+        self::assertNotContains(self::FIXTURE_NAMESPACE . 'Gamma\GammaFactory', $loaded);
+    }
+
+    /**
+     * The other half: touching one module loads that module and leaves the
+     * others alone, which is what "charged per module you touch" means.
+     *
+     * It also proves the check above is not vacuous -- the same helper does
+     * report a module once something reaches for it. Beta belongs to this test;
+     * the one above asks about the two nothing here touches.
+     */
+    public function test_touching_one_module_loads_only_that_one(): void
+    {
+        $this->bootstrapFixture();
+
+        $facadeClass = self::FIXTURE_NAMESPACE . 'Beta\BetaFacade';
+        /** @var callable():string $reachTheFactory */
+        $reachTheFactory = [new $facadeClass(), 'name'];
+
+        // Calling it is the point: the Factory resolves on first use, so this
+        // is what makes BetaFactory load.
+        self::assertSame('Beta', $reachTheFactory());
+
+        $loaded = $this->loadedFixtureClasses();
+
+        self::assertContains(self::FIXTURE_NAMESPACE . 'Beta\BetaFacade', $loaded);
+        self::assertContains(self::FIXTURE_NAMESPACE . 'Beta\BetaFactory', $loaded);
+        self::assertNotContains(self::FIXTURE_NAMESPACE . 'Alpha\AlphaFacade', $loaded);
+        self::assertNotContains(self::FIXTURE_NAMESPACE . 'Gamma\GammaFacade', $loaded);
+    }
+
+    private function bootstrapFixture(): void
+    {
+        Gacela::bootstrap(self::FIXTURE_DIR, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+        });
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function loadedFixtureClasses(): array
+    {
+        return array_values(array_filter(
+            get_declared_classes(),
+            static fn (string $class): bool => str_starts_with($class, self::FIXTURE_NAMESPACE),
+        ));
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Alpha/AlphaFacade.php
+++ b/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Alpha/AlphaFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\Alpha;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<AlphaFactory>
+ */
+final class AlphaFacade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->buildName();
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Alpha/AlphaFactory.php
+++ b/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Alpha/AlphaFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\Alpha;
+
+use Gacela\Framework\AbstractFactory;
+
+final class AlphaFactory extends AbstractFactory
+{
+    public function buildName(): string
+    {
+        return 'Alpha';
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Beta/BetaFacade.php
+++ b/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Beta/BetaFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\Beta;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<BetaFactory>
+ */
+final class BetaFacade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->buildName();
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Beta/BetaFactory.php
+++ b/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Beta/BetaFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\Beta;
+
+use Gacela\Framework\AbstractFactory;
+
+final class BetaFactory extends AbstractFactory
+{
+    public function buildName(): string
+    {
+        return 'Beta';
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Gamma/GammaFacade.php
+++ b/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Gamma/GammaFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\Gamma;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<GammaFactory>
+ */
+final class GammaFacade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return $this->getFactory()->buildName();
+    }
+}

--- a/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Gamma/GammaFactory.php
+++ b/tests/Integration/Framework/Bootstrap/ModuleCountFixture/Gamma/GammaFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap\ModuleCountFixture\Gamma;
+
+use Gacela\Framework\AbstractFactory;
+
+final class GammaFactory extends AbstractFactory
+{
+    public function buildName(): string
+    {
+        return 'Gamma';
+    }
+}


### PR DESCRIPTION
## 📚 Description

`production-performance.md` makes the strongest claim in the docs, and it is the
reason the page tells you to tune bootstrap and class loading rather than the
size of your codebase:

> **Module count.** Bootstrapping does not walk your modules […] and costs the
> same in a project with five modules as in one with five hundred. **Measured
> flat from 10 to 500.**
>
> Resolution is charged per module you actually **touch**, not per module you
> have.

Nothing enforced it. A module scan added to bootstrap would make the page wrong
and every test would still pass.

I verified it independently first, by generating projects and measuring:

| modules on disk | bootstrap (best-of-5 × 200) |
|---|---|
| 10 | 45.08 µs |
| 100 | 44.83 µs |
| 500 | 44.90 µs |

and, with 500 modules present throughout, resolution scaling with what is
*touched* rather than what exists — +7.42 µs for the first module, ~3.10 µs each
at twenty.

## 🔖 Changes

- `BootstrapDoesNotWalkModulesTest`, asserted **structurally**: a stopwatch on a
  sub-100 µs bootstrap is noise, while "which classes did this load" is exact
  and cannot go flaky. Bootstrap loads none of the fixture modules; touching one
  loads that one's Facade and Factory and leaves the others alone
- A three-module fixture. Every class name is a **string literal**: writing
  `AlphaFacade::class` would autoload it and make the test pass or fail on its
  own reference
- The two tests own **different** modules. `get_declared_classes()` is
  process-global and this suite runs in random order, so asking "nothing at all
  is loaded" would fail whenever the other test happened to run first and load
  Beta. Verified across seeds
- The second test also proves the first is not vacuous: the same helper does
  report a module once something reaches for it

## 🔎 Also verified on that page, unchanged

`cache:warm` writes the three cache files and `cache:clear` removes all of them.
The keying claim holds exactly — three bootstraps differing only in
`projectNamespaces` or suffix types produced three different class-name cache
files, so no entrypoint answers for another.
