### PR TITLE
docs: name the tool that catches a rule governing nothing

### DIFF
--- a/docs/module-boundaries.md
+++ b/docs/module-boundaries.md
@@ -156,6 +156,14 @@ One file, two readers, on purpose: a boundary that holds in CI and not in the ed
 
 The rules are **self-invalidating**, like the cycle allow list. A `from`, `allow` or `deny` naming a namespace that matches no module fails the check — a rule about a module nobody has any more still reads as a boundary being watched. A `deny` that never fires is not an error; that is the rule doing its job.
 
+**Only `debug:graph --check --rules` reports that**, and it is worth a CI step for it alone:
+
+```
+✗ Module rule governs nothing: App\Paymnet matches no module. Remove the rule, or fix the namespace.
+```
+
+Neither analyser can. They are handed one class at a time and asked whether *this* dependency is allowed; deciding that a namespace matches **no** module needs the whole graph, which only the command builds. So a rule with a typo in it passes PHPStan and Psalm in silence, enforcing nothing — the precise failure the paragraph above is about. The JSON report names them under `unknownRuleNamespaces`.
+
 `--rules` cannot be combined with a filter argument: in a narrowed graph, a rule about a filtered-out module is indistinguishable from a rule about a module that no longer exists, and those two must not look alike.
 
 `--check --format=json` writes the findings as a report instead of lines, for a CI job that wants more than an exit code:


### PR DESCRIPTION
## 📚 Description

`docs/module-boundaries.md` shows `phpstan.neon`, then `psalm.xml`, then:

> One file, **two readers**, on purpose: a boundary that holds in CI and not in the editor is a boundary nobody trusts.

and immediately after:

> A `from`, `allow` or `deny` naming a namespace that matches no module **fails the check**.

In that position, "the check" reads as the two analysers just configured. It isn't — **only `debug:graph --check --rules` reports it.**

Verified both directions against the same fixture. The CLI, handed a rules file whose `from` names a namespace no module matches:

```
✗ Module rule governs nothing: ...Paymnet matches no module. Remove the rule, or fix the namespace.
```

PHPStan, same fixture, same typo: **nothing at all.**

## 🔎 The asymmetry is inherent, and the doc now says why

An analyser is handed one class at a time and asked whether *this* dependency is allowed. Deciding that a namespace matches **no** module needs the whole graph, which only the command builds. `governs nothing` appears exactly once in `src/`, in `DebugGraphCommand`, and that is the right place for it.

**Why it matters:** it is precisely the failure the paragraph warns about. A team enforcing boundaries through PHPStan and Psalm in CI, with a typo in one rule, gets a green build and a boundary watching nothing — *"a rule about a module nobody has any more still reads as a boundary being watched"*, as the doc already puts it. The one tool that would have said so is the one the section never mentions.

## 🔖 Changes

- `docs/module-boundaries.md`: names the command, shows its output, explains why neither analyser can do it, and points at the `unknownRuleNamespaces` field in the JSON report

Behaviour unchanged. Both the message text and the JSON field name were read out of `DebugGraphCommand` rather than remembered.

## 🔎 Three things I checked this round and found already correct

- **`ConfigSchemaCheck`** — all three branches are covered end-to-end by `ConfigSchemaCommandsTest`, asserting the real output strings. My class-name grep showed "0 tests" because those tests drive it through the command, which is the stronger form
- **`AnonymousGlobal::getByKey()`'s second lookup** — I suspected dead code, instrumented it across the full suite, and it fires exactly once, from a test passing a hand-written unnormalized key. It is a public-API tolerance
- **The rules file's three consumers** — PHPStan, Psalm and the CLI all call `ModuleRuleSet::fromFile()`. One loader, so format drift between them is structurally impossible
