### PR TITLE
test: pin #[Inject] on a property under either namespace

### DIFF
--- a/laravel-bridge/tests/Fixtures/BridgeAttributePropertyConsumer.php
+++ b/laravel-bridge/tests/Fixtures/BridgeAttributePropertyConsumer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\LaravelBridge\Fixtures;
+
+use Gacela\LaravelBridge\Attribute\Inject;
+
+/**
+ * The other half of {@see PropertyConsumer}: the *bridge's* attribute on a
+ * property.
+ *
+ * The README shows the bridge attribute first, for the constructor case, so it
+ * is the import a reader already has when they reach the property example --
+ * and the attribute declares `TARGET_PROPERTY`, so nothing stops them. It works
+ * because the listener matches `IS_INSTANCEOF` and this one extends the Gacela
+ * attribute; a matcher tightened to the exact class would break it silently,
+ * which is the failure an attribute always has.
+ */
+final class BridgeAttributePropertyConsumer
+{
+    #[Inject]
+    private CountingService $service;
+
+    public function service(): CountingService
+    {
+        return $this->service;
+    }
+}

--- a/laravel-bridge/tests/GacelaInjectTest.php
+++ b/laravel-bridge/tests/GacelaInjectTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\LaravelBridge;
 use Gacela\Framework\Gacela;
 use Gacela\LaravelBridge\GacelaInjectListener;
 use GacelaTest\LaravelBridge\Fixtures\BareConstructorConsumer;
+use GacelaTest\LaravelBridge\Fixtures\BridgeAttributePropertyConsumer;
 use GacelaTest\LaravelBridge\Fixtures\ConstructorConsumer;
 use GacelaTest\LaravelBridge\Fixtures\ContractPropertyConsumer;
 use GacelaTest\LaravelBridge\Fixtures\ContractSetterConsumer;
@@ -74,6 +75,18 @@ final class GacelaInjectTest extends LaravelBridgeTestCase
     public function test_a_property_is_injected_after_laravel_builds_the_instance(): void
     {
         $consumer = $this->app->make(PropertyConsumer::class);
+
+        self::assertSame(CountingService::FROM_LARAVEL, $consumer->service()->name());
+    }
+
+    /**
+     * "Honouring the attribute under either namespace" is a README promise, and
+     * only the Gacela one was exercised on a property. The bridge's is the
+     * import a reader already has from the constructor example above it.
+     */
+    public function test_a_property_carrying_the_bridge_attribute_is_injected_too(): void
+    {
+        $consumer = $this->app->make(BridgeAttributePropertyConsumer::class);
 
         self::assertSame(CountingService::FROM_LARAVEL, $consumer->service()->name());
     }


### PR DESCRIPTION
## 📚 Description

`laravel-bridge/README.md` promises, of property injection:

> The provider listens to `afterResolving` and injects into every instance
> Laravel builds, **honouring the attribute under either namespace**.

Only one namespace was exercised on a property. Every fixture carrying the
*bridge's* attribute used a constructor or a setter:

| fixture | attribute | member |
|---|---|---|
| `PropertyConsumer` | `Gacela\Container\…\Inject` | property |
| `SetterConsumer`, `ConstructorConsumer`, … | `Gacela\LaravelBridge\…\Inject` | setter / constructor |

The bridge attribute on a **property** — the combination the README makes most
likely, since its constructor example is the import a reader already has when
they reach the property one — was untested. It declares `TARGET_PROPERTY`, so
nothing stops anyone writing it.

It works, and now says so.

## 🔖 Changes

- `BridgeAttributePropertyConsumer`, and a test that Laravel's `afterResolving`
  fills it

It works because the listener matches with `ReflectionAttribute::IS_INSTANCEOF`
and the bridge attribute extends the Gacela one. Tightening that matcher to the
exact class would break this silently — which is the only way an attribute ever
fails, and why the combination is worth a test rather than a comment. The
existing `PropertyConsumer` docblock already asserted the intent in prose:
*"the listener must honor either namespace"*.

## 🔎 Also checked in the bridges, nothing to change

- The two `Configuration` classes accept the **same eight keys** — no drift
- Symfony rejects an unknown key at compile time, and that is already tested
- Both bridges test that an external service keyed by a class or interface
  additionally becomes a binding
- Every other README claim about `#[Inject]` is covered: a bare constructor
  parameter refused with directions, a `readonly` property refused by name, a
  private setter refused, an explicit implementation preferred over the declared
  type, and a parent's private property injected alongside the child's
