### PR TITLE
docs: picture the layout make:module actually writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ app/
 ├── gacela.php
 ├── config/
 └── src/
-    └── ModuleA/
-        ├── Facade.php
-        ├── Factory.php
-        ├── Provider.php
-        └── Config.php
+    └── Blog/
+        ├── BlogFacade.php
+        ├── BlogFactory.php
+        ├── BlogProvider.php
+        └── BlogConfig.php
 ```
+
+That is what `make:module App/Blog` below writes. Pass `--short-name` for `Facade.php` instead of `BlogFacade.php` — both resolve; the prefix is the default because it survives being read out of context.
 
 ## CLI
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,10 +122,10 @@ Add the optional pillars only when you actually need them:
 Scaffold just the two-file floor with the CLI:
 
 ```bash
-vendor/bin/gacela make:module App/Hello --minimal
+vendor/bin/gacela make:module App/Hello --minimal --short-name
 ```
 
-Use `make:module App/Hello` (or `--template=basic`) for the full four-pillar shape, or `--template=service` for a module wired to a `Domain` service.
+`--short-name` is what writes `Facade.php` rather than `HelloFacade.php`, matching the tree above; drop it for the prefixed names the rest of the docs use. Use `make:module App/Hello` (or `--template=basic`) for the full four-pillar shape, or `--template=service` for a module wired to a `Domain` service.
 
 `src/Hello/Greeter.php`
 ```php


### PR DESCRIPTION
## 📚 Description

The README shows a module like this:

```
└── src/
    └── ModuleA/
        ├── Facade.php
        ├── Factory.php
```

and five lines below offers `vendor/bin/gacela make:module App/Blog`. Run it:

```
$ ls src/Blog/
BlogConfig.php  BlogFacade.php  BlogFactory.php  BlogProvider.php
```

**The front page pictures one layout and its own quickstart produces another**, on a newcomer's first command. Verified by running it in a scratch project rather than reading the generator.

## 🔖 Changes

- README pictures the prefixed layout `make:module` writes, and says `--short-name` gives the other
- `docs/getting-started.md` gains the `--short-name` its own tree needs

## 🔎 The second page has the same split, from the other side

`getting-started.md` shows `Facade.php` **and** declares `final class Facade` in the code below it — then offers `make:module App/Hello --minimal`, which writes `HelloFacade.php`.

There the short names are deliberate: the page teaches the four pillars with the least noise, and rewriting its examples to `HelloFacade` would be a large diff for no gain. So the command gains the flag that produces what the tree shows — verified to output exactly `Facade.php` and `Factory.php`:

```
$ make:module App/Hello --minimal --short-name
Facade.php  Factory.php
```

## 🔎 Two of three diagrams disagreed

| page | pictures | matches the default? |
|---|---|---|
| `README.md` | `Facade.php` | ✗ |
| `docs/getting-started.md` | `Facade.php` | ✗ (its command wrote the other) |
| `docs/getting-a-dependency.md` | `CatalogFacade.php` | ✅ |

`docs/container-configuration.md` also has a tree, but it is `debug:dependencies` output rather than a module layout, so it is untouched.
