### PR TITLE
ref(bootstrap): share the bridge bootstrapping instead of copying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 
 ### Internal
 
+- Move the bridge bootstrapping into `Gacela\Framework\Bootstrap\IntegrationBootstrapper`. Both bridges held a copy of it that was byte-identical once the docblocks were stripped, and none of it was specific to a framework — including the `resetInMemoryCache()` call that keeps a host booting twice in one process from serving the previous boot's container, which each bridge had to learn separately. The host is reached through a closure rather than a PSR-11 container, so this carries no dependency an integration might not have. Each bridge keeps its own `GacelaBootstrapper` name and constructor, now an adapter
 - Delete `ContextualBindingRegistrar`. It narrowed the stored `mixed` before handing it to the container's `give()` — class strings and objects through, anything else wrapped in a closure — and its only remaining reason was that `give(null)` threw upstream. That shipped in container 2.0 (container#169), so the class had become a pass-through. All nine implementation shapes were compared through it and around it before removing it, and its tests were rewritten against the call it used to make rather than deleted with it
 
 ### Documentation

--- a/laravel-bridge/src/GacelaBootstrapper.php
+++ b/laravel-bridge/src/GacelaBootstrapper.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace Gacela\LaravelBridge;
 
-use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\Gacela;
+use Gacela\Framework\Bootstrap\IntegrationBootstrapper;
 use Psr\Container\ContainerInterface;
-
-use function class_exists;
-use function interface_exists;
 
 /**
  * Bootstraps Gacela from what the Laravel application already knows.
  *
- * Every Laravel project that uses Gacela writes this by hand -- the base path,
- * the handful of Laravel services a Factory needs to reach. It is the same
- * code every time, which is what a bridge is for.
+ * Everything it does is {@see IntegrationBootstrapper}, which is where the logic lives: none of it
+ * was specific to Laravel, and both bridges held a byte-identical copy of it.
+ * This is the adapter -- it turns Laravel's container into the lookup that
+ * takes, and keeps the name and constructor the service provider already constructs.
  *
  * Package tests build fresh applications constantly, so bootstrapping is
  * idempotent by being repeated: each boot re-runs it, and the latest
@@ -24,78 +21,33 @@ use function interface_exists;
  */
 final class GacelaBootstrapper
 {
+    private readonly IntegrationBootstrapper $inner;
+
     /**
      * @param array{cache_dir: ?string, file_cache: ?bool, project_namespaces: list<string>} $options
      * @param array<string, string> $externalServices gacela key => laravel binding id
      */
     public function __construct(
-        private readonly string $appRootDir,
-        private readonly array $options,
-        private readonly ContainerInterface $services,
-        private readonly array $externalServices = [],
+        string $appRootDir,
+        array $options,
+        ContainerInterface $services,
+        array $externalServices = [],
     ) {
+        $this->inner = new IntegrationBootstrapper(
+            $appRootDir,
+            $options,
+            static function (string $serviceId) use ($services): object {
+                /** @var object $service */
+                $service = $services->get($serviceId);
+
+                return $service;
+            },
+            $externalServices,
+        );
     }
 
     public function bootstrap(): void
     {
-        Gacela::bootstrap($this->appRootDir, function (GacelaConfig $config): void {
-            // Without this, a re-bootstrap keeps the previous boot's locator,
-            // which keeps serving the previous boot's container -- the #597
-            // class of bug, one layer down. A first boot resets nothing but
-            // empty caches, so it only costs where it is needed.
-            $config->resetInMemoryCache();
-
-            $this->applyOptions($config);
-            $this->applyExternalServices($config);
-        });
-    }
-
-    private function applyOptions(GacelaConfig $config): void
-    {
-        if ($this->options['file_cache'] !== null) {
-            $config->setFileCache($this->options['file_cache'], $this->options['cache_dir']);
-        } elseif ($this->options['cache_dir'] !== null) {
-            $config->enableFileCache($this->options['cache_dir']);
-        }
-
-        if ($this->options['project_namespaces'] !== []) {
-            $config->setProjectNamespaces($this->options['project_namespaces']);
-        }
-    }
-
-    /**
-     * A listed service reaches Gacela two ways, and which ones apply is decided
-     * by the key the project chose.
-     *
-     * Every key becomes an external service: that is what a project's own
-     * `gacela.php` reads through `getExternalService()` when it declares its
-     * bindings. A key that *names a type* additionally becomes a binding, so
-     * `LoggerInterface::class => 'log'` is resolvable on its own -- by
-     * `Gacela::get()`, by autowiring, by `#[Inject]`. Bindings map types to
-     * implementations, so a key like `logger` has no business being one.
-     *
-     * Both take a closure, so a Laravel binding reaches Gacela without being
-     * constructed by the act of configuring it: a bridge that instantiated the
-     * database connection on every boot would cost more than it saves.
-     */
-    private function applyExternalServices(GacelaConfig $config): void
-    {
-        foreach ($this->externalServices as $key => $serviceId) {
-            $factory = fn (): object => $this->service($serviceId);
-
-            $config->addExternalService($key, $factory);
-
-            if (class_exists($key) || interface_exists($key)) {
-                $config->addBinding($key, $factory);
-            }
-        }
-    }
-
-    private function service(string $serviceId): object
-    {
-        /** @var object $service */
-        $service = $this->services->get($serviceId);
-
-        return $service;
+        $this->inner->bootstrap();
     }
 }

--- a/src/Framework/Bootstrap/IntegrationBootstrapper.php
+++ b/src/Framework/Bootstrap/IntegrationBootstrapper.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap;
+
+use Closure;
+use Gacela\Framework\Gacela;
+
+use function class_exists;
+use function interface_exists;
+
+/**
+ * Bootstraps Gacela from what a host application already knows.
+ *
+ * Every project integrating Gacela with another framework writes this by hand:
+ * the root directory, the cache settings, and the handful of host services a
+ * Factory needs to reach. It is the same code every time, which is what a
+ * bridge is for -- and it was the same code in both bridges, byte for byte
+ * once the docblocks were stripped.
+ *
+ * It lives here rather than in either of them because none of it is specific to
+ * a framework, and because of the one line that is easy not to know about:
+ * `resetInMemoryCache()`. A host that boots twice in one process -- which
+ * functional tests do constantly -- otherwise keeps the previous boot's
+ * locator, which keeps serving the previous boot's container. Both bridges had
+ * to learn that separately (#665, #667). A third integration now gets it
+ * without being told.
+ *
+ * The host is reached through a closure rather than a PSR-11 container so that
+ * this carries no dependency an integration might not have, and so an
+ * integration whose lookup is not a container can still use it.
+ */
+final class IntegrationBootstrapper
+{
+    /**
+     * @param array{cache_dir: ?string, file_cache: ?bool, project_namespaces: list<string>} $options
+     * @param Closure(string): object $resolveService looks a host service up by its id
+     * @param array<string, string> $externalServices gacela key => host service id
+     */
+    public function __construct(
+        private readonly string $appRootDir,
+        private readonly array $options,
+        private readonly Closure $resolveService,
+        private readonly array $externalServices = [],
+    ) {
+    }
+
+    public function bootstrap(): void
+    {
+        Gacela::bootstrap($this->appRootDir, function (GacelaConfig $config): void {
+            // Without this, a re-bootstrap keeps the previous boot's locator,
+            // which keeps serving the previous boot's container -- the #597
+            // class of bug, one layer down (#666). A first boot resets nothing
+            // but empty caches, so it only costs where it is needed.
+            $config->resetInMemoryCache();
+
+            $this->applyOptions($config);
+            $this->applyExternalServices($config);
+        });
+    }
+
+    private function applyOptions(GacelaConfig $config): void
+    {
+        if ($this->options['file_cache'] !== null) {
+            $config->setFileCache($this->options['file_cache'], $this->options['cache_dir']);
+        } elseif ($this->options['cache_dir'] !== null) {
+            $config->enableFileCache($this->options['cache_dir']);
+        }
+
+        if ($this->options['project_namespaces'] !== []) {
+            $config->setProjectNamespaces($this->options['project_namespaces']);
+        }
+    }
+
+    /**
+     * A listed service reaches Gacela two ways, and which ones apply is decided
+     * by the key the project chose.
+     *
+     * Every key becomes an external service: that is what a project's own
+     * `gacela.php` reads through `getExternalService()` when it declares its
+     * bindings. A key that *names a type* additionally becomes a binding, so
+     * `LoggerInterface::class => 'monolog.logger'` is resolvable on its own --
+     * by `Gacela::get()`, by autowiring, by `#[Inject]`. Bindings map types to
+     * implementations, so a key like `logger` has no business being one.
+     *
+     * Both take a closure, so a host service reaches Gacela without being
+     * constructed by the act of configuring it: a bridge that instantiated the
+     * entity manager on every boot would cost more than it saves.
+     */
+    private function applyExternalServices(GacelaConfig $config): void
+    {
+        foreach ($this->externalServices as $key => $serviceId) {
+            $factory = fn (): object => ($this->resolveService)($serviceId);
+
+            $config->addExternalService($key, $factory);
+
+            if (class_exists($key) || interface_exists($key)) {
+                $config->addBinding($key, $factory);
+            }
+        }
+    }
+}

--- a/symfony-bridge/src/GacelaBootstrapper.php
+++ b/symfony-bridge/src/GacelaBootstrapper.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace Gacela\SymfonyBridge;
 
-use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\Gacela;
+use Gacela\Framework\Bootstrap\IntegrationBootstrapper;
 use Psr\Container\ContainerInterface;
-
-use function class_exists;
-use function interface_exists;
 
 /**
  * Bootstraps Gacela from what the Symfony kernel already knows.
  *
- * Every Symfony project that uses Gacela writes this by hand -- the project
- * dir, the environment, the handful of Symfony services a Factory needs to
- * reach. It is the same code every time, which is what a bridge is for.
+ * Everything it does is {@see IntegrationBootstrapper}, which is where the logic lives: none of it
+ * was specific to Symfony, and both bridges held a byte-identical copy of it.
+ * This is the adapter -- it turns Symfony's container into the lookup that
+ * takes, and keeps the name and constructor the bundle registers as a service and checks with `instanceof`.
  *
  * A kernel can boot more than once in one process (functional tests do it
  * constantly), so bootstrapping is idempotent by being repeated: each boot
@@ -24,78 +21,33 @@ use function interface_exists;
  */
 final class GacelaBootstrapper
 {
+    private readonly IntegrationBootstrapper $inner;
+
     /**
      * @param array{cache_dir: ?string, file_cache: ?bool, project_namespaces: list<string>} $options
      * @param array<string, string> $externalServices gacela key => symfony service id
      */
     public function __construct(
-        private readonly string $appRootDir,
-        private readonly array $options,
-        private readonly ContainerInterface $services,
-        private readonly array $externalServices = [],
+        string $appRootDir,
+        array $options,
+        ContainerInterface $services,
+        array $externalServices = [],
     ) {
+        $this->inner = new IntegrationBootstrapper(
+            $appRootDir,
+            $options,
+            static function (string $serviceId) use ($services): object {
+                /** @var object $service */
+                $service = $services->get($serviceId);
+
+                return $service;
+            },
+            $externalServices,
+        );
     }
 
     public function bootstrap(): void
     {
-        Gacela::bootstrap($this->appRootDir, function (GacelaConfig $config): void {
-            // Without this, a re-bootstrap keeps the previous boot's locator,
-            // which keeps serving the previous boot's container -- the #597
-            // class of bug, one layer down (#666). A first boot resets nothing
-            // but empty caches, so it only costs where it is needed.
-            $config->resetInMemoryCache();
-
-            $this->applyOptions($config);
-            $this->applyExternalServices($config);
-        });
-    }
-
-    private function applyOptions(GacelaConfig $config): void
-    {
-        if ($this->options['file_cache'] !== null) {
-            $config->setFileCache($this->options['file_cache'], $this->options['cache_dir']);
-        } elseif ($this->options['cache_dir'] !== null) {
-            $config->enableFileCache($this->options['cache_dir']);
-        }
-
-        if ($this->options['project_namespaces'] !== []) {
-            $config->setProjectNamespaces($this->options['project_namespaces']);
-        }
-    }
-
-    /**
-     * A listed service reaches Gacela two ways, and which ones apply is decided
-     * by the key the project chose.
-     *
-     * Every key becomes an external service: that is what a project's own
-     * `gacela.php` reads through `getExternalService()` when it declares its
-     * bindings. A key that *names a type* additionally becomes a binding, so
-     * `LoggerInterface::class => 'monolog.logger'` is resolvable on its own --
-     * by `Gacela::get()`, by autowiring, by `#[Inject]`. Bindings map types to
-     * implementations, so a key like `logger` has no business being one.
-     *
-     * Both take a closure, so a Symfony service reaches Gacela without being
-     * constructed by the act of configuring it: a bridge that instantiated the
-     * entity manager on every boot would cost more than it saves.
-     */
-    private function applyExternalServices(GacelaConfig $config): void
-    {
-        foreach ($this->externalServices as $key => $serviceId) {
-            $factory = fn (): object => $this->service($serviceId);
-
-            $config->addExternalService($key, $factory);
-
-            if (class_exists($key) || interface_exists($key)) {
-                $config->addBinding($key, $factory);
-            }
-        }
-    }
-
-    private function service(string $serviceId): object
-    {
-        /** @var object $service */
-        $service = $this->services->get($serviceId);
-
-        return $service;
+        $this->inner->bootstrap();
     }
 }

--- a/tests/Integration/Framework/Bootstrap/IntegrationBootstrapperTest.php
+++ b/tests/Integration/Framework/Bootstrap/IntegrationBootstrapperTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Bootstrap;
+
+use Gacela\Framework\Bootstrap\IntegrationBootstrapper;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The two behaviours that are the reason this is in core rather than copied
+ * into each bridge, driven by a plain closure so no framework is involved.
+ *
+ * Everything else it does -- the cache options, the type-key binding rule -- is
+ * covered through the adapters in each bridge's own `GacelaBootstrapperTest`.
+ */
+final class IntegrationBootstrapperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+        Config::resetInstance();
+    }
+
+    /**
+     * A bridge that instantiated the entity manager by the act of configuring
+     * it would cost more than it saves, so the host is asked for a service only
+     * when something reaches for it.
+     */
+    public function test_a_listed_service_is_not_resolved_by_bootstrapping(): void
+    {
+        $resolved = 0;
+
+        $this->bootstrap([HostService::class => 'host.service'], static function (string $id) use (&$resolved): object {
+            ++$resolved;
+
+            return new HostService($id);
+        });
+
+        self::assertSame(0, $resolved, 'bootstrapping asked the host for a service');
+
+        Gacela::get(HostService::class);
+
+        self::assertSame(1, $resolved);
+    }
+
+    /**
+     * The line an integration is most likely not to know it needs.
+     *
+     * A host that boots twice in one process keeps the previous boot's locator
+     * without it, and that locator keeps serving the previous boot's container
+     * -- so the second boot's configuration is registered and ignored.
+     */
+    public function test_a_second_bootstrap_replaces_the_first_configuration(): void
+    {
+        $this->bootstrap(
+            [HostService::class => 'first'],
+            static fn (string $id): object => new HostService($id),
+        );
+
+        self::assertSame('first', Gacela::get(HostService::class)?->id);
+
+        $this->bootstrap(
+            [HostService::class => 'second'],
+            static fn (string $id): object => new HostService($id),
+        );
+
+        self::assertSame('second', Gacela::get(HostService::class)?->id);
+    }
+
+    /**
+     * @param array<string, string> $externalServices
+     * @param callable(string): object $resolveService
+     */
+    private function bootstrap(array $externalServices, callable $resolveService): void
+    {
+        (new IntegrationBootstrapper(
+            __DIR__,
+            ['cache_dir' => null, 'file_cache' => false, 'project_namespaces' => []],
+            $resolveService(...),
+            $externalServices,
+        ))->bootstrap();
+    }
+}
+
+final class HostService
+{
+    public function __construct(
+        public readonly string $id,
+    ) {
+    }
+}


### PR DESCRIPTION
## 📚 Description

Following #843, which found the command list written out three times, the bridges had a second copy-paste: `GacelaBootstrapper`.

Stripping comments and normalising the namespace, the **code-only diff between the two files is zero lines**. 101 lines each, identical logic, and none of it specific to Laravel or Symfony — it takes a root dir, cache options, and a map of `gacela key => host service id`.

The line that makes this worth sharing rather than just tidying is `resetInMemoryCache()`:

> Without this, a re-bootstrap keeps the previous boot's locator, which keeps serving the previous boot's container.

A host that boots twice in one process — which functional tests do constantly — otherwise registers the second boot's configuration and ignores it. **Both bridges had to learn that separately** (#665, #667). A third integration now gets it without being told.

### Decisions worth reviewing

- **A closure, not a PSR-11 container.** Core does not require `psr/container`, and importing a namespace a manifest never declares is exactly what `doctor`'s package-manifest check reports. A `Closure(string): object` also lets an integration whose lookup is not a container use this.
- **Each bridge keeps its own `GacelaBootstrapper`.** The Symfony bundle registers it as a service `Definition` and checks it with `instanceof`, so the name and constructor had to stay. They are now adapters that turn their container into that closure.
- **Composition, not inheritance**, so the core class stays `final` — the same choice `Container` makes over the upstream container.

### Verification

- Both bridges' **110 tests passed untouched**, which is what says the adapters are equivalent
- The core class gets a test for the two behaviours that are the *reason* it is shared, driven by a plain closure with no framework: bootstrapping does not resolve a listed service, and a second bootstrap replaces the first
- That second test was checked to **fail when `resetInMemoryCache()` is removed**, so it is not vacuous

## 🔖 Changes

- Add `Gacela\Framework\Bootstrap\IntegrationBootstrapper`
- Reduce both bridge classes to adapters — **142 lines deleted, 46 added**
- Add `IntegrationBootstrapperTest`