### PR TITLE
test: reattach the thirteen orphaned docblocks in tests/

### DIFF
--- a/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
+++ b/tests/Feature/Console/DebugDependencies/DebugDependenciesCommandTest.php
@@ -399,9 +399,6 @@ $reference = ' . stdClass::class . '::class;
     }
 
     /**
-     * @param array<string, mixed> $options
-     */
-    /**
      * `DependencyTreeInspector` catches `GacelaNotBootstrappedException` from
      * `Gacela::container()` and reports `containerAvailable: false`, which is
      * the one line the reader sees for it. Nothing asserted that line, and the
@@ -429,6 +426,9 @@ $reference = ' . stdClass::class . '::class;
         }
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     private function inspect(string $argument, array $options = []): CommandTester
     {
         $tester = new CommandTester(new DebugDependenciesCommand());

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -369,10 +369,6 @@ final class DoctorCommandTest extends TestCase
     }
 
     /**
-     * @param list<object|string> $healthChecks
-     * @param array<string, bool|string> $input
-     */
-    /**
      * `--strict` already answers "did anything go wrong" with an exit code. A
      * job that wants to say *which* check, and repeat its remediation into a
      * review comment, had to parse the prose -- which is why
@@ -509,6 +505,10 @@ final class DoctorCommandTest extends TestCase
         );
     }
 
+    /**
+     * @param list<object|string> $healthChecks
+     * @param array<string, bool|string> $input
+     */
     private function doctor(array $healthChecks, array $input = []): CommandTester
     {
         $this->bootstrapDoctor($healthChecks);

--- a/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
+++ b/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
@@ -224,9 +224,6 @@ final class DtoGenerateCommandTest extends TestCase
     }
 
     /**
-     * @param list<string> $classNames
-     */
-    /**
      * The CI question this command could not answer: are the generated classes
      * in the repository up to date with what `gacela.php` declares? `--dry-run`
      * reports it and exits 0 either way, so a job had to parse the output.
@@ -295,6 +292,9 @@ final class DtoGenerateCommandTest extends TestCase
         );
     }
 
+    /**
+     * @param list<string> $classNames
+     */
     private function generateMany(array $classNames): CommandTester
     {
         Gacela::bootstrap($this->projectDir, static function (GacelaConfig $config) use ($classNames): void {

--- a/tests/Feature/Console/ProfileReport/ProfileReportCommandTest.php
+++ b/tests/Feature/Console/ProfileReport/ProfileReportCommandTest.php
@@ -177,9 +177,6 @@ final class ProfileReportCommandTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $input
-     */
-    /**
      * An operation missing from the report because its `stop()` misspelled the
      * subject looks exactly like one that was never instrumented. This is the
      * difference.
@@ -303,6 +300,9 @@ final class ProfileReportCommandTest extends TestCase
         self::assertStringNotContainsString('Started and never stopped', $display);
     }
 
+    /**
+     * @param array<string, string> $input
+     */
     private function runCommand(array $input): CommandTester
     {
         $tester = new CommandTester(new ProfileReportCommand());

--- a/tests/Feature/Console/Stubs/StubsPublishCommandTest.php
+++ b/tests/Feature/Console/Stubs/StubsPublishCommandTest.php
@@ -239,10 +239,6 @@ final class StubsPublishCommandTest extends TestCase
     }
 
     /**
-     * The repository is its own scaffolding target: `data/` is a psr-4 path
-     * here, and the generator writes relative to the working directory.
-     */
-    /**
      * The stub filenames a run reported, whichever verb reported them.
      *
      * @return list<string>
@@ -254,6 +250,10 @@ final class StubsPublishCommandTest extends TestCase
         return $matches[1];
     }
 
+    /**
+     * The repository is its own scaffolding target: `data/` is a psr-4 path
+     * here, and the generator writes relative to the working directory.
+     */
     private function bootstrapRepositoryWithStubsDir(): void
     {
         $stubsDir = $this->stubsDir;

--- a/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
+++ b/tests/Feature/Console/ValidateConfig/ValidateConfigCommandTest.php
@@ -419,9 +419,6 @@ final class ValidateConfigCommandTest extends TestCase
     }
 
     /**
-     * @param Closure(GacelaConfig):void $configFn
-     */
-    /**
      * `doctor --strict` has always offered this bargain: a warning is worth
      * reading but not worth failing a build over, until a project says it is.
      * This command reported warnings and exited SUCCESS with no way to say so,
@@ -639,6 +636,7 @@ final class ValidateConfigCommandTest extends TestCase
     }
 
     /**
+     * @param Closure(GacelaConfig):void $configFn
      * @param array<string, mixed> $input
      */
     private function validate(Closure $configFn, array $input = []): CommandTester

--- a/tests/Integration/Architecture/OrphanedDocblockTest.php
+++ b/tests/Integration/Architecture/OrphanedDocblockTest.php
@@ -30,28 +30,32 @@ use function token_get_all;
  * analysers only notice when the annotation was load-bearing for a type, which
  * is how one of these reached `main` and stayed.
  *
- * There were nine in `src/` when this test was written, and three more
- * introduced in a single afternoon. It is an easy edit to make and an easy one
- * to miss in review, which is exactly the kind a test should own.
+ * There were twenty-one across the repository when this test was written,
+ * three of them introduced in a single afternoon. It is an easy edit to make
+ * and an easy one to miss in review, which is exactly the kind a test should
+ * own.
  *
- * `tests/` is not covered yet -- the same fault is there and is tracked
- * separately, so this starts where a wrong `@param` reaches a reader of the
- * shipped code.
+ * `tests/` is covered too: the annotations there feed psalm and phpstan the
+ * same way, so a `@param list<string>` attached to the wrong method is a type
+ * assertion about the wrong thing wherever it sits.
  */
 final class OrphanedDocblockTest extends TestCase
 {
     /** @var list<string> */
-    private const SHIPPED_DIRECTORIES = [
+    private const SCANNED_DIRECTORIES = [
         'src',
+        'tests',
         'symfony-bridge/src',
         'laravel-bridge/src',
+        'symfony-bridge/tests',
+        'laravel-bridge/tests',
     ];
 
     public function test_no_docblock_describes_another_docblock(): void
     {
         $orphans = [];
 
-        foreach (self::SHIPPED_DIRECTORIES as $directory) {
+        foreach (self::SCANNED_DIRECTORIES as $directory) {
             foreach ($this->phpFilesIn($directory) as $file) {
                 foreach ($this->orphansIn($file) as $line) {
                     $orphans[] = sprintf('%s:%d', $this->relative($file), $line);
@@ -67,13 +71,13 @@ final class OrphanedDocblockTest extends TestCase
     }
 
     /**
-     * The scan finds something, so an empty result means the shipped code is
+     * The scan finds something, so an empty result means the code is
      * clean rather than the walk being broken.
      */
-    public function test_the_scan_reaches_the_shipped_code(): void
+    public function test_the_scan_reaches_the_code(): void
     {
         $files = [];
-        foreach (self::SHIPPED_DIRECTORIES as $directory) {
+        foreach (self::SCANNED_DIRECTORIES as $directory) {
             foreach ($this->phpFilesIn($directory) as $file) {
                 $files[] = $file;
             }

--- a/tests/Integration/Framework/Container/AfterResolvingHookTest.php
+++ b/tests/Integration/Framework/Container/AfterResolvingHookTest.php
@@ -336,9 +336,6 @@ final class AfterResolvingHookTest extends TestCase
     }
 
     /**
-     * @param callable(GacelaConfig):void $configFn
-     */
-    /**
      * Resolving through `?->` made a service that failed to resolve read as a
      * null logger, so the assertion failed on the value instead of on the cause.
      */
@@ -358,6 +355,9 @@ final class AfterResolvingHookTest extends TestCase
         return $service;
     }
 
+    /**
+     * @param callable(GacelaConfig):void $configFn
+     */
     private function bootstrapWith(callable $configFn): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {

--- a/tests/Unit/Console/Application/Doctor/Check/ServiceExtensionTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/ServiceExtensionTargetCheckTest.php
@@ -128,9 +128,6 @@ final class ServiceExtensionTargetCheckTest extends TestCase
     }
 
     /**
-     * @param class-string|null $providerClass
-     */
-    /**
      * `extendProviderService()` names the Provider, so the miss is sharper
      * than the app-wide one: not "nobody set this id" but "the Provider you
      * named does not". Its own docblock promised `doctor` reported this, and
@@ -221,6 +218,9 @@ final class ServiceExtensionTargetCheckTest extends TestCase
         self::assertContains('2 extension id(s) matched', $check->run()->details);
     }
 
+    /**
+     * @param class-string|null $providerClass
+     */
     private function module(?string $providerClass): AppModule
     {
         return new AppModule(

--- a/tests/Unit/Console/Application/Doctor/Check/UndiscoveredFacadeCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/UndiscoveredFacadeCheckTest.php
@@ -52,9 +52,8 @@ final class UndiscoveredFacadeCheckTest extends TestCase
     /**
      * The two faults have different fixes, which is the whole reason to tell
      * them apart rather than report "not found".
-     */
-    /**
-     * Whole sentences, not fragments of them. A remediation is the one line a
+     *
+     * Whole sentences, not fragments of them: a remediation is the one line a
      * reader acts on, and `assertStringContainsString('psr-4', ...)` passes just
      * as happily for half a sentence in the wrong order.
      */

--- a/tests/Unit/Framework/Plugins/LazyPluginStackTest.php
+++ b/tests/Unit/Framework/Plugins/LazyPluginStackTest.php
@@ -75,11 +75,6 @@ final class LazyPluginStackTest extends TestCase
     }
 
     /**
-     * A class name in gacela.php is a string until something loads it, so the
-     * contract is checked on first resolve -- and the failure names the class
-     * and the stack, instead of a TypeError wherever the consumer used it.
-     */
-    /**
      * A class name in `gacela.php` is a string until something loads it, and
      * the container answers `null` for one that resolves to nothing -- so the
      * contract check reported a missing class as one that "does not implement"

--- a/tests/Unit/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/FacadeInterfaceInSyncAnalyserTest.php
@@ -6,7 +6,6 @@ namespace GacelaTest\Unit\StaticAnalysis\Rules;
 
 use Gacela\Framework\AbstractFacade;
 use Gacela\StaticAnalysis\Rules\FacadeInterfaceInSyncAnalyser;
-use Gacela\StaticAnalysis\Violation;
 use GacelaTest\Unit\StaticAnalysis\Double\FakeAnalysedClass;
 use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
 use PHPUnit\Framework\TestCase;
@@ -18,13 +17,12 @@ final class FacadeInterfaceInSyncAnalyserTest extends TestCase
      * the scan, not end it, or a single private method near the top of a facade
      * hides every drifted method behind it.
      *
+     * The static method sits *between* two instance methods for the same
+     * reason: it is skipped, and skipping must not abandon the methods after
+     * it. With it last, `continue` and `break` are indistinguishable.
+     *
      * Kept as a string rather than a fixture file because cs-fixer reorders a
      * real class by visibility, which would undo exactly that ordering.
-     */
-    /**
-     * The static method sits *between* two instance methods on purpose: it is
-     * skipped, and skipping must not abandon the methods after it. With it
-     * last, `continue` and `break` are indistinguishable.
      */
     private const SOURCE = <<<'PHP'
         <?php
@@ -133,11 +131,6 @@ final class FacadeInterfaceInSyncAnalyserTest extends TestCase
     }
 
     /**
-     * @param list<string> $declaredInInterface
-     *
-     * @return list<Violation>
-     */
-    /**
      * The drift this rule catches is a consumer holding the interface being
      * unable to reach a method. A static one is not reached through an
      * instance anyway, so requiring it would force every implementer -- test
@@ -151,6 +144,11 @@ final class FacadeInterfaceInSyncAnalyserTest extends TestCase
         self::assertSame([], $violations);
     }
 
+    /**
+     * @param list<string> $declaredInInterface
+     *
+     * @return list<Violation>
+     */
     private function analyse(array $declaredInInterface): array
     {
         $analyser = new FacadeInterfaceInSyncAnalyser();

--- a/tests/Unit/StaticAnalysis/Rules/FacadeOnlyDelegatesAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/FacadeOnlyDelegatesAnalyserTest.php
@@ -178,9 +178,6 @@ final class FacadeOnlyDelegatesAnalyserTest extends TestCase
     }
 
     /**
-     * @return list<Violation>
-     */
-    /**
      * A static method has no `$this` to delegate through, so no body it could
      * hold would satisfy this rule -- and the tip names a call it cannot make.
      * Reporting it leaves a rename or a baseline entry as the only way out,
@@ -202,6 +199,9 @@ final class FacadeOnlyDelegatesAnalyserTest extends TestCase
         self::assertNotSame([], $this->analyse('$x = 1; return $x + 1;'));
     }
 
+    /**
+     * @return list<Violation>
+     */
     private function analyse(string $body, string $visibility = 'public'): array
     {
         return $this->analyseSource(


### PR DESCRIPTION
## 📚 Description

Finishes what #824 started. That PR fixed the nine orphaned docblocks in the shipped code and scoped the guard to `src/`, leaving thirteen in `tests/` tracked as #825. These are those thirteen, and the guard now covers the whole repository.

The annotations in `tests/` feed psalm and phpstan the same way — a `@param list<string>` attached to the wrong method is a type assertion about the wrong thing wherever it sits.

Closes #825

## 🔖 Changes

**Three shapes, not one**, which is why #825 said this was never going to be a script:

- **A helper's `@param` stranded above the test methods added in front of it** — eight of these. Each moved onto the helper it names: `bootstrapWith()`, `validate()`, `inspect()`, `doctor()`, `generateMany()`, `runCommand()`, `analyse()`, `module()`
- **A stale duplicate left by a rewrite** — `LazyPluginStackTest` had two docblocks saying the same thing in different words; `UndiscoveredFacadeCheckTest` had two halves of one thought, because I replaced its docblock during the mutation-testing fix and kept both. Merged and deduplicated respectively
- **Two complementary notes on one const** — `FacadeInterfaceInSyncAnalyserTest::SOURCE` had one explaining why the skipped methods come first and another explaining why the static method sits between two instance methods. Both true, neither redundant, so they are one docblock now

`tests`, `symfony-bridge/tests` and `laravel-bridge/tests` added to the guard's scan, and `SHIPPED_DIRECTORIES` renamed to `SCANNED_DIRECTORIES` to match.

## ⚠️ Two of the thirteen were mine

Introduced in #820 and #822 — while this pattern was already the thing I was fixing. That is the argument for the guard rather than for care: it is an easy edit to make, an easy one to miss in review, and knowing about it demonstrably does not prevent it.

## 🧪 Verification

`0` orphans repo-wide, from the same token scan that found the original 21. The full gate is green, and the guard was already proven to fail on an injected orphan in #824.
