### PR TITLE
feat: fail dto:generate --check when a generated class is stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Answer "are the generated DTO classes up to date?" with `dto:generate --check`. The classes are committed, so a declaration edited without regenerating leaves the repository behind what `gacela.php` says — and `--dry-run` reported it while exiting `0` either way, so a CI job had to parse the output. `--check` writes nothing, names each stale file, and exits non-zero, like `debug:graph --check`. Nothing declared is a pass: there is nothing to be stale
+
 - Report in `doctor` listeners registered while `disableEventListeners()` is in effect. No dispatcher is built, so every registration is inert — which `docs/events.md` already calls the first thing to check when a listener appears dead, and which the check itself used to give a green tick to. Generic listeners count too: they carry no target, so a project whose only listeners are generic looked like one that had registered nothing. Disabling with nothing registered stays silent, and an unfireable target is still reported alongside, because it has to be right for the day the switch goes back on
 
 - Name what `profile:report` never saw finish. A `stop()` that misspells the operation or subject is ignored — there is no start time to measure from — so the entry vanishes and looks exactly like code nobody instrumented. The report now lists what is still open, counted where several spans of one operation are, and `--format=json` carries the same answer in an `unfinished` field

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,7 @@ Five of the built-in checks report the same kind of fault: **configuration a pro
 |---|---|
 | `cache:warm` | Pre-resolves every module class and populates the on-disk caches. `--clear` first, `--attributes` to pre-scan `#[ServiceMap]` |
 | `cache:clear` | Removes every Gacela cache file |
-| `dto:generate` | Writes the classes declared with `declareDtoSchema()`. `--dry-run` reports without writing. See [DTO schema](dto-schema.md) |
+| `dto:generate` | Writes the classes declared with `declareDtoSchema()`. `--dry-run` reports without writing; `--check` does the same and exits non-zero when a class is stale, for CI. See [DTO schema](dto-schema.md) |
 | `ide:meta` | Writes editor metadata typing `getProvidedDependency()` from the `#[Provides]` attributes. `--dry-run` reports without writing. See [IDE metadata](static-analysis.md#ide-metadata) |
 | `profile:report` | Performance profiling report — the recording side is the [Profiler](profiling.md) |
 

--- a/docs/dto-schema.md
+++ b/docs/dto-schema.md
@@ -19,7 +19,10 @@ $config->declareDtoSchema(App\Checkout\Order::class, [
 ```bash
 vendor/bin/gacela dto:generate            # write the classes
 vendor/bin/gacela dto:generate --dry-run  # report what would change, write nothing
+vendor/bin/gacela dto:generate --check    # the same, and exit non-zero if anything would change
 ```
+
+`--check` is the CI form: the generated classes are committed, so a declaration edited without regenerating leaves the repository behind what `gacela.php` says. It writes nothing — writing is what it exists to catch — and names each file that is stale.
 
 ```php
 $order = Order::fromArray(['reference' => 'ord-1187', 'total' => 4990]);

--- a/src/Console/Infrastructure/Command/DtoGenerateCommand.php
+++ b/src/Console/Infrastructure/Command/DtoGenerateCommand.php
@@ -29,12 +29,16 @@ final class DtoGenerateCommand extends Command
         $this->setName('dto:generate')
             ->setDescription('Generate the immutable DTO classes declared with declareDtoSchema()')
             ->setHelp($this->getHelpText())
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change, write nothing');
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change, write nothing')
+            ->addOption('check', null, InputOption::VALUE_NONE, 'Like --dry-run, and exit non-zero when a class would be written');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $dryRun = $input->getOption('dry-run') === true;
+        // --check is a --dry-run that fails: writing is what it exists to catch,
+        // so it must not do any.
+        $check = $input->getOption('check') === true;
+        $dryRun = $check || $input->getOption('dry-run') === true;
         $result = $this->getFacade()->generateDtoClasses($dryRun);
 
         if ($result->total() === 0) {
@@ -45,6 +49,15 @@ final class DtoGenerateCommand extends Command
 
         $this->writeWritten($result, $dryRun, $output);
         $this->writeUnplaceable($result, $output);
+
+        // Under --check, a class that would be written is the answer the caller
+        // asked for: the generated files in the repository are behind what
+        // gacela.php declares.
+        if ($check && $result->hasChanges()) {
+            $output->writeln('<comment>Run `dto:generate` and commit the result.</comment>');
+
+            return Command::FAILURE;
+        }
 
         // An unplaceable shape is the one failure this command can have: the
         // declaration is fine and there is simply nowhere the class may live.

--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -129,6 +129,41 @@ final class DebugDependenciesCommandTest extends TestCase
         self::assertMatchesRegularExpression('/Unresolvable:\s+2/', $display);
     }
 
+    /**
+     * A binding's value is a class name, a closure or an already-built object,
+     * and only the first was covered. The other two are what a provider-style
+     * registration looks like, and the report has to say something useful about
+     * each rather than printing whatever `(string)` makes of it.
+     */
+    public function test_a_closure_binding_is_reported_as_a_closure(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(
+                BoundContract::class,
+                static fn (): BoundImplementation => new BoundImplementation(),
+            );
+        });
+
+        self::assertStringContainsString(
+            sprintf('$bound %s (bound -> Closure instance)', BoundContract::class),
+            $this->inspect(MixedDependenciesService::class)->getDisplay(),
+        );
+    }
+
+    public function test_an_object_binding_is_reported_by_its_class(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->addBinding(BoundContract::class, new BoundImplementation());
+        });
+
+        self::assertStringContainsString(
+            sprintf('$bound %s (bound -> %s instance)', BoundContract::class, BoundImplementation::class),
+            $this->inspect(MixedDependenciesService::class)->getDisplay(),
+        );
+    }
+
     public function test_a_fully_resolvable_constructor_omits_the_remediation_hint(): void
     {
         $tester = $this->inspect(Fixtures\InjectService::class);

--- a/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
+++ b/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
@@ -203,6 +203,75 @@ final class DtoGenerateCommandTest extends TestCase
     /**
      * @param list<string> $classNames
      */
+    /**
+     * The CI question this command could not answer: are the generated classes
+     * in the repository up to date with what `gacela.php` declares? `--dry-run`
+     * reports it and exits 0 either way, so a job had to parse the output.
+     */
+    public function test_check_fails_when_a_class_would_be_written(): void
+    {
+        $tester = $this->generate(['--check' => true]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('would write', $tester->getDisplay());
+    }
+
+    public function test_check_writes_nothing_even_though_it_fails(): void
+    {
+        $this->generate(['--check' => true]);
+
+        self::assertFileDoesNotExist($this->orderFile(), 'a check must not write what it is checking');
+    }
+
+    public function test_check_passes_once_the_classes_are_generated(): void
+    {
+        $this->generate();
+
+        $tester = $this->generate(['--check' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * With nothing declared there is nothing to be stale, which is a pass --
+     * the same answer `--check` gives a project whose classes are current.
+     */
+    public function test_check_passes_when_no_shape_is_declared(): void
+    {
+        Gacela::bootstrap($this->projectDir, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+        });
+
+        $tester = new CommandTester(new DtoGenerateCommand());
+        $tester->execute(['--check' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * The command's own empty case: nothing declared is not a failure, and the
+     * message has to name the call that would change that. Untested until now,
+     * which is why `DtoGenerateResult::total()` had no coverage at all -- it is
+     * read only here.
+     */
+    public function test_a_project_declaring_no_shape_is_told_how_to_declare_one(): void
+    {
+        Gacela::bootstrap($this->projectDir, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+        });
+
+        $tester = new CommandTester(new DtoGenerateCommand());
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString(
+            'No shape declared. Use $config->declareDtoSchema(...) in gacela.php.',
+            $tester->getDisplay(),
+        );
+    }
+
     private function generateMany(array $classNames): CommandTester
     {
         Gacela::bootstrap($this->projectDir, static function (GacelaConfig $config) use ($classNames): void {


### PR DESCRIPTION
## 📚 Description

The generated DTO classes are **committed** — that is the design, and the reason
no analyser extension is needed. So a declaration edited without regenerating
leaves the repository behind what `gacela.php` says, and nothing catches it:

```bash
vendor/bin/gacela dto:generate --dry-run   # prints "would write …", exits 0
```

A CI job had to parse the output. `debug:graph --check`, right next to it,
already answers its question with an exit code.

```bash
vendor/bin/gacela dto:generate --check
```
```
would write /app/src/Checkout/Receipt.php
Run `dto:generate` and commit the result.
```
exit `1`, and **nothing written** — writing is what it exists to catch. Once
`dto:generate` has run, `--check` exits `0`.

## 🔖 Changes

- `--check` implies `--dry-run` and fails when a class would be written
- Nothing declared is a **pass**: there is nothing to be stale, which is the
  same answer a current project gets
- Four tests: it fails on a stale class, writes nothing while failing, passes
  once generated, and passes with no shape declared

## 🔎 How it was found

Coverage, looking for untested code. `DtoGenerateResult::hasChanges()` sat at
**0%** with no caller anywhere — my first grep said otherwise because
`GraphDiffResult` has a method of the same name that *is* used. It was the
predicate for a question the command could not answer, so this wires it up
rather than deleting it.

Two more untested paths were verified by hand in a scratch project and are now
pinned rather than changed, since both were already correct:

- `dto:generate` with nothing declared — names the call that would change that,
  exits 0 (this is what read `total()`, the class's other uncovered method)
- `debug:dependencies` rendering a binding whose value is a **closure**
  (`bound -> Closure instance`) or an **already-built object**
  (`bound -> …Impl instance`). Only the class-string form was covered, and those
  are what a provider-style registration looks like
