### PR TITLE
docs(console): explain doctor's verdict model in its own help

### DIFF
--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -68,7 +68,8 @@ final class DoctorCommand extends Command
             ->addOption('strict', null, InputOption::VALUE_NONE, 'Exit with a failure code on warnings too, for CI')
             ->addOption('only-problems', null, InputOption::VALUE_NONE, 'Report only the checks that found something')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format: text|json', 'text')
-            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Shorthand for --format=json');
+            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Shorthand for --format=json')
+            ->setHelp($this->getHelpText());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -369,5 +370,52 @@ final class DoctorCommand extends Command
         $output->writeln($line);
         $output->writeln('');
         return $code;
+    }
+
+    /**
+     * Deliberately free of a check list or a count: both would go stale the
+     * next time one is added, and a run already names every check it made.
+     * What is not visible from a run is the verdict model, which is what this
+     * explains.
+     */
+    private function getHelpText(): string
+    {
+        return <<<'HELP'
+Runs every built-in health check against the current setup, plus any registered
+with `GacelaConfig::addHealthCheck()`. Each check names what it found and how to
+fix it; a run lists them all, so this help does not repeat them.
+
+<info>Errors and warnings are different claims:</info>
+  <error>Errors</error>   something is broken now -- a pillar file nothing can load, a
+           binding whose class does not exist. These always fail the run.
+  <fg=yellow>Warnings</fg=yellow> something is inert or will not do what it looks like it does --
+           a listener nothing can dispatch to, a `#[Cacheable]` method on
+           storage that dies with the process. These pass by default,
+           because several of them are correct in some deployments.
+
+<info>Examples:</info>
+  # Report everything
+  bin/gacela doctor
+
+  # Fail the build on warnings too -- the usual CI setting
+  bin/gacela doctor --strict
+
+  # Only what found something, for a short report
+  bin/gacela doctor --only-problems
+
+  # Say which check failed, for a job that acts on it
+  bin/gacela doctor --json
+
+  # Narrow the module-scoped checks to one namespace
+  bin/gacela doctor App/Checkout
+
+<comment>The filter narrows which modules get inspected, not which checks run.</comment>
+Every check still reports; the ones about configuration, caches and manifests
+describe the whole project and ignore it.
+
+<comment>Complements:</comment>
+  bin/gacela validate:config       bindings, dependency cycles, config schema
+  bin/gacela debug:modules --check whether each pillar's constructor resolves
+HELP;
     }
 }

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -72,6 +72,39 @@ final class DoctorCommandTest extends TestCase
         }
     }
 
+    /**
+     * `doctor` runs more checks than any other command and is the only one
+     * whose exit code depends on a distinction the flags do not explain: an
+     * error always fails, a warning fails only under `--strict`.
+     *
+     * The help is asserted for that model rather than for a list of checks --
+     * a run already names every check it made, and a list here would go stale
+     * the next time one is added.
+     */
+    public function test_the_help_explains_the_verdict_model(): void
+    {
+        $help = (new DoctorCommand())->getHelp();
+
+        self::assertStringContainsString('always fail the run', $help);
+        self::assertStringContainsString('--strict', $help);
+        self::assertStringContainsString('narrows which modules get inspected, not which checks run', $help);
+    }
+
+    /**
+     * The claim above about the filter, checked against the command rather than
+     * trusted: every check reports either way, and only the modules they walk
+     * change.
+     */
+    public function test_a_filter_matching_nothing_still_reports_every_check(): void
+    {
+        $unfiltered = $this->statusLinesOf($this->doctor([]));
+        $filtered = $this->statusLinesOf($this->doctor([], ['filter' => 'NoSuchNamespaceXYZ']));
+
+        // Two empty lists are also "the same", and would prove nothing.
+        self::assertGreaterThan(10, count($unfiltered));
+        self::assertSame($unfiltered, $filtered);
+    }
+
     public function test_reports_every_built_in_check_when_nothing_is_registered(): void
     {
         $tester = $this->doctor([]);

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -174,9 +174,15 @@ final class DoctorCommandTest extends TestCase
     }
 
     /**
-     * Twelve checks is a lot of "✓" to read to find the one "⚠". `-q` is not
-     * the answer: it suppresses everything, so `--strict -q` fails a build with
-     * no indication of what failed.
+     * A full run is a lot of "✓" to read to find the one "⚠". `-q` is not the
+     * answer: it suppresses everything, so `--strict -q` fails a build with no
+     * indication of what failed.
+     *
+     * The count is deliberately not written out here. The changelog's copy of
+     * this sentence is guarded by
+     * `test_the_changelog_counts_the_checks_doctor_actually_runs()`; an
+     * unguarded second copy would just be one more number to get wrong -- as
+     * this one was, sitting at "Twelve" through six more checks.
      */
     public function test_only_problems_hides_the_passing_checks(): void
     {
@@ -495,10 +501,11 @@ final class DoctorCommandTest extends TestCase
     }
 
     /**
-     * The `--only-problems` changelog entry opens "Fourteen checks is a lot of
-     * ✓ to read to find the one ⚠", and adding a check makes that wrong. It has
-     * been wrong twice: #796 took it to thirteen and #797 to fourteen, both
-     * caught by hand, both while still in `## Unreleased` and shipping.
+     * The `--only-problems` changelog entry opens by counting the checks in
+     * words -- "<N> checks is a lot of ✓ to read to find the one ⚠" -- and
+     * adding a check makes that wrong. It had been wrong twice before this
+     * guard: #796 took it to thirteen and #797 to fourteen, both caught by
+     * hand, both while still in `## Unreleased` and shipping.
      *
      * #798 guarded the sibling count in `docs/cli.md` and deliberately left
      * this one alone, because it needed the number of checks the command


### PR DESCRIPTION
## 📚 Description

`doctor` runs more checks than any other command, and is the only one whose **exit code turns on a distinction its flags do not explain**: an error always fails the run, a warning fails only under `--strict`. It had no help text at all — while smaller commands like `debug:modules`, `validate:config` and `debug:container` do.

```console
$ vendor/bin/gacela help doctor
...
Help:
  Errors and warnings are different claims:
    Errors   something is broken now — a pillar file nothing can load, a
             binding whose class does not exist. These always fail the run.
    Warnings something is inert or will not do what it looks like it does —
             a listener nothing can dispatch to, a `#[Cacheable]` method on
             storage that dies with the process. These pass by default,
             because several of them are correct in some deployments.
```

## ⚖️ What it deliberately does not say

**No check list and no count.** A run already names every check it made, and either would go stale the next time one is added — which is exactly the trap the changelog's own `--only-problems` count keeps falling into (Fifteen → Sixteen → Seventeen → Eighteen in a single day).

## 🔍 A claim I got wrong, and checked

The first draft said the filter "narrows the checks that walk modules", implying some checks are skipped. Running it says otherwise: **all 17 checks still report under a filter matching nothing** — it narrows which *modules* they inspect, not which checks run. The wording is corrected, and a test pins the behaviour by comparing the filtered and unfiltered status lines.

That test asserts the unfiltered list is non-empty first, because two empty lists are also "the same" and would prove nothing.

## 🧪 Tests

Two. One asserts the help explains the verdict model (`always fail the run`, `--strict`, and the filter sentence) rather than asserting its prose wholesale. The other is the filter behaviour above.

## 📝 Note

Branches off `main`, so it does not include #833's check. Both touch `DoctorCommand`; the conflict is one line each in the registration list and the asserted check list.
