### PR TITLE
perf(console): ask whether a class is a Facade before building a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Changed
 
+- Ask whether a class is a Facade before building a module out of it. Module discovery built an `AppModule` for *every* class in the project — three class resolvers run for a Factory, a Config and a Provider — and then discarded it for the ~90% that turned out not to be Facades. On a 121-module project that step was 1292 constructions to keep 121, and asking first costs a `ReflectionClass` on a set it already had. Discovery drops from a 251 ms median to 238 ms (15 runs each, same 121 modules found)
+
 - Accept `--json` on every command that can emit it. Two spellings had grown side by side — `--json` where a command has exactly two output formats (`debug:module`, `debug:provides`) and `--format=json` where it has more (`debug:graph`, `profile:report`, and `doctor` as of this release) — so a reader who learned one met `The "--json" option does not exist.` on the other, in both directions. `--json` now works everywhere; `--format` still chooses among the commands that offer a real choice, and the two produce the same document
 
 - Say what an empty module listing means, in `list:modules`, `debug:graph` and `debug:modules` alike. With no argument the first two reported `No modules match filter ""`, quoting a filter the reader never typed and giving "nothing here is a module" in the words of "your filter matched nothing"; the third had its own third wording. One message now answers for all of them, and the empty case names the cause worth naming: discovery reflects on the class to see whether it descends from `AbstractFacade`, so a Facade whose namespace composer cannot map is skipped in silence — and the files sitting on disk are what make the empty list read as a bug in the command

--- a/infection.json5
+++ b/infection.json5
@@ -172,7 +172,7 @@
         },
         // normalizeDirectory(): Windows-specific branches (UNC/backslash folding)
         // that are dead code on the POSIX machines running this suite.
-        // createAppModule()/getNamespace(): the realPath and file_get_contents
+        // findFacadeClass()/getNamespace(): the realPath and file_get_contents
         // false-branches need a file that vanishes or turns unreadable between the
         // directory scan and the read, i.e. a filesystem race. buildClassName()'s
         // `strpos() !== false` needs an extensionless file, which the .php filter
@@ -183,7 +183,7 @@
         FalseValue: {
             ignore: [
                 "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
-                "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::createAppModule",
+                "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::findFacadeClass",
                 "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::getNamespace",
                 "Gacela\\Console\\Domain\\AllAppModules\\AllAppModulesFinder::buildClassName",
                 "Gacela\\Console\\Domain\\AllAppModules\\AppModuleCreator::fullModuleName",

--- a/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
+++ b/src/Console/Domain/AllAppModules/AllAppModulesFinder.php
@@ -31,10 +31,12 @@ final class AllAppModulesFinder
 
         /** @var SplFileInfo $fileInfo */
         foreach ($this->fileIterator as $fileInfo) {
-            $appModule = $this->createAppModule($fileInfo, $filter);
-            if ($appModule instanceof AppModule && $this->isFacade($appModule)) {
-                $result[$appModule->facadeClass()] = $appModule;
+            $facadeClass = $this->findFacadeClass($fileInfo, $filter);
+            if ($facadeClass === null) {
+                continue;
             }
+
+            $result[$facadeClass] = $this->appModuleCreator->fromClass($facadeClass);
         }
 
         uksort($result, static fn ($a, $b): int => $a <=> $b);
@@ -42,7 +44,19 @@ final class AllAppModulesFinder
         return array_values($result);
     }
 
-    private function createAppModule(SplFileInfo $fileInfo, string $filter): ?AppModule
+    /**
+     * The class this file declares, when it is a Facade -- and nothing more.
+     *
+     * The module used to be built first and the Facade question asked of it
+     * afterwards, so every class in the project got an `AppModule`: three class
+     * resolvers run for a Factory, a Config and a Provider, each one resolving
+     * to an *instance*, and the whole thing discarded for the ~90% of classes
+     * that are not Facades at all. Asking first costs a `ReflectionClass` and
+     * answers for the same set.
+     *
+     * @return ?class-string
+     */
+    private function findFacadeClass(SplFileInfo $fileInfo, string $filter): ?string
     {
         $realPath = $fileInfo->getRealPath();
 
@@ -79,7 +93,11 @@ final class AllAppModulesFinder
             return null;
         }
 
-        return $this->appModuleCreator->fromClass($fullyQualifiedClassName);
+        if (!$this->isFacade($fullyQualifiedClassName)) {
+            return null;
+        }
+
+        return $fullyQualifiedClassName;
     }
 
     private function getNamespace(SplFileInfo $fileInfo): string
@@ -118,10 +136,12 @@ final class AllAppModulesFinder
      *
      * isSubclassOf() is false for AbstractFacade itself, which is what we want:
      * the base class is not a module.
+     *
+     * @param class-string $className
      */
-    private function isFacade(AppModule $appModule): bool
+    private function isFacade(string $className): bool
     {
-        return (new ReflectionClass($appModule->facadeClass()))
+        return (new ReflectionClass($className))
             ->isSubclassOf(AbstractFacade::class);
     }
 }


### PR DESCRIPTION
## 📚 Description

Module discovery built an `AppModule` for **every class in the project**, then discarded it when the class turned out not to be a Facade. Building one runs three class resolvers — Factory, Config and Provider. On this repo scanned whole that is **1292 constructions to keep 121**.

The Facade check was already there; only its position moves.

```php
// before: build, then ask
$appModule = $this->createAppModule($fileInfo, $filter);
if ($appModule instanceof AppModule && $this->isFacade($appModule)) { … }

// after: ask, then build
$facadeClass = $this->findFacadeClass($fileInfo, $filter);
if ($facadeClass === null) { continue; }
$result[$facadeClass] = $this->appModuleCreator->fromClass($facadeClass);
```

Related to #811

## 📈 Measurement

Baseline `3515d5cd`, PHP 8.4.24, `XDEBUG_MODE=off`, this repo scanned whole (121 modules, 1990 files — **not** the `src`-only scan its own `gacela.php` configures). 15 separate processes per side, since class loading is sticky and an in-process repeat measures a warm cache:

| | min | median | max |
|---|---|---|---|
| before | 230.7 | 251.4 | 269.9 |
| after | **223.3** | **238.3** | **247.3** |

Same 121 modules either way. ~5% — modest, and the honest number.

No benchmark is added here on purpose: changing the corpus in the same commit that measures a delta invalidates the measurement. A discovery benchmark is worth landing on its own.

## 🔖 Changes

- `createAppModule()` → `findFacadeClass()`, returning `?class-string` instead of a built module
- `isFacade()` takes the class name rather than an `AppModule` it only used to read one field off
- `infection.json5`'s ignore entry and its explanatory comment follow the rename — `InfectionConfigTest` caught this, which is the guard working

## ⚠️ What this does *not* do

#811 asks for the big win, and I could not find one. Recording the measurements so nobody repeats the attempts:

**Component breakdown** of the 223.6 ms run — the assumption that class loading dominates is only half right:

| step | ms | share |
|---|---|---|
| `class_exists` | 96.9 | 43% |
| iterator walk | 67.7 | 30% |
| file read | 30.9 | 14% |
| `AppModule` construction | 21.3 | 10% |
| namespace regex | 0.4 | — |
| `isSubclassOf` | 0.2 | — |

**A "no `extends`" source pre-filter** (a class extending nothing provably cannot be a Facade) is *correct* — 121 modules, no loss — and skips 478 loads. It bought 13–26 ms. Real but small, because avoided loads are only ~0.05 ms each.

**Full static inheritance resolution** — parse every file's `extends`, resolve through `use` statements, walk the chain, load only what reaches `AbstractFacade` or has an unresolvable parent — finds exactly the right 121 and would cut loads from 1327 to 546. But 425 files have parents outside the scanned set and must be loaded anyway, and the resolve pass costs ~103 ms to save ~38 ms of loading. **Net loss.**

The remaining 30% in the iterator walk is untouched and is where any further win would have to come from.
