### PR TITLE
docs: name the one path a cache dir does escape the app root

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -35,6 +35,8 @@ Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
 
 A path given here is resolved **relative to the app root**, and a leading `/` does not escape it: `enableFileCache('/var/cache/gacela')` writes to `{appRoot}/var/cache/gacela`. To point the cache at a genuinely absolute path outside the project, use the `GACELA_CACHE_DIR` environment variable, which is read first and taken verbatim — also the handy way to reuse one image across environments.
 
+**One exception, on Windows**: a drive-letter path (`C:\cache`, `C:/cache`) is taken as given and does escape the app root, because rebasing it would produce `{appRoot}\C:\cache`, which names nothing. A path already inside the app root is likewise left alone on either platform. So `GACELA_CACHE_DIR` is the portable way to ask for a directory outside the project — the only spelling that means the same thing on both.
+
 Typical wiring:
 
 - **Development** — file cache **off**. Edits take effect immediately.

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -332,6 +332,13 @@ final class GacelaConfig
 
     /**
      * Shortcut to setFileCache(true)
+     *
+     * `$dir` is resolved **relative to the app root**, and a leading `/` does
+     * not escape it -- `'/var/cache'` writes to `{appRoot}/var/cache`. The
+     * exceptions are a path already inside the app root, and a Windows
+     * drive-letter path, both of which are taken as given. For a directory
+     * genuinely outside the project, use `GACELA_CACHE_DIR`: it is read first,
+     * taken verbatim, and means the same thing on either platform.
      */
     public function enableFileCache(?string $dir = null): self
     {


### PR DESCRIPTION
## 📚 Description

`docs/caching.md` states the rule flatly:

> A path given here is resolved **relative to the app root**, and a leading `/` does not escape it.

True on POSIX. On Windows a drive-letter path is taken as given and **does** escape — `getDefaultCacheDir()` returns it before reaching the rebasing branch, and there is a test pinning exactly that:

```php
// test_get_cache_dir_returns_windows_style_absolute_path_unchanged
->setFileCache(true, 'C:/winapp/cache');
$config->setAppRootDir('/tmp/unused-root');

self::assertSame('C:/winapp/cache', $config->getCacheDir());
```

**The exception is right.** Rebasing it would build `{appRoot}\C:/cache`, which names nothing — and this repo has already met that shape: `FileCacheTest::test_normalize_keeps_single_embedded_drive_reference_intact` carries `C:\demo\example-app/C:\Users\...` and cites phel-lang #1459. So the code is not what is wrong here; the sentence claiming the rule holds everywhere is.

Behaviour unchanged.

## 🔖 Changes

- `docs/caching.md`: which two paths are taken as given (already inside the app root; Windows drive-letter), and that `GACELA_CACHE_DIR` is the **portable** spelling — the only one meaning the same thing on both platforms
- `enableFileCache()` gains a docblock saying so

The docblock matters on its own. `enableFileCache(?string $dir = null)` said only *"Shortcut to setFileCache(true)"*, so the signature was no help — and the one place the rebasing was written down is under a **different** method, `addAppConfigFromFile()`, phrased as *"unlike `enableFileCache()` it is not rebased under the application root"*. You had to already know, to find it.

## 🔎 How this came up, and what I did not change

A report reached me that the rebasing was a bug: an absolute path had been passed to `enableFileCache()` and files appeared under the app root.

**It is not a bug.** It is deliberate containment, it is documented at `docs/caching.md:36`, and every branch is covered:

| input | result | test |
|---|---|---|
| empty | `sys_get_temp_dir()` | ✅ |
| relative | `{appRoot}/{dir}` | ✅ |
| absolute, inside app root | unchanged | ✅ |
| absolute, outside | `{appRoot}{dir}` | ✅ |
| Windows drive letter | unchanged | ✅ |

So nothing in `src/` needed touching — except that the reporter had read the docs' rule and been surprised by the platform it does not cover, which is the part worth fixing.
