### PR TITLE
fix(console): say what an empty list:modules means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 
 ### Changed
 
+- Say what an empty `list:modules` means. With no argument it reported `No modules match filter ""`, quoting a filter the reader never typed and giving "nothing here is a module" in the words of "your filter matched nothing". It now names the two apart, and the empty case points at the cause worth naming: discovery reflects on the class to see whether it descends from `AbstractFacade`, so a Facade whose namespace composer cannot map is skipped in silence — and the files sitting on disk are what make the empty list read as a bug in the command
+
 - Memoize the resolvable-type normalization in `DocBlockResolver`, cutting service resolution by 10–16% on all four `DocBlockResolverBench` subjects (1.130 → 0.968 µs attribute, 1.158 → 0.974 µs phpdoc, rstdev ≤ 2.9%). `getDocBlockResolvable()` asks two questions about a caller: which class the accessor names, already read through `ServiceResolverCache`, and which kind that class's suffix belongs to, which was recomputed on every call — up to three `is_a()` class lookups for an answer fixed once the class is loaded. Cleared by `Gacela::resetCache()` like the caches beside it
 
 - Name the class in the docblock-fallback deprecation, so the `#[ServiceMap]` line it suggests can be pasted. The notice printed a literal `className: ...` while reporting that it had just resolved that very class — handing back the one question it had already answered, and for a pillar named unqualified the answer depends on the file's imports *and* its namespace. It is now spelled `\Fully\Qualified\Name::class`, which pastes into any namespace unchanged

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -49,7 +49,7 @@ final class ListModulesCommand extends Command
         $modules = $this->getFacade()->findAllAppModules($filter);
 
         if ($modules === []) {
-            $output->writeln(sprintf('<comment>No modules match filter "%s".</comment>', $filter));
+            $this->reportNothingFound($output, $filter);
 
             return self::SUCCESS;
         }
@@ -65,6 +65,32 @@ final class ListModulesCommand extends Command
     private function output(): OutputInterface
     {
         return $this->output ?? new ConsoleOutput();
+    }
+
+    /**
+     * A filter that matched nothing and a project where nothing is a module are
+     * different answers, and `No modules match filter ""` gave the second one
+     * in the words of the first -- quoting an empty filter as though the reader
+     * had typed it.
+     *
+     * The hint is the cause worth naming: discovery reflects on the class to
+     * see whether it descends from `AbstractFacade`, so a file whose namespace
+     * composer cannot map is skipped in silence. The files are right there on
+     * disk, which is what makes the empty list read as a bug in the command.
+     */
+    private function reportNothingFound(OutputInterface $output, string $filter): void
+    {
+        if ($filter !== '') {
+            $output->writeln(sprintf('<comment>No modules match filter "%s".</comment>', $filter));
+
+            return;
+        }
+
+        $output->writeln('<comment>No modules found.</comment>');
+        $output->writeln(
+            'A module is found by its Facade: the filename carries the suffix, and the class has to be'
+            . ' autoloadable. If the files are there, check the psr-4 mapping in composer.json.',
+        );
     }
 
     /**

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -93,6 +93,45 @@ final class ListModulesCommandTest extends TestCase
         self::assertStringNotContainsString('ToBeIgnored', $out);
     }
 
+    /**
+     * A filter that matched nothing and a project where nothing is a module are
+     * different answers. With no argument the command used to give the second
+     * in the words of the first -- `No modules match filter ""`, quoting an
+     * empty filter as though the reader had typed one.
+     *
+     * The hint names the cause worth naming: discovery reflects on the class to
+     * see whether it descends from `AbstractFacade`, so a Facade whose
+     * namespace composer cannot map is skipped in silence, and the files sitting
+     * on disk make the empty list read as a bug in the command. It cost me an
+     * investigation before it cost anyone else one.
+     */
+    public function test_finding_nothing_without_a_filter_does_not_quote_an_empty_one(): void
+    {
+        // A real directory with nothing in it: pointing at one that does not
+        // exist makes Gacela warn about the path instead, which is a different
+        // report and would leave this asserting on the wrong thing.
+        $emptyDir = sys_get_temp_dir() . '/gacela-empty-' . bin2hex(random_bytes(4));
+        mkdir($emptyDir, 0777, true);
+
+        try {
+            Gacela::bootstrap($emptyDir, static function (GacelaConfig $config): void {
+                $config->resetInMemoryCache();
+                $config->setAppModulePaths(['.']);
+            });
+
+            $tester = new CommandTester(new ListModulesCommand());
+            $tester->execute([]);
+            $display = $tester->getDisplay();
+
+            self::assertStringContainsString('No modules found.', $display);
+            self::assertStringNotContainsString('filter ""', $display);
+            self::assertStringContainsString('autoloadable', $display);
+        } finally {
+            // Names exactly what this test created.
+            rmdir($emptyDir);
+        }
+    }
+
     public function test_non_matching_filter_reports_no_modules(): void
     {
         $this->command->execute(['filter' => 'NoSuchModuleXYZ']);


### PR DESCRIPTION
## 📚 Description

With no argument, `list:modules` reported:

```
No modules match filter ""
```

It quotes a filter the reader never typed, and gives *"nothing here is a module"* in the words of *"your filter matched nothing"*. Those are different answers.

```
No modules found.
A module is found by its Facade: the filename carries the suffix, and the class has to be
autoloadable. If the files are there, check the psr-4 mapping in composer.json.
```

The hint names the cause worth naming. Discovery reflects on the class to decide whether it descends from `AbstractFacade`, so a Facade whose namespace composer cannot map is skipped in silence — `AllAppModulesFinder::createAppModule()` returns `null` on `!class_exists(...)` and says nothing. **The files are right there on disk, which is what makes the empty list read as a bug in the command rather than in the autoload map.**

## 🔎 Found by hitting it, and isolated before reporting

A scratch project where `make:module` had just generated four modules — modules that **resolved correctly at runtime** — listed none of them. Before calling that a product bug I isolated it:

```
autoloader registered: no  -> 0 module(s)
autoloader registered: yes -> 3 module(s)
```

So it was my harness (a symlinked vendor that knows nothing about `App\`), not the product. That is the right outcome — and the message is precisely what turned it into an investigation.

## 🔖 Changes

- The two cases are named apart; the filtered message is unchanged
- One feature test, and a changelog entry

The test points `appModulePaths` at a **real empty directory** rather than a missing one: a path that does not exist makes Gacela warn about the path instead, which is a different report and would have left the assertion pointing at the wrong thing.

## 🔎 Also verified while there, nothing to change

The scaffolder is correct across every template and flag, run end to end:

| run | result |
|---|---|
| `make:module --template=service --with-tests` | 6 files; the **generated test passes as shipped** |
| `--with-tests` on `--template=basic` | refused, exit 1, naming both ways out |
| `--minimal` | Facade + Factory only |
| `--short-name` | `Facade.php`, and `App\Brief\Facade` **resolves** to `App\Brief\Factory` |
