### PR TITLE
feat(console): fail a validate:config run on warnings with --strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Fail a `validate:config` run on warnings with `--strict`, the bargain `doctor` has always offered: a warning is worth reading but not worth failing a build over, until a project says it is. The command reported warnings — an incompatible binding value, for one — and exited `SUCCESS` regardless, leaving grep as the only way to act on one, which is what an exit code exists to avoid. Errors still fail without it, and a clean run still passes with it
+
 - Report `doctor` as a document with `--format=json`. `--strict` already answers "did anything go wrong" with an exit code, and a job that wants to say *which* check, or repeat its remediation into a review comment, had to parse the prose — which is why `debug:graph --check` grew the same flag first. Every check is reported with its `name`, `status`, `details` and `remediation`, under an overall `status`; `--only-problems` narrows it exactly as it narrows the text report, and the exit code is unchanged. The statuses are the values `CheckStatus` already carries — `ok`, `warn`, `error` — rather than a second vocabulary invented for the report
 
 - Find which Provider declares an id with `debug:provides`. `getProvidedDependency()` answers `null` for an id nothing declares and says nothing about it, so the question that follows is "who was supposed to declare this?" — and the only way to ask it was `debug:module`, once per module. The argument narrows to ids containing it, `--json` carries the same answer, and an id nothing declares says so rather than printing an empty table. Two modules declaring one id keep both rows: each resolves through its own container, so that is two modules answering for themselves rather than a collision

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,7 +62,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 | Command | What it does |
 |---|---|
 | `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md) and each package's `composer.json` against what it imports. Takes an optional namespace to restrict module-scoped checks, `--strict` to exit non-zero on warnings too, `--only-problems` to print just the checks that found something, and `--format=json` for a CI job that wants to say *which* check failed rather than only that one did |
-| `validate:config` | Checks the configuration for errors and best-practice violations, and against the [declared schema](config-schema.md) |
+| `validate:config` | Checks the configuration for errors and best-practice violations, and against the [declared schema](config-schema.md). `--strict` exits non-zero on warnings too, as on `doctor` |
 
 Every command that can emit JSON accepts `--json`. Where a command has more than two output formats — `debug:graph`, `profile:report` — `--format=` chooses among them and `--json` is shorthand for the one you were going to pick anyway.
 

--- a/src/Console/Infrastructure/Command/ValidateConfigCommand.php
+++ b/src/Console/Infrastructure/Command/ValidateConfigCommand.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Container\Container;
 use Gacela\Framework\Gacela;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -32,6 +33,7 @@ final class ValidateConfigCommand extends Command
     {
         $this->setName('validate:config')
             ->setDescription('Validate Gacela configuration for errors and best practices')
+            ->addOption('strict', null, InputOption::VALUE_NONE, 'Exit with a failure code on warnings too, for CI')
             ->setHelp($this->getHelpText());
     }
 
@@ -69,7 +71,12 @@ final class ValidateConfigCommand extends Command
         if ($hasWarnings) {
             $output->writeln('<fg=yellow>⚠ Validation completed with warnings</fg=yellow>');
             $output->writeln('');
-            return Command::SUCCESS;
+
+            // The same bargain `doctor --strict` offers: a warning is worth
+            // reading but not worth failing a build over, until a project says
+            // it is. Without this the only way to act on one was to grep the
+            // output, which is what an exit code exists to avoid.
+            return $input->getOption('strict') === true ? Command::FAILURE : Command::SUCCESS;
         }
 
         $output->writeln('<fg=green>✓ Configuration is valid!</fg=green>');

--- a/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
+++ b/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
@@ -421,7 +421,38 @@ final class ValidateConfigCommandTest extends TestCase
     /**
      * @param Closure(GacelaConfig):void $configFn
      */
-    private function validate(Closure $configFn): CommandTester
+    /**
+     * `doctor --strict` has always offered this bargain: a warning is worth
+     * reading but not worth failing a build over, until a project says it is.
+     * This command reported warnings and exited SUCCESS with no way to say so,
+     * leaving grep as the only way to act on one -- which is what an exit code
+     * exists to avoid.
+     */
+    public function test_a_warning_fails_a_strict_run(): void
+    {
+        $tester = $this->validate(
+            static function (GacelaConfig $config): void {
+                $config->addBinding(SomeContract::class, MismatchedImplementation::class);
+            },
+            ['--strict' => true],
+        );
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('⚠ Validation completed with warnings', $tester->getDisplay());
+    }
+
+    public function test_a_clean_run_still_passes_under_strict(): void
+    {
+        $tester = $this->validate(static function (GacelaConfig $config): void {
+        }, ['--strict' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function validate(Closure $configFn, array $input = []): CommandTester
     {
         Gacela::bootstrap($this->appRoot, static function (GacelaConfig $config) use ($configFn): void {
             $config->resetInMemoryCache();
@@ -429,7 +460,7 @@ final class ValidateConfigCommandTest extends TestCase
         });
 
         $tester = new CommandTester(new ValidateConfigCommand());
-        $tester->execute([]);
+        $tester->execute($input);
 
         return $tester;
     }


### PR DESCRIPTION
## 📚 Description

`doctor --strict` has always offered this bargain: a warning is worth reading but not worth failing a build over, until a project says it is.

`validate:config` reported warnings — an incompatible binding value, for one — and exited `SUCCESS` regardless:

```
⚠ Warning: Binding value may not be compatible with key: SomeContract -> MismatchedImplementation
⚠ Validation completed with warnings
$ echo $?
0
```

Grep was the only way to act on that, which is what an exit code exists to avoid.

## 🔖 Changes

- `--strict` on `validate:config`
- Two tests: a warning fails under the flag, a clean run still passes with it
- `docs/cli.md` row and a changelog entry

Errors still fail without the flag; the existing tests cover that and are untouched.

## 🔎 How this came up, and what I checked first

After #806 and #807, tabulating the command family left `validate:config` as the only one with **no options at all**. I nearly dismissed it as covered by `doctor` — then compared what each reports:

| | `doctor` | `validate:config` |
|---|---|---|
| config schema | ✅ | ✅ |
| config sources | ✅ | — |
| **binding cycles in the container** | — | ✅ |

So they do not overlap, a CI job wanting both is running both, and only one could be told to care about warnings.

## 🔎 What I did not do

Its findings still have no machine-readable form. Giving it `--json` means refactoring three validators that write straight to the output and return booleans, in a command whose exact text several tests assert. That is a real refactor with a real chance of changing what is printed, for a command that overlaps substantially with `doctor --json` — not the right trade, so `--strict` is where I stopped.
