### PR TITLE
ref(console): list the commands once, not once per registry

### DIFF
--- a/laravel-bridge/src/GacelaCommands.php
+++ b/laravel-bridge/src/GacelaCommands.php
@@ -4,25 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\LaravelBridge;
 
-use Gacela\Console\Infrastructure\Command\CacheClearCommand;
-use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
-use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
-use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
-use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
-use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
-use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
-use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
-use Gacela\Console\Infrastructure\Command\DebugProvidesCommand;
-use Gacela\Console\Infrastructure\Command\DoctorCommand;
-use Gacela\Console\Infrastructure\Command\DtoGenerateCommand;
-use Gacela\Console\Infrastructure\Command\IdeMetaCommand;
-use Gacela\Console\Infrastructure\Command\InitCommand;
-use Gacela\Console\Infrastructure\Command\ListModulesCommand;
-use Gacela\Console\Infrastructure\Command\MakeFileCommand;
-use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
-use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
-use Gacela\Console\Infrastructure\Command\StubsPublishCommand;
-use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Gacela\Console\Infrastructure\Command\CommandCatalog;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -36,33 +18,10 @@ use Symfony\Component\Console\Command\Command;
  */
 final class GacelaCommands
 {
-    /** @var list<class-string<Command>> */
-    private const CLASSES = [
-        MakeFileCommand::class,
-        MakeModuleCommand::class,
-        ListModulesCommand::class,
-        DebugConfigCommand::class,
-        DebugContainerCommand::class,
-        DebugDependenciesCommand::class,
-        DebugGraphCommand::class,
-        DebugModuleCommand::class,
-        DebugModulesCommand::class,
-        DebugProvidesCommand::class,
-        CacheWarmCommand::class,
-        CacheClearCommand::class,
-        ValidateConfigCommand::class,
-        ProfileReportCommand::class,
-        DoctorCommand::class,
-        InitCommand::class,
-        DtoGenerateCommand::class,
-        IdeMetaCommand::class,
-        StubsPublishCommand::class,
-    ];
-
     /**
-     * Constructing a command runs its `configure()`, which sets a name and
-     * options and touches nothing else -- no bootstrap, no filesystem -- so it
-     * is safe while the provider is still registering.
+     * Read off {@see CommandCatalog}, the one list, rather than a copy of it
+     * kept here. Constructing a command is safe while the provider is still registering:
+     * see the catalog for why.
      *
      * @return array<class-string<Command>, string>
      */
@@ -70,9 +29,8 @@ final class GacelaCommands
     {
         $names = [];
 
-        foreach (self::CLASSES as $class) {
-            $command = $class === InitCommand::class ? new InitCommand('') : new $class();
-            $names[$class] = (string)$command->getName();
+        foreach (CommandCatalog::instances('') as $command) {
+            $names[$command::class] = (string)$command->getName();
         }
 
         return $names;

--- a/src/Console/ConsoleProvider.php
+++ b/src/Console/ConsoleProvider.php
@@ -5,25 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Console;
 
 use Gacela\Console\Domain\FilenameSanitizer\FilenameSanitizer;
-use Gacela\Console\Infrastructure\Command\CacheClearCommand;
-use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
-use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
-use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
-use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
-use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
-use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
-use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
-use Gacela\Console\Infrastructure\Command\DebugProvidesCommand;
-use Gacela\Console\Infrastructure\Command\DoctorCommand;
-use Gacela\Console\Infrastructure\Command\DtoGenerateCommand;
-use Gacela\Console\Infrastructure\Command\IdeMetaCommand;
-use Gacela\Console\Infrastructure\Command\InitCommand;
-use Gacela\Console\Infrastructure\Command\ListModulesCommand;
-use Gacela\Console\Infrastructure\Command\MakeFileCommand;
-use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
-use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
-use Gacela\Console\Infrastructure\Command\StubsPublishCommand;
-use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Gacela\Console\Infrastructure\Command\CommandCatalog;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Config\Config;
@@ -46,27 +28,7 @@ final class ConsoleProvider extends AbstractProvider
     #[Provides(self::COMMANDS)]
     public function commands(): array
     {
-        return [
-            new MakeFileCommand(),
-            new MakeModuleCommand(),
-            new ListModulesCommand(),
-            new DebugConfigCommand(),
-            new DebugContainerCommand(),
-            new DebugDependenciesCommand(),
-            new DebugGraphCommand(),
-            new DebugModuleCommand(),
-            new DebugModulesCommand(),
-            new DebugProvidesCommand(),
-            new CacheWarmCommand(),
-            new CacheClearCommand(),
-            new ValidateConfigCommand(),
-            new ProfileReportCommand(),
-            new DoctorCommand(),
-            new DtoGenerateCommand(),
-            new IdeMetaCommand(),
-            new InitCommand(Config::getInstance()->getAppRootDir()),
-            new StubsPublishCommand(),
-        ];
+        return CommandCatalog::instances(Config::getInstance()->getAppRootDir());
     }
 
     /**

--- a/src/Console/Infrastructure/Command/CommandCatalog.php
+++ b/src/Console/Infrastructure/Command/CommandCatalog.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+use function array_map;
+
+/**
+ * Every command Gacela ships, listed once.
+ *
+ * There were three copies of this list: `ConsoleProvider::commands()`, which
+ * `vendor/bin/gacela` reads, and a `GacelaCommands` in each bridge. Adding a
+ * command meant remembering all three, and three commands had already been
+ * missing from the bridges once.
+ *
+ * Guards were written after that -- `RegisteredCommandsTest` for the CLI and a
+ * `GacelaCommandsTest` in each bridge, all reading the command directory rather
+ * than restating the list -- and they work: they turn a forgotten registry into
+ * a failing build. They do not make the list one list, which is what stops the
+ * question being asked a fourth time.
+ *
+ * The guards stay. They now cover a different mistake: a command class added to
+ * the directory and to no list at all.
+ *
+ * @internal
+ */
+final class CommandCatalog
+{
+    /** @var list<class-string<Command>> */
+    private const CLASSES = [
+        MakeFileCommand::class,
+        MakeModuleCommand::class,
+        ListModulesCommand::class,
+        DebugConfigCommand::class,
+        DebugContainerCommand::class,
+        DebugDependenciesCommand::class,
+        DebugGraphCommand::class,
+        DebugModuleCommand::class,
+        DebugModulesCommand::class,
+        DebugProvidesCommand::class,
+        CacheWarmCommand::class,
+        CacheClearCommand::class,
+        ValidateConfigCommand::class,
+        ProfileReportCommand::class,
+        DoctorCommand::class,
+        InitCommand::class,
+        DtoGenerateCommand::class,
+        IdeMetaCommand::class,
+        StubsPublishCommand::class,
+    ];
+
+    /**
+     * @return list<class-string<Command>>
+     */
+    public static function classes(): array
+    {
+        return self::CLASSES;
+    }
+
+    /**
+     * One instance of each, with the one command that needs a value given it.
+     *
+     * `InitCommand` is the only command taking a constructor argument, and that
+     * special case used to be written out in all three registries -- including
+     * the two that only wanted to read a name off it and passed `''`.
+     *
+     * Constructing a command runs its `configure()`, which sets a name and
+     * options and touches nothing else: no bootstrap, no filesystem. That is
+     * what makes this safe to call while a framework container is still being
+     * built.
+     *
+     * @return list<Command>
+     */
+    public static function instances(string $appRootDir): array
+    {
+        return array_map(
+            static fn (string $class): Command => $class === InitCommand::class
+                ? new InitCommand($appRootDir)
+                : new $class(),
+            self::CLASSES,
+        );
+    }
+}

--- a/symfony-bridge/src/GacelaCommands.php
+++ b/symfony-bridge/src/GacelaCommands.php
@@ -4,25 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\SymfonyBridge;
 
-use Gacela\Console\Infrastructure\Command\CacheClearCommand;
-use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
-use Gacela\Console\Infrastructure\Command\DebugConfigCommand;
-use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
-use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
-use Gacela\Console\Infrastructure\Command\DebugGraphCommand;
-use Gacela\Console\Infrastructure\Command\DebugModuleCommand;
-use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
-use Gacela\Console\Infrastructure\Command\DebugProvidesCommand;
-use Gacela\Console\Infrastructure\Command\DoctorCommand;
-use Gacela\Console\Infrastructure\Command\DtoGenerateCommand;
-use Gacela\Console\Infrastructure\Command\IdeMetaCommand;
-use Gacela\Console\Infrastructure\Command\InitCommand;
-use Gacela\Console\Infrastructure\Command\ListModulesCommand;
-use Gacela\Console\Infrastructure\Command\MakeFileCommand;
-use Gacela\Console\Infrastructure\Command\MakeModuleCommand;
-use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
-use Gacela\Console\Infrastructure\Command\StubsPublishCommand;
-use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Gacela\Console\Infrastructure\Command\CommandCatalog;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -36,33 +18,10 @@ use Symfony\Component\Console\Command\Command;
  */
 final class GacelaCommands
 {
-    /** @var list<class-string<Command>> */
-    private const CLASSES = [
-        MakeFileCommand::class,
-        MakeModuleCommand::class,
-        ListModulesCommand::class,
-        DebugConfigCommand::class,
-        DebugContainerCommand::class,
-        DebugDependenciesCommand::class,
-        DebugGraphCommand::class,
-        DebugModuleCommand::class,
-        DebugModulesCommand::class,
-        DebugProvidesCommand::class,
-        CacheWarmCommand::class,
-        CacheClearCommand::class,
-        ValidateConfigCommand::class,
-        ProfileReportCommand::class,
-        DoctorCommand::class,
-        InitCommand::class,
-        DtoGenerateCommand::class,
-        IdeMetaCommand::class,
-        StubsPublishCommand::class,
-    ];
-
     /**
-     * Constructing a command runs its `configure()`, which sets a name and
-     * options and touches nothing else -- no bootstrap, no filesystem -- so it
-     * is safe while Symfony's container is still being compiled.
+     * Read off {@see CommandCatalog}, the one list, rather than a copy of it
+     * kept here. Constructing a command is safe while Symfony's container is still being compiled:
+     * see the catalog for why.
      *
      * @return array<class-string<Command>, string>
      */
@@ -70,9 +29,8 @@ final class GacelaCommands
     {
         $names = [];
 
-        foreach (self::CLASSES as $class) {
-            $command = $class === InitCommand::class ? new InitCommand('') : new $class();
-            $names[$class] = (string)$command->getName();
+        foreach (CommandCatalog::instances('') as $command) {
+            $names[$command::class] = (string)$command->getName();
         }
 
         return $names;


### PR DESCRIPTION
## 📚 Description

The same nineteen commands were written out **three times**:

- `ConsoleProvider::commands()` — what `vendor/bin/gacela` reads
- `laravel-bridge/src/GacelaCommands`
- `symfony-bridge/src/GacelaCommands`

Adding a command meant remembering all three. Three commands had already been missed once — `dto:generate`, `ide:meta` and `stubs:publish` were runnable by `vendor/bin/gacela` and by no Laravel or Symfony project, which is what prompted the guards that exist today.

Those guards are good and they stay: `RegisteredCommandsTest` for the CLI and a `GacelaCommandsTest` per bridge, each reading the command *directory* rather than restating the list. But a guard turns a forgotten registry into a failing build; it does not make the list one list. This does.

It also absorbs the one special case all three spelled out: `InitCommand` is the only command taking a constructor argument, and both bridges passed `''` purely to read a name off it.

### The guards were checked to still bite

With `GacelaCommands::names()` now derived from the catalog, the bridge tests could have become vacuous — asserting the catalog against itself. They have not. Dropping an unlisted command class into the directory fails all three, each naming its own surface:

```
These commands exist but `vendor/bin/gacela` cannot run them: …\ZzProbeCommand
These commands exist but no Symfony project can run them:     …\ZzProbeCommand
These commands exist but no Laravel project can run them:     …\ZzProbeCommand
Tests: 5, Assertions: 5, Failures: 3
```

## 🔖 Changes

- Add `CommandCatalog` (`@internal`) with the list and an `instances()` that hands `InitCommand` its root dir
- Rewire `ConsoleProvider` and both bridges onto it — **136 lines deleted, 14 added**
- No behaviour change: same commands, same names, same order; the three existing guards passed untouched