### PR TITLE
docs: say what containerTempDir() returns, and what else the trait has

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,24 @@ $resolved = $this->recordedGacelaEventsOf(ServiceResolvedEvent::class); // one t
 
 If you only need the reset helpers inside an existing test hierarchy, use the [`ContainerFixture`](../src/Framework/Testing/ContainerFixture.php) trait directly — `GacelaTestCase` builds on it.
 
+### What else the trait gives you
+
+Beyond the resets and the `swapModule*()` calls below:
+
+```php
+$dir = $this->containerTempDir();   // a new temp dir, removed when the process ends
+```
+
+**One directory per call**, not one per test — two calls hand back two paths. Hold the return value rather than calling it again to name the same place twice. Nothing needs cleaning up by hand; `cleanupContainerTempDirs()` exists for when you want it to happen between methods rather than at process end.
+
+```php
+$snapshot = $this->captureContainerState();
+// ... a test that bootstraps differently, rebinds, or rewrites config
+$this->restoreContainerState($snapshot);
+```
+
+The snapshot covers the in-memory class-name cache, the config values, the app root and the cache directory. It deliberately does **not** capture resolved service instances — those can hold file handles and connections — so restoring rebuilds them lazily rather than handing back objects that outlived their resources.
+
 ### Bootstrapping twice without either of them
 
 Neither is required. But calling `Gacela::bootstrap()` a second time in one process on your own keeps the **previous** boot's services, and says nothing:

--- a/src/Framework/Testing/ContainerFixture.php
+++ b/src/Framework/Testing/ContainerFixture.php
@@ -200,10 +200,14 @@ trait ContainerFixture
     }
 
     /**
-     * Create (on first access) and return a unique temporary directory
-     * for the current test method. The directory is automatically
-     * removed at the end of the PHP process via a shutdown function,
-     * so tests do not need to clean up manually.
+     * Create and return a **new** temporary directory, one per call. Two calls
+     * in one test method hand back two directories, which
+     * {@see \GacelaTest\Unit\Framework\Testing\ContainerFixtureTest::test_container_temp_dir_returns_unique_existing_directory}
+     * pins -- so hold the return value rather than calling this again to name
+     * the same place twice.
+     *
+     * Every directory handed out is removed at the end of the PHP process via a
+     * shutdown function, so tests do not need to clean up manually.
      */
     protected function containerTempDir(): string
     {


### PR DESCRIPTION
## 📚 Description

Two things about `ContainerFixture`, both found by using it.

**1. `containerTempDir()` described a memo it does not have.**

> Create (**on first access**) and return a unique temporary directory **for the current test method**.

"On first access" and the singular "The directory" both promise one directory per test method. There is none — every call builds a fresh random directory and appends it to the list, and the behaviour is deliberate and already pinned:

```php
// test_container_temp_dir_returns_unique_existing_directory
$dir1 = $this->containerTempDir();
$dir2 = $this->containerTempDir();

self::assertNotSame($dir1, $dir2);
```

The implementation is the intended one; the docblock described something else. The failure it invites is silent — write to the first path, read from the second, find nothing there. Found by calling it twice and asserting what the docblock said, which failed.

**2. Most of the trait was undiscoverable.**

`docs/testing.md` introduced the whole thing in one line, as *"the reset helpers"*, pointing at the source file. `containerTempDir()`, `captureContainerState()` and `restoreContainerState()` appeared **nowhere** in `docs/` — the way to find them was to read the class.

The temp dir is the one worth finding. Hand-rolling it is how a test ends up owning cleanup code that globs a path it did not create.

## 🔖 Changes

- `containerTempDir()` docblock now says one directory **per call**, points at the test that pins it, and says to hold the return value
- `docs/testing.md` gains a short section covering the temp dir and the snapshot pair

Behaviour unchanged.

## 🔎 Verified, not transcribed

Both examples were run before being written. The snapshot round-trip was checked across two different bootstraps:

```
bootstrap with probe=original  ->  capture
bootstrap with probe=changed   ->  reads "changed"
restoreContainerState($snap)   ->  reads "original"   ✓
```

The doc also states what the snapshot deliberately omits — resolved service instances, because they can hold file handles and connections — which is the class's own reasoning, not mine.
