### PR TITLE
docs: say that getProvidedDependency() returns null on a miss

### DIFF
--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -116,6 +116,24 @@ For "this interface means that implementation" across the whole app, use `addBin
 $config->addBinding(PaymentGateway::class, StripeGateway::class);
 ```
 
+### What a miss looks like
+
+`getProvidedDependency()` **returns `null` for an id nothing provides** — it does not throw. Measured across the shapes you can pass it:
+
+| what you pass | you get |
+|---|---|
+| an id a Provider declares | the value |
+| a **misspelled** string id | `null` |
+| an unregistered **concrete** class | an autowired instance |
+| an unregistered **interface** | `null` |
+| a class name that does not exist | `null` |
+
+The concrete-class row is why it cannot simply throw: the container autowires a class it can construct, which is the behaviour `make()` relies on. But it means a typo in a string id is not reported anywhere — the `null` travels until something calls a method on it, and the stack points at the consumer rather than at the id.
+
+Two habits cost nothing and remove the guesswork: declare ids as constants on the Provider (`Provider::BILLING_FACADE`, not `'billing.facade'`), so a typo is a fatal undefined-constant at the call site; and check `vendor/bin/gacela debug:module App/Blog`, which lists every id that module's Provider declares.
+
+This is the same shape as an [unanswerable tagged id](cli.md), which `doctor` reports — a group iterating one hole, failing on the consumer. Nothing reports this one, because an id may legitimately come from another module's Provider, from `addBinding()`, or from `extendService()`, so "no Provider declares it" is not the same as "it is wrong".
+
 ## Collect several implementations
 
 Two shapes, and which one you want is decided by a single question: **do you look a member up, or do you use all of them?**


### PR DESCRIPTION
## 📚 Description

`docs/getting-a-dependency.md` already draws this distinction for the two neighbouring concepts:

> a registry answers *"the handler for this key"* and **throws on an unknown one**, while a tag answers *"all of these"* and has no notion of a key to miss.

and says nothing about the one in between, which silently returns `null`.

Measured across every shape the parameter takes, not assumed:

| what you pass | you get |
|---|---|
| an id a Provider declares | the value |
| a **misspelled** string id | `null` |
| an unregistered **concrete** class | an autowired instance |
| an unregistered **interface** | `null` |
| a class name that does not exist | `null` |

**The concrete-class row is why it cannot simply throw**: the container constructs what it can, which is the behaviour `make()` relies on. The cost is that a typo in a string id is reported nowhere — the `null` travels until something calls a method on it, and the stack then points at the consumer rather than at the id.

That is the same failure the changelog describes for an unanswerable tagged id, which `doctor` *does* report:

> the group a module iterates silently carries a hole and the failure lands on the consumer as "Call to a member function … on null" — pointing at the loop rather than the registration

## 🔖 Changes

- A "What a miss looks like" subsection in `docs/getting-a-dependency.md`

Behaviour unchanged.

## 🔎 Why nothing reports it, said plainly rather than left as an oversight

An id may legitimately come from **another module's** Provider, from `addBinding()` in `gacela.php`, or from `extendService()`. So "no Provider declares this id" is not the same as "this id is wrong", and a rule saying otherwise would fire on correct code. I checked: no analyser rule, no doctor check, and the PHPStan/Psalm extensions only type the *class-string* form.

The doc gives the two habits that do work instead:

- **ids as Provider constants** — a typo is then a fatal `Error: Undefined constant Gacela\Console\ConsoleProvider::COMMANDZ` at the call site, verified rather than assumed
- **`debug:module App/Blog`** — which lists every id that module's Provider declares, as of #794
