### PR TITLE
ci: cap every workflow job's runtime with timeout-minutes

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -17,6 +17,8 @@ jobs:
   coding-guidelines:
     name: Coding Guidelines
     runs-on: ubuntu-latest
+    # Finishes in under a minute; the margin is for a cold composer cache.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -52,6 +54,8 @@ jobs:
   type-checker:
     name: Type Checker
     runs-on: ubuntu-latest
+    # Finishes in under a minute; the margin is for a cold composer cache.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -50,6 +50,8 @@ jobs:
     name: "Mutation testing (changed lines)"
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # Scoped to the diff, but a wide PR can still mutate a lot of lines.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,6 +114,8 @@ jobs:
     name: "Mutation testing (full, min MSI 90%)"
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # The longest job in the repository: every mutant, not just the diff.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/module-cycles.yml
+++ b/.github/workflows/module-cycles.yml
@@ -31,6 +31,8 @@ jobs:
   cycle-gate:
     name: "Module dependency cycles"
     runs-on: ubuntu-latest
+    # Finishes in under a minute; the margin is for a cold composer cache.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/module-graph.yml
+++ b/.github/workflows/module-graph.yml
@@ -24,6 +24,8 @@ jobs:
   graph-diff:
     name: "Module dependency graph"
     runs-on: ubuntu-latest
+    # Finishes in under a minute; the margin is for a cold composer cache.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -23,6 +23,10 @@ jobs:
   regression-guard:
     name: "Performance regression guard"
     runs-on: ubuntu-latest
+    # Observed 1.5-6 min. The widest margin of the fast jobs: it runs composer
+    # install twice, once for the base checkout and once for the head, so a
+    # cold cache legitimately costs several times the median.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
   tests:
     name: "PHP version ${{ matrix.php-version }}, deps. ${{ matrix.dependencies }} in ${{ matrix.operating-system }}"
     runs-on: ${{ matrix.operating-system }}
+    # Observed 1-2.5 min. The margin covers a Windows runner installing
+    # dependencies from a cold cache.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Every CI job declares `timeout-minutes`, sized against observed durations: 10 for the sub-minute gates, 20 for `Tests` and `PHPBench`, 45 for either mutation-testing job. Without one a job inherits GitHub's 6-hour default, so a runner that stalls seconds after starting — five times in one day on `PHPBench` — holds a pull request's checks open until somebody cancels the run by hand, and a cancel alone marks it failed rather than re-queueing it. A timeout turns the same stall into an ordinary red check anyone can re-run. An architecture test fails the build if a new job forgets one
+
 ## [2.3.0](https://github.com/gacela-project/gacela/compare/2.2.0...2.3.0) - 2026-08-15
 
 ### Added

--- a/tests/Integration/Architecture/WorkflowJobTimeoutTest.php
+++ b/tests/Integration/Architecture/WorkflowJobTimeoutTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function dirname;
+use function is_array;
+use function preg_match;
+use function sprintf;
+
+/**
+ * Guards that every CI job caps its own runtime.
+ *
+ * A job without `timeout-minutes` inherits GitHub's 6-hour default. A runner
+ * that stalls on checkout or `setup-php` therefore holds the PR's checks open
+ * for six hours, and only a human with `gh run cancel` -- followed by an
+ * explicit `gh run rerun`, because a cancel alone marks the run failed --
+ * can clear it. That happened five times in one day on `phpbench.yml`.
+ *
+ * With a timeout the same stall surfaces as an ordinary red check anyone can
+ * re-run. The values are sized generously against observed durations, so this
+ * test also refuses a timeout so large it re-creates the problem it fixes.
+ */
+final class WorkflowJobTimeoutTest extends TestCase
+{
+    /**
+     * No job in this repository legitimately runs this long; the slowest is
+     * the full mutation-testing sweep. A larger value is a typo, not a need.
+     */
+    private const int MAX_TIMEOUT_MINUTES = 60;
+
+    /**
+     * @return iterable<string, array{string, string, int|null}>
+     */
+    public static function workflowJobProvider(): iterable
+    {
+        foreach (self::workflowFiles() as $file) {
+            $name = basename($file);
+
+            foreach (self::jobsOf($file) as $job => $timeout) {
+                yield sprintf('%s: %s', $name, $job) => [$name, $job, $timeout];
+            }
+        }
+    }
+
+    #[DataProvider('workflowJobProvider')]
+    public function test_workflow_job_declares_a_timeout(string $workflow, string $job, ?int $timeout): void
+    {
+        self::assertNotNull($timeout, sprintf(
+            "Job '%s' in %s has no timeout-minutes, so it inherits GitHub's 6-hour default. "
+            . 'A stalled runner would block the PR until somebody cancels it by hand.',
+            $job,
+            $workflow,
+        ));
+    }
+
+    #[DataProvider('workflowJobProvider')]
+    public function test_workflow_job_timeout_stays_within_reach(string $workflow, string $job, ?int $timeout): void
+    {
+        if ($timeout === null) {
+            self::markTestSkipped('Covered by test_workflow_job_declares_a_timeout.');
+        }
+
+        self::assertGreaterThan(0, $timeout, sprintf(
+            "Job '%s' in %s declares timeout-minutes: %d.",
+            $job,
+            $workflow,
+            $timeout,
+        ));
+
+        self::assertLessThanOrEqual(self::MAX_TIMEOUT_MINUTES, $timeout, sprintf(
+            "Job '%s' in %s declares timeout-minutes: %d. Nothing here runs that long; "
+            . 'a cap above %d leaves a stalled runner blocking the PR, which is what the cap is for.',
+            $job,
+            $workflow,
+            $timeout,
+            self::MAX_TIMEOUT_MINUTES,
+        ));
+    }
+
+    public function test_every_workflow_declares_at_least_one_job(): void
+    {
+        foreach (self::workflowFiles() as $file) {
+            self::assertNotEmpty(self::jobsOf($file), sprintf(
+                '%s parsed to no jobs at all; the guard would pass vacuously.',
+                basename($file),
+            ));
+        }
+    }
+
+    public function test_the_repository_has_workflows_to_check(): void
+    {
+        self::assertGreaterThan(1, count(self::workflowFiles()));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function workflowFiles(): array
+    {
+        $found = glob(dirname(__DIR__, 3) . '/.github/workflows/*.yml');
+
+        return is_array($found) ? $found : [];
+    }
+
+    /**
+     * Maps each job id declared under the top-level `jobs:` key to its
+     * `timeout-minutes`, or to null when it declares none.
+     *
+     * Job ids sit at two spaces of indentation and their own keys at four, so
+     * a line parser separates them without a YAML extension -- which this
+     * repository does not require, and which would only be needed here.
+     *
+     * @return array<string, int|null>
+     */
+    private static function jobsOf(string $file): array
+    {
+        $jobs = [];
+        $current = null;
+        $inJobs = false;
+
+        foreach (file($file, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            if (preg_match('/^jobs:\s*$/', $line) === 1) {
+                $inJobs = true;
+                continue;
+            }
+
+            if (!$inJobs) {
+                continue;
+            }
+
+            if (preg_match('/^\S/', $line) === 1) {
+                break;
+            }
+
+            if (preg_match('/^ {2}([A-Za-z0-9_-]+):\s*$/', $line, $matches) === 1) {
+                $current = $matches[1];
+                $jobs[$current] = null;
+                continue;
+            }
+
+            if ($current !== null && preg_match('/^ {4}timeout-minutes:\s*(\d+)\s*$/', $line, $matches) === 1) {
+                $jobs[$current] = (int)$matches[1];
+            }
+        }
+
+        return $jobs;
+    }
+}

--- a/tests/Integration/Architecture/WorkflowJobTimeoutTest.php
+++ b/tests/Integration/Architecture/WorkflowJobTimeoutTest.php
@@ -42,7 +42,7 @@ final class WorkflowJobTimeoutTest extends TestCase
         foreach (self::workflowFiles() as $file) {
             $name = basename($file);
 
-            foreach (self::jobsOf($file) as $job => $timeout) {
+            foreach (self::jobTimeoutsIn($file) as $job => $timeout) {
                 yield sprintf('%s: %s', $name, $job) => [$name, $job, $timeout];
             }
         }
@@ -86,7 +86,7 @@ final class WorkflowJobTimeoutTest extends TestCase
     public function test_every_workflow_declares_at_least_one_job(): void
     {
         foreach (self::workflowFiles() as $file) {
-            self::assertNotEmpty(self::jobsOf($file), sprintf(
+            self::assertNotEmpty(self::jobTimeoutsIn($file), sprintf(
                 '%s parsed to no jobs at all; the guard would pass vacuously.',
                 basename($file),
             ));
@@ -103,7 +103,7 @@ final class WorkflowJobTimeoutTest extends TestCase
      */
     private static function workflowFiles(): array
     {
-        $found = glob(dirname(__DIR__, 3) . '/.github/workflows/*.yml');
+        $found = glob(dirname(__DIR__, 3) . '/.github/workflows/*.{yml,yaml}', GLOB_BRACE);
 
         return is_array($found) ? $found : [];
     }
@@ -118,7 +118,7 @@ final class WorkflowJobTimeoutTest extends TestCase
      *
      * @return array<string, int|null>
      */
-    private static function jobsOf(string $file): array
+    private static function jobTimeoutsIn(string $file): array
     {
         $jobs = [];
         $current = null;


### PR DESCRIPTION
## 📚 Description

No job in any workflow set `timeout-minutes`, so each inherited GitHub's 6-hour default. A runner that stalled seconds after starting held a pull request's checks open until somebody cancelled the run by hand — five times in one day on `PHPBench` — and a cancel alone marks the run failed rather than re-queueing it, so an explicit rerun had to follow. A timeout turns the same stall into an ordinary red check anyone can re-run.

## 🔖 Changes

- `timeout-minutes` on all 8 jobs, sized against observed durations so a legitimately slow run is never killed: `10` for the sub-minute gates (Code style ×2, Module cycles, Module graph), `20` for Tests and PHPBench, `45` for either Infection job
- PHPBench gets the widest margin of the fast ones: it runs `composer install` twice, for the base checkout and for the head, so a cold cache legitimately costs several times the median
- New `WorkflowJobTimeoutTest` parses the workflows and fails the build if a job declares no timeout, or declares one above 60 minutes — large enough to re-create the problem the cap exists to fix

Closes #823