### PR TITLE
docs(symfony-bridge): document the enabled config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 
 ### Fixed
 
+- Document the Symfony bridge's `enabled` key, which the configuration has always declared and the README never mentioned. `GacelaExtension::load()` returns before registering the bootstrapper, the cache warmer or the commands when it is false, so `enabled: false` is the supported way to keep the bundle in `config/bundles.php` while leaving Gacela un-bootstrapped — and the only way to find it was to read the tree. The Laravel bridge's README already listed its own. A test now walks the config tree and asserts every declared key appears in the README, so the next one added fails rather than shipping undiscoverable
+
 - Emit a document from `profile:report --format=json` on the two runs that report nothing: profiler disabled, and nothing recorded. Both returned before the format was read and printed prose, so a consumer piping the output to a parser got a syntax error rather than an empty report — and those are the two runs a CI job most often gets. The second matters twice over: a span started and never stopped leaves `entries` empty while `unfinished` holds the only thing there is to say, and that was exactly what the JSON consumer lost. The text report still says it in words
 
 - List the `autoload-dev` prefixes too when `make:*` cannot match a namespace. The lookup searches `autoload` and `autoload-dev` together — that is what "Read autoload-dev psr-4 namespaces for gacela make commands" shipped — but the `Known PSR-4:` list it prints on a miss was built from `autoload` alone. Mistyping a namespace that lives in `autoload-dev` produced a list with no dev prefix in it at all, about namespaces Gacela had just been willing to resolve, and the list is the only thing the reader has to compare the typo against

--- a/symfony-bridge/README.md
+++ b/symfony-bridge/README.md
@@ -31,6 +31,7 @@ Plus the `#[Inject]` compiler pass, described at the bottom.
 ```yaml
 # config/packages/gacela.yaml
 gacela:
+    enabled: true                          # false leaves the kernel un-bootstrapped
     app_root_dir: '%kernel.project_dir%'   # where gacela.php lives
     cache_dir: '%kernel.cache_dir%/gacela'
     file_cache: true
@@ -43,6 +44,8 @@ gacela:
 ```
 
 Every key is validated at compile time — a mistyped one fails the build instead of quietly configuring nothing. `cache_dir` and `file_cache` left unset leave Gacela's own defaults in place.
+
+`enabled: false` is how you keep the bundle registered while leaving Gacela un-bootstrapped: the extension returns before wiring anything, so no services are registered and no commands are added. Useful for an environment that loads the bundle from `config/bundles.php` under `['all' => true]` but should not run Gacela — removing the bundle per-environment is the alternative, and this is the one you can toggle from a config file.
 
 ### External services
 

--- a/symfony-bridge/tests/ConfigurationTest.php
+++ b/symfony-bridge/tests/ConfigurationTest.php
@@ -9,6 +9,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
+use function dirname;
+use function sprintf;
+
 final class ConfigurationTest extends TestCase
 {
     public function test_an_empty_configuration_carries_the_defaults(): void
@@ -59,6 +62,35 @@ final class ConfigurationTest extends TestCase
         $this->expectException(InvalidConfigurationException::class);
 
         $this->process([['file_cache' => 'yes please']]);
+    }
+
+    /**
+     * The tree is the list of keys a project may write, and the README is the
+     * only place a project reads it from. They drifted: `enabled` was declared
+     * here, acted on by `GacelaExtension::load()` -- which returns before
+     * registering anything when it is false -- and documented nowhere, so the
+     * supported way to keep the bundle registered while leaving Gacela
+     * un-bootstrapped was undiscoverable.
+     *
+     * Asserted against the tree rather than a hand-written list, so the next key
+     * added fails this instead of shipping undocumented.
+     */
+    public function test_every_configuration_key_is_documented_in_the_readme(): void
+    {
+        $readme = (string)file_get_contents(
+            dirname(__DIR__) . DIRECTORY_SEPARATOR . 'README.md',
+        );
+
+        $children = (new Configuration())->getConfigTreeBuilder()->buildTree()->getChildren();
+        self::assertNotEmpty($children, 'no keys to check would make this pass for nothing');
+
+        foreach ($children as $name => $_node) {
+            self::assertStringContainsString(
+                $name . ':',
+                $readme,
+                sprintf('config key "%s" is declared but the README never mentions it', $name),
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

`symfony-bridge/src/DependencyInjection/Configuration.php` declares **8** keys. `symfony-bridge/README.md` documented **7**. The missing one was `enabled`, and it is not decorative:

```php
if (!$config['enabled']) {
    return;
}
```

`GacelaExtension::load()` returns there — before registering the bootstrapper, the cache warmer or the commands. So `enabled: false` is the supported way to keep the bundle in `config/bundles.php` under `['all' => true]` while leaving Gacela un-bootstrapped, and the only way to discover it was to read the config tree.

The Laravel bridge's README already documents its own `enabled`, so this was a gap in one bridge rather than a decision taken across both.

Closes #814

## 🔖 Changes

- `enabled: true` added to the README's YAML block, with what `false` does
- A paragraph saying what it actually switches off, and why you would reach for it over removing the bundle per-environment
- `test_every_configuration_key_is_documented_in_the_readme` walks `getConfigTreeBuilder()->buildTree()->getChildren()` and asserts each name appears in the README — built from the tree rather than a hand-written list, so the next key added fails this instead of shipping undiscoverable
- The guard asserts the child list is non-empty first, so an empty tree cannot pass it for nothing

Verified the guard is not vacuous: temporarily declaring an `undocumented_probe` node reds it with `config key "undocumented_probe" is declared but the README never mentions it`.

The behaviour itself was already covered — `GacelaExtensionTest` loads `[['enabled' => false]]` — so this is the documentation catching up to it, not a fix to the bundle.
