### PR TITLE
fix: throw the not-bootstrapped exception from Config too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 ### Fixed
 
+- Throw `GacelaNotBootstrappedException` from `Config::getInstance()`, like `Gacela::container()` and `Gacela::rootDir()` already did. It threw a bare `RuntimeException` telling you to `call createWithSetup() first` — an `@internal` method only `Gacela::bootstrap()` calls, so the one instruction the message gave was one you must not follow. It is also the way a project reaches this state first: every pillar goes through `Config::getInstance()`, so a `new SomeFacade()` before the bootstrap landed here rather than on the two that were right. Catching the typed exception to degrade, as `debug:container` and `debug:dependencies` do, therefore missed the commonest case
+
 - Register `dto:generate`, `ide:meta` and `stubs:publish` in the Symfony and Laravel bridges. Both bridges keep a hand-written list of the commands they expose, and those three were never added — so `bin/console` and `artisan` could not run commands `vendor/bin/gacela` could, including the `dto:generate --check` a CI job wants. All three write files into the project exactly like `make:module` and `init`, which were listed. A test in each bridge now reads the command directory and fails when the list falls behind it
 
 - Round the per-operation `total_duration` in `Profiler::getStats()` like every other duration in that payload. It was handed on as summed, one line from its rounded twin, so float addition noise reached `profile:report --format=json` in one field and not its siblings — `0.1 + 0.2` arriving as `0.30000000000000004` next to a `total_duration` of `0.3`

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -14,7 +14,7 @@ use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Exception\ConfigException;
-use RuntimeException;
+use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 
 use function array_key_exists;
 use function array_keys;
@@ -59,10 +59,13 @@ final class Config implements ConfigInterface
         return self::$instance;
     }
 
+    /**
+     * @throws GacelaNotBootstrappedException if Gacela has not been bootstrapped yet
+     */
     public static function getInstance(): self
     {
         if (!self::$instance instanceof self) {
-            throw new RuntimeException('You have to call createWithSetup() first. Have you forgot to bootstrap Gacela?');
+            throw new GacelaNotBootstrappedException();
         }
 
         return self::$instance;

--- a/tests/Integration/Framework/Config/ConfigTest.php
+++ b/tests/Integration/Framework/Config/ConfigTest.php
@@ -8,9 +8,9 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\ConfigFactory;
+use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 use function getcwd;
 use function putenv;
@@ -51,12 +51,22 @@ final class ConfigTest extends TestCase
         self::assertSame(DIRECTORY_SEPARATOR . 'directory2', $config->getAppRootDir());
     }
 
-    public function test_get_instance_throws_when_not_bootstrapped(): void
+    /**
+     * The way a project reaches an unbootstrapped Gacela first: every pillar
+     * goes through here, so a `new SomeFacade()` before the bootstrap lands on
+     * this and not on `Gacela::container()` or `Gacela::rootDir()`, which
+     * already threw `GacelaNotBootstrappedException`.
+     *
+     * Asserting the type, not just a fragment of the text, is the point: code
+     * catching that exception to degrade -- as `ConstructorInspector` and
+     * `DependencyTreeInspector` do -- never caught the one thrown from here.
+     */
+    public function test_get_instance_throws_the_not_bootstrapped_exception(): void
     {
         Config::resetInstance();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('bootstrap Gacela');
+        $this->expectException(GacelaNotBootstrappedException::class);
+        $this->expectExceptionMessage(GacelaNotBootstrappedException::MESSAGE);
 
         Config::getInstance();
     }


### PR DESCRIPTION
## 📚 Description

Three ways to reach an unbootstrapped Gacela. Two threw `GacelaNotBootstrappedException`:

| entry point | threw |
|---|---|
| `Gacela::container()` | `GacelaNotBootstrappedException` |
| `Gacela::rootDir()` | `GacelaNotBootstrappedException` |
| `Config::getInstance()` | `RuntimeException('You have to call createWithSetup() first. Have you forgot to bootstrap Gacela?')` |

`createWithSetup()` is `@internal` and called by `Gacela::bootstrap()` and nothing else, so **the one instruction that message gave was one you must not follow**.

It is also the path a project reaches first. Every pillar goes through `Config::getInstance()`, so a `new SomeFacade()` before the bootstrap lands here rather than on either of the two that were right — verified by resolving a facade with no bootstrap, which produced exactly that message.

**The type mattered as much as the text.** `ConstructorInspector` and `DependencyTreeInspector` both do this:

```php
try {
    return Gacela::container()->getBindings();
} catch (GacelaNotBootstrappedException) {
    return [];
}
```

That catch never covered the commonest way of being unbootstrapped.

## 🔖 Changes

- `Config::getInstance()` throws `GacelaNotBootstrappedException`, with the `@throws` its siblings carry
- Changelog entry under Fixed

Backward compatible: the exception extends `RuntimeException`, so anything catching the old type still does.

## 🔎 Why the existing test did not catch it

There was one, and it passed:

```php
$this->expectException(RuntimeException::class);
$this->expectExceptionMessage('bootstrap Gacela');
```

Both halves are the loosest form available — the base class, and a fragment that survives almost any rewording. It asserted that an exception happened, not which one, so it went on passing while the message drifted to naming an internal method. It now asserts the type and the shared `MESSAGE` const.

That looseness cost me something too: I checked for dependents by grepping the message's other fragments and concluded there were none. This test asserts a third fragment and was not in that result — the suite found it a minute later.
