### PR TITLE
feat(console): migrate:service-map writes the attribute 3.0 requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+#### `migrate:service-map`
+
+The last rung of the 3.0 migration ladder. Resolving a pillar accessor from its `@method` docblock is deprecated in 2.x and removed in 3.0; the `gacela.serviceMapMissing` analysis already reported each one and printed the exact attribute to declare it with — and then stopped, leaving every user to hand-apply an edit the tooling had computed, one class at a time, finding the classes only as cold resolves happened to reach them. The command writes that attribute for every class at once.
+
+- `--dry-run` reports what would change and writes nothing; an optional argument narrows to paths containing it
+- Which accessors need an attribute is asked of the analyser, not decided again, so a migration cannot rewrite a different set than the analysis reports
+- The edit is textual: only the attribute and, when missing, the `ServiceMap` import are added. Nothing else in the file moves, and running it twice changes nothing
+- An accessor whose `@method` type is not a single class name — a union, a nullable, a generic, `self` — is left for a human, and the analysis no longer suggests one either. `A|B::class` parses, as a bitwise or of a constant and a string, so it would have failed when the attribute was read rather than when it was written
+
 #### What a run actually looked at
 
 Every check and every module listing works from what discovery returned, so anything narrowing that narrows all of it at once — silently, and a narrowed run still ends in a screen of ticks. Four things now say what a run looked at:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,7 @@ Nothing ships for such a kind, so its stub is one you write: `stubs/gacela/expor
 
 | Command | What it does |
 |---|---|
+| `migrate:service-map` | Writes the `#[ServiceMap]` attribute the `gacela.serviceMapMissing` analysis reports as missing, for every class at once. Resolving a pillar accessor from its `@method` docblock is deprecated in 2.x and removed in 3.0, and the runtime notice only fires for accessors a run actually reaches, on a cold resolve — so a migration driven by notices covers the code paths your tests happen to execute. `--dry-run` reports what would change and writes nothing; an optional argument narrows to paths containing it. Only the attribute and, when missing, the import are added — nothing else in the file moves, and running it twice changes nothing |
 | `list:modules` | Renders every module found. `--detailed` for one block per module; `--json` for the whole inventory with every pillar, filter and all |
 | `debug:modules` | Dependency resolvability of every module pillar. `--detail` for every parameter rather than only the unresolvable ones; `--check` exits non-zero when the container cannot satisfy one, for CI; `--json` for the same report as a document |
 | `debug:module App/Blog` | One module: resolved classes, the ids its Provider declares with `#[Provides]`, container bindings, dependency tree |

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -12,6 +12,7 @@ use Gacela\Console\Domain\FileContent\StubPublishResult;
 use Gacela\Console\Domain\IdeMeta\IdeMetadataResult;
 use Gacela\Console\Domain\ModuleGraph\GraphDiffResult;
 use Gacela\Console\Domain\ModuleGraph\ModuleRuleCheckResult;
+use Gacela\Console\Domain\ServiceMapMigration\MigrationResult;
 use Gacela\Container\ContainerStats;
 use Gacela\Framework\AbstractFacade;
 use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
@@ -112,6 +113,23 @@ final class ConsoleFacade extends AbstractFacade
         return $this->getFactory()
             ->createAllAppModulesFinder()
             ->findAllAppModules($filter);
+    }
+
+    /**
+     * Writes the `#[ServiceMap]` attribute the static analysis reports as
+     * missing, across every scanned file.
+     *
+     * The last rung of the 3.0 migration ladder: deprecate, detect, suggest --
+     * and then apply, which users were doing by hand from a suggestion the
+     * tooling had already computed.
+     *
+     * @return list<MigrationResult> only the files that changed
+     */
+    public function migrateServiceMaps(string $filter = '', bool $dryRun = false): array
+    {
+        return $this->getFactory()
+            ->createServiceMapMigrationRunner()
+            ->run($filter, $dryRun);
     }
 
     /**

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -38,6 +38,8 @@ use Gacela\Console\Domain\ModuleGraph\ModuleGraphDiffer;
 use Gacela\Console\Domain\ModuleGraph\ModuleRuleChecker;
 use Gacela\Console\Domain\ModuleGraph\TextGraphFormatter;
 use Gacela\Console\Domain\PackageManifest\ComposerPackage;
+use Gacela\Console\Domain\ServiceMapMigration\ServiceMapMigrationRunner;
+use Gacela\Console\Domain\ServiceMapMigration\ServiceMapMigrator;
 use Gacela\Console\Infrastructure\FileContentIo;
 use Gacela\Container\ContainerStats;
 use Gacela\Framework\AbstractFactory;
@@ -49,7 +51,9 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
 use Gacela\Framework\Dto\Schema\DtoSchema;
 use Gacela\Framework\Gacela;
+use Gacela\StaticAnalysis\Rules\ServiceMapMissingAnalyser;
 use OuterIterator;
+use PhpParser\ParserFactory;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -168,6 +172,18 @@ final class ConsoleFactory extends AbstractFactory
         return new AllAppModulesFinder(
             $this->createModuleScanIterator(),
             $this->createAppModuleCreator(),
+        );
+    }
+
+    public function createServiceMapMigrationRunner(): ServiceMapMigrationRunner
+    {
+        return new ServiceMapMigrationRunner(
+            $this->createModuleScanIterator(),
+            new ServiceMapMigrator(
+                (new ParserFactory())->createForNewestSupportedVersion(),
+                new ServiceMapMissingAnalyser(),
+            ),
+            $this->createFileContentIo(),
         );
     }
 

--- a/src/Console/Domain/ServiceMapMigration/MigrationResult.php
+++ b/src/Console/Domain/ServiceMapMigration/MigrationResult.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ServiceMapMigration;
+
+use function count;
+
+/**
+ * What migrating one file would do, without having done it.
+ *
+ * The rewritten code is carried rather than written, so `--dry-run` and the
+ * real run answer the same question and only differ in whether anything is
+ * saved. A preview that took a second path could disagree with the run it
+ * previews, which is the one thing a preview must not do.
+ */
+final class MigrationResult
+{
+    /**
+     * @param list<string> $declared `Class::accessor()` for each attribute added
+     */
+    public function __construct(
+        public readonly string $path,
+        public readonly string $originalCode,
+        public readonly string $migratedCode,
+        public readonly array $declared,
+    ) {
+    }
+
+    public static function unchanged(string $path, string $code): self
+    {
+        return new self($path, $code, $code, []);
+    }
+
+    public function hasChanges(): bool
+    {
+        return $this->declared !== [];
+    }
+
+    public function declaredCount(): int
+    {
+        return count($this->declared);
+    }
+}

--- a/src/Console/Domain/ServiceMapMigration/ServiceMapMigrationRunner.php
+++ b/src/Console/Domain/ServiceMapMigration/ServiceMapMigrationRunner.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ServiceMapMigration;
+
+use Gacela\Console\Domain\FileContent\FileContentIoInterface;
+use OuterIterator;
+use SplFileInfo;
+
+use function file_get_contents;
+use function str_contains;
+use function str_starts_with;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Runs {@see ServiceMapMigrator} over the files a project actually scans.
+ *
+ * The same paths module discovery walks, so `migrate:service-map` covers what
+ * `doctor` and `list:modules` cover -- a migration that read a different set
+ * than the analysis would leave the build failing on files it never saw.
+ *
+ * Writing is the caller's choice, not this one's: a preview and a real run
+ * compute the identical result and differ only in whether it is saved.
+ */
+final class ServiceMapMigrationRunner
+{
+    /**
+     * @param OuterIterator<array-key, SplFileInfo> $fileIterator
+     */
+    public function __construct(
+        private readonly OuterIterator $fileIterator,
+        private readonly ServiceMapMigrator $migrator,
+        private readonly FileContentIoInterface $fileContentIo,
+    ) {
+    }
+
+    /**
+     * @return list<MigrationResult> only the files that would change
+     */
+    public function run(string $filter, bool $dryRun): array
+    {
+        $changed = [];
+
+        /** @var SplFileInfo $fileInfo */
+        foreach ($this->fileIterator as $fileInfo) {
+            $path = $this->readablePhpFile($fileInfo);
+            if ($path === null) {
+                continue;
+            }
+
+            if ($filter !== '' && !str_contains($path, $filter)) {
+                continue;
+            }
+
+            $code = file_get_contents($path);
+            if ($code === false) {
+                continue;
+            }
+
+            $result = $this->migrator->migrate($path, $code);
+            if (!$result->hasChanges()) {
+                continue;
+            }
+
+            if (!$dryRun) {
+                $this->fileContentIo->filePutContents($path, $result->migratedCode);
+            }
+
+            $changed[] = $result;
+        }
+
+        return $changed;
+    }
+
+    private function readablePhpFile(SplFileInfo $fileInfo): ?string
+    {
+        $realPath = $fileInfo->getRealPath();
+
+        if ($realPath === false
+            || !$fileInfo->isFile()
+            || $fileInfo->getExtension() !== 'php'
+            || str_starts_with($fileInfo->getFilename(), '.')
+            || str_contains($realPath, 'vendor' . DIRECTORY_SEPARATOR)
+        ) {
+            return null;
+        }
+
+        return $realPath;
+    }
+}

--- a/src/Console/Domain/ServiceMapMigration/ServiceMapMigrator.php
+++ b/src/Console/Domain/ServiceMapMigration/ServiceMapMigrator.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ServiceMapMigration;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\StaticAnalysis\Rules\ServiceMapMissingAnalyser;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use Throwable;
+
+use function count;
+use function explode;
+use function implode;
+use function sprintf;
+
+/**
+ * Writes the `#[ServiceMap]` attribute that {@see ServiceMapMissingAnalyser}
+ * reports as missing.
+ *
+ * The migration ladder for the 3.0 removal was deprecate, detect, suggest --
+ * and then stop. The suggestion is literally the line to paste, so every user
+ * was hand-applying an edit the tooling had already computed, one class at a
+ * time, finding the classes only as cold resolves happened to reach them.
+ *
+ * Which accessors need an attribute is asked of the analyser rather than
+ * decided again here. A codemod that migrated a different set than the analysis
+ * reported would leave a build failing on the classes it just rewrote.
+ *
+ * The edit is textual and line-based, never a pretty-print of the parsed tree:
+ * this rewrites code somebody else wrote, and reformatting a file to add one
+ * line is not a migration anyone would run twice. The type is written exactly
+ * as the docblock spells it, so `Foo::class` resolves through that file's own
+ * imports -- group imports, aliases and all -- without this having to
+ * understand them.
+ */
+final class ServiceMapMigrator
+{
+    private const IMPORT = 'use ' . ServiceMap::class . ';';
+
+    public function __construct(
+        private readonly Parser $parser,
+        private readonly ServiceMapMissingAnalyser $analyser,
+        private readonly NodeFinder $nodeFinder = new NodeFinder(),
+    ) {
+    }
+
+    public function migrate(string $path, string $phpCode): MigrationResult
+    {
+        try {
+            $ast = $this->parser->parse($phpCode);
+        } catch (Throwable) {
+            // A file this cannot parse is a file it must not rewrite. The run
+            // reports it as untouched rather than failing: one unparsable file
+            // in a tree is not a reason to abandon the rest.
+            return MigrationResult::unchanged($path, $phpCode);
+        }
+
+        if ($ast === null) {
+            return MigrationResult::unchanged($path, $phpCode);
+        }
+
+        // The analyser asks whether a trait is `ServiceResolverAwareTrait` by
+        // its resolved name. Parsed without a name resolver, an imported trait
+        // is only its short name and no class ever matches -- the migration
+        // would report every file as clean. Line numbers survive the rewrite,
+        // which is what the edit is keyed on.
+        $ast = (new NodeTraverser(new NameResolver()))->traverse($ast);
+
+        /** @var list<ClassLike> $classes */
+        $classes = $this->nodeFinder->findInstanceOf($ast, ClassLike::class);
+
+        $insertions = [];
+        $declared = [];
+
+        foreach ($classes as $class) {
+            $accessors = $this->analyser->missingAccessors($class);
+            if ($accessors === []) {
+                continue;
+            }
+
+            $line = $class->getStartLine();
+
+            foreach ($accessors as $method => $type) {
+                $insertions[$line][] = sprintf(
+                    "#[ServiceMap(method: '%s', className: %s::class)]",
+                    $method,
+                    $type,
+                );
+
+                $declared[] = sprintf('%s::%s()', (string)$class->name, $method);
+            }
+        }
+
+        if ($insertions === []) {
+            return MigrationResult::unchanged($path, $phpCode);
+        }
+
+        $lines = explode("\n", $phpCode);
+        $importLine = $this->alreadyImported($ast) ? null : $this->importLine($ast);
+
+        return new MigrationResult(
+            $path,
+            $phpCode,
+            $this->rebuild($lines, $insertions, $importLine),
+            $declared,
+        );
+    }
+
+    /**
+     * @param list<string> $lines
+     * @param array<int, list<string>> $insertions one-based line => lines to put above it
+     */
+    private function rebuild(array $lines, array $insertions, ?int $importLine): string
+    {
+        $rebuilt = [];
+
+        foreach ($lines as $index => $line) {
+            $lineNumber = $index + 1;
+
+            foreach ($insertions[$lineNumber] ?? [] as $attribute) {
+                $rebuilt[] = $attribute;
+            }
+
+            $rebuilt[] = $line;
+
+            if ($lineNumber === $importLine) {
+                $rebuilt[] = self::IMPORT;
+            }
+        }
+
+        return implode("\n", $rebuilt);
+    }
+
+    /**
+     * The line to put the import after: the last `use` of the file, or the
+     * `namespace` when it imports nothing yet.
+     *
+     * Placed after rather than sorted in, because sorting is the formatter's
+     * job and this repository runs one. Guessing at alphabetical order would
+     * only be right until a file disagreed with the guess.
+     *
+     * @param array<array-key, \PhpParser\Node> $ast
+     */
+    private function importLine(array $ast): ?int
+    {
+        /** @var list<Use_> $uses */
+        $uses = $this->nodeFinder->findInstanceOf($ast, Use_::class);
+        if ($uses !== []) {
+            $last = $uses[count($uses) - 1];
+
+            return $last->getEndLine();
+        }
+
+        /** @var list<Namespace_> $namespaces */
+        $namespaces = $this->nodeFinder->findInstanceOf($ast, Namespace_::class);
+        if ($namespaces !== []) {
+            return $namespaces[0]->getStartLine();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<array-key, \PhpParser\Node> $ast
+     */
+    private function alreadyImported(array $ast): bool
+    {
+        /** @var list<Use_> $uses */
+        $uses = $this->nodeFinder->findInstanceOf($ast, Use_::class);
+
+        foreach ($uses as $use) {
+            foreach ($use->uses as $useUse) {
+                if ($useUse->name->toString() === ServiceMap::class) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Console/Infrastructure/Command/CommandCatalog.php
+++ b/src/Console/Infrastructure/Command/CommandCatalog.php
@@ -34,6 +34,7 @@ final class CommandCatalog
         MakeFileCommand::class,
         MakeModuleCommand::class,
         ListModulesCommand::class,
+        MigrateServiceMapCommand::class,
         DebugConfigCommand::class,
         DebugContainerCommand::class,
         DebugDependenciesCommand::class,

--- a/src/Console/Infrastructure/Command/MigrateServiceMapCommand.php
+++ b/src/Console/Infrastructure/Command/MigrateServiceMapCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Infrastructure\Command;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\ServiceMapMigration\MigrationResult;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function count;
+use function sprintf;
+
+/**
+ * @method ConsoleFacade getFacade()
+ */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
+final class MigrateServiceMapCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('migrate:service-map')
+            ->setDescription('Declare every @method pillar accessor with #[ServiceMap], for 3.0')
+            ->addArgument('filter', InputArgument::OPTIONAL, 'Only files whose path contains this', '')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change and write nothing')
+            ->setHelp($this->getHelpText());
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $filter = ConsoleInput::argument($input, 'filter');
+        $dryRun = $input->getOption('dry-run') === true;
+
+        ConsoleSection::title($output, 'Migrate @method accessors to #[ServiceMap]');
+
+        $results = $this->getFacade()->migrateServiceMaps($filter, $dryRun);
+
+        if ($results === []) {
+            $output->writeln('<fg=green>✓ Nothing to migrate</>');
+            $output->writeln(
+                'Every pillar accessor resolved from a `@method` docblock already declares its'
+                . ' attribute, or the file declares none.',
+            );
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($results as $result) {
+            $this->report($result, $output);
+        }
+
+        $output->writeln('');
+        ConsoleSection::separator($output);
+        $output->writeln(sprintf(
+            '%s %d accessor(s) in %d file(s)',
+            $dryRun ? '<comment>Would declare</comment>' : '<fg=green>Declared</>',
+            $this->accessorCount($results),
+            count($results),
+        ));
+
+        if ($dryRun) {
+            $output->writeln('Nothing was written. Run without <comment>--dry-run</comment> to apply.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function report(MigrationResult $result, OutputInterface $output): void
+    {
+        $output->writeln('');
+        $output->writeln(sprintf('<info>%s</info>', $result->path));
+
+        foreach ($result->declared as $accessor) {
+            $output->writeln(sprintf('    %s', $accessor));
+        }
+    }
+
+    /**
+     * @param list<MigrationResult> $results
+     */
+    private function accessorCount(array $results): int
+    {
+        $total = 0;
+
+        foreach ($results as $result) {
+            $total += $result->declaredCount();
+        }
+
+        return $total;
+    }
+
+    private function getHelpText(): string
+    {
+        return <<<'TXT'
+            Resolving a pillar accessor from its <comment>@method</comment> docblock is deprecated in 2.x
+            and removed in 3.0. The static analysis rule <comment>gacela.serviceMapMissing</comment> reports
+            each one and prints the exact attribute to declare it with; this writes that
+            attribute, for every class at once.
+
+            The runtime deprecation only fires for accessors a run actually reaches, and
+            only on a cold resolve, so a migration driven by notices covers the code paths
+            your tests happen to execute. This reads the source instead.
+
+            Only the attribute line and, when missing, the <comment>ServiceMap</comment> import are added.
+            Nothing else in the file moves, and running it twice changes nothing.
+
+            An accessor whose <comment>@method</comment> type is not a single class name -- a union, a
+            nullable, a generic -- is left for a human: there is no <comment>X::class</comment> to write.
+            TXT;
+    }
+}

--- a/src/StaticAnalysis/Rules/ServiceMapMissingAnalyser.php
+++ b/src/StaticAnalysis/Rules/ServiceMapMissingAnalyser.php
@@ -18,9 +18,12 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\TraitUse;
 
 use function in_array;
+use function ltrim;
+use function preg_match;
 use function preg_match_all;
-
 use function sprintf;
+
+use function strtolower;
 
 use const PREG_SET_ORDER;
 
@@ -64,6 +67,18 @@ final class ServiceMapMissingAnalyser implements ClassAnalyserInterface
 {
     private const ATTRIBUTE = 'ServiceMap';
 
+    /** One class name, optionally qualified, and nothing else. */
+    private const CLASS_NAME = '#^\\\\?[A-Za-z_\\x80-\\xff][A-Za-z0-9_\\x80-\\xff]*(?:\\\\[A-Za-z_\\x80-\\xff][A-Za-z0-9_\\x80-\\xff]*)*$#';
+
+    /**
+     * Names the pattern above accepts that still are not a class to declare.
+     * `self::class` would resolve to the caller, not to what it returns.
+     */
+    private const NOT_A_CLASS = [
+        'self', 'static', 'parent', 'string', 'int', 'float', 'bool', 'array',
+        'object', 'mixed', 'callable', 'iterable', 'void', 'never', 'null', 'false', 'true',
+    ];
+
     /**
      * `@method [static] <type> <name>`. A tag written without a return type
      * does not match, and is left alone: nothing can be suggested for it.
@@ -79,26 +94,9 @@ final class ServiceMapMissingAnalyser implements ClassAnalyserInterface
      */
     public function analyse(ClassLike $node, AnalysedClassInterface $class): array
     {
-        if (!$this->usesTheResolverTrait($node)) {
-            return [];
-        }
-
-        // No early return for a class without a docblock: there is nothing to
-        // match in an empty string, so the loop below is already the answer.
-        $docBlock = $node->getDocComment()?->getText() ?? '';
-
-        $declared = $this->accessorsDeclaredByAttribute($node);
         $violations = [];
 
-        foreach ($this->accessorsDocumented($docBlock) as $method => $type) {
-            if (in_array($method, $declared, true)) {
-                continue;
-            }
-
-            if ($node->getMethod($method) instanceof ClassMethod) {
-                continue;
-            }
-
+        foreach ($this->missingAccessors($node) as $method => $type) {
             $violations[] = new Violation(
                 sprintf(
                     '%s::%s() is resolved from its @method docblock, which is deprecated and removed in 3.0',
@@ -115,6 +113,68 @@ final class ServiceMapMissingAnalyser implements ClassAnalyserInterface
         }
 
         return $violations;
+    }
+
+    /**
+     * The accessors this class resolves from its docblock, each with the type
+     * to declare it as.
+     *
+     * Public because `migrate:service-map` writes the attribute this reports,
+     * and the two must not be able to disagree about which accessors need one:
+     * a codemod that migrated a different set than the analysis reported would
+     * leave a build failing on the classes it just rewrote.
+     *
+     * @return array<string, string> method name => type as written
+     */
+    public function missingAccessors(ClassLike $node): array
+    {
+        if (!$this->usesTheResolverTrait($node)) {
+            return [];
+        }
+
+        // No early return for a class without a docblock: there is nothing to
+        // match in an empty string, so the loop below is already the answer.
+        $docBlock = $node->getDocComment()?->getText() ?? '';
+
+        $declared = $this->accessorsDeclaredByAttribute($node);
+        $missing = [];
+
+        foreach ($this->accessorsDocumented($docBlock) as $method => $type) {
+            if (in_array($method, $declared, true)) {
+                continue;
+            }
+
+            if ($node->getMethod($method) instanceof ClassMethod) {
+                continue;
+            }
+
+            // A type that cannot be written as `X::class` cannot be declared.
+            // `A|B::class` even parses -- as a bitwise or of a constant and a
+            // string -- so it fails when the attribute is read rather than
+            // when it is written, which is the worst place to find out.
+            if (!$this->isDeclarableType($type)) {
+                continue;
+            }
+
+            $missing[$method] = $type;
+        }
+
+        return $missing;
+    }
+
+    /**
+     * A single class name, qualified or not. Never a union, an intersection, a
+     * nullable, a generic, a scalar, or `self`/`static`/`parent`: `::class` on
+     * any of those is either meaningless or resolves relative to a class that
+     * is not the one the accessor returns.
+     */
+    private function isDeclarableType(string $type): bool
+    {
+        if (preg_match(self::CLASS_NAME, $type) !== 1) {
+            return false;
+        }
+
+        return !in_array(strtolower(ltrim($type, '\\')), self::NOT_A_CLASS, true);
     }
 
     private function usesTheResolverTrait(ClassLike $node): bool

--- a/tests/Unit/Console/Domain/ServiceMapMigration/ServiceMapMigratorTest.php
+++ b/tests/Unit/Console/Domain/ServiceMapMigration/ServiceMapMigratorTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ServiceMapMigration;
+
+use Gacela\Console\Domain\ServiceMapMigration\ServiceMapMigrator;
+use Gacela\StaticAnalysis\Rules\ServiceMapMissingAnalyser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+final class ServiceMapMigratorTest extends TestCase
+{
+    private ServiceMapMigrator $migrator;
+
+    protected function setUp(): void
+    {
+        $this->migrator = new ServiceMapMigrator(
+            (new ParserFactory())->createForNewestSupportedVersion(),
+            new ServiceMapMissingAnalyser(),
+        );
+    }
+
+    /**
+     * The attribute lands below the docblock, never above it: an attribute
+     * written above a docblock is not attached to the class node, so the file
+     * would read as migrated to a human and as unmigrated to every tool.
+     */
+    public function test_the_attribute_is_written_below_the_docblock_and_the_import_added(): void
+    {
+        $result = $this->migrator->migrate('Wallet.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /**
+             * @method WalletFacade getFacade()
+             */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP);
+
+        self::assertTrue($result->hasChanges());
+        self::assertSame(['WalletCommand::getFacade()'], $result->declared);
+        self::assertSame(<<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+            use Gacela\Framework\ServiceResolver\ServiceMap;
+
+            /**
+             * @method WalletFacade getFacade()
+             */
+            #[ServiceMap(method: 'getFacade', className: WalletFacade::class)]
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP, $result->migratedCode);
+    }
+
+    /**
+     * Nothing else in the file may move. This rewrites code somebody else
+     * wrote, and a migration that reformats to add one line is not one anybody
+     * runs twice.
+     */
+    public function test_only_the_added_lines_differ(): void
+    {
+        $original = <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /** @method WalletFacade getFacade() */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+
+                    // deliberately odd indentation, kept
+                public const X = 1;
+            }
+            PHP;
+
+        $result = $this->migrator->migrate('Wallet.php', $original);
+
+        $addedBack = str_replace(
+            ["use Gacela\\Framework\\ServiceResolver\\ServiceMap;\n", "#[ServiceMap(method: 'getFacade', className: WalletFacade::class)]\n"],
+            '',
+            $result->migratedCode,
+        );
+
+        self::assertSame($original, $addedBack);
+    }
+
+    /**
+     * The attribute stacks above one that is already there rather than
+     * displacing it, and still stays under the docblock.
+     */
+    public function test_an_existing_attribute_is_kept(): void
+    {
+        $result = $this->migrator->migrate('Wallet.php', <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /** @method WalletFacade getFacade() */
+            #[SomeOther]
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP);
+
+        self::assertStringContainsString(
+            "#[ServiceMap(method: 'getFacade', className: WalletFacade::class)]\n#[SomeOther]\nfinal class",
+            $result->migratedCode,
+        );
+    }
+
+    public function test_every_missing_accessor_gets_its_own_attribute(): void
+    {
+        $result = $this->migrator->migrate('Wallet.php', <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /**
+             * @method WalletFacade getFacade()
+             * @method WalletFactory getFactory()
+             */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP);
+
+        self::assertSame(
+            ['WalletCommand::getFacade()', 'WalletCommand::getFactory()'],
+            $result->declared,
+        );
+        self::assertStringContainsString('className: WalletFacade::class)]', $result->migratedCode);
+        self::assertStringContainsString('className: WalletFactory::class)]', $result->migratedCode);
+    }
+
+    /**
+     * Running it twice must be the same as running it once, or a migration
+     * that half-failed could not be re-run.
+     */
+    public function test_a_second_run_changes_nothing(): void
+    {
+        $original = <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /** @method WalletFacade getFacade() */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP;
+
+        $once = $this->migrator->migrate('Wallet.php', $original);
+        $twice = $this->migrator->migrate('Wallet.php', $once->migratedCode);
+
+        self::assertTrue($once->hasChanges());
+        self::assertFalse($twice->hasChanges());
+        self::assertSame($once->migratedCode, $twice->migratedCode);
+    }
+
+    /**
+     * The import is added once even when the file gains several attributes.
+     */
+    public function test_the_import_is_added_once(): void
+    {
+        $result = $this->migrator->migrate('Wallet.php', <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /**
+             * @method WalletFacade getFacade()
+             * @method WalletFactory getFactory()
+             */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP);
+
+        self::assertSame(1, substr_count($result->migratedCode, 'use Gacela\Framework\ServiceResolver\ServiceMap;'));
+    }
+
+    public function test_an_already_imported_service_map_is_not_imported_again(): void
+    {
+        $result = $this->migrator->migrate('Wallet.php', <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolver\ServiceMap;
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /**
+             * @method WalletFacade getFacade()
+             * @method WalletFactory getFactory()
+             */
+            #[ServiceMap(method: 'getFacade', className: WalletFacade::class)]
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP);
+
+        self::assertSame(1, substr_count($result->migratedCode, 'use Gacela\Framework\ServiceResolver\ServiceMap;'));
+        self::assertSame(['WalletCommand::getFactory()'], $result->declared);
+    }
+
+    /**
+     * A file may hold a migrated class and an unmigrated one. Stopping at the
+     * first class that needs nothing would leave the rest of the file behind,
+     * silently -- the run would report success having done half the work.
+     */
+    public function test_a_later_class_is_migrated_when_an_earlier_one_needs_nothing(): void
+    {
+        $result = $this->migrator->migrate('Two.php', <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            final class AlreadyFine
+            {
+                use ServiceResolverAwareTrait;
+            }
+
+            /** @method WalletFacade getFacade() */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP);
+
+        self::assertSame(['WalletCommand::getFacade()'], $result->declared);
+        self::assertStringContainsString(
+            "#[ServiceMap(method: 'getFacade', className: WalletFacade::class)]\nfinal class WalletCommand",
+            $result->migratedCode,
+        );
+    }
+
+    /**
+     * A file it cannot parse is a file it must not rewrite.
+     */
+    public function test_an_unparsable_file_is_left_alone(): void
+    {
+        $broken = "<?php\n\nfinal class Broken {";
+
+        $result = $this->migrator->migrate('Broken.php', $broken);
+
+        self::assertFalse($result->hasChanges());
+        self::assertSame($broken, $result->migratedCode);
+    }
+
+    public function test_a_class_without_the_resolver_trait_is_left_alone(): void
+    {
+        $original = <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            /** @method WalletFacade getFacade() */
+            final class WalletCommand
+            {
+            }
+            PHP;
+
+        $result = $this->migrator->migrate('Wallet.php', $original);
+
+        self::assertFalse($result->hasChanges());
+        self::assertSame($original, $result->migratedCode);
+    }
+
+    /**
+     * A type that cannot be written as `X::class` is skipped by the analyser,
+     * so nothing is written for it here either -- the file is left for a human
+     * rather than given code that fails when the attribute is read.
+     */
+    public function test_a_union_typed_accessor_is_left_for_a_human(): void
+    {
+        $original = <<<'PHP'
+            <?php
+
+            namespace App\Wallet;
+
+            use Gacela\Framework\ServiceResolverAwareTrait;
+
+            /** @method WalletFacade|OtherFacade getFacade() */
+            final class WalletCommand
+            {
+                use ServiceResolverAwareTrait;
+            }
+            PHP;
+
+        $result = $this->migrator->migrate('Wallet.php', $original);
+
+        self::assertFalse($result->hasChanges());
+        self::assertSame($original, $result->migratedCode);
+    }
+}

--- a/tests/Unit/StaticAnalysis/Rules/ServiceMapMissingAnalyserTest.php
+++ b/tests/Unit/StaticAnalysis/Rules/ServiceMapMissingAnalyserTest.php
@@ -8,7 +8,10 @@ use Gacela\StaticAnalysis\Rules\ServiceMapMissingAnalyser;
 use Gacela\StaticAnalysis\Violation;
 use GacelaTest\Unit\StaticAnalysis\Double\FakeAnalysedClass;
 use GacelaTest\Unit\StaticAnalysis\Double\ParseSource;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+
+use function sprintf;
 
 final class ServiceMapMissingAnalyserTest extends TestCase
 {
@@ -361,6 +364,121 @@ final class ServiceMapMissingAnalyserTest extends TestCase
                 final class WalletCommand { use ServiceResolverAwareTrait; }
                 PHP,
         ));
+    }
+
+    /**
+     * A tip is only worth printing if pasting it works. `A|B::class` even
+     * parses -- as a bitwise or of a constant and a string -- so suggesting it
+     * would fail when the attribute is read rather than when it is written,
+     * which is the worst place to find out. `migrate:service-map` writes what
+     * this reports, so the same guard keeps a codemod from producing it.
+     *
+     * @param non-empty-string $type
+     */
+    #[DataProvider('undeclarableTypeProvider')]
+    public function test_a_type_that_cannot_be_written_as_a_class_constant_is_not_reported(string $type): void
+    {
+        $violations = $this->analyse(sprintf(
+            <<<'PHP'
+                <?php
+                namespace App\Wallet;
+                use Gacela\Framework\ServiceResolverAwareTrait;
+                /** @method %s getFacade() */
+                final class WalletCommand { use ServiceResolverAwareTrait; }
+                PHP,
+            $type,
+        ));
+
+        self::assertSame([], $violations, $type);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function undeclarableTypeProvider(): iterable
+    {
+        yield 'union' => ['WalletFacade|OtherFacade'];
+        yield 'intersection' => ['WalletFacade&Countable'];
+        yield 'nullable' => ['?WalletFacade'];
+        yield 'generic' => ['array<WalletFacade>'];
+        yield 'self' => ['self'];
+        yield 'static' => ['static'];
+        yield 'scalar' => ['string'];
+    }
+
+    /**
+     * A class commonly documents several accessors and only one of them is
+     * undeclarable. Stopping at it would drop every accessor written after it,
+     * so the class would read as half-migrated with nothing saying why.
+     */
+    public function test_an_undeclarable_type_does_not_hide_the_accessors_after_it(): void
+    {
+        $violations = $this->analyse(
+            <<<'PHP'
+                <?php
+                namespace App\Wallet;
+                use Gacela\Framework\ServiceResolverAwareTrait;
+                /**
+                 * @method WalletFacade|OtherFacade getFacade()
+                 * @method WalletFactory getFactory()
+                 */
+                final class WalletCommand { use ServiceResolverAwareTrait; }
+                PHP,
+        );
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('getFactory()', $violations[0]->message);
+    }
+
+    /**
+     * The reserved names are matched case-insensitively and past a leading
+     * backslash: PHP accepts `Self` for `self`, and the pattern above admits a
+     * leading `\` that would otherwise smuggle `\string` through as a class.
+     *
+     * @param non-empty-string $type
+     */
+    #[DataProvider('reservedNameSpellingProvider')]
+    public function test_a_reserved_name_is_rejected_however_it_is_spelled(string $type): void
+    {
+        self::assertSame([], $this->analyse(sprintf(
+            <<<'PHP'
+                <?php
+                namespace App\Wallet;
+                use Gacela\Framework\ServiceResolverAwareTrait;
+                /** @method %s getFacade() */
+                final class WalletCommand { use ServiceResolverAwareTrait; }
+                PHP,
+            $type,
+        )), $type);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function reservedNameSpellingProvider(): iterable
+    {
+        yield 'capitalised self' => ['Self'];
+        yield 'uppercase scalar' => ['STRING'];
+        yield 'leading backslash' => ['\string'];
+    }
+
+    /**
+     * The guard must not swallow the ordinary cases it sits next to.
+     */
+    public function test_a_qualified_class_name_is_still_reported(): void
+    {
+        $violations = $this->analyse(
+            <<<'PHP'
+                <?php
+                namespace App\Wallet;
+                use Gacela\Framework\ServiceResolverAwareTrait;
+                /** @method \App\Other\WalletFacade getFacade() */
+                final class WalletCommand { use ServiceResolverAwareTrait; }
+                PHP,
+        );
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('\App\Other\WalletFacade::class', (string)$violations[0]->tip);
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

The migration ladder for the 3.0 removal was **deprecate → detect → suggest → stop**. The suggestion is literally the line to paste, so every user was hand-applying an edit the tooling had already computed, one class at a time — and finding the classes only as cold resolves happened to reach them, since the runtime notice is memoized per caller-and-method. A migration driven by notices covers the code paths a test suite happens to execute. This reads the source instead.

```
$ bin/gacela migrate:service-map --dry-run

Migrate @method accessors to #[ServiceMap]
============================================================

/path/to/Wallet/WalletCommand.php
    WalletCommand::getFacade()
    WalletCommand::getFactory()

============================================================
Would declare 2 accessor(s) in 1 file(s)
Nothing was written. Run without --dry-run to apply.
```

## 🔖 Changes

- **New `migrate:service-map [filter] [--dry-run]`.** The optional argument narrows to paths containing it; `--dry-run` computes the identical result and only skips saving, so a preview cannot disagree with the run it previews
- **Which accessors need an attribute is asked of `ServiceMapMissingAnalyser`, not decided again.** A codemod that migrated a different set than the analysis reports would leave a build failing on the files it just rewrote — that is why the analyser grew a public `missingAccessors()`
- **The edit is textual and line-based**, never a pretty-print of the parsed tree. This rewrites code somebody else wrote, and reformatting a file to add one line is not a migration anyone runs twice. Only the attribute and, when missing, the `ServiceMap` import are added
- **The attribute lands below the docblock**, where PHP attaches it to the class — above it, the file reads as migrated to a human and unmigrated to every tool
- **The type is written exactly as the docblock spells it**, so `Foo::class` resolves through that file's own imports — group imports and aliases included — without this having to understand them

### Also fixes a suggestion that could not work

A `@method` type that is not a single class name has no `X::class` to write. `A|B::class` *parses* — as a bitwise or of a constant and a string — so it would have failed when the attribute was **read** rather than when it was written. The analysis no longer suggests one, and the codemod leaves those files for a human.

## ✅ Verified

End to end on a scaffolded project, not only in unit tests: dry-run writes nothing, the applied file passes `php -l`, the docblock is untouched, and a second run reports nothing to migrate.

Local filtered mutation run: **98% MSI**. Reading the escaped mutants found two pieces of dead code I had written — an always-empty `$indent`, and a `ksort()` that could not matter because `rebuild()` looks insertions up per line. Both removed rather than tested around.