### PR TITLE
fix(console): generate a gacela.php that names the project's namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
 
 ### Fixed
 
+- Generate a `gacela.php` that names the project's own namespaces. `init` wrote the literal `setProjectNamespaces(['App'])` into every project it scaffolded, which is right for the ones that use `App\` and quietly wrong for the rest — the resolver tries those prefixes *before* the module's own namespace, so a wrong one costs a failed lookup on every cold resolution and resolves the wrong class for a project that does have an `App\` module of the same name. The prefixes now come from `composer.json`, falling back to `['App']` when there is no manifest
+
 - Reattach nine docblocks in the shipped code that described nothing, orphaned when a method was added between an existing docblock and its signature. Both halves stay valid php, so the analysers only object when the annotation was load-bearing for a type. A test now walks the shipped directories and fails on any docblock whose next meaningful token is another docblock
 - Say whose bindings `debug:module` is listing. The section headed `Bindings` reports the application's container, the same list whichever module is named, so it is now `Application bindings (project-wide)`; `Provides (#[Provides])` above it is the section that answers for the module. The `--json` field keeps its name
 - Document the Symfony bridge's `enabled` key: `enabled: false` keeps the bundle in `config/bundles.php` while leaving Gacela un-bootstrapped, and the only way to find it was to read the config tree. A test now asserts every declared key appears in the README, so the next one fails rather than shipping undiscoverable

--- a/src/Console/Infrastructure/Command/InitCommand.php
+++ b/src/Console/Infrastructure/Command/InitCommand.php
@@ -4,17 +4,23 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Infrastructure\Command;
 
+use Gacela\Console\Domain\FileContent\JsonFile;
+use Gacela\Console\Domain\PackageManifest\ComposerPackage;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_keys;
 use function dirname;
+use function implode;
 use function is_dir;
 use function is_file;
 use function mkdir;
 use function sprintf;
+use function str_replace;
+use function trim;
 
 /**
  * Scaffolds the `gacela.php` a project needs before anything else works.
@@ -75,7 +81,13 @@ final class InitCommand extends Command
         }
 
         $output->writeln('');
-        $output->writeln('Next: <comment>bin/gacela make:module App/YourModule --minimal</comment>');
+        // Named after the project's own prefix, so the suggested command is one
+        // that works here rather than one that scaffolds into a namespace
+        // composer does not map.
+        $output->writeln(sprintf(
+            'Next: <comment>bin/gacela make:module %s/YourModule --minimal</comment>',
+            $this->projectNamespaces()[0] ?? 'App',
+        ));
 
         return self::SUCCESS;
     }
@@ -124,6 +136,52 @@ final class InitCommand extends Command
             throw new RuntimeException(sprintf('Template "%s" could not be read', self::TEMPLATE));
         }
 
-        return $template;
+        return str_replace('$PROJECT_NAMESPACES$', $this->renderProjectNamespaces(), $template);
+    }
+
+    /**
+     * The project's own psr-4 prefixes, as a php array literal.
+     *
+     * This used to be the literal `['App']` for every project, which is right
+     * for the projects that use it and quietly wrong for the rest. It is not
+     * decoration: the resolver builds `\{projectNamespace}\{Module}\{Module}Factory`
+     * from these and tries them *before* the module's own namespace, so a wrong
+     * prefix costs a failed lookup on every cold resolution -- and resolves the
+     * wrong class outright for a project that does have an `App\` module of the
+     * same name.
+     */
+    private function renderProjectNamespaces(): string
+    {
+        $prefixes = $this->projectNamespaces();
+
+        if ($prefixes === []) {
+            // No manifest, or one that declares no autoloading. `App` is the
+            // convention and a better guess than an empty list, which would
+            // read as a decision.
+            return "['App']";
+        }
+
+        return sprintf("['%s']", implode("', '", $prefixes));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function projectNamespaces(): array
+    {
+        $decoded = JsonFile::decode($this->appRootDir . DIRECTORY_SEPARATOR . 'composer.json');
+        if ($decoded === null) {
+            return [];
+        }
+
+        $namespaces = [];
+        foreach (array_keys(ComposerPackage::autoloadPrefixesOf($decoded)) as $prefix) {
+            $trimmed = trim($prefix, '\\');
+            if ($trimmed !== '') {
+                $namespaces[] = $trimmed;
+            }
+        }
+
+        return $namespaces;
     }
 }

--- a/src/Console/Infrastructure/Template/Command/gacela-php.txt
+++ b/src/Console/Infrastructure/Template/Command/gacela-php.txt
@@ -10,7 +10,7 @@ return static function (GacelaConfig $config): void {
     $config->addAppConfig('config/*.php', 'config/local.php');
 
     // Namespaces Gacela scans when resolving a module's pillars.
-    $config->setProjectNamespaces(['App']);
+    $config->setProjectNamespaces($PROJECT_NAMESPACES$);
 
     // Always pass an explicit directory. Without one the cache falls back to
     // the system temp directory, which is shared with every other app on the

--- a/tests/Feature/Console/Init/InitCommandTest.php
+++ b/tests/Feature/Console/Init/InitCommandTest.php
@@ -40,7 +40,7 @@ final class InitCommandTest extends TestCase
         // directory it made before anything is removed under it.
         self::assertStringStartsWith(sys_get_temp_dir() . '/gacela-init-test-', $this->appRoot);
 
-        foreach (['/gacela.php', '/config/app.php'] as $relative) {
+        foreach (['/gacela.php', '/config/app.php', '/composer.json'] as $relative) {
             $file = $this->appRoot . $relative;
             if (is_file($file)) {
                 unlink($file);
@@ -175,12 +175,97 @@ final class InitCommandTest extends TestCase
     }
 
     /**
+     * The generated `setProjectNamespaces()` used to be the literal `['App']`
+     * for every project — right for the ones that use it, quietly wrong for the
+     * rest.
+     *
+     * It is not decoration. The resolver builds
+     * `\{projectNamespace}\{Module}\{Module}Factory` from these and tries them
+     * *before* the module's own namespace, so a wrong prefix costs a failed
+     * lookup on every cold resolution, and resolves the wrong class outright
+     * for a project that does have an `App\` module of the same name.
+     */
+    public function test_the_generated_config_names_the_projects_own_namespace(): void
+    {
+        $this->writeComposerJson(['autoload' => ['psr-4' => ['Acme\\' => 'src']]]);
+
+        $this->init($this->appRoot, []);
+
+        self::assertStringContainsString(
+            "setProjectNamespaces(['Acme'])",
+            (string)file_get_contents($this->appRoot . '/gacela.php'),
+        );
+    }
+
+    public function test_every_declared_prefix_is_named(): void
+    {
+        $this->writeComposerJson(['autoload' => ['psr-4' => ['Acme\\' => 'src', 'Shop\\' => 'shop']]]);
+
+        $this->init($this->appRoot, []);
+
+        self::assertStringContainsString(
+            "setProjectNamespaces(['Acme', 'Shop'])",
+            (string)file_get_contents($this->appRoot . '/gacela.php'),
+        );
+    }
+
+    /**
+     * `App` is the convention, and a better guess than an empty list — which
+     * would read as a decision the project had made.
+     */
+    public function test_a_project_with_no_manifest_falls_back_to_the_convention(): void
+    {
+        $this->init($this->appRoot, []);
+
+        self::assertStringContainsString(
+            "setProjectNamespaces(['App'])",
+            (string)file_get_contents($this->appRoot . '/gacela.php'),
+        );
+    }
+
+    public function test_a_manifest_declaring_no_autoloading_falls_back_too(): void
+    {
+        $this->writeComposerJson(['name' => 'acme/app']);
+
+        $this->init($this->appRoot, []);
+
+        self::assertStringContainsString(
+            "setProjectNamespaces(['App'])",
+            (string)file_get_contents($this->appRoot . '/gacela.php'),
+        );
+    }
+
+    /**
+     * The suggested next command has to be one that works here: `App/YourModule`
+     * scaffolds into a namespace composer does not map.
+     */
+    public function test_the_next_step_names_the_projects_own_namespace(): void
+    {
+        $this->writeComposerJson(['autoload' => ['psr-4' => ['Acme\\' => 'src']]]);
+
+        $tester = $this->init($this->appRoot, []);
+
+        self::assertStringContainsString('make:module Acme/YourModule', $tester->getDisplay());
+    }
+
+    /**
      * As the command spells it, so a mismatch is a real difference rather than
      * a separator.
      */
     private function configPath(): string
     {
         return 'config' . DIRECTORY_SEPARATOR . 'app.php';
+    }
+
+    /**
+     * @param array<string, mixed> $manifest
+     */
+    private function writeComposerJson(array $manifest): void
+    {
+        file_put_contents(
+            $this->appRoot . '/composer.json',
+            json_encode($manifest, JSON_THROW_ON_ERROR),
+        );
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

`init` wrote the literal `setProjectNamespaces(['App'])` into **every** project it scaffolded. The template was copied verbatim — no substitution at all — so a project whose psr-4 prefix is anything else got configuration naming a namespace it does not have.

```php
// before, in a project whose composer.json maps "Acme\\" => "src"
$config->setProjectNamespaces(['App']);
```

## ⚠️ Why it is not cosmetic

The resolver builds `\{projectNamespace}\{Module}\{Module}Factory` from these and tries them **before** the module's own namespace. So a wrong prefix means:

- a failed lookup on every cold resolution, for every pillar
- and, for a project that *does* have an `App\` module of the same name, resolving **the wrong class**

## 🔖 Changes

- The prefixes come from the project's `composer.json` — every declared one, not just the first
- Falls back to `['App']` when there is no manifest or it declares no autoloading: the convention is a better guess than an empty list, which would read as a decision the project had made
- The `Next:` hint the command prints follows the same prefix, so the suggested `make:module` is one that works in that project rather than one scaffolding into a namespace composer does not map

## 🔍 How it was found

Running the documented workflow end to end against a scratch project whose prefix is `Acme\`: `init`, `make:module`, `list:modules`, `doctor`, `validate:config`, `debug:modules --check`, `debug:module`, `cache:warm`.

Everything else behaved. Worth recording, since that exercise existed to check fixtures had not drifted from real scaffolder output:

- `doctor` is clean on a freshly scaffolded module — **16 checks, no false positives** from the two added this week
- breaking a real module's Factory namespace makes the new `unresolved pillar files` check fire, with `list:modules` showing the blank cell that motivated it
- breaking the Facade namespace makes `undiscovered facades` fire and `list:modules` print its hint
- `--dry-run` wrote nothing, `list:modules --json` and `debug:config --json` both parse

## 🧪 Tests

Five: the project's own prefix, several prefixes, no manifest, a manifest with no autoload section, and the hint.

The mutation gate reports nothing for this change and that is expected rather than a gap being hidden — `infection.json5` puts `Infrastructure\Command\*` in `global-ignore` on purpose. I ran it to confirm: zero mutants generated.

`OrphanedDocblockTest` — added earlier this week — caught me orphaning a docblock in the test file while writing this. Fourth time today for that pattern, first time a test rather than a reviewer caught it.
