### PR TITLE
test: drive the Cacheable rule through PHPStan too

### DIFF
--- a/tests/Integration/PHPStan/CacheableFixture/CachedFacade.php
+++ b/tests/Integration/PHPStan/CacheableFixture/CachedFacade.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\PHPStan\CacheableFixture;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableTrait;
+
+/**
+ * A `#[Cacheable]` key that never mentions the arguments, driven through
+ * PHPStan's own front end.
+ *
+ * @extends AbstractFacade<CachedFactory>
+ */
+final class CachedFacade extends AbstractFacade
+{
+    use CacheableTrait;
+
+    #[Cacheable(ttl: 60, key: 'thing')]
+    public function bareKey(int $id): string
+    {
+        return $this->cached(fn (): string => $this->getFactory()->createThing());
+    }
+
+    #[Cacheable(ttl: 60, key: 'thing-{0}')]
+    public function keyedByArgument(int $id): string
+    {
+        return $this->cached(fn (): string => $this->getFactory()->createThing());
+    }
+
+    #[Cacheable(ttl: 60, key: 'no-args')]
+    public function takesNothing(): string
+    {
+        return $this->cached(fn (): string => $this->getFactory()->createThing());
+    }
+}

--- a/tests/Integration/PHPStan/CacheableFixture/CachedFactory.php
+++ b/tests/Integration/PHPStan/CacheableFixture/CachedFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\PHPStan\CacheableFixture;
+
+use Gacela\Framework\AbstractFactory;
+
+final class CachedFactory extends AbstractFactory
+{
+    public function createThing(): string
+    {
+        return 'thing';
+    }
+}

--- a/tests/Integration/PHPStan/CacheableFixture/phpstan-cacheable.neon
+++ b/tests/Integration/PHPStan/CacheableFixture/phpstan-cacheable.neon
@@ -1,0 +1,9 @@
+includes:
+    - ../../../../phpstan-gacela.neon
+
+parameters:
+    level: max
+    paths:
+        - .
+    excludePaths:
+        - phpstan-cacheable.neon

--- a/tests/Integration/PHPStan/CacheableKeyIgnoresArgumentsTest.php
+++ b/tests/Integration/PHPStan/CacheableKeyIgnoresArgumentsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\PHPStan;
+
+use Override;
+
+/**
+ * Runs PHPStan for real over the same shape
+ * {@see \GacelaTest\Integration\Psalm\ArchitectureRulesTest} hands Psalm.
+ *
+ * Every other rule Gacela ships had both halves of that pair. This one had the
+ * analyser's own unit tests and the Psalm front end, and nothing driving the
+ * PHPStan rule -- the only rule in the file where the pair was incomplete,
+ * while being registered uncommented in `phpstan-gacela.neon`, so every
+ * consumer runs it.
+ *
+ * The half a unit test cannot reach is the adaptation: `getNodeType()` naming
+ * a node PHPStan hands over, `getOriginalNode()` still carrying the attribute,
+ * and the reflection wrapper answering what the analyser asks. A rule that
+ * silently matches nothing analyses clean, which is indistinguishable from code
+ * that has nothing wrong with it.
+ */
+final class CacheableKeyIgnoresArgumentsTest extends PhpStanFixtureTestCase
+{
+    public function test_a_key_that_never_mentions_the_arguments_is_reported(): void
+    {
+        $errors = $this->analyseFixture();
+
+        self::assertStringContainsString('The #[Cacheable] key "thing" on', $errors);
+        self::assertStringContainsString('CachedFacade::bareKey()', $errors);
+    }
+
+    /**
+     * The consequence, not just the fact: what makes this worth a rule is that
+     * nothing fails -- the wrong record is simply served.
+     */
+    public function test_the_finding_says_what_goes_wrong(): void
+    {
+        self::assertStringContainsString(
+            'every call shares one entry and the first result is served to all of them',
+            $this->analyseFixture(),
+        );
+    }
+
+    /**
+     * The same fixture carries both shapes that must stay silent. A rule that
+     * fired on either would be one a project turns off, which costs more than
+     * the rule was worth.
+     */
+    public function test_a_key_that_uses_its_argument_is_left_alone(): void
+    {
+        self::assertStringNotContainsString('keyedByArgument', $this->analyseFixture());
+    }
+
+    public function test_a_method_without_arguments_is_left_alone(): void
+    {
+        self::assertStringNotContainsString('takesNothing', $this->analyseFixture());
+    }
+
+    #[Override]
+    protected static function configPath(): string
+    {
+        return __DIR__ . '/CacheableFixture/phpstan-cacheable.neon';
+    }
+}


### PR DESCRIPTION
## 📚 Description

Every rule Gacela ships is one shared analyser behind two front ends, and the repo already states why both halves get driven —

> The pair is the test. One rules file feeds `debug:graph --check --rules` and both analysers, and **a boundary that held in one host and not the other would be a boundary nobody trusts.**
> — `DeclaredModuleDependencyTest`

and the Psalm fixture for *this* rule makes the same argument:

> driven through Psalm's own front end — the analyser has host-free unit tests, and **this is the half they cannot cover**.

`CacheableKeyIgnoresArgumentsRule` was the one rule where the pair was incomplete:

| | analyser unit tests | Psalm front end | PHPStan front end |
|---|---|---|---|
| the other 8 rules | ✅ | ✅ | ✅ |
| `CacheableKeyIgnoresArguments` | ✅ | ✅ | **✗** |

It is registered **uncommented** in `phpstan-gacela.neon`, so every consumer runs it.

**It works** — verified by running the shipped neon over the new fixture, which reports `bareKey()` and leaves the other two alone. The point is that nothing said so. The half a unit test cannot reach is the adaptation: `getNodeType()` naming a node PHPStan hands over, `getOriginalNode()` still carrying the attribute, the reflection wrapper answering what the analyser asks. **A rule that silently matches nothing analyses clean**, which is indistinguishable from code that has nothing wrong with it.

## 🔖 Changes

- `CacheableFixture/` — one facade carrying all three shapes, and its own neon that includes the shipped config
- `CacheableKeyIgnoresArgumentsTest`, alongside the existing PHPStan fixture tests

| fixture method | key | expected |
|---|---|---|
| `bareKey(int $id)` | `'thing'` | reported |
| `keyedByArgument(int $id)` | `'thing-{0}'` | silent |
| `takesNothing()` | `'no-args'` | silent |

One fixture carries all three, so the two negatives cannot pass vacuously: if the rule stops firing, the two positive tests fail. Verified by pointing `getNodeType()` at a node the fixture has none of — exactly those two fail, and the negatives stay green.

## 🔎 No config change needed

`phpstan-tests.neon` deliberately does not include `phpstan-gacela.neon` — its own comment says so — so the shipped rules never run over `tests/` and this deliberately-wrong fixture needs no `excludePaths` entry, unlike the two under `tests/Unit/PHPStan/`.
