### PR TITLE
feat(console): show what a module provides in debug:module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- List what a module's Provider declares in `debug:module`, under `Provides (#[Provides])` and in the `provides` field of `--json`. The Provider was printed as one of the four pillars with its whole purpose left blank, while the `Bindings` section beside it reports the *application's* container — the same list for every module printed, and not an answer to "what does this module provide?", which is the question `getProvidedDependency('...')` asks. Attribute-declared ids only, and labelled as such: finding the ones a Provider `set()`s imperatively means running it against a container, which resolves the services, and this command describes rather than builds
+
 - Answer "are the generated DTO classes up to date?" with `dto:generate --check`. The classes are committed, so a declaration edited without regenerating leaves the repository behind what `gacela.php` says — and `--dry-run` reported it while exiting `0` either way, so a CI job had to parse the output. `--check` writes nothing, names each stale file, and exits non-zero, like `debug:graph --check`. Nothing declared is a pass: there is nothing to be stale
 
 - Report in `doctor` listeners registered while `disableEventListeners()` is in effect. No dispatcher is built, so every registration is inert — which `docs/events.md` already calls the first thing to check when a listener appears dead, and which the check itself used to give a green tick to. Generic listeners count too: they carry no target, so a project whose only listeners are generic looked like one that had registered nothing. Disabling with nothing registered stays silent, and an unfireable target is still reported alongside, because it has to be right for the day the switch goes back on

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 |---|---|
 | `list:modules` | Renders every module found |
 | `debug:modules` | Dependency resolvability of every module pillar |
-| `debug:module App/Blog` | One module: resolved classes, container bindings, dependency tree |
+| `debug:module App/Blog` | One module: resolved classes, the ids its Provider declares with `#[Provides]`, container bindings, dependency tree |
 | `debug:config` | The effective merged configuration, after every source and override, each key marked `declared`, `undeclared` or `missing` against the [schema](config-schema.md) |
 | `debug:container` | Container contents — user bindings and plugins only |
 | `debug:dependencies Foo::class` | A class's constructor parameters and whether the container can supply each. `--tree` walks the whole graph and marks every node `binding`, `instance`, `autowired` or `unresolvable` |

--- a/src/Console/Infrastructure/Command/DebugModuleCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModuleCommand.php
@@ -8,8 +8,10 @@ use Gacela\Console\Application\Debug\DependencyTreeInspector;
 use Gacela\Console\Application\Debug\DependencyTreeRenderer;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Framework\Attribute\ProvidesScanner;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use ReflectionClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +19,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function class_exists;
 use function json_encode;
 
 use function sprintf;
@@ -84,6 +87,7 @@ final class DebugModuleCommand extends Command
                 'factory' => $module->factoryClass(),
                 'config' => $module->configClass(),
                 'provider' => $module->providerClass(),
+                'provides' => $this->providedIds($module),
                 'bindings' => $bindings,
                 'contextualBindings' => $contextualBindings,
                 'dependencyTree' => $this->getFacade()->getContainerDependencyTree($module->facadeClass()),
@@ -104,6 +108,7 @@ final class DebugModuleCommand extends Command
 
         if (!$treeOnly) {
             $this->renderResolvedClasses($output, $module);
+            $this->renderProvides($output, $module);
             $this->renderBindings($output);
         }
 
@@ -117,6 +122,54 @@ final class DebugModuleCommand extends Command
         $output->writeln(sprintf('  <fg=cyan>Factory</>   → %s', $module->factoryClass() ?? self::NOT_FOUND));
         $output->writeln(sprintf('  <fg=cyan>Config</>    → %s', $module->configClass() ?? self::NOT_FOUND));
         $output->writeln(sprintf('  <fg=cyan>Provider</>  → %s', $module->providerClass() ?? self::NOT_FOUND));
+    }
+
+    /**
+     * The ids this module's own Provider declares, which is the question
+     * `getProvidedDependency('...')` asks and the one nothing here answered:
+     * the Provider was listed as a pillar and its whole purpose left blank,
+     * while `Bindings` below reports the *application's* container, identical
+     * for every module printed.
+     *
+     * Attribute-declared ids only, and labelled as such. A Provider may also
+     * `set()` ids imperatively inside `provideModuleDependencies()`, and
+     * finding those means running it against a container -- which resolves the
+     * services, for a command whose job is to describe rather than to build.
+     */
+    private function renderProvides(OutputInterface $output, AppModule $module): void
+    {
+        $output->writeln('  <fg=cyan>Provides</> (#[Provides]):');
+
+        $ids = $this->providedIds($module);
+        if ($ids === []) {
+            $output->writeln('    (none)');
+
+            return;
+        }
+
+        foreach ($ids as $id) {
+            $output->writeln(sprintf('    %s', $id));
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function providedIds(AppModule $module): array
+    {
+        $providerClass = $module->providerClass();
+        if ($providerClass === null || !class_exists($providerClass)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach (ProvidesScanner::entriesFor(new ReflectionClass($providerClass)) as $entry) {
+            $ids[] = $entry['id'];
+        }
+
+        sort($ids);
+
+        return $ids;
     }
 
     private function renderBindings(OutputInterface $output): void

--- a/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
+++ b/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
@@ -164,6 +164,8 @@ final class DebugModuleCommandTest extends TestCase
             'factory' => null,
             'config' => null,
             'provider' => null,
+            // WiredModule has no Provider at all, so there is nothing to declare.
+            'provides' => [],
             'bindings' => [PaymentGatewayInterface::class => StripeGateway::class],
             'contextualBindings' => [],
             'dependencyTree' => [WiredCollaborator::class],
@@ -172,6 +174,57 @@ final class DebugModuleCommandTest extends TestCase
         // JSON_UNESCAPED_SLASHES keeps the "bin/gacela"-style paths readable; the
         // namespace separators must still be escaped as JSON requires.
         self::assertStringContainsString('GacelaTest\\\\Feature', $display);
+    }
+
+    /**
+     * The Provider is listed as one of the four pillars, and what it declares
+     * is the question `getProvidedDependency('...')` asks. Nothing here
+     * answered it: `Bindings` below reports the application's container, which
+     * is the same list for every module printed.
+     */
+    public function test_lists_the_ids_the_modules_provider_declares(): void
+    {
+        $tester = $this->debugModule(['module' => 'CheckoutModule']);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Provides (#[Provides]):', $display);
+        self::assertStringContainsString(CheckoutModuleProvider::GATEWAY, $display);
+        self::assertStringContainsString(CheckoutModuleProvider::RETRIES, $display);
+    }
+
+    /**
+     * Sorted, so the section does not reorder itself between runs on a
+     * Provider whose methods get shuffled around.
+     */
+    public function test_the_provided_ids_are_listed_in_a_stable_order(): void
+    {
+        $display = $this->debugModule(['module' => 'CheckoutModule'])->getDisplay();
+
+        self::assertLessThan(
+            strpos($display, CheckoutModuleProvider::RETRIES),
+            strpos($display, CheckoutModuleProvider::GATEWAY),
+        );
+    }
+
+    public function test_a_module_without_a_provider_declares_nothing(): void
+    {
+        $display = $this->debugModule(['module' => 'WiredModule'])->getDisplay();
+
+        self::assertStringContainsString('Provides (#[Provides]):', $display);
+        self::assertMatchesRegularExpression('/Provides \(#\[Provides\]\):\s*\R\s*\(none\)/u', $display);
+    }
+
+    public function test_json_carries_the_provided_ids_too(): void
+    {
+        $display = $this->debugModule(['module' => 'CheckoutModule', '--json' => true])->getDisplay();
+
+        /** @var list<array<string, mixed>> $decoded */
+        $decoded = json_decode($display, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(
+            [CheckoutModuleProvider::GATEWAY, CheckoutModuleProvider::RETRIES],
+            $decoded[0]['provides'],
+        );
     }
 
     public function test_tree_option_limits_output_to_the_dependency_tree(): void

--- a/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleProvider.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/CheckoutModule/CheckoutModuleProvider.php
@@ -5,11 +5,28 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 
 final class CheckoutModuleProvider extends AbstractProvider
 {
+    public const GATEWAY = 'CHECKOUT_GATEWAY';
+
+    public const RETRIES = 'CHECKOUT_RETRIES';
+
     public function provideModuleDependencies(Container $container): void
     {
+    }
+
+    #[Provides(self::GATEWAY)]
+    public function gateway(): PaymentGatewayInterface
+    {
+        return new StripeGateway();
+    }
+
+    #[Provides(self::RETRIES)]
+    public function retries(): int
+    {
+        return 3;
     }
 }


### PR DESCRIPTION
## 📚 Description

`debug:module` printed the Provider as one of the four pillars and left its whole purpose blank:

```
  Provider  → Gacela\Console\ConsoleProvider
  Bindings:
    (none)
```

The `Bindings` section beside it is the **application's** container — `getContainerBindings()`, fetched once and attached to every module printed. So the one thing the command said about wiring was identical for every module, and was not an answer to *"what does this module provide?"*, which is the question `getProvidedDependency('...')` asks.

Now:

```
  Provider  → Gacela\Console\ConsoleProvider
  Provides (#[Provides]):
    COMMANDS
    SERVICE_TEMPLATE_FILENAME_MAP
    TEMPLATE_FILENAME_MAP
  Bindings:
    (none)
```

`--json` carries the same list under `provides`.

## 🔖 Changes

- `Provides (#[Provides])` section in `debug:module`, and a `provides` key in `--json`
- Four tests: the ids are listed, the order is stable, a module with no Provider says `(none)`, and the JSON field carries them
- `docs/cli.md` row and a changelog entry

Read through `ProvidesScanner::entriesFor()`, which is public for exactly this reason, in its own words:

> Public so that a reader which only has the class name — the IDE metadata scanner — asks the same question the container asks, rather than re-deriving "a public method carrying `#[Provides]`" beside it.

Sorted, so the section does not reorder itself when the Provider's methods move.

## 🔎 Scope, deliberately

**Attribute-declared ids only, and the heading says so.** A Provider may also `set()` ids imperatively inside `provideModuleDependencies()`. Finding those means running it against a container, which resolves the services — for a command whose job is to describe rather than to build.

## 🔎 Two nearby ideas I measured and dropped

Before this, I tried adding a **Factory** dependency tree, and extending the Facade one. Both are worthless here: Gacela factories take dependencies through `getProvidedDependency()` rather than a constructor, so `debug:dependencies Gacela\Console\ConsoleFactory --tree` reports `No constructor` and `No transitive dependencies`. The tree would have been empty for exactly the reason the Facade's already is — which is what sent me looking at the Provider instead.
