### PR TITLE
fix: round the per-operation duration like every other one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Round the per-operation `total_duration` in `Profiler::getStats()` like every other duration in that payload. It was handed on as summed, one line from its rounded twin, so float addition noise reached `profile:report --format=json` in one field and not its siblings — `0.1 + 0.2` arriving as `0.30000000000000004` next to a `total_duration` of `0.3`
 - Name the file in "must return a `callable(GacelaConfig)`", and say what it returned instead. The same factory reads `gacela-{APP_ENV}.php` as well as `gacela.php`, but the message always said `gacela.php` — so a broken `gacela-prod.php` sent you to the file that was fine, in the one environment where the other was read. `include` yields `1` for a file that returns nothing, which is unrecognisable until it is named
 - Report the shape of an `--allowed-cycles` file before judging its entries. An object's values were walked as if they were entries, so `{"cycles": [...]}` — the shape the sibling `--rules` flag on the same command really does take — was reported as `Allowed-cycle entry #0 must list at least two "modules"`, pointing at an entry when the file's shape was wrong. A correct entry that was never wrapped in the array got the same message. Both now name the keys found, and say either to wrap a stray entry in `[ ]` or that `--rules` is the flag taking an object
 

--- a/src/Framework/Profiler/Profiler.php
+++ b/src/Framework/Profiler/Profiler.php
@@ -179,7 +179,10 @@ final class Profiler
         foreach ($tally as $operation => $stats) {
             $byOperation[$operation] = [
                 'count' => $stats['count'],
-                'total_duration' => $stats['total_duration'],
+                // Rounded like every other duration in this payload. Averaged
+                // from the summed value rather than this one, so the rounding
+                // is applied once at the end instead of compounding.
+                'total_duration' => round($stats['total_duration'], 6),
                 'avg_duration' => $this->average($stats['total_duration'], $stats['count']),
             ];
         }

--- a/tests/Unit/Framework/Profiler/ProfilerTest.php
+++ b/tests/Unit/Framework/Profiler/ProfilerTest.php
@@ -373,6 +373,38 @@ final class ProfilerTest extends TestCase
         self::assertSame(0.004, $stats['by_operation']['op2']['total_duration']);
     }
 
+    /**
+     * Every other duration in the payload is rounded to microseconds; this one
+     * was handed on as summed, one line from its rounded twin. Float addition
+     * is what makes that visible -- `0.1 + 0.2` is `0.30000000000000004` -- and
+     * `getStats()` goes straight into `profile:report --format=json`, so a
+     * consumer saw one field carrying noise its siblings do not.
+     */
+    public function test_per_operation_total_duration_is_rounded_like_every_other_duration(): void
+    {
+        $this->injectEntries([
+            $this->entry('op', 's1', duration: 0.1),
+            $this->entry('op', 's2', duration: 0.2),
+        ]);
+
+        $stats = $this->profiler->getStats();
+
+        self::assertSame(0.3, $stats['by_operation']['op']['total_duration']);
+        self::assertSame(0.3, $stats['total_duration'], 'the top-level total was already rounded');
+    }
+
+    /**
+     * Six decimals, which is microseconds: the unit `hrtime()` measures in and
+     * the precision every other duration here keeps. A value that differs at
+     * the seventh is what pins it.
+     */
+    public function test_per_operation_total_duration_keeps_microsecond_precision(): void
+    {
+        $this->injectEntries([$this->entry('op', 's1', duration: 0.12345678)]);
+
+        self::assertSame(0.123457, $this->profiler->getStats()['by_operation']['op']['total_duration']);
+    }
+
     public function test_per_operation_avg_duration_is_that_operations_total_over_count(): void
     {
         $this->injectEntries([


### PR DESCRIPTION
## 📚 Description

`Profiler::getStats()` rounds every duration to microseconds — except one:

```php
'total_duration' => $stats['total_duration'],                              // by_operation: as summed
'avg_duration'   => $this->average($stats['total_duration'], $count),      // rounded
...
'total_duration' => round($totalDuration, 6),                              // top level: rounded
```

One line apart from its rounded twin. `getStats()` is what
`profile:report --format=json` emits, so a consumer got float addition noise in
one field and not its siblings:

```json
{
  "total_duration": 0.003043,
  "by_operation": { "db": { "total_duration": 0.0030425419099628925, "avg_duration": 0.001521 } }
}
```

Spotted while verifying `profiling.md` end to end — it was sitting in the output
of a passing check.

## 🔖 Changes

- The per-operation total is rounded like the rest. The average is still taken
  from the **summed** value, so rounding happens once at the end rather than
  compounding
- Two tests: `0.1 + 0.2` (which is `0.30000000000000004`, so the noise is
  visible) and a value differing at the seventh decimal, which pins the
  precision itself. The existing test summed `0.001 + 0.002` — a value that
  rounds to itself, which is why this survived

**100% covered-code MSI**, no escaped mutants; the second test exists because
the first left `round(…, 6)` → `round(…, 7)` alive.

## 🔎 The rest of `profiling.md` checks out

All ten claims verified: subjects stay separate and aggregate per operation,
**nested spans of one label close as a stack** (two entries, none left open), a
`stop()` with no `start()` is ignored, `disable()` drops in-flight spans so a
later `enable()` cannot pair a fresh `stop()` with a stale start, `reset()`
clears both, the `getStats()` keys are as documented, durations are in seconds,
and the documented typo example returns exactly `['db-query:orders' => 1]`.
