### PR TITLE
feat(console): fail a debug:modules run on an unsatisfiable pillar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Fail a `debug:modules` run on an unsatisfiable pillar with `--check`. The command already counted the constructor parameters the container cannot supply and exited `SUCCESS` regardless, so acting on that count meant grepping the output. Only faults fail it — an unbound interface, a scalar with no default, a missing type hint, a type that does not exist. A union or intersection type is not walked by the inspector, so it is reported and deliberately does not fail the run: that is a gap in the tool rather than a fault in the project
+
 - Document `setAppModulePaths()`, which decides how much of a project every CLI command walks. Unconfigured, the module scan starts at the project root: on this repository that is 14,290 filesystem entries against 1,826 when narrowed, same modules found, discovery dropping from roughly 220 ms to 157 ms. It is a CLI and `cache:warm` cost, not a request-time one, so the note sits with the commands and is linked from the deploy step that pays it
 - Preview what a scaffolder would write with `--dry-run`, on `make:module`, `make:file` and `stubs:publish`. The preview resolves its paths through the same code generation uses, so it names the files the real run writes, and it refuses where the real run refuses. "Would replace" is said separately from "would create", because losing a file's content is the case a preview exists to check
 - Emit the effective configuration from `debug:config --json`, for diffing environments. Each key carries its `declared`/`undeclared`/`missing` verdict against the schema, values keep their own types (`true` a boolean, `42` an int), and a filter matching nothing is an empty list

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,7 +50,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 | Command | What it does |
 |---|---|
 | `list:modules` | Renders every module found. `--detailed` for one block per module; `--json` for the whole inventory with every pillar, filter and all |
-| `debug:modules` | Dependency resolvability of every module pillar |
+| `debug:modules` | Dependency resolvability of every module pillar. `--detail` for every parameter rather than only the unresolvable ones; `--check` exits non-zero when the container cannot satisfy one, for CI |
 | `debug:module App/Blog` | One module: resolved classes, the ids its Provider declares with `#[Provides]`, container bindings, dependency tree |
 | `debug:provides ID` | Which Provider declares an id with `#[Provides]`, across every module — the inverse of `getProvidedDependency()`, which answers `null` for an id nothing declares and says nothing about it. The argument narrows to ids containing it; `--json` for a script |
 | `debug:config` | The effective merged configuration, after every source and override, each key marked `declared`, `undeclared` or `missing` against the [schema](config-schema.md). `--json` keeps the values as their own types, for diffing one environment against another |
@@ -58,7 +58,9 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 | `debug:dependencies Foo::class` | A class's constructor parameters and whether the container can supply each. `--tree` walks the whole graph and marks every node `binding`, `instance`, `autowired` or `unresolvable` |
 | `debug:graph` | The module dependency graph. `--format=text\|mermaid\|graphviz\|json`, `--check` to fail on cycles, `--compare-to`. `--allowed-cycles` and `--rules` are read only by `--check`, and are refused without it |
 
-`debug:graph --check` is the one built for CI; see [module boundaries](module-boundaries.md) for wiring it into a workflow.
+Two of these are built for CI. `debug:graph --check` fails on a dependency cycle — see [module boundaries](module-boundaries.md) for wiring it into a workflow — and `debug:modules --check` fails when a pillar needs a constructor parameter the container cannot satisfy.
+
+`--check` fails only on parameters the inspector looked at and rejected: an unbound interface, a scalar with no default, a missing type hint, a type that does not exist. A union or intersection type is **not** walked, so it is reported as unresolvable and does not fail the run — that is a gap in the tool rather than a fault in your project. The count of those is printed, so a passing `--check` does not read as "every parameter was checked".
 
 ### Where these commands look for modules
 

--- a/src/Console/Application/Debug/ConstructorInspection.php
+++ b/src/Console/Application/Debug/ConstructorInspection.php
@@ -35,6 +35,43 @@ final class ConstructorInspection
     }
 
     /**
+     * Parameters the container cannot satisfy, having looked.
+     *
+     * Narrower than {@see unresolvableCount()}, which also counts the ones the
+     * inspector declined to read: a union-typed parameter is not walked, and
+     * failing a build over it would blame a project for a gap in this tool.
+     */
+    public function faultCount(): int
+    {
+        $faults = 0;
+
+        foreach ($this->parameters as $parameter) {
+            if ($parameter->status->isFault()) {
+                ++$faults;
+            }
+        }
+
+        return $faults;
+    }
+
+    /**
+     * Parameters nothing here has an opinion about, reported so a clean run
+     * does not read as "everything was checked".
+     */
+    public function notInspectedCount(): int
+    {
+        $notInspected = 0;
+
+        foreach ($this->parameters as $parameter) {
+            if ($parameter->status->isNotInspected()) {
+                ++$notInspected;
+            }
+        }
+
+        return $notInspected;
+    }
+
+    /**
      * @return list<ParameterInspection>
      */
     public function unresolvableParameters(): array

--- a/src/Console/Application/Debug/ParameterStatus.php
+++ b/src/Console/Application/Debug/ParameterStatus.php
@@ -23,4 +23,29 @@ enum ParameterStatus: string
             default => false,
         };
     }
+
+    /**
+     * The inspector declined to look, rather than looked and found a problem.
+     *
+     * Union and intersection types are not walked, so a parameter typed that
+     * way is unresolvable only in the sense that nothing here has an opinion
+     * about it. That is a gap in this tool, and a check that failed a build
+     * over it would be blaming a project for using a language feature.
+     */
+    public function isNotInspected(): bool
+    {
+        return $this === self::UnsupportedType;
+    }
+
+    /**
+     * The container cannot satisfy this parameter, and said so after looking.
+     *
+     * `MissingType` belongs here rather than beside `UnsupportedType`: a type
+     * that does not exist is a typo or a deleted class, not a shape the
+     * inspector declined to read.
+     */
+    public function isFault(): bool
+    {
+        return !$this->isResolvable() && !$this->isNotInspected();
+    }
 }

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -39,7 +39,8 @@ final class DebugModulesCommand extends Command
             ->setDescription('Show dependency resolvability of every Gacela module pillar (Facade, Factory, Config, Provider)')
             ->setHelp($this->getHelpText())
             ->addArgument('filter', InputArgument::OPTIONAL, 'Restrict output to a namespace substring (e.g. "App\\\\Shop") or a directory on disk (e.g. "src/")', '')
-            ->addOption('detail', 'd', InputOption::VALUE_NONE, 'Include every parameter, not just unresolvable ones');
+            ->addOption('detail', 'd', InputOption::VALUE_NONE, 'Include every parameter, not just unresolvable ones')
+            ->addOption('check', null, InputOption::VALUE_NONE, 'Exit non-zero when a pillar has a parameter the container cannot satisfy, for CI');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -74,6 +75,8 @@ final class DebugModulesCommand extends Command
         $moduleCount = 0;
         $pillarCount = 0;
         $unresolvableTotal = 0;
+        $faultTotal = 0;
+        $notInspectedTotal = 0;
 
         foreach ($modules as $module) {
             $pillars = $this->existingPillarClasses($module);
@@ -85,6 +88,8 @@ final class DebugModulesCommand extends Command
                 ++$pillarCount;
                 $inspection = $inspector->inspect($pillarClass);
                 $unresolvableTotal += $inspection->unresolvableCount();
+                $faultTotal += $inspection->faultCount();
+                $notInspectedTotal += $inspection->notInspectedCount();
 
                 $this->writePillar($output, $inspection, $detail);
             }
@@ -94,7 +99,47 @@ final class DebugModulesCommand extends Command
 
         $this->writeSummary($output, $moduleCount, $pillarCount, $unresolvableTotal);
 
-        return Command::SUCCESS;
+        if ($input->getOption('check') !== true) {
+            return Command::SUCCESS;
+        }
+
+        return $this->checkVerdict($output, $faultTotal, $notInspectedTotal);
+    }
+
+    /**
+     * The CI half. This command already counted the pillars nothing can build
+     * and exited `SUCCESS` regardless, so acting on the count meant grepping
+     * the output -- which is what an exit code exists to avoid.
+     *
+     * Only faults fail. A union-typed parameter is reported as unresolvable
+     * because the inspector does not walk one, and failing a build over that
+     * would blame a project for a gap in this tool rather than for anything it
+     * did. It is still named, so a passing `--check` does not read as "every
+     * parameter was checked".
+     */
+    private function checkVerdict(OutputInterface $output, int $faultTotal, int $notInspectedTotal): int
+    {
+        if ($notInspectedTotal > 0) {
+            $output->writeln(sprintf(
+                '<comment>%d parameter%s not inspected (union or intersection types), and not counted against this check.</comment>',
+                $notInspectedTotal,
+                $notInspectedTotal === 1 ? '' : 's',
+            ));
+        }
+
+        if ($faultTotal === 0) {
+            $output->writeln('<fg=green>✓ Every inspected parameter can be satisfied.</>');
+
+            return Command::SUCCESS;
+        }
+
+        $output->writeln(sprintf(
+            '<error>✗ %d parameter%s the container cannot satisfy.</error>',
+            $faultTotal,
+            $faultTotal === 1 ? '' : 's',
+        ));
+
+        return Command::FAILURE;
     }
 
     private function asPathFilter(string $filter): ?string

--- a/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
+++ b/tests/Feature/Console/DebugModules/DebugModulesCommandTest.php
@@ -229,6 +229,64 @@ final class DebugModulesCommandTest extends TestCase
     }
 
     /**
+     * The command already counted the pillars nothing can build and exited
+     * `SUCCESS` regardless, so acting on the count meant grepping the output --
+     * which is what an exit code exists to avoid.
+     */
+    public function test_check_fails_when_a_pillar_needs_something_the_container_cannot_supply(): void
+    {
+        $tester = $this->debugModules('BrokenFixtures', ['--check' => true]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('the container cannot satisfy', $tester->getDisplay());
+    }
+
+    public function test_check_passes_when_every_pillar_resolves(): void
+    {
+        $tester = $this->debugModules('Fixtures', ['--check' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('Every inspected parameter can be satisfied', $tester->getDisplay());
+    }
+
+    /**
+     * The reason `--check` is not simply `unresolvableCount() > 0`.
+     *
+     * A union-typed parameter is reported as unresolvable because the inspector
+     * does not walk one -- that is a gap in this tool, and failing a build over
+     * it would blame a project for using a language feature.
+     */
+    public function test_check_does_not_fail_on_a_parameter_it_declined_to_inspect(): void
+    {
+        $tester = $this->debugModules('UnionFixtures', ['--check' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('not inspected', $tester->getDisplay());
+    }
+
+    /**
+     * ...and it is still named, so a passing `--check` does not read as "every
+     * parameter was checked".
+     */
+    public function test_an_uninspected_parameter_is_still_reported_as_unresolvable(): void
+    {
+        $tester = $this->debugModules('UnionFixtures', []);
+
+        self::assertStringContainsString('1 unresolvable parameter', $tester->getDisplay());
+    }
+
+    /**
+     * Without the flag the command reports and passes, exactly as before.
+     */
+    public function test_without_check_a_broken_module_still_exits_successfully(): void
+    {
+        $tester = $this->debugModules('BrokenFixtures', []);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringNotContainsString('the container cannot satisfy', $tester->getDisplay());
+    }
+
+    /**
      * @param array<string, bool|string> $input
      * @param array<string, bool> $options
      */

--- a/tests/Feature/Console/DebugModules/UnionFixtures/UnionModule/UnionModuleFacade.php
+++ b/tests/Feature/Console/DebugModules/UnionFixtures/UnionModule/UnionModuleFacade.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\UnionFixtures\UnionModule;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<UnionModuleFactory>
+ */
+final class UnionModuleFacade extends AbstractFacade
+{
+}

--- a/tests/Feature/Console/DebugModules/UnionFixtures/UnionModule/UnionModuleFactory.php
+++ b/tests/Feature/Console/DebugModules/UnionFixtures/UnionModule/UnionModuleFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModules\UnionFixtures\UnionModule;
+
+use Gacela\Framework\AbstractFactory;
+
+/**
+ * A union-typed constructor parameter, which `ConstructorInspector` does not
+ * walk. It is reported as unresolvable because nothing here has an opinion
+ * about it -- and `--check` must not fail a build over a gap in the tool.
+ */
+final class UnionModuleFactory extends AbstractFactory
+{
+    public function __construct(
+        public readonly int|string $eitherWay,
+    ) {
+    }
+}

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectionTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Debug;
+
+use Gacela\Console\Application\Debug\ConstructorInspection;
+use Gacela\Console\Application\Debug\ParameterInspection;
+use Gacela\Console\Application\Debug\ParameterStatus;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+/**
+ * The counts `debug:modules --check` acts on.
+ *
+ * Asserted here rather than through the command, which only observes whether a
+ * total is zero: a count that walked the wrong way or started at the wrong
+ * number still produces a non-zero total and the same exit code, so the
+ * command's own tests cannot see the difference.
+ */
+final class ConstructorInspectionTest extends TestCase
+{
+    /**
+     * `unresolvable` is the union of the two: what the container cannot supply,
+     * plus what nothing here looked at.
+     */
+    public function test_it_separates_a_fault_from_a_parameter_it_declined_to_inspect(): void
+    {
+        $inspection = $this->inspectionOf(
+            ParameterStatus::Bound,
+            ParameterStatus::Autowirable,
+            ParameterStatus::UnboundInterface,
+            ParameterStatus::ScalarWithoutDefault,
+            ParameterStatus::UnsupportedType,
+        );
+
+        self::assertSame(2, $inspection->resolvableCount());
+        self::assertSame(3, $inspection->unresolvableCount());
+        self::assertSame(2, $inspection->faultCount());
+        self::assertSame(1, $inspection->notInspectedCount());
+    }
+
+    /**
+     * A type that does not exist is a typo or a deleted class, not a shape the
+     * inspector declined to read -- so it fails a check, and a union type does
+     * not.
+     */
+    public function test_a_missing_type_is_a_fault_and_a_union_type_is_not(): void
+    {
+        self::assertSame(1, $this->inspectionOf(ParameterStatus::MissingType)->faultCount());
+        self::assertSame(0, $this->inspectionOf(ParameterStatus::MissingType)->notInspectedCount());
+
+        self::assertSame(0, $this->inspectionOf(ParameterStatus::UnsupportedType)->faultCount());
+        self::assertSame(1, $this->inspectionOf(ParameterStatus::UnsupportedType)->notInspectedCount());
+    }
+
+    public function test_a_constructor_with_nothing_wrong_counts_none_of_either(): void
+    {
+        $inspection = $this->inspectionOf(ParameterStatus::Bound, ParameterStatus::HasDefault, ParameterStatus::Inject);
+
+        self::assertSame(0, $inspection->faultCount());
+        self::assertSame(0, $inspection->notInspectedCount());
+        self::assertTrue($inspection->isFullyResolvable());
+    }
+
+    public function test_a_constructor_with_no_parameters_counts_none_of_either(): void
+    {
+        $inspection = $this->inspectionOf();
+
+        self::assertSame(0, $inspection->faultCount());
+        self::assertSame(0, $inspection->notInspectedCount());
+    }
+
+    /**
+     * Every status lands on exactly one side, so a new one cannot be silently
+     * neither -- which would make it invisible to both the report and the check.
+     */
+    public function test_every_status_is_resolvable_a_fault_or_not_inspected(): void
+    {
+        foreach (ParameterStatus::cases() as $status) {
+            $sides = (int)$status->isResolvable() + (int)$status->isFault() + (int)$status->isNotInspected();
+
+            self::assertSame(1, $sides, sprintf('%s lands on %d sides, not exactly one', $status->value, $sides));
+        }
+    }
+
+    private function inspectionOf(ParameterStatus ...$statuses): ConstructorInspection
+    {
+        $parameters = [];
+        foreach ($statuses as $i => $status) {
+            $parameters[] = new ParameterInspection('$p' . $i, 'mixed', $status, 'detail');
+        }
+
+        return new ConstructorInspection(self::class, $parameters !== [], $parameters);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`debug:modules` already counted the constructor parameters the container cannot supply — and exited `SUCCESS` regardless. Acting on that count meant grepping the output, which is what an exit code exists to avoid, and is the same bargain `doctor --strict`, `debug:graph --check` and `dto:generate --check` already offer.

```console
$ vendor/bin/gacela debug:modules --check
  App\Blog
    BlogFactory  1 unresolvable parameter
      $logger: LoggerInterface — unbound interface
✗ 1 parameter the container cannot satisfy.
$ echo $?
1
```

## ⚖️ The part worth reviewing

**`--check` is not `unresolvableCount() > 0`.** That count includes parameters the inspector *declined to read*:

| status | meaning | fails `--check` |
|---|---|---|
| `UnboundInterface`, `ScalarWithoutDefault`, `NoTypeHint`, `MissingType` | looked, and the container cannot supply it | **yes** |
| `UnsupportedType` | *"union/intersection types not inspected"* | **no** |

Failing a build because a constructor uses `int\|string` would blame a project for a gap in this tool rather than for anything it did. Those are still counted, printed and reported as unresolvable, so a passing `--check` does not read as "every parameter was checked".

`MissingType` is deliberately on the failing side despite sounding similar: a type that does not exist is a typo or a deleted class, not a shape the inspector skipped.

## 🔖 Changes

- `debug:modules --check`
- `ParameterStatus::isFault()` and `isNotInspected()` carry the split; `ConstructorInspection` gains `faultCount()` and `notInspectedCount()`
- `docs/cli.md` — the row, and the line that called `debug:graph --check` "the one built for CI" now names both and explains what `--check` will not fail on

## 🧪 Tests

Five feature tests (fails on an unbound dependency, passes on a clean fixture, **does not** fail on a union-typed one, still reports it as unresolvable, and without the flag a broken module still exits 0) plus a new `ConstructorInspectionTest`.

That unit test exists because the changed-lines mutation gate came in at **77%**: five mutants escaped, all arithmetic in the two new counters. The feature tests only observe whether a total is *zero*, so `++$faults` → `--$faults` still produced a non-zero total and the same exit code. Counting is now asserted directly, and the gate reports **100%**.

One of its cases asserts every `ParameterStatus` lands on exactly one of resolvable / fault / not-inspected — a new status cannot be silently neither, which would make it invisible to both the report and the check.
