### PR TITLE
feat(doctor): name the paths discovery walked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `doctor` names the paths discovery walked, as `Scanned: src` above the checks and a `scanned` key in `--format=json`. Every check works from the modules discovery returned, so `appModulePaths` narrowing the scan narrows all nineteen at once — a run over a project with a hundred modules can inspect one and still print a screen of ticks
 - `list:modules`, `debug:modules` and `debug:graph` name the paths they scanned when they find nothing: `Scanned: src`. `appModulePaths` narrows discovery to a subset of the project, so a module outside that subset is missing for a reason nothing about the module itself reveals — the report already said to check the psr-4 mapping, but never said where it had looked. Read from the configured entries rather than their resolved absolute paths, because the entry is what you would edit
 
 ### Fixed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,7 +85,7 @@ This is a CLI and `cache:warm` cost, not a request-time one — resolving a Faca
 
 | Command | What it does |
 |---|---|
-| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md) and each package's `composer.json` against what it imports. Takes an optional namespace to restrict module-scoped checks, `--strict` to exit non-zero on warnings too, `--only-problems` to print just the checks that found something, and `--format=json` for a CI job that wants to say *which* check failed rather than only that one did |
+| `doctor` | Environmental and wiring health checks, including the [declared config schema](config-schema.md) and each package's `composer.json` against what it imports. Takes an optional namespace to restrict module-scoped checks, `--strict` to exit non-zero on warnings too, `--only-problems` to print just the checks that found something, and `--format=json` for a CI job that wants to say *which* check failed rather than only that one did. Every run names the paths discovery walked (`Scanned: src`, and a `scanned` key in the JSON): every check works from the modules discovery returned, so `appModulePaths` narrowing the scan narrows all of them at once |
 | `validate:config` | Checks the configuration for errors and best-practice violations, and against the [declared schema](config-schema.md). `--strict` exits non-zero on warnings too, as on `doctor`; `--json` reports which check found what |
 
 Every command that can emit JSON accepts `--json`. Where a command has more than two output formats — `debug:graph`, `profile:report` — `--format=` chooses among them and `--json` is shorthand for the one you were going to pick anyway.

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -95,6 +95,15 @@ final class DoctorCommand extends Command
 
         ConsoleSection::title($output, 'Gacela Doctor');
 
+        // Every check below works from the modules discovery returned, so the
+        // paths it walked bound all of them at once. `appModulePaths` narrowing
+        // the scan is invisible in a report of nineteen ticks otherwise.
+        $output->writeln(sprintf(
+            'Scanned: %s',
+            implode(', ', $this->getFacade()->scannedModulePaths()),
+        ));
+        $output->writeln('');
+
         $checks = $this->buildChecks($filter);
         $worst = CheckStatus::Ok;
         $rendered = false;
@@ -169,6 +178,7 @@ final class DoctorCommand extends Command
 
         $output->writeln(json_encode([
             'status' => $worst->value,
+            'scanned' => $this->getFacade()->scannedModulePaths(),
             'checks' => $reported,
         ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -106,6 +106,36 @@ final class DoctorCommandTest extends TestCase
     }
 
     /**
+     * Every check works from the modules discovery returned, so a narrowed scan
+     * narrows all of them at once -- silently. `appModulePaths` is what narrows
+     * it, and this repository's own gacela.php pins it to `src`, which is how a
+     * run over a project with a hundred modules can inspect one and look fine.
+     *
+     * The report names the paths it walked, so the scope of every verdict below
+     * it is on the screen rather than in a config file the reader has to think
+     * of opening.
+     */
+    public function test_the_report_names_the_paths_discovery_walked(): void
+    {
+        $display = $this->doctor([])->getDisplay();
+
+        self::assertStringContainsString('Scanned: ', $display);
+    }
+
+    public function test_the_json_report_carries_the_scanned_paths_too(): void
+    {
+        $tester = $this->doctor([], ['--format' => 'json']);
+
+        /** @var array{scanned: list<string>, checks: list<array<string, mixed>>} $decoded */
+        $decoded = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('scanned', $decoded);
+        self::assertNotEmpty($decoded['scanned']);
+        // Still a document about checks; the scope is added, not substituted.
+        self::assertArrayHasKey('checks', $decoded);
+    }
+
+    /**
      * `--format=xml` used to print the text report and exit 0, so a pipeline
      * that asked for a document it cannot produce could not tell that run apart
      * from a healthy one.


### PR DESCRIPTION
## 📚 Description

Every check works from the modules discovery returned, so the paths it walked bound all nineteen of them at once. `appModulePaths` narrowing the scan is invisible in a report of ticks: a run over a project with a hundred modules can inspect one and look perfectly healthy. The only hint today is a module count buried in one check's detail line.

## 🔖 Changes

- `Scanned: src` under the title, and the same list under a `scanned` key in `--format=json` — added beside `checks`, replacing nothing
- `--only-problems` shows it too, where it doubles as proof the run happened at all (that mode otherwise prints nothing on a clean project)
- `docs/cli.md` notes the new line, since it describes what `doctor` reports

Completes the pair with #854, which gave the same answer for `list:modules`, `debug:modules` and `debug:graph` when they find nothing.