### PR TITLE
test: pin the bridge between addHealthCheck() and doctor

### DIFF
--- a/docs/module-health-checks.md
+++ b/docs/module-health-checks.md
@@ -84,7 +84,7 @@ Gacela Doctor
 ✓ All checks passed
 ```
 
-A `degraded` check reports as a warning; an `unhealthy` check reports as an error and makes `doctor` exit non-zero. Check metadata is printed under the status line.
+A `degraded` check reports as a warning; an `unhealthy` check reports as an error and makes `doctor` exit non-zero. Their metadata is printed under the status line, one `key: value` per line, with a value that is not a scalar named by its type. A **healthy** check stays a single line: it takes metadata like the other two, and `doctor` does not print it, because a passing check is not what you are reading the report for.
 
 Several checks may report under the same module name. Gacela combines them into one module result whose level is the worst result, and keeps every individual status under the result's `health_checks` metadata. A later healthy check therefore cannot hide an earlier degraded or unhealthy one.
 

--- a/tests/Unit/Console/Application/Doctor/Check/ModuleHealthCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/ModuleHealthCheckTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Doctor\Check\ModuleHealthCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Framework\Health\HealthStatus;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * The documented bridge between `GacelaConfig::addHealthCheck()` and `doctor`:
+ * a project's own check becomes a doctor check, and its level decides whether
+ * the command passes.
+ *
+ * Nothing covered this, so `name()` sat at 0% while the integration it belongs
+ * to is a documented feature with an exit code attached.
+ */
+final class ModuleHealthCheckTest extends TestCase
+{
+    public function test_a_healthy_module_passes(): void
+    {
+        $result = $this->check(HealthStatus::healthy('Database operational'))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame('module health: Database', $result->title);
+        self::assertSame(['Database operational'], $result->details);
+    }
+
+    public function test_a_degraded_module_is_a_warning(): void
+    {
+        $result = $this->check(HealthStatus::degraded('High latency'))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+    }
+
+    /**
+     * The level that makes `doctor` exit non-zero.
+     */
+    public function test_an_unhealthy_module_is_an_error(): void
+    {
+        $result = $this->check(HealthStatus::unhealthy('Database unreachable'))->run();
+
+        self::assertSame(CheckStatus::Error, $result->status);
+    }
+
+    public function test_metadata_is_printed_under_the_message(): void
+    {
+        $result = $this->check(
+            HealthStatus::unhealthy('Database unreachable', ['host' => 'db1', 'retries' => 3]),
+        )->run();
+
+        self::assertSame(['Database unreachable', 'host: db1', 'retries: 3'], $result->details);
+    }
+
+    /**
+     * A passing check stays one line, whatever it was handed. Worth pinning
+     * because `healthy()` takes metadata like the other two, so this is the one
+     * level where passing it changes nothing.
+     */
+    public function test_a_healthy_module_reports_its_message_alone(): void
+    {
+        $result = $this->check(HealthStatus::healthy('All good', ['latency_ms' => 12]))->run();
+
+        self::assertSame(['All good'], $result->details);
+    }
+
+    /**
+     * Metadata reaches a console line, so a value that cannot be one is named by
+     * type rather than crashing the report it appears in.
+     */
+    public function test_a_non_scalar_metadata_value_is_named_by_type(): void
+    {
+        $result = $this->check(
+            HealthStatus::unhealthy('Broken', ['payload' => new stdClass(), 'ids' => [1, 2]]),
+        )->run();
+
+        self::assertSame(['Broken', 'payload: stdClass', 'ids: array'], $result->details);
+    }
+
+    /**
+     * The name is the module, while the title the report prints is prefixed --
+     * the doctor lists checks by name and renders by title.
+     */
+    public function test_the_check_is_named_after_the_module(): void
+    {
+        self::assertSame('Database', $this->check(HealthStatus::healthy())->name());
+    }
+
+    private function check(HealthStatus $status): ModuleHealthCheck
+    {
+        return new ModuleHealthCheck('Database', $status);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`GacelaConfig::addHealthCheck()` → `doctor` is a documented feature with an exit
code attached, and nothing in the suite covered it: `ModuleHealthCheck::name()`
sat at **0%**, which is how I found it.

Verified by hand against a scratch project first, then pinned:

```
✗ module health: Database
    Database unreachable
    host: db1
    retries: 3
```

## 🔖 Changes

- Seven tests: the level mapping (healthy passes, degraded warns, **unhealthy
  errors** — the level that makes `doctor` exit non-zero), metadata rendered one
  `key: value` per line, and the name/title split
- A non-scalar metadata value is named by its type (`payload: stdClass`) rather
  than crashing the report it appears in — that branch had no test either
- `module-health-checks.md` now says what metadata does at each level

**100% covered-code MSI**, no escaped mutants.

## 🤔 One asymmetry, documented rather than changed

`HealthStatus::healthy()` takes metadata like the other two, and `doctor` drops
it — a passing check stays one line:

```php
HealthStatus::healthy('Database operational', ['latency_ms' => 12]);
```
```
✓ module health: Database
    Database operational
```

The page said "Check metadata is printed under the status line" without
qualifying, so I have made it say what actually happens at each level. Printing
it would be defensible too — the caller did pass it — but quiet passing output is
a deliberate-looking choice and changing it adds lines to every green report, so
that is your call rather than mine. The test pins today's behaviour either way.

## 🔎 What else the coverage sweep turned up

Nothing else actionable, which is worth saying:

- `Container::getStats()` looks dead but the upstream `ContainerInterface` still
  declares it in 2.x, so it stays
- `--rules` already rejects a wrong file shape properly — it was the good
  example that #775 brought the allow list up to
- `CacheInterface::getAll()` and `ClassInfoInterface::getResolvableType()` are
  declared and implemented but **called nowhere in `src/`**. Neither interface is
  marked `@internal`, so removing them is a BC decision I have left alone —
  flagging it here instead
