### PR TITLE
test: state the not-bootstrapped contract once, as a set

### DIFF
--- a/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
+++ b/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
@@ -7,11 +7,11 @@ namespace GacelaTest\Feature\Framework\Testing;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Testing\GacelaTestCase;
 use GacelaTest\Fixtures\StringValue;
 use GacelaTest\Fixtures\StringValueInterface;
-use RuntimeException;
 use Throwable;
 
 use function count;
@@ -86,7 +86,11 @@ final class GacelaTestCaseTest extends GacelaTestCase
 
         $this->tearDown();
 
-        $this->expectException(RuntimeException::class);
+        // The typed exception, not the base class: `tearDown()` leaving the
+        // process unbootstrapped is the same condition `Gacela::container()`
+        // and `Gacela::rootDir()` report, and asserting the base class here
+        // would pass for any RuntimeException at all.
+        $this->expectException(GacelaNotBootstrappedException::class);
         Config::getInstance();
     }
 

--- a/tests/Integration/Framework/NotBootstrappedContractTest.php
+++ b/tests/Integration/Framework/NotBootstrappedContractTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Exception\GacelaNotBootstrappedException;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Throwable;
+
+/**
+ * Every way of reaching Gacela before it is bootstrapped answers the same.
+ *
+ * Stated once, as a set, rather than left to each entry point's own test.
+ * `Config::getInstance()` had drifted to a bare `RuntimeException` naming an
+ * `@internal` method, and no test noticed, because each site was asserted alone
+ * and the assertion was the base class the drifted exception still matched.
+ *
+ * The type is what the guard is for. `ConstructorInspector` and
+ * `DependencyTreeInspector` both catch `GacelaNotBootstrappedException` to
+ * degrade instead of failing, so an entry point that throws anything else is a
+ * hole in a handler written for exactly this condition -- and it is silent, in
+ * the way an exception nobody catches usually is not.
+ */
+final class NotBootstrappedContractTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // Leave the process bootstrapped, or every later test in it inherits
+        // the state this one creates on purpose.
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+    }
+
+    /**
+     * @return iterable<string, array{callable(): mixed}>
+     */
+    public static function entryPointProvider(): iterable
+    {
+        // The one a project reaches first: every pillar goes through it, so a
+        // `new SomeFacade()` before the bootstrap lands here.
+        yield 'Config::getInstance()' => [Config::getInstance(...)];
+
+        yield 'Gacela::container()' => [Gacela::container(...)];
+
+        yield 'Gacela::rootDir()' => [Gacela::rootDir(...)];
+    }
+
+    /**
+     * @param callable(): mixed $entryPoint
+     */
+    #[DataProvider('entryPointProvider')]
+    public function test_it_throws_the_not_bootstrapped_exception(callable $entryPoint): void
+    {
+        $this->unbootstrap();
+
+        $this->expectException(GacelaNotBootstrappedException::class);
+        $this->expectExceptionMessage(GacelaNotBootstrappedException::MESSAGE);
+
+        $entryPoint();
+    }
+
+    /**
+     * Guards the case above against passing for the wrong reason: if
+     * `unbootstrap()` stopped clearing something, the entry point would answer
+     * normally and the test would fail rather than pass -- but if an entry
+     * point were dropped from the provider, nothing would say so. This asserts
+     * every one of them is still reached.
+     */
+    public function test_every_entry_point_is_exercised(): void
+    {
+        $names = array_keys([...self::entryPointProvider()]);
+
+        self::assertSame(
+            ['Config::getInstance()', 'Gacela::container()', 'Gacela::rootDir()'],
+            $names,
+        );
+    }
+
+    /**
+     * Sanity: the reset really does un-bootstrap, so a green run above is the
+     * exception being thrown and not the entry point quietly succeeding.
+     */
+    public function test_the_reset_actually_unbootstraps(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+        self::assertSame(__DIR__, Gacela::rootDir());
+
+        $this->unbootstrap();
+
+        $threw = false;
+        try {
+            Gacela::rootDir();
+        } catch (Throwable) {
+            $threw = true;
+        }
+
+        self::assertTrue($threw, 'unbootstrap() left Gacela usable, so the contract tests prove nothing');
+    }
+
+    /**
+     * Both statics behind the three entry points, put back to the state a
+     * process has before `Gacela::bootstrap()` runs.
+     */
+    private function unbootstrap(): void
+    {
+        Config::resetInstance();
+
+        $gacela = new ReflectionClass(Gacela::class);
+        $gacela->getProperty('appRootDir')->setValue($gacela, value: null);
+        $gacela->getProperty('mainContainer')->setValue($gacela, value: null);
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
+++ b/tests/Unit/Framework/Bootstrap/SetupGacelaTest.php
@@ -453,6 +453,9 @@ final class SetupGacelaTest extends TestCase
     public function test_from_file_throws_for_missing_path(): void
     {
         $this->expectException(RuntimeException::class);
+        // The path is the whole content of this failure: naming a file that is
+        // not there is the only way the reader learns which one was looked for.
+        $this->expectExceptionMessage("Invalid file path: '/nonexistent/dir/gacela.php'");
 
         SetupGacela::fromFile('/nonexistent/dir/gacela.php');
     }


### PR DESCRIPTION
## 📚 Description

#786 fixed `Config::getInstance()` throwing a bare `RuntimeException` where its two siblings threw `GacelaNotBootstrappedException`. **What let it drift was the shape of the tests, not the absence of one.** Each entry point was asserted on its own, and the assertion was the base class the drifted exception still matched — so the suite went on being green while one of three answers to the same question changed underneath it.

So state the rule once, over all three, asserting the type and the shared `MESSAGE`. A fourth entry point added with its own ad-hoc exception now has something to fail.

## 🔖 Changes

`NotBootstrappedContractTest`, plus two supporting tests — because a contract test that quietly stops exercising anything is the failure mode of a contract test:

- the provider still names all three entry points
- `unbootstrap()` really does un-bootstrap, so a green run is the exception being thrown and not the entry points quietly succeeding

Verified non-vacuous by restoring the old throw in `Config`: only the `Config::getInstance()` data set fails, and it names itself.

Two loose assertions the sweep turned up, tightened:

| test | was | now |
|---|---|---|
| `GacelaTestCaseTest` | `RuntimeException` from `Config::getInstance()` after `tearDown()` | the typed exception — same condition, same type |
| `SetupGacelaTest::test_from_file_throws_for_missing_path` | no message asserted at all | the message, which names the path |

## 🔎 What I checked and left alone

Sixteen tests in the suite assert a base exception class. Fourteen pair it with a message specific enough to fail on a real change — `sprintf('Directory "%s" was not created', ...)`, `'wrap it in [ ]'`, `'never redefined'`. The two above were the only ones asserting either nothing or a fragment generic enough to survive a rewrite.

I also checked whether any *other* place in `src/` detects a not-bootstrapped state and throws something else. There is none — #786 closed the only divergence, and this pins it that way.
