### PR TITLE
docs: correct the remedy for a misspelled provided-dependency id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@
 - Preload the framework and the packages it runs on, discovered rather than named in a list. A preloaded class is only kept if everything it extends, implements and uses came along, so the hand-written list silently linked none of the pillars, the resolvers or either container
 - Read `gacela.php` once when bootstrapping without a closure, instead of loading it as a config source it is already the source of. Everything the project declared arrived twice: one `addAppConfig()` globbed twice, a plugin declared once ran twice. Passing a closure to `Gacela::bootstrap()` was never affected
 
+### Documentation
+
+- Correct the remedy offered for a misspelled provided-dependency id. "Check `debug:module`, which lists every id that module's Provider declares" does not hold: the command lists what `#[Provides]` declares and not what a Provider registers imperatively with `$container->set()`, so the module the advice was written for prints `(none)` however many ids it has. Declaring with the attribute is what makes an id visible to tooling, which is now what the page says
+
 ## [2.2.0](https://github.com/gacela-project/gacela/compare/2.1.0...2.2.0) - 2026-08-11
 
 ### Added

--- a/docs/getting-a-dependency.md
+++ b/docs/getting-a-dependency.md
@@ -130,7 +130,11 @@ $config->addBinding(PaymentGateway::class, StripeGateway::class);
 
 The concrete-class row is why it cannot simply throw: the container autowires a class it can construct, which is the behaviour `make()` relies on. But it means a typo in a string id is not reported anywhere — the `null` travels until something calls a method on it, and the stack points at the consumer rather than at the id.
 
-Two habits cost nothing and remove the guesswork: declare ids as constants on the Provider (`Provider::BILLING_FACADE`, not `'billing.facade'`), so a typo is a fatal undefined-constant at the call site; and check `vendor/bin/gacela debug:module App/Blog`, which lists every id that module's Provider declares.
+Two habits cost nothing and remove the guesswork.
+
+Declare ids as **constants on the Provider** (`Provider::BILLING_FACADE`, not `'billing.facade'`), so a typo is a fatal undefined-constant at the call site instead of a `null` that travels.
+
+Declare the dependency with **`#[Provides]`**, which is what puts the id in `vendor/bin/gacela debug:module App/Blog`. That command lists the ids the attribute declares and not the ones a Provider registers imperatively with `$container->set()` — its heading says `Provides (#[Provides])` for exactly that reason. A module wired the imperative way prints `(none)` there however many ids it registers, so the attribute is what makes an id visible to tooling at all.
 
 This is the same shape as an [unanswerable tagged id](cli.md), which `doctor` reports — a group iterating one hole, failing on the consumer. Nothing reports this one, because an id may legitimately come from another module's Provider, from `addBinding()`, or from `extendService()`, so "no Provider declares it" is not the same as "it is wrong".
 

--- a/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
+++ b/tests/Feature/Console/DebugModule/DebugModuleCommandTest.php
@@ -15,6 +15,7 @@ use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\CheckoutModul
 use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\PaymentGatewayInterface;
 use GacelaTest\Feature\Console\DebugModule\Fixtures\CheckoutModule\StripeGateway;
 use GacelaTest\Feature\Console\DebugModule\Fixtures\GadgetModule\GadgetModuleFacade;
+use GacelaTest\Feature\Console\DebugModule\Fixtures\ImperativeModule\ImperativeModuleProvider;
 use GacelaTest\Feature\Console\DebugModule\Fixtures\WiredModule\WiredCollaborator;
 use GacelaTest\Feature\Console\DebugModule\Fixtures\WiredModule\WiredModuleFacade;
 use PHPUnit\Framework\TestCase;
@@ -154,6 +155,7 @@ final class DebugModuleCommandTest extends TestCase
         self::assertSame([
             'Module: CheckoutModule',
             'Module: GadgetModule',
+            'Module: ImperativeModule',
             'Module: WiredModule',
         ], array_values(array_filter(
             $lines,
@@ -231,6 +233,26 @@ final class DebugModuleCommandTest extends TestCase
             strpos($display, CheckoutModuleProvider::RETRIES),
             strpos($display, CheckoutModuleProvider::GATEWAY),
         );
+    }
+
+    /**
+     * A Provider that registers with `$container->set()` and declares no
+     * attribute reports `(none)`, however many ids it registers. The heading
+     * says `#[Provides]` for that reason, and finding the imperative ones means
+     * running the Provider, which this command does not do.
+     *
+     * Pinned because the documented remedy for a misspelled id used to be
+     * "check `debug:module`, which lists every id that module's Provider
+     * declares" -- advice that sends a reader with an imperative Provider to a
+     * command that shows them nothing.
+     */
+    public function test_a_provider_that_registers_imperatively_declares_nothing(): void
+    {
+        $display = $this->debugModule(['module' => 'ImperativeModule'])->getDisplay();
+
+        self::assertStringContainsString(ImperativeModuleProvider::class, $display);
+        self::assertStringNotContainsString(ImperativeModuleProvider::GATEWAY, $display);
+        self::assertMatchesRegularExpression('/Provides \(#\[Provides\]\):\s*\R\s*\(none\)/u', $display);
     }
 
     public function test_a_module_without_a_provider_declares_nothing(): void

--- a/tests/Feature/Console/DebugModule/Fixtures/ImperativeModule/ImperativeModuleFacade.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/ImperativeModule/ImperativeModuleFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\ImperativeModule;
+
+use Gacela\Framework\AbstractFacade;
+
+final class ImperativeModuleFacade extends AbstractFacade
+{
+}

--- a/tests/Feature/Console/DebugModule/Fixtures/ImperativeModule/ImperativeModuleProvider.php
+++ b/tests/Feature/Console/DebugModule/Fixtures/ImperativeModule/ImperativeModuleProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugModule\Fixtures\ImperativeModule;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Registers everything imperatively and declares no `#[Provides]`, which is how
+ * a Provider was written before the attribute existed and how most still are.
+ *
+ * Deliberately without the attribute: this module exists to hold the line that
+ * `debug:module` reports what `#[Provides]` declares and not what `set()`
+ * registers.
+ */
+final class ImperativeModuleProvider extends AbstractProvider
+{
+    public const GATEWAY = 'IMPERATIVE_GATEWAY';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::GATEWAY, 'the gateway');
+    }
+}


### PR DESCRIPTION
## 📚 Description

`getting-a-dependency.md` documents that `getProvidedDependency()` returns `null` for an id nothing provides, and then offers two habits to remove the guesswork. The second one does not work:

> check `vendor/bin/gacela debug:module App/Blog`, which **lists every id that module's Provider declares**

It lists what `#[Provides]` declares, and not what a Provider registers imperatively with `$container->set()`. The command's own heading says `Provides (#[Provides])` for that reason, and `cli.md` describes it correctly — only this page overstated it.

So the reader the advice was written for, chasing a misspelled string id in a Provider wired the imperative way, runs the command and gets:

```
  Provides (#[Provides]):
    (none)
```

however many ids that Provider registers. Verified against a scratch project: a Provider with `$container->set('payment-gateway', …)` prints `(none)`; adding `#[Provides]` to a method makes its id appear.

The page now says that declaring with the attribute is what makes an id visible to tooling at all — which is the actionable version of the same advice, and reinforces the first habit rather than sending the reader to a command that shows them nothing.

## 🔖 Changes

- Correct the claim in `docs/getting-a-dependency.md`, and split the two habits so each is a sentence a reader can act on
- Add an `ImperativeModule` fixture whose Provider registers only with `set()`, and pin the behaviour. The existing `(none)` test covers a module with **no** Provider, which reports the same thing for a different reason — so nothing was holding this line
- No behaviour change; `debug:module` is right and stays as it is