### PR TITLE
test: guard the command registry bin/gacela actually reads

### DIFF
--- a/tests/Feature/Console/BinGacela/RegisteredCommandsTest.php
+++ b/tests/Feature/Console/BinGacela/RegisteredCommandsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\BinGacela;
+
+use Gacela\Console\Infrastructure\ConsoleBootstrap;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Console\Command\Command;
+
+use function array_diff;
+use function array_map;
+use function array_values;
+use function basename;
+use function class_exists;
+use function glob;
+use function implode;
+use function is_subclass_of;
+use function sort;
+use function sprintf;
+
+/**
+ * `ConsoleProvider::commands()` is a hand-written list, and it is the one
+ * `vendor/bin/gacela` reads. Both bridges grew a guard over their own lists
+ * after three commands had been missing from them; the primary path never had
+ * one.
+ *
+ * That ordering is the trap. Add a command and forget every registry: the
+ * bridge tests fail and name the bridges, so the fix looks complete once they
+ * are green -- while the command the CLI ships is still unreachable from the
+ * CLI. The failure that fires points somewhere other than the hole.
+ *
+ * Asserted through a booted application rather than off the provider array, so
+ * it covers the whole chain: two commands answering the same `getName()` would
+ * leave only one registered, and `ConsoleBootstrap` keys by name.
+ */
+final class RegisteredCommandsTest extends TestCase
+{
+    private const string COMMAND_DIR = __DIR__ . '/../../../../src/Console/Infrastructure/Command';
+
+    private const string COMMAND_NAMESPACE = 'Gacela\Console\Infrastructure\Command\\';
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+    }
+
+    public function test_bin_gacela_can_run_every_command_gacela_ships(): void
+    {
+        $registered = array_map(
+            static fn (Command $command): string => $command::class,
+            array_values((new ConsoleBootstrap())->all()),
+        );
+
+        $missing = array_values(array_diff($this->everyCommandClass(), $registered));
+
+        self::assertSame([], $missing, sprintf(
+            'These commands exist but `vendor/bin/gacela` cannot run them: %s',
+            implode(', ', $missing),
+        ));
+    }
+
+    /**
+     * Read off the directory rather than listed again here, or this test would
+     * be the same list carrying the same gap.
+     *
+     * @return list<class-string<Command>>
+     */
+    private function everyCommandClass(): array
+    {
+        $classes = [];
+
+        foreach (glob(self::COMMAND_DIR . '/*.php') ?: [] as $file) {
+            /** @var class-string $class */
+            $class = self::COMMAND_NAMESPACE . basename($file, '.php');
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            if (!is_subclass_of($class, Command::class)) {
+                continue;
+            }
+
+            if ((new ReflectionClass($class))->isAbstract()) {
+                continue;
+            }
+
+            /** @var class-string<Command> $class */
+            $classes[] = $class;
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+}


### PR DESCRIPTION
## 📚 Description

Both bridges grew a guard over their command lists in #780, after three commands
had been found missing from them. `ConsoleProvider::commands()` — the list
`vendor/bin/gacela` itself reads — never had one, and it is the **primary** path.

The ordering is the trap. Add a command and forget every registry:

1. the bridge tests fail, and their message names the *bridges*
2. you register it in both bridges — green
3. the command Gacela ships is still unreachable from Gacela's own CLI

The failure that fires points somewhere other than the hole, which is worse than
no failure at all. All 18 commands are registered correctly today; this is the
guard, not a fix.

## 🔖 Changes

- `RegisteredCommandsTest`, asserting every command class in
  `src/Console/Infrastructure/Command` is reachable from a booted
  `ConsoleBootstrap`

Asserted through a booted application rather than off the provider array, so it
covers the whole chain — provider → factory → bootstrap. `ConsoleBootstrap` keys
commands by name, so two commands answering the same `getName()` would leave
only one registered; that is caught here too.

The directory is read rather than listed again, or this test would be the same
list carrying the same gap. Verified non-vacuous by unregistering
`DoctorCommand`: the test fails and names it.

## 🔎 One thing I did not change

`ConsoleBootstrap::getDefaultCommands()` drops any command whose `getName()` is
`null`:

```php
$name = $command->getName();
if ($name !== null) {
    $commands[$name] = $command;
}
```

A project appends its own commands with
`extendService(ConsoleProvider::COMMANDS, …)`. If one of them has no name — no
`setName()`, no `#[AsCommand]` — it vanishes with no output. Symfony's own
`Application::add()` would have said:

```
The command defined in "NamelessCommand" cannot have an empty name.
```

So the filter suppresses a better error than anything Gacela prints in its place.
Left alone deliberately: `MalformedProvidedValuesTest` records the opposite
decision for the sibling case ("the filter is what keeps `bin/gacela` starting at
all"), and reversing that is a judgement call about whether a nameless command
should take the whole CLI down, not a bug fix to slip into a test PR.
