### PR TITLE
fix: name the autoload-dev prefixes in the "Known PSR-4" list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 ### Fixed
 
+- List the `autoload-dev` prefixes too when `make:*` cannot match a namespace. The lookup searches `autoload` and `autoload-dev` together — that is what "Read autoload-dev psr-4 namespaces for gacela make commands" shipped — but the `Known PSR-4:` list it prints on a miss was built from `autoload` alone. Mistyping a namespace that lives in `autoload-dev` produced a list with no dev prefix in it at all, about namespaces Gacela had just been willing to resolve, and the list is the only thing the reader has to compare the typo against
+
 - Throw `GacelaNotBootstrappedException` from `Config::getInstance()`, like `Gacela::container()` and `Gacela::rootDir()` already did. It threw a bare `RuntimeException` telling you to `call createWithSetup() first` — an `@internal` method only `Gacela::bootstrap()` calls, so the one instruction the message gave was one you must not follow. It is also the way a project reaches this state first: every pillar goes through `Config::getInstance()`, so a `new SomeFacade()` before the bootstrap landed here rather than on the two that were right. Catching the typed exception to degrade, as `debug:container` and `debug:dependencies` do, therefore missed the commonest case
 
 - Register `dto:generate`, `ide:meta` and `stubs:publish` in the Symfony and Laravel bridges. Both bridges keep a hand-written list of the commands they expose, and those three were never added — so `bin/console` and `artisan` could not run commands `vendor/bin/gacela` could, including the `dto:generate --check` a CI job wants. All three write files into the project exactly like `make:module` and `init`, which were listed. A test in each bridge now reads the command directory and fails when the list falls behind it

--- a/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
+++ b/src/Console/Domain/CommandArguments/CommandArgumentsParser.php
@@ -54,7 +54,11 @@ final class CommandArgumentsParser implements CommandArgumentsParserInterface
             }
         }
 
-        throw CommandArgumentsException::noAutoloadPsr4MatchFound($desiredNamespace, array_keys($psr4));
+        // Every prefix the lookup above searched, not just `autoload`: this list
+        // is the only thing the reader has to compare their typo against, and
+        // one missing the `autoload-dev` prefixes reads as "Gacela does not see
+        // those" -- about namespaces it had just been willing to resolve.
+        throw CommandArgumentsException::noAutoloadPsr4MatchFound($desiredNamespace, array_keys($psr4All));
     }
 
     /**

--- a/tests/Unit/Console/Domain/CommandArguments/CommandArgumentsParserTest.php
+++ b/tests/Unit/Console/Domain/CommandArguments/CommandArgumentsParserTest.php
@@ -82,6 +82,37 @@ final class CommandArgumentsParserTest extends TestCase
         $parser->parse('Unknown/Module');
     }
 
+    /**
+     * `autoload-dev` prefixes are resolvable -- that is what "Read autoload-dev
+     * psr-4 namespaces for gacela make commands" shipped. Pinned here because
+     * nothing else at this level says so, which is how the message below came
+     * to disagree with it.
+     */
+    public function test_a_namespace_declared_only_in_autoload_dev_resolves(): void
+    {
+        $parser = new CommandArgumentsParser($this->exampleComposerJsonWithAutoloadDev());
+
+        self::assertSame('tests/Wallet', $parser->parse('AppTest/Wallet')->directory());
+    }
+
+    /**
+     * The list is the only thing the reader has to compare a typo against, so
+     * it has to be every prefix the lookup searched. It was built from
+     * `autoload` alone while the lookup used `autoload + autoload-dev`: someone
+     * mistyping a dev namespace was shown a list without a single dev prefix in
+     * it, and would conclude Gacela does not read them -- about namespaces it
+     * had just been willing to resolve.
+     */
+    public function test_the_known_list_names_the_autoload_dev_prefixes_too(): void
+    {
+        $this->expectExceptionMessage(
+            'No autoload psr-4 match found for AppTst/Wallet. Known PSR-4: App, AppTest, Fixtures',
+        );
+
+        $parser = new CommandArgumentsParser($this->exampleComposerJsonWithAutoloadDev());
+        $parser->parse('AppTst/Wallet');
+    }
+
     public function test_parse_with_multibyte_namespace(): void
     {
         $parser = new CommandArgumentsParser($this->exampleMultibyteComposerJson());
@@ -214,6 +245,30 @@ JSON;
     }
 }
 JSON;
+        return json_decode($composerJson, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array{autoload: array{psr-4: array<string,string>}, autoload-dev: array{psr-4: array<string,string>}}
+     */
+    private function exampleComposerJsonWithAutoloadDev(): array
+    {
+        $composerJson = <<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "AppTest\\": "tests/",
+            "Fixtures\\": "fixtures/"
+        }
+    }
+}
+JSON;
+
         return json_decode($composerJson, true, 512, JSON_THROW_ON_ERROR);
     }
 


### PR DESCRIPTION
## 📚 Description

`CommandArgumentsParser` searches both autoload sections:

```php
$psr4All = $psr4 + $psr4Dev;   // line 47
```

That merge is a shipped feature — *"Read autoload-dev psr-4 namespaces for gacela make commands"*. But the list printed when nothing matches was built from `autoload` alone:

```php
throw CommandArgumentsException::noAutoloadPsr4MatchFound($desiredNamespace, array_keys($psr4));
```

So mistyping a namespace that lives in `autoload-dev` produced a list with **no dev prefix in it at all** — about namespaces Gacela had just been willing to resolve. Reproduced with `autoload: App` and `autoload-dev: AppTest, Fixtures`:

```
AppTest/Wallet   -> resolves
AppTst/Wallet    -> No autoload psr-4 match found for AppTst/Wallet. Known PSR-4: App
```

The list is the entire content of that message — it exists to be compared against — and it was showing a set the lookup does not use. A reader would reasonably conclude Gacela ignores `autoload-dev`.

Now:

```
AppTst/Wallet    -> ... Known PSR-4: App, AppTest, Fixtures
```

## 🔖 Changes

- `array_keys($psr4All)`, so the list is every prefix the lookup searched
- Two tests, and the `autoload-dev` fixture neither had

| test | pins |
|---|---|
| `test_a_namespace_declared_only_in_autoload_dev_resolves` | the shipped feature |
| `test_the_known_list_names_the_autoload_dev_prefixes_too` | that the message agrees with it |

## 🔎 Why it survived

There *is* a test on this message, asserting the full string. It passed because its fixture has no `autoload-dev` block — and neither did any other fixture in the class. **The dev-namespace support had no coverage at this level at all**, so the two halves were free to disagree: one path read `autoload-dev`, the path that reports on failure did not, and nothing exercised the combination.

Verified non-vacuous by restoring `array_keys($psr4)`: the new test fails and prints both lists.
