### PR TITLE
docs: state where addBindingIf stops being conditional

### DIFF
--- a/docs/container-configuration.md
+++ b/docs/container-configuration.md
@@ -111,6 +111,42 @@ $container->get(LoggerInterface::class);
 
 `addBindingIf()` compares against the bindings already declared in the same config. If no binding exists for the key, it behaves exactly like `addBinding()`.
 
+A package does not write into the application's `gacela.php`, though, so the arrangement it actually ships is an extending config:
+
+```php
+// vendor/acme/clock/src/GacelaConfig.php — what the package ships
+final class AcmeClockGacelaConfig
+{
+    public function __invoke(GacelaConfig $config): void
+    {
+        $config->addBindingIf(ClockInterface::class, SystemClock::class);
+    }
+}
+
+// gacela.php — what the application writes
+return static function (GacelaConfig $config): void {
+    $config->addBinding(ClockInterface::class, FrozenClock::class);
+    $config->extendGacelaConfig(AcmeClockGacelaConfig::class);
+};
+
+// Resolves to FrozenClock. Drop the addBinding() line and it resolves to SystemClock.
+```
+
+This works because extending configs run against the *same* `GacelaConfig`, so the package's `addBindingIf()` can see what the application bound. The order of the two lines does not matter: extending configs run after the whole closure has.
+
+**Between separate config sources there is nothing to see yet**, and the usual merge order decides instead. `gacela.php` merges onto the bootstrap closure, so a conditional binding in `gacela.php` still replaces an unconditional one in the closure — the same as a plain `addBinding()` would:
+
+```php
+Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+    $config->addBinding(ClockInterface::class, FrozenClock::class);
+});
+
+// gacela.php
+$config->addBindingIf(ClockInterface::class, SystemClock::class);
+
+// Resolves to SystemClock: the condition had no sibling binding to compare against.
+```
+
 ## Contextual Bindings
 
 Provide different implementations based on which class is requesting a dependency.

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -263,6 +263,17 @@ final class GacelaConfig
      * Bind a key only when it is not already bound in this config, so plugins can
      * register a default that the application (or an earlier binding) can override.
      *
+     * "In this config" is the whole of it: the check runs against the bindings on
+     * this instance, not against every config source. `extendGacelaConfig()` is
+     * what makes the promise work, because extending configs run against the same
+     * instance -- so a package registering its default there sees what the
+     * application already bound and declines.
+     *
+     * Between separate sources there is nothing to see yet, and the usual merge
+     * order decides instead: `gacela.php` merges onto the bootstrap closure, so a
+     * conditional binding in `gacela.php` still replaces an unconditional one in
+     * the closure, exactly as a plain {@see addBinding()} there would.
+     *
      * @param class-string $key
      * @param class-string|object|callable $value
      */

--- a/tests/Feature/Framework/BindingIfPlugin/ApplicationClock.php
+++ b/tests/Feature/Framework/BindingIfPlugin/ApplicationClock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\BindingIfPlugin;
+
+final class ApplicationClock implements Clock
+{
+    public function source(): string
+    {
+        return 'application';
+    }
+}

--- a/tests/Feature/Framework/BindingIfPlugin/Clock.php
+++ b/tests/Feature/Framework/BindingIfPlugin/Clock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\BindingIfPlugin;
+
+interface Clock
+{
+    public function source(): string;
+}

--- a/tests/Feature/Framework/BindingIfPlugin/FeatureTest.php
+++ b/tests/Feature/Framework/BindingIfPlugin/FeatureTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\BindingIfPlugin;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `addBindingIf()` exists for one scenario, named in its own docblock: a package
+ * registers a default that the application can override. That scenario needs two
+ * config sources to exist at all, and it was only ever exercised on a single
+ * `GacelaConfig` -- where `addBinding()` immediately before it is the whole test.
+ *
+ * `extendGacelaConfig()` is the mechanism the promise rides on: every extending
+ * config runs against the *same* `GacelaConfig`, so the package's `bindIf` can
+ * see what the application already bound. Nothing else about the arrangement
+ * makes that true, which is why it is worth pinning end to end.
+ */
+final class FeatureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_a_package_default_fills_a_binding_the_application_left_open(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->extendGacelaConfig(PackageGacelaConfig::class);
+        });
+
+        self::assertSame('package-default', Gacela::get(Clock::class)?->source());
+    }
+
+    /**
+     * The promise itself. The application binds first and the package's
+     * `bindIf` runs afterwards against the same config, so it declines.
+     */
+    public function test_a_package_default_declines_to_replace_the_applications_binding(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->addBinding(Clock::class, ApplicationClock::class);
+            $config->extendGacelaConfig(PackageGacelaConfig::class);
+        });
+
+        self::assertSame('application', Gacela::get(Clock::class)?->source());
+    }
+
+    /**
+     * Order inside the closure does not decide it. Extending configs run after
+     * the whole closure has, so stating the binding last works the same -- which
+     * matters, because the two lines read as if the second could clobber the
+     * first.
+     */
+    public function test_the_application_binding_wins_whichever_line_comes_first(): void
+    {
+        $this->bootstrapWith(static function (GacelaConfig $config): void {
+            $config->extendGacelaConfig(PackageGacelaConfig::class);
+            $config->addBinding(Clock::class, ApplicationClock::class);
+        });
+
+        self::assertSame('application', Gacela::get(Clock::class)?->source());
+    }
+
+    private function bootstrapWith(callable $setup): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($setup): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $setup($config);
+        });
+    }
+}

--- a/tests/Feature/Framework/BindingIfPlugin/PackageDefaultClock.php
+++ b/tests/Feature/Framework/BindingIfPlugin/PackageDefaultClock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\BindingIfPlugin;
+
+final class PackageDefaultClock implements Clock
+{
+    public function source(): string
+    {
+        return 'package-default';
+    }
+}

--- a/tests/Feature/Framework/BindingIfPlugin/PackageGacelaConfig.php
+++ b/tests/Feature/Framework/BindingIfPlugin/PackageGacelaConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\BindingIfPlugin;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+/**
+ * What a package ships for its consumers to `extendGacelaConfig()`: a working
+ * default that gets out of the way the moment the application states its own.
+ */
+final class PackageGacelaConfig
+{
+    public function __invoke(GacelaConfig $config): void
+    {
+        $config->addBindingIf(Clock::class, PackageDefaultClock::class);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`addBindingIf()` exists for one scenario, named in its own docblock:

> Bind a key only when it is not already bound in this config, so **plugins can
> register a default that the application (or an earlier binding) can override**.

That scenario needs two config sources to exist at all. It was only ever
exercised on a single `GacelaConfig`, where an `addBinding()` on the line above
is the whole test — nothing about a package, and nothing that would notice if
the mechanism carrying the promise stopped working.

`extendGacelaConfig()` is that mechanism: `GacelaConfigExtender` runs every
extending config against the **same** `GacelaConfig`, so the package's `bindIf`
can see what the application already bound and decline. Nothing else about the
arrangement makes that true.

**Between separate config sources there is nothing to see yet.** Measured:

| bootstrap closure | `gacela.php` | resolves to |
|---|---|---|
| `addBinding(App)` | `addBindingIf(Default)` | **Default** |
| `addBinding(App)` | `addBinding(Default)` | Default |

The conditional and the unconditional form behave identically across sources —
`gacela.php` merges onto the closure and wins either way, because the condition
had no sibling binding to compare against. That is the documented merge order
doing its job, not a defect, so **behaviour is unchanged here**. But "only when
it is not already bound" reads like a guarantee that holds everywhere, and a
package default quietly beating an application's explicit choice is not something
you notice — so the docblock and the docs now say where the condition applies.

## 🔖 Changes

- `BindingIfPlugin` feature test: a package default fills a binding the
  application left open, declines to replace one it made, and does so whichever
  order the two lines appear in — extending configs run after the whole closure,
  so the two lines read as if the second could clobber the first, and it cannot
- `addBindingIf()` docblock: what "in this config" excludes, and the merge order
  that governs instead
- `docs/container-configuration.md`: the example moves to the arrangement a
  package actually ships. It had both calls in the application's own
  `gacela.php`, which is not somewhere a package can write, so the one form
  readers would copy was the one the section is not about

Verified non-vacuous: switching the package's `addBindingIf` to `addBinding`
fails exactly the two tests that assert the application wins.
