### PR TITLE
test: pin the tree that explains why it is empty

### DIFF
--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -401,6 +401,34 @@ $reference = ' . stdClass::class . '::class;
     /**
      * @param array<string, mixed> $options
      */
+    /**
+     * `DependencyTreeInspector` catches `GacelaNotBootstrappedException` from
+     * `Gacela::container()` and reports `containerAvailable: false`, which is
+     * the one line the reader sees for it. Nothing asserted that line, and the
+     * catch it belongs to is the one #786 widened -- `Config::getInstance()`
+     * used to throw a bare `RuntimeException`, which this handler never caught.
+     *
+     * So the degrade is deliberate and now says so: `--tree` without a
+     * bootstrap explains itself instead of printing an empty tree, which would
+     * read as "this class has no dependencies".
+     */
+    public function test_the_tree_says_why_it_is_empty_without_a_bootstrap(): void
+    {
+        $gacela = new ReflectionClass(Gacela::class);
+        $gacela->getProperty('mainContainer')->setValue($gacela, value: null);
+
+        try {
+            $display = $this->inspect(BoundImplementation::class, ['--tree' => true])->getDisplay();
+
+            self::assertStringContainsString('No container available', $display);
+            self::assertStringContainsString('bootstrap Gacela to resolve the tree', $display);
+            self::assertStringNotContainsString('No transitive dependencies', $display);
+        } finally {
+            // Put the process back the way setUp() leaves it.
+            $this->setUp();
+        }
+    }
+
     private function inspect(string $argument, array $options = []): CommandTester
     {
         $tester = new CommandTester(new DebugDependenciesCommand());


### PR DESCRIPTION
## 📚 Description

`DependencyTreeInspector` catches `GacelaNotBootstrappedException` from `Gacela::container()` and reports `containerAvailable: false`. The command turns that into one line for the reader:

```
No container available — bootstrap Gacela to resolve the tree.
```

**Nothing asserted it.** Found by listing every message a console command writes and checking each against the suite — of the branches that print and return, this was the only one with no coverage at all.

## 🔎 Why it matters

Without that line, `--tree` on an unbootstrapped process prints an **empty tree**, which reads as *"this class has no dependencies"* — a wrong answer rather than an absent one. The degrade is deliberate, and now something says so.

Verified non-vacuous by deleting the early return: the test fails, and the run prints `No transitive dependencies` instead — exactly the wrong answer the line exists to prevent.

## 🔎 It is the user-visible half of #786

That fix made `Config::getInstance()` throw `GacelaNotBootstrappedException` instead of a bare `RuntimeException`, so this handler — written for that exception — finally covers the commonest way of being unbootstrapped. The catch had tests; the line it produces did not.

## 🔖 Changes

- One feature test

It restores the bootstrap in a `finally`, because it nulls a static the rest of the process shares — and the feature suite passes under three random seeds (`5521`, `991`, `7714`).

## 🔎 The rest of the sweep

Every other early-return message in a console command is asserted somewhere, either directly or through the primary message it accompanies. The remaining unmatched strings were secondary hint lines — `Pass --force to overwrite it.`, `Add --template=service, or drop --with-tests.` — each covered by the assertion on the line above it.
