### PR TITLE
docs: say which properties toArray() carries, and pin it

### DIFF
--- a/docs/dto-schema.md
+++ b/docs/dto-schema.md
@@ -76,7 +76,7 @@ A shape under a namespace no `autoload` prefix covers is reported and the comman
 - **The output is derived. Do not edit it.** Regenerating an unchanged declaration produces a byte-identical file, so a repeat run leaves version control quiet.
 - **Declaration order never matters.** Shapes and properties are emitted sorted, so two config sources produce the same class whichever loads first.
 - **Required and defaulted are exclusive.** A default is what makes an absent value legitimate; requiring it as well is two answers to one question, and is refused.
-- **`toArray()` omits what was never set**, so `fromArray($order->toArray())` round-trips to an equal instance.
+- **`toArray()` carries every property that has a value**, and omits the ones that do not — so `fromArray($order->toArray())` round-trips to an equal instance. A declared default *is* a value: `currency` appears as `'EUR'` in the array even though nobody set it, while `couponCode` — optional and undefaulted — is absent. Worth knowing where the array becomes JSON, because the consumer cannot tell a `currency` somebody chose from one nobody did.
 - **Nothing is generated while booting.** The declaration is only read by `dto:generate`.
 
 ## Not here yet

--- a/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
+++ b/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
@@ -113,6 +113,29 @@ final class DtoGenerateCommandTest extends TestCase
         self::assertNull($order->getCouponCode());
     }
 
+    /**
+     * What "omits what was never set" excludes, and what it does not. An
+     * optional property nobody set has no value and is absent; one with a
+     * declared default has a value, so it is present -- and only the round-trip
+     * was asserted, which holds either way because the default would reapply.
+     *
+     * It shows in what a consumer sees: `toArray()` reaches JSON, and a reader
+     * cannot tell a `currency` somebody chose from one nobody did.
+     */
+    public function test_an_array_carries_a_default_and_omits_a_property_with_no_value(): void
+    {
+        $this->generate();
+        require_once $this->orderFile();
+
+        /** @var class-string $class */
+        $class = $this->orderClass();
+
+        $array = $class::fromArray(['reference' => 'ord-1187', 'total' => 4990])->toArray();
+
+        self::assertSame('EUR', $array['currency'] ?? null, 'a declared default is a value, so it is carried');
+        self::assertArrayNotHasKey('couponCode', $array, 'optional with no default and never set: nothing to carry');
+    }
+
     public function test_an_array_round_trips(): void
     {
         $this->generate();


### PR DESCRIPTION
## 📚 Description

`docs/dto-schema.md` states the rule as:

> **`toArray()` omits what was never set**, so `fromArray($order->toArray())` round-trips to an equal instance.

That reads as though a defaulted property nobody set would be absent. It is not. I generated the documented shape and ran it:

```php
$order = Order::fromArray(['reference' => 'ord-1187', 'total' => 4990]);

$order->toArray();
// ['currency' => 'EUR', 'reference' => 'ord-1187', 'total' => 4990]
```

`currency` was **never set** — it is declared `->default('EUR')` — and it is carried. `couponCode`, optional and undefaulted, is absent.

So the rule is *"carries every property that has a value"*, and a declared default **is** a value — which the page already says one line earlier, about the getter: *"a declared default is not missing"*.

## 🔖 Changes

- `docs/dto-schema.md`: what is carried, what is omitted, and where it shows
- A test pinning it

## 🔎 Why the existing test did not catch it

There is one, and it passes:

```php
self::assertEquals($order, $class::fromArray($order->toArray()));
```

The round trip holds **either way**: were defaults omitted, `fromArray()` would reapply them and the two instances would still compare equal. So the assertion cannot distinguish the two behaviours, and the distinguishing one had no test at all.

It matters where the array becomes JSON: a consumer reading `currency` cannot tell one somebody chose from one nobody did, and that is better known before it is in an API response.

## 🔎 The rest of the page is accurate

Run end to end in a scratch project — `gacela.php` with the documented declaration, then `dto:generate`:

| claim | result |
|---|---|
| `dto:generate` writes the class | ✅ `wrote …/src/Checkout/Order.php` |
| optional, never set | ✅ `getCouponCode()` → `null` |
| declared default | ✅ `getCurrency()` → `'EUR'` |
| `with*()` returns a new instance | ✅ original still `null` |
| round trip | ✅ equal |
| missing required | ✅ `"App\Checkout\Order::$reference" is required but was never set.` — verbatim |
