### PR TITLE
fix(console): stop telling readers a missing module is a naming problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `list:modules`, `debug:modules` and `debug:graph` name the paths they scanned when they find nothing: `Scanned: src`. `appModulePaths` narrows discovery to a subset of the project, so a module outside that subset is missing for a reason nothing about the module itself reveals — the report already said to check the psr-4 mapping, but never said where it had looked. Read from the configured entries rather than their resolved absolute paths, because the entry is what you would edit
 
+### Fixed
+
+- The "no modules found" hint said a module is found because "the filename carries the suffix". Discovery accepts by inheritance and never reads a suffix — a class extending `AbstractFacade` is a module whatever it is called — so the sentence sent a reader whose module was missing off to rename files that were never the cause. It now names the real conditions: extends `AbstractFacade`, named after the file that declares it, and autoloadable. Both are pinned by tests, the second being the true part the old wording was reaching for
+
 ### Changed
 
 - Every CI job declares `timeout-minutes`, sized against observed durations: 10 for the sub-minute gates, 20 for `Tests` and `PHPBench`, 45 for either mutation-testing job. Without one a job inherits GitHub's 6-hour default, so a runner that stalls seconds after starting — five times in one day on `PHPBench` — holds a pull request's checks open until somebody cancels the run by hand, and a cancel alone marks it failed rather than re-queueing it. A timeout turns the same stall into an ordinary red check anyone can re-run. An architecture test fails the build if a new job forgets one

--- a/src/Console/Infrastructure/Command/ConsoleSection.php
+++ b/src/Console/Infrastructure/Command/ConsoleSection.php
@@ -46,6 +46,15 @@ final class ConsoleSection
      * there on disk, which is what makes an empty list read as a bug in the
      * command rather than in the autoload map.
      *
+     * It used to say "the filename carries the suffix", which is not what
+     * decides anything here: `AllAppModulesFinder` accepts by inheritance and
+     * never looks at a suffix, so a class extending `AbstractFacade` is a
+     * module whatever it is called. Sending a reader whose module is missing
+     * to rename files costs them the one thing this sentence exists to save.
+     * What the filename *does* decide is the class name discovery looks for,
+     * so a file declaring a differently named class is skipped -- which is the
+     * true half of what the old wording was reaching for.
+     *
      * Both answers name the paths that were scanned. `appModulePaths` narrows
      * discovery to a subset of the project, so a module outside that subset is
      * absent for a reason no amount of looking at the module itself reveals.
@@ -68,8 +77,9 @@ final class ConsoleSection
         $output->writeln(sprintf('%s<comment>No modules found.</comment>', $indent));
         self::writeScannedPaths($output, $indent, $scannedPaths);
         $output->writeln(sprintf(
-            '%sA module is found by its Facade: the filename carries the suffix, and the class has to be'
-            . ' autoloadable. If the files are there, check the psr-4 mapping in composer.json.',
+            '%sA module is found by its Facade: a class extending AbstractFacade, named after the file that'
+            . ' declares it, and autoloadable. The suffix is not what decides it.'
+            . ' If the files are there, check the psr-4 mapping in composer.json.',
             $indent,
         ));
     }

--- a/tests/Feature/Console/ListModules/ListModulesCommandTest.php
+++ b/tests/Feature/Console/ListModules/ListModulesCommandTest.php
@@ -126,6 +126,12 @@ final class ListModulesCommandTest extends TestCase
             self::assertStringContainsString('No modules found.', $display);
             self::assertStringNotContainsString('filter ""', $display);
             self::assertStringContainsString('autoloadable', $display);
+
+            // Discovery accepts by inheritance and never reads a suffix, so the
+            // hint must not send a reader off to rename files. Pinned as words
+            // because that is the whole of what this sentence is.
+            self::assertStringContainsString('extending AbstractFacade', $display);
+            self::assertStringNotContainsString('the filename carries the suffix', $display);
         } finally {
             // Names exactly what this test created.
             rmdir($emptyDir);

--- a/tests/Unit/Console/Domain/AllAppModules/AllAppModulesFinderTest.php
+++ b/tests/Unit/Console/Domain/AllAppModules/AllAppModulesFinderTest.php
@@ -129,6 +129,70 @@ final class AllAppModulesFinderTest extends TestCase
     }
 
     /**
+     * Discovery accepts by inheritance, not by name: nothing here looks at the
+     * filename suffix, so a class descending from `AbstractFacade` is a module
+     * whatever it is called. The empty report used to say the opposite -- "the
+     * filename carries the suffix" -- which sends a reader whose module is
+     * missing to rename files that were never the cause.
+     *
+     * The suffix does decide other things (which files the undiscovered-facades
+     * check looks at, how the pillars of a found module are resolved), so the
+     * contract is pinned here rather than left to the wording of a message.
+     */
+    public function test_a_facade_is_found_even_when_its_filename_carries_no_suffix(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('nosuffix');
+        $filePath = $tempDir . '/Whatever.php';
+        $className = 'TempAllAppModulesNoSuffix\\Whatever';
+
+        $this->writeTempFacadeFile($filePath, $className);
+        require_once $filePath;
+
+        $finder = new AllAppModulesFinder(
+            $this->iteratorFor($this->fileInfoFor($filePath, 'Whatever.php')),
+            $this->createAppModuleCreator(),
+        );
+
+        try {
+            $modules = $finder->findAllAppModules('');
+
+            self::assertCount(1, $modules);
+            self::assertSame($className, $modules[0]->facadeClass());
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    /**
+     * The other half of the same contract, and the half the old wording was
+     * groping at: the class name comes from the *filename*, so a file whose
+     * declared class is named something else is invisible to discovery even
+     * though the class itself loads perfectly well.
+     */
+    public function test_a_facade_whose_class_name_does_not_match_its_filename_is_not_found(): void
+    {
+        $tempDir = $this->createTempModuleDirectory('mismatch');
+        $filePath = $tempDir . '/Mismatch.php';
+
+        // Declares TempAllAppModulesMismatch\DifferentName, not ...\Mismatch.
+        $this->writeTempFacadeFile($filePath, 'TempAllAppModulesMismatch\\DifferentName');
+        require_once $filePath;
+
+        $finder = new AllAppModulesFinder(
+            $this->iteratorFor($this->fileInfoFor($filePath, 'Mismatch.php')),
+            $this->createAppModuleCreator(),
+        );
+
+        try {
+            // The class is loaded, so this can only be the filename deciding.
+            self::assertTrue(class_exists('TempAllAppModulesMismatch\\DifferentName', false));
+            self::assertSame([], $finder->findAllAppModules(''));
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    /**
      * Widening to "any descendant" must not widen to "any class at all".
      */
     public function test_a_class_that_does_not_extend_abstract_facade_is_not_a_module(): void


### PR DESCRIPTION
## 📚 Description

The "no modules found" hint said a module is found because *"the filename carries the suffix"*. Nothing in `AllAppModulesFinder` reads a suffix — it accepts by inheritance, so a class extending `AbstractFacade` is a module whatever it is called. A reader whose module went missing was therefore pointed at renaming files, the one thing that cannot be the cause, by the very sentence that exists to save them the search.

Verified both ways before changing the words: an unsuffixed `Whatever.php` extending `AbstractFacade` **is** discovered, and a `Mismatch.php` declaring `class DifferentName` is **not**, even once that class is loaded.

## 🔖 Changes

- The hint now names the real conditions: extends `AbstractFacade`, named after the file that declares it, and autoloadable — keeping the psr-4 pointer that was already right
- Two unit tests pin the contract, neither of which existed: a facade in an unsuffixed file is found, and a file declaring a differently named class is not. The second is the true half the old wording was reaching for, since the filename supplies the class name discovery looks up
- A feature test pins the wording itself, so it cannot regress to the false claim

The suffix still decides other things — which files the undiscovered-facades check looks at, and how a found module's pillars resolve — which is likely how the two got conflated.