### PR TITLE
feat(console): say which paths were scanned when no module is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `list:modules`, `debug:modules` and `debug:graph` name the paths they scanned when they find nothing: `Scanned: src`. `appModulePaths` narrows discovery to a subset of the project, so a module outside that subset is missing for a reason nothing about the module itself reveals — the report already said to check the psr-4 mapping, but never said where it had looked. Read from the configured entries rather than their resolved absolute paths, because the entry is what you would edit
+
 ### Changed
 
 - Every CI job declares `timeout-minutes`, sized against observed durations: 10 for the sub-minute gates, 20 for `Tests` and `PHPBench`, 45 for either mutation-testing job. Without one a job inherits GitHub's 6-hour default, so a runner that stalls seconds after starting — five times in one day on `PHPBench` — holds a pull request's checks open until somebody cancels the run by hand, and a cancel alone marks it failed rather than re-queueing it. A timeout turns the same stall into an ordinary red check anyone can re-run. An architecture test fails the build if a new job forgets one

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -115,6 +115,17 @@ final class ConsoleFacade extends AbstractFacade
     }
 
     /**
+     * The `appModulePaths` entries discovery walked, for a report that found
+     * nothing and has to say where it looked.
+     *
+     * @return list<string>
+     */
+    public function scannedModulePaths(): array
+    {
+        return $this->getFactory()->scannedModulePaths();
+    }
+
+    /**
      * Files named like a Facade that discovery did not turn into a module.
      *
      * The inverse of findAllAppModules(): every check works from the modules

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -296,6 +296,25 @@ final class ConsoleFactory extends AbstractFactory
     }
 
     /**
+     * The directories discovery actually walked, as configured rather than as
+     * resolved: `appModulePaths` is what a reader would edit, and an absolute
+     * path expanded from it is noise next to the entry it came from.
+     *
+     * An entry that is not a directory is reported all the same. It scans
+     * nothing, which is exactly what someone reading an empty module list
+     * needs to see -- the `trigger_error` above says so once, on a stream the
+     * command's own output may not share.
+     *
+     * @return list<string>
+     */
+    public function scannedModulePaths(): array
+    {
+        $paths = Config::getInstance()->getSetupGacela()->getAppModulePaths();
+
+        return $paths === [] ? [Gacela::rootDir()] : $paths;
+    }
+
+    /**
      * Read from the same place `doctor` reads the rest of the suffix map, rather
      * than from `ResolvableTypes`' static: that one is synced from configuration
      * and a check has no way to know whether it has been yet.

--- a/src/Console/Infrastructure/Command/ConsoleSection.php
+++ b/src/Console/Infrastructure/Command/ConsoleSection.php
@@ -45,16 +45,28 @@ final class ConsoleSection
      * namespace composer cannot map is skipped in silence. The files are right
      * there on disk, which is what makes an empty list read as a bug in the
      * command rather than in the autoload map.
+     *
+     * Both answers name the paths that were scanned. `appModulePaths` narrows
+     * discovery to a subset of the project, so a module outside that subset is
+     * absent for a reason no amount of looking at the module itself reveals.
+     *
+     * @param list<string> $scannedPaths
      */
-    public static function noModulesFound(OutputInterface $output, string $filter, string $indent = ''): void
-    {
+    public static function noModulesFound(
+        OutputInterface $output,
+        string $filter,
+        string $indent = '',
+        array $scannedPaths = [],
+    ): void {
         if ($filter !== '') {
             $output->writeln(sprintf('%s<comment>No modules match filter "%s".</comment>', $indent, $filter));
+            self::writeScannedPaths($output, $indent, $scannedPaths);
 
             return;
         }
 
         $output->writeln(sprintf('%s<comment>No modules found.</comment>', $indent));
+        self::writeScannedPaths($output, $indent, $scannedPaths);
         $output->writeln(sprintf(
             '%sA module is found by its Facade: the filename carries the suffix, and the class has to be'
             . ' autoloadable. If the files are there, check the psr-4 mapping in composer.json.',
@@ -104,5 +116,17 @@ final class ConsoleSection
             'Nothing was written. Pass <comment>--force</comment> to replace %s.',
             count($paths) === 1 ? 'it' : 'them',
         ));
+    }
+
+    /**
+     * @param list<string> $scannedPaths
+     */
+    private static function writeScannedPaths(OutputInterface $output, string $indent, array $scannedPaths): void
+    {
+        if ($scannedPaths === []) {
+            return;
+        }
+
+        $output->writeln(sprintf('%sScanned: %s', $indent, implode(', ', $scannedPaths)));
     }
 }

--- a/src/Console/Infrastructure/Command/DebugGraphCommand.php
+++ b/src/Console/Infrastructure/Command/DebugGraphCommand.php
@@ -94,7 +94,7 @@ final class DebugGraphCommand extends Command
         }
 
         if ($graph === []) {
-            ConsoleSection::noModulesFound($output, $filter);
+            ConsoleSection::noModulesFound($output, $filter, '', $this->getFacade()->scannedModulePaths());
 
             return self::SUCCESS;
         }

--- a/src/Console/Infrastructure/Command/DebugModulesCommand.php
+++ b/src/Console/Infrastructure/Command/DebugModulesCommand.php
@@ -90,7 +90,7 @@ final class DebugModulesCommand extends Command
         $this->writeHeader($output, $filter);
 
         if ($modules === []) {
-            ConsoleSection::noModulesFound($output, $filter, '  ');
+            ConsoleSection::noModulesFound($output, $filter, '  ', $this->getFacade()->scannedModulePaths());
             $output->writeln('');
             return Command::SUCCESS;
         }

--- a/src/Console/Infrastructure/Command/ListModulesCommand.php
+++ b/src/Console/Infrastructure/Command/ListModulesCommand.php
@@ -63,7 +63,7 @@ final class ListModulesCommand extends Command
         }
 
         if ($modules === []) {
-            ConsoleSection::noModulesFound($output, $filter);
+            ConsoleSection::noModulesFound($output, $filter, '', $this->getFacade()->scannedModulePaths());
 
             return self::SUCCESS;
         }

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -132,6 +132,39 @@ final class ListModulesCommandTest extends TestCase
         }
     }
 
+    /**
+     * The empty report says what to check but never said where it looked.
+     *
+     * `appModulePaths` narrows discovery to a subset of the project -- this
+     * repository's own `gacela.php` pins it to `src` -- and a reader whose
+     * module sits outside that subset sees files on disk, an empty list, and
+     * no way to connect the two without opening the config. Naming the paths
+     * turns "why is my module missing" into one line of output.
+     */
+    public function test_finding_nothing_names_the_paths_that_were_scanned(): void
+    {
+        $emptyDir = sys_get_temp_dir() . '/gacela-scanned-' . bin2hex(random_bytes(4));
+        mkdir($emptyDir . '/inner', 0777, true);
+
+        try {
+            Gacela::bootstrap($emptyDir, static function (GacelaConfig $config): void {
+                $config->resetInMemoryCache();
+                $config->setAppModulePaths(['inner']);
+            });
+
+            $tester = new CommandTester(new ListModulesCommand());
+            $tester->execute([]);
+            $display = $tester->getDisplay();
+
+            self::assertStringContainsString('No modules found.', $display);
+            self::assertStringContainsString('Scanned: inner', $display);
+        } finally {
+            // Names exactly what this test created.
+            rmdir($emptyDir . '/inner');
+            rmdir($emptyDir);
+        }
+    }
+
     public function test_non_matching_filter_reports_no_modules(): void
     {
         $this->command->execute(['filter' => 'NoSuchModuleXYZ']);
@@ -140,6 +173,17 @@ final class ListModulesCommandTest extends TestCase
 
         self::assertStringContainsString('No modules match filter "NoSuchModuleXYZ".', $output);
         self::assertStringNotContainsString('┌────', $output);
+    }
+
+    /**
+     * A filter that matched nothing has the same question behind it as an empty
+     * project: the answer depends on where discovery was pointed.
+     */
+    public function test_a_non_matching_filter_also_names_the_paths_that_were_scanned(): void
+    {
+        $this->command->execute(['filter' => 'NoSuchModuleXYZ']);
+
+        self::assertStringContainsString('Scanned: ', $this->command->getDisplay());
     }
 
     public function test_non_matching_filter_reports_no_modules_in_detailed_view(): void


### PR DESCRIPTION
## 📚 Description

`appModulePaths` narrows discovery to a subset of the project — this repository's own `gacela.php` pins it to `src` — so a module outside that subset is absent for a reason nothing about the module itself reveals. The empty report already named a cause worth naming (the psr-4 mapping) but never said *where* it had looked, which leaves the reader comparing files on disk against a list that had no chance of containing them.

## 🔖 Changes

- `list:modules`, `debug:modules` and `debug:graph` add `Scanned: <paths>` to both empty answers — the no-filter one and the filter-matched-nothing one
- The configured `appModulePaths` entries are reported rather than their resolved absolute paths, because the entry is what you would edit
- An entry that is not a directory is listed too: it scans nothing, which is the thing worth seeing, and the existing `trigger_error` says so on a stream this output may not share
- New `ConsoleFacade::scannedModulePaths()`; `ConsoleSection::noModulesFound()` takes the paths as a trailing optional argument, so the signature stays backward compatible