### PR TITLE
fix(console): write an array default as one readable expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 ### Fixed
 
+- Write an array default as one readable expression, in `dto:generate`'s output and in `debug:dependencies`/`debug:modules`. It went through `var_export()`, which puts `array (` on its own line and indents the body from column zero — so a generated constructor call came out across five mangled lines in a file the developer commits, a one-parameter-per-line listing grew line breaks mid-row, and the same text reached the `detail` field of the JSON those commands emit. Now `['a' => 1, 'b' => ['c' => 2]]`, with a list writing its values alone and `null` spelled the way the rest of the generated file spells it
 - Generate a `gacela.php` that names the project's own namespaces. `init` wrote the literal `setProjectNamespaces(['App'])` into every project it scaffolded, which is right for the ones that use `App\` and quietly wrong for the rest — the resolver tries those prefixes *before* the module's own namespace, so a wrong one costs a failed lookup on every cold resolution and resolves the wrong class for a project that does have an `App\` module of the same name. The prefixes now come from `composer.json`, falling back to `['App']` when there is no manifest
 
 - Reattach nine docblocks in the shipped code that described nothing, orphaned when a method was added between an existing docblock and its signature. Both halves stay valid php, so the analysers only object when the annotation was load-bearing for a type. A test now walks the shipped directories and fails on any docblock whose next meaningful token is another docblock

--- a/src/Console/Application/Debug/ConstructorInspector.php
+++ b/src/Console/Application/Debug/ConstructorInspector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Application\Debug;
 
+use Gacela\Console\Domain\FileContent\PhpValue;
+
 use Gacela\Container\Attribute\Inject;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
@@ -19,7 +21,6 @@ use function interface_exists;
 use function is_callable;
 use function is_object;
 use function sprintf;
-use function var_export;
 
 /**
  * @psalm-import-type BindingsMap from GacelaConfigFileInterface
@@ -118,7 +119,7 @@ final class ConstructorInspector
     {
         /** @var mixed $default */
         $default = $parameter->getDefaultValue();
-        return sprintf('= %s', var_export($default, true));
+        return sprintf('= %s', PhpValue::export($default));
     }
 
     /**

--- a/src/Console/Domain/DtoGenerate/DtoClassBuilder.php
+++ b/src/Console/Domain/DtoGenerate/DtoClassBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Domain\DtoGenerate;
 
+use Gacela\Console\Domain\FileContent\PhpValue;
+
 use Gacela\Framework\Dto\MissingDtoPropertyException;
 use Gacela\Framework\Dto\Schema\DtoType;
 
@@ -12,7 +14,6 @@ use function sprintf;
 use function strrpos;
 use function substr;
 use function ucfirst;
-use function var_export;
 
 /**
  * Writes one declared shape as php source.
@@ -106,7 +107,7 @@ final class DtoClassBuilder
             $args[] = sprintf(
                 "            \$data['%s'] ?? %s,",
                 $property,
-                $type->hasDefault ? var_export($type->default, true) : 'null',
+                $type->hasDefault ? PhpValue::export($type->default) : 'null',
             );
         }
 

--- a/src/Console/Domain/FileContent/PhpValue.php
+++ b/src/Console/Domain/FileContent/PhpValue.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\FileContent;
+
+use function array_is_list;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+use function var_export;
+
+/**
+ * A PHP value as the source you would write for it, on one line.
+ *
+ * `var_export()` is the obvious way to do this and is wrong wherever the result
+ * is placed inside something already formatted. It emits `array (` on its own
+ * line and indents the body from column zero, so an array default rendered into
+ * a constructor call came out as:
+ *
+ *     $data['meta'] ?? array (
+ *   'a' => 1,
+ *   'b' =>
+ *   array (
+ *     'c' => 2,
+ *   ),
+ * ),
+ *
+ * -- valid PHP, mangled to read, and committed by whoever ran `dto:generate`.
+ * The same call put line breaks into a `debug:dependencies` listing, whose
+ * whole shape is one parameter per line, and into the `detail` field of the
+ * JSON those commands emit.
+ *
+ * Scalars are still `var_export()`: it already quotes and escapes strings the
+ * way PHP source needs, and there is nothing to reformat.
+ */
+final class PhpValue
+{
+    public static function export(mixed $value): string
+    {
+        if (is_array($value)) {
+            return self::exportArray($value);
+        }
+
+        // `var_export()` spells it `NULL`, and the same generator writes a
+        // lowercase `null` for a property with no declared default -- so both
+        // spellings would sit in one generated file.
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_bool($value) || is_int($value) || is_float($value) || is_string($value)) {
+            return var_export($value, true);
+        }
+
+        // An object or a resource has no literal to write. Described rather
+        // than rendered, so it cannot read as source somebody pastes back.
+        return is_object($value) ? 'object(' . $value::class . ')' : 'resource';
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function exportArray(array $value): string
+    {
+        // No case for the empty array: the loop below adds nothing and the
+        // brackets are written either way, so `[]` falls out of the general
+        // path. A special case for it was dead the day it was written.
+        $isList = array_is_list($value);
+        $parts = [];
+
+        /** @var mixed $item */
+        foreach ($value as $key => $item) {
+            // A list writes its values alone: `[0 => 'eur', 1 => 'usd']` is the
+            // same array spelled longer, and these are read by people.
+            $parts[] = $isList
+                ? self::export($item)
+                : var_export($key, true) . ' => ' . self::export($item);
+        }
+
+        return '[' . implode(', ', $parts) . ']';
+    }
+}

--- a/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
+++ b/tests/Feature/Console/DtoGenerate/DtoGenerateCommandTest.php
@@ -293,6 +293,37 @@ final class DtoGenerateCommandTest extends TestCase
     }
 
     /**
+     * An array default used to be written by `var_export()`, which puts
+     * `array (` on its own line and indents the body from column zero -- so the
+     * generated constructor call came out across five mangled lines, in a file
+     * whoever ran the command commits and reads.
+     */
+    public function test_an_array_default_is_written_as_one_readable_expression(): void
+    {
+        $orderClass = $this->orderClass();
+
+        Gacela::bootstrap($this->projectDir, static function (GacelaConfig $config) use ($orderClass): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+            $config->declareDtoSchema($orderClass, [
+                'reference' => DtoType::string()->required(),
+                'tags' => DtoType::array()->default(['eur', 'usd']),
+                'meta' => DtoType::array()->default(['a' => 1, 'b' => ['c' => 2]]),
+                'empty' => DtoType::array()->default([]),
+            ]);
+        });
+
+        (new CommandTester(new DtoGenerateCommand()))->execute([]);
+
+        $generated = (string)file_get_contents($this->orderFile());
+
+        self::assertStringContainsString("\$data['tags'] ?? ['eur', 'usd'],", $generated);
+        self::assertStringContainsString("\$data['meta'] ?? ['a' => 1, 'b' => ['c' => 2]],", $generated);
+        self::assertStringContainsString("\$data['empty'] ?? [],", $generated);
+        self::assertStringNotContainsString('array (', $generated);
+    }
+
+    /**
      * @param list<string> $classNames
      */
     private function generateMany(array $classNames): CommandTester

--- a/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
+++ b/tests/Unit/Console/Application/Debug/ConstructorInspectorTest.php
@@ -32,6 +32,25 @@ final class ConstructorInspectorTest extends TestCase
         $this->inspector = new ConstructorInspector();
     }
 
+    /**
+     * The detail is one line in a report that puts one parameter per line, and
+     * in a JSON string field. `var_export()` on an array default put line
+     * breaks through both.
+     */
+    public function test_an_array_default_is_described_on_one_line(): void
+    {
+        $inspection = (new ConstructorInspector())->inspect(WithArrayDefaults::class);
+
+        $details = [];
+        foreach ($inspection->parameters as $parameter) {
+            $details[$parameter->name] = $parameter->detail;
+        }
+
+        self::assertSame("= ['a' => 1, 'b' => ['c' => 2]]", $details['$nested']);
+        self::assertSame('= []', $details['$empty']);
+        self::assertSame("= ['eur', 'usd']", $details['$list']);
+    }
+
     public function test_class_without_constructor(): void
     {
         $inspection = $this->inspector->inspect(NoConstructorService::class);
@@ -161,5 +180,20 @@ final class ConstructorInspectorTest extends TestCase
             'bound -> ' . BoundImplementation::class . ' instance',
             $inspection->parameters[0]->detail,
         );
+    }
+}
+
+final class WithArrayDefaults
+{
+    /**
+     * @param array<string, mixed> $nested
+     * @param array<array-key, mixed> $empty
+     * @param list<string> $list
+     */
+    public function __construct(
+        public readonly array $nested = ['a' => 1, 'b' => ['c' => 2]],
+        public readonly array $empty = [],
+        public readonly array $list = ['eur', 'usd'],
+    ) {
     }
 }

--- a/tests/Unit/Console/Domain/FileContent/PhpValueTest.php
+++ b/tests/Unit/Console/Domain/FileContent/PhpValueTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\FileContent;
+
+use Gacela\Console\Domain\FileContent\PhpValue;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function fclose;
+use function fopen;
+
+final class PhpValueTest extends TestCase
+{
+    /**
+     * The reason this exists. `var_export()` writes `array (` on its own line
+     * and indents from column zero, which mangles anything already formatted:
+     * a generated constructor call, a one-parameter-per-line listing, and a
+     * JSON string field.
+     */
+    public function test_no_export_contains_a_line_break(): void
+    {
+        foreach ([[], [1, 2], ['a' => 1], ['a' => ['b' => ['c' => 1]]], 'x', 1, null] as $value) {
+            self::assertStringNotContainsString(
+                "\n", PhpValue::export($value),
+                'a line break would break every caller',
+            );
+        }
+    }
+
+    public function test_an_empty_array_is_the_short_syntax(): void
+    {
+        self::assertSame('[]', PhpValue::export([]));
+    }
+
+    /**
+     * A list writes its values alone: `[0 => 'eur', 1 => 'usd']` is the same
+     * array spelled longer, and these are read by people.
+     */
+    public function test_a_list_omits_its_keys(): void
+    {
+        self::assertSame("['eur', 'usd']", PhpValue::export(['eur', 'usd']));
+    }
+
+    public function test_a_map_keeps_its_keys(): void
+    {
+        self::assertSame("['a' => 1, 'b' => 2]", PhpValue::export(['a' => 1, 'b' => 2]));
+    }
+
+    public function test_a_nested_array_stays_on_one_line(): void
+    {
+        self::assertSame("['a' => 1, 'b' => ['c' => 2]]", PhpValue::export(['a' => 1, 'b' => ['c' => 2]]));
+    }
+
+    /**
+     * An array that is a list of maps is the shape a declared default most
+     * often has, and it exercises both branches at once.
+     */
+    public function test_a_list_of_maps_renders_both_ways_at_once(): void
+    {
+        self::assertSame(
+            "[['id' => 1], ['id' => 2]]",
+            PhpValue::export([['id' => 1], ['id' => 2]]),
+        );
+    }
+
+    /**
+     * A key that is a string still gets quoted, and one that is an int does
+     * not -- which is what makes a non-list map read back as itself.
+     */
+    public function test_integer_keys_on_a_non_list_are_kept_unquoted(): void
+    {
+        self::assertSame('[5 => 1, 9 => 2]', PhpValue::export([5 => 1, 9 => 2]));
+    }
+
+    /**
+     * Scalars go through `var_export()` on purpose: it already quotes and
+     * escapes strings the way PHP source needs.
+     */
+    public function test_a_string_is_quoted_and_escaped(): void
+    {
+        self::assertSame("'it\\'s'", PhpValue::export("it's"));
+        self::assertSame("'EUR'", PhpValue::export('EUR'));
+    }
+
+    public function test_scalars_keep_their_php_spelling(): void
+    {
+        self::assertSame('null', PhpValue::export(null));
+        self::assertSame('true', PhpValue::export(true));
+        self::assertSame('false', PhpValue::export(false));
+        self::assertSame('3', PhpValue::export(3));
+        self::assertSame('1.5', PhpValue::export(1.5));
+    }
+
+    /**
+     * An object has no literal to write. It is described rather than rendered,
+     * so it cannot read as source somebody pastes back -- `var_export()` would
+     * emit a `\stdClass::__set_state(...)` call that does not even run.
+     */
+    public function test_an_object_is_described_rather_than_rendered(): void
+    {
+        self::assertSame('object(stdClass)', PhpValue::export(new stdClass()));
+    }
+
+    public function test_a_resource_is_described(): void
+    {
+        $handle = fopen('php://memory', 'rb');
+
+        self::assertSame('resource', PhpValue::export($handle));
+
+        if ($handle !== false) {
+            fclose($handle);
+        }
+    }
+}

--- a/tests/Unit/Console/Domain/FileContent/PhpValueTest.php
+++ b/tests/Unit/Console/Domain/FileContent/PhpValueTest.php
@@ -23,7 +23,8 @@ final class PhpValueTest extends TestCase
     {
         foreach ([[], [1, 2], ['a' => 1], ['a' => ['b' => ['c' => 1]]], 'x', 1, null] as $value) {
             self::assertStringNotContainsString(
-                "\n", PhpValue::export($value),
+                "\n",
+                PhpValue::export($value),
                 'a line break would break every caller',
             );
         }


### PR DESCRIPTION
## 📚 Description

Found by running `dto:generate` against a scratch project with an array default. `var_export()` puts `array (` on its own line and indents the body from column zero, so its result is wrong anywhere it lands inside something already formatted — and three surfaces were doing exactly that.

**Generated code**, in a file whoever ran the command commits and reads:

```php
            $data['meta'] ?? array (
  'a' => 1,
  'b' =>
  array (
    'c' => 2,
  ),
),
            $data['tags'] ?? array (
  0 => 'eur',
  1 => 'usd',
),
```

Now:

```php
            $data['meta'] ?? ['a' => 1, 'b' => ['c' => 2]],
            $data['tags'] ?? ['eur', 'usd'],
```

**`debug:dependencies`**, whose whole shape is one parameter per line:

```
  ✓ $opts array = array (        →    ✓ $opts array = ['a' => 1, 'b' => ['c' => 2]]
  'a' => 1,                           ✓ $empty array = []
  'b' => 2,                           ✓ $list array = ['eur', 'usd']
)
  ✓ $empty array = array (
)
```

**And the JSON** those commands emit, where the same text became a `detail` field with embedded newlines — including the documents added in #839 and #842.

## 🔖 Changes

- Add `PhpValue::export()`, used by `DtoClassBuilder` and `ConstructorInspector`
- A list writes its values alone — `[0 => 'eur', 1 => 'usd']` is the same array spelled longer, and these are read by people
- `null` is lowercase: `var_export()` says `NULL`, while the same generator writes `null` for a property with no declared default, so both spellings were landing in one generated file
- Objects and resources are *described* (`object(stdClass)`) rather than rendered, since `var_export()` emits a `\stdClass::__set_state(...)` call that does not even run
- Scalars still go through `var_export()`: it already quotes and escapes strings the way PHP source needs
- Regression tests at both consuming surfaces, plus unit tests; `infection` kills all 33 mutants

### One thing the mutation gate corrected

I wrote an early `return '[]'` for the empty array. A surviving mutant showed it was dead on arrival — the general path already yields `'[' . '' . ']'`. Deleted rather than tested.