### PR TITLE
fix(doctor): name an API the reader can actually call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- The suffix-mismatch doctor check told you to "add the missing suffix via `SuffixTypesBuilder::addFacade` in gacela.php". `SuffixTypesBuilder` is a private collaborator of `GacelaConfig`, and what gacela.php hands you is the `GacelaConfig` — which has no `addFacade()`. Both remediations now name `GacelaConfig::addSuffixTypeFacade()` and its siblings, verified to take the check from error to ok. A new architecture test walks every backticked `Class::method()` in the checks' string literals and fails when one names a method that does not exist
 - The "no modules found" hint said a module is found because "the filename carries the suffix". Discovery accepts by inheritance and never reads a suffix — a class extending `AbstractFacade` is a module whatever it is called — so the sentence sent a reader whose module was missing off to rename files that were never the cause. It now names the real conditions: extends `AbstractFacade`, named after the file that declares it, and autoloadable. Both are pinned by tests, the second being the true part the old wording was reaching for
 
 ### Changed

--- a/src/Console/Application/Doctor/Check/SuffixMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/SuffixMismatchCheck.php
@@ -76,8 +76,7 @@ final class SuffixMismatchCheck implements HealthCheck
             return CheckResult::error(
                 $this->name(),
                 [...$errors, ...$warnings],
-                'add the missing suffix in gacela.php with `GacelaConfig::addSuffixTypeFacade()`'
-                . ' -- or its Factory, Config and Provider siblings',
+                'add the missing suffix in gacela.php with `GacelaConfig::addSuffixTypeFacade()`, or its Factory, Config and Provider siblings',
             );
         }
 
@@ -85,8 +84,7 @@ final class SuffixMismatchCheck implements HealthCheck
             return CheckResult::warn(
                 $this->name(),
                 $warnings,
-                'configure the suffix in gacela.php with `GacelaConfig::addSuffixTypeFactory()`'
-                . ' (or its Config and Provider siblings), or rename the file to match a configured suffix',
+                'configure the suffix in gacela.php with `GacelaConfig::addSuffixTypeFactory()` (or its Config and Provider siblings), or rename the file to match a configured suffix',
             );
         }
 

--- a/src/Console/Application/Doctor/Check/SuffixMismatchCheck.php
+++ b/src/Console/Application/Doctor/Check/SuffixMismatchCheck.php
@@ -76,7 +76,8 @@ final class SuffixMismatchCheck implements HealthCheck
             return CheckResult::error(
                 $this->name(),
                 [...$errors, ...$warnings],
-                'add the missing suffix via `SuffixTypesBuilder::addFacade/Factory/Config/Provider` in gacela.php',
+                'add the missing suffix in gacela.php with `GacelaConfig::addSuffixTypeFacade()`'
+                . ' -- or its Factory, Config and Provider siblings',
             );
         }
 
@@ -84,7 +85,8 @@ final class SuffixMismatchCheck implements HealthCheck
             return CheckResult::warn(
                 $this->name(),
                 $warnings,
-                'configure the suffix in gacela.php or rename the file to match a configured suffix',
+                'configure the suffix in gacela.php with `GacelaConfig::addSuffixTypeFactory()`'
+                . ' (or its Config and Provider siblings), or rename the file to match a configured suffix',
             );
         }
 

--- a/tests/Integration/Architecture/RemediationNamesRealApiTest.php
+++ b/tests/Integration/Architecture/RemediationNamesRealApiTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Architecture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function count;
+use function dirname;
+use function is_array;
+use function method_exists;
+use function preg_match_all;
+use function sprintf;
+
+/**
+ * A doctor finding is only worth printing if its remediation can be followed.
+ *
+ * The suffix-mismatch check told the reader to "add the missing suffix via
+ * `SuffixTypesBuilder::addFacade` in gacela.php". `SuffixTypesBuilder` is a
+ * private collaborator of `GacelaConfig`, and what gacela.php hands you is the
+ * `GacelaConfig` -- which has no `addFacade()` at all. The method that does the
+ * job is `addSuffixTypeFacade()`. So the one line printed to get somebody
+ * unstuck named an API they could not call from the place it named.
+ *
+ * Advice drifts the way any prose beside code drifts, and nothing else reads
+ * it. This walks the API references in the checks' own string literals and
+ * asks the only question that matters about each: does it exist.
+ */
+final class RemediationNamesRealApiTest extends TestCase
+{
+    /**
+     * Backticks are how these strings mark an API reference, which keeps this
+     * away from ordinary prose that happens to contain a `::`.
+     */
+    private const string REFERENCE_PATTERN = '/`\\\\?([A-Za-z_][A-Za-z0-9_]*)::([A-Za-z_][A-Za-z0-9_]*)\(\)`/';
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function apiReferenceProvider(): iterable
+    {
+        $index = self::classIndex();
+
+        foreach (self::checkFiles() as $file) {
+            foreach (self::stringLiteralsOf($file) as $literal) {
+                if (preg_match_all(self::REFERENCE_PATTERN, $literal, $matches, PREG_SET_ORDER) === false) {
+                    continue;
+                }
+
+                foreach ($matches as $match) {
+                    [, $shortName, $method] = $match;
+
+                    yield sprintf('%s: %s::%s()', basename($file), $shortName, $method) => [
+                        basename($file),
+                        $index[$shortName] ?? $shortName,
+                        $method,
+                    ];
+                }
+            }
+        }
+    }
+
+    #[DataProvider('apiReferenceProvider')]
+    public function test_an_api_named_in_a_check_message_exists(string $file, string $class, string $method): void
+    {
+        self::assertTrue(class_exists($class) || interface_exists($class), sprintf(
+            '%s names `%s::%s()`, and no such class is declared under src/.',
+            $file,
+            $class,
+            $method,
+        ));
+
+        self::assertTrue(method_exists($class, $method), sprintf(
+            "%s tells the reader to call `%s::%s()`, which does not exist.\n"
+            . 'A remediation naming an uncallable method costs the reader the search it was printed to save.',
+            $file,
+            $class,
+            $method,
+        ));
+    }
+
+    public function test_there_are_api_references_to_check(): void
+    {
+        self::assertGreaterThan(0, count([...self::apiReferenceProvider()]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function checkFiles(): array
+    {
+        $found = glob(dirname(__DIR__, 3) . '/src/Console/Application/Doctor/Check/*.php');
+
+        return is_array($found) ? $found : [];
+    }
+
+    /**
+     * Only the strings the commands print, never the code around them: a
+     * remediation is prose, and prose is what goes stale unnoticed.
+     *
+     * @return list<string>
+     */
+    private static function stringLiteralsOf(string $file): array
+    {
+        $source = file_get_contents($file);
+        if ($source === false) {
+            return [];
+        }
+
+        $literals = [];
+        foreach (token_get_all($source) as $token) {
+            if (is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
+                $literals[] = $token[1];
+            }
+        }
+
+        return $literals;
+    }
+
+    /**
+     * Short name to fully qualified name for everything under `src/`, so a
+     * message can name `GacelaConfig` the way a reader would write it.
+     *
+     * @return array<string, string>
+     */
+    private static function classIndex(): array
+    {
+        $root = dirname(__DIR__, 3) . '/src';
+        $index = [];
+
+        /** @var iterable<string, SplFileInfo> $files */
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+
+        foreach ($files as $path => $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $source = file_get_contents((string)$path);
+            if ($source === false) {
+                continue;
+            }
+
+            if (preg_match('#^namespace\s+(.+);#m', $source, $namespaceMatch) !== 1) {
+                continue;
+            }
+
+            $shortName = $file->getBasename('.php');
+            $index[$shortName] = $namespaceMatch[1] . '\\' . $shortName;
+        }
+
+        return $index;
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/SuffixMismatchCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/SuffixMismatchCheckTest.php
@@ -305,6 +305,47 @@ final class SuffixMismatchCheckTest extends TestCase
     }
 
     /**
+     * The remediation used to name `SuffixTypesBuilder::addFacade`, which is a
+     * private collaborator of `GacelaConfig` -- so the reader was told to call
+     * something that does not exist on the object gacela.php hands them.
+     *
+     * Asserted through a real run rather than by reading the source, because
+     * the architecture test that scans these strings reads the file from disk
+     * and so cannot see the method name go wrong at runtime.
+     */
+    public function test_the_error_remediation_names_the_method_that_widens_a_facade_suffix(): void
+    {
+        $module = new AppModule('App\\Foo', 'Foo', 'App\\Foo\\FooPublicApi');
+
+        $result = (new SuffixMismatchCheck([$module], $this->defaultSuffixes()))->run();
+
+        self::assertSame(CheckStatus::Error, $result->status);
+        self::assertStringContainsString('GacelaConfig::addSuffixTypeFacade()', $result->remediation);
+        self::assertStringContainsString('siblings', $result->remediation);
+        self::assertStringNotContainsString('SuffixTypesBuilder', $result->remediation);
+    }
+
+    /**
+     * The warning branch said only "configure the suffix in gacela.php", which
+     * leaves the reader with the question the sentence exists to answer.
+     */
+    public function test_the_warning_remediation_names_the_method_too(): void
+    {
+        $module = new AppModule(
+            'App\\Foo',
+            'Foo',
+            'App\\Foo\\FooFacade',
+            'App\\Foo\\FooBuilder',
+        );
+
+        $result = (new SuffixMismatchCheck([$module], $this->defaultSuffixes()))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('GacelaConfig::addSuffixTypeFactory()', $result->remediation);
+        self::assertStringContainsString('rename the file', $result->remediation);
+    }
+
+    /**
      * @return array{Facade: list<string>, Factory: list<string>, Config: list<string>, Provider: list<string>}
      */
     private function defaultSuffixes(): array


### PR DESCRIPTION
## 📚 Description

The suffix-mismatch check told the reader to *"add the missing suffix via `SuffixTypesBuilder::addFacade` in gacela.php"*. `SuffixTypesBuilder` is a private collaborator of `GacelaConfig`, and what gacela.php hands you is the `GacelaConfig` — which has no `addFacade()` at all. The one line printed to get somebody unstuck named an API they could not call from the place it named, in the check whose whole job is to explain a naming problem.

Verified rather than assumed: with the default suffixes the check reports `Error` for a `BlogPublicApi` facade, and after `addSuffixTypeFacade('PublicApi')` it reports `Ok`.

## 🔖 Changes

- Both remediations name `GacelaConfig::addSuffixTypeFacade()` and its siblings. The warn branch previously said only "configure the suffix in gacela.php", leaving the same reader with the same question, so it names the method too
- New `RemediationNamesRealApiTest` walks every backticked `` `Class::method()` `` in the checks' **string literals** — prose, never the code around it — and fails when one names a method that does not exist. Confirmed to fail on the wording this PR replaces
- It also covers the pre-existing `CacheableConfig::setStorage()` reference, which is valid