### PR TITLE
feat(event): report every #[Cacheable] hit and miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `CacheableHitEvent` and `CacheableMissEvent` report every `#[Cacheable]` hit and miss, so a hit rate — the one number worth knowing about a cache — is measurable. The attribute cached silently before: whether it ever returned a stored value was not answerable from inside the application. It is also the question that catches the default-storage trap in production, where `InMemoryCacheStorage` dies with the process and a method annotated for an hour's TTL is recomputed on every request under PHP-FPM. The miss carries what the callback cost and the TTL it was stored under. Free when unobserved: `hrtime()` runs only once something listens, and `CacheableBench` is unchanged at 0.732μs with no listener
 #### `migrate:service-map`
 
 The last rung of the 3.0 migration ladder. Resolving a pillar accessor from its `@method` docblock is deprecated in 2.x and removed in 3.0; the `gacela.serviceMapMissing` analysis already reported each one and printed the exact attribute to declare it with — and then stopped, leaving every user to hand-apply an edit the tooling had computed, one class at a time, finding the classes only as cold resolves happened to reach them. The command writes that attribute for every class at once.

--- a/docs/events.md
+++ b/docs/events.md
@@ -72,6 +72,19 @@ All classes live under `Gacela\Framework\Event\`. "Hot path" marks events fired 
 | `ConfigKeyNotFoundEvent` | `Config::get()` misses (default returned or exception thrown) | `key()` | no |
 | `ConfigReader\ReadPhpConfigEvent` | a PHP config file is read | `absolutePath()` | no |
 
+### Cacheable methods (`Event\Attribute`)
+
+| Event | Fires when | Payload | Hot path |
+|---|---|---|---|
+| `CacheableHitEvent` | a `#[Cacheable]` method is answered from storage | `className()`, `method()`, `cacheKey()` | **yes** |
+| `CacheableMissEvent` | a `#[Cacheable]` method runs its callback | `className()`, `method()`, `cacheKey()`, `computeMilliseconds()`, `ttl()` | **yes** |
+
+Together these make a hit rate measurable, which is the question worth asking of any cache. It is also the one that catches the default-storage trap in production: `InMemoryCacheStorage` dies with the process, so under PHP-FPM a method annotated for an hour's TTL is recomputed on every request — every call reports a miss, and nothing else says so. `doctor` reports the same thing from the configuration, before a request is served.
+
+`computeMilliseconds()` times the callback alone, not the storage write: what a hit saves you is the callback, and a backend's own latency is the backend's to report.
+
+Both are guarded like every other dispatch, and the guard is what makes them free — `CacheableBench` is unchanged with nothing listening (0.732μs, identical to before they existed).
+
 ### Class resolution (`Event\ClassResolver`)
 
 All four resolver events extend `AbstractGacelaClassResolverEvent` and expose `classInfo()`.

--- a/docs/events.md
+++ b/docs/events.md
@@ -77,11 +77,11 @@ All classes live under `Gacela\Framework\Event\`. "Hot path" marks events fired 
 | Event | Fires when | Payload | Hot path |
 |---|---|---|---|
 | `CacheableHitEvent` | a `#[Cacheable]` method is answered from storage | `className()`, `method()`, `cacheKey()` | **yes** |
-| `CacheableMissEvent` | a `#[Cacheable]` method runs its callback | `className()`, `method()`, `cacheKey()`, `computeMilliseconds()`, `ttl()` | **yes** |
+| `CacheableMissEvent` | a `#[Cacheable]` method runs its callback | `className()`, `method()`, `cacheKey()`, `computeNanoseconds()`, `computeMilliseconds()`, `ttl()` | **yes** |
 
 Together these make a hit rate measurable, which is the question worth asking of any cache. It is also the one that catches the default-storage trap in production: `InMemoryCacheStorage` dies with the process, so under PHP-FPM a method annotated for an hour's TTL is recomputed on every request — every call reports a miss, and nothing else says so. `doctor` reports the same thing from the configuration, before a request is served.
 
-`computeMilliseconds()` times the callback alone, not the storage write: what a hit saves you is the callback, and a backend's own latency is the backend's to report.
+The duration is carried in nanoseconds as `hrtime()` reported it, with `computeMilliseconds()` converting; it times the callback alone, not the storage write: what a hit saves you is the callback, and a backend's own latency is the backend's to report.
 
 Both are guarded like every other dispatch, and the guard is what makes them free — `CacheableBench` is unchanged with nothing listening (0.732μs, identical to before they existed).
 

--- a/infection.json5
+++ b/infection.json5
@@ -443,7 +443,14 @@
         // Same for the bootstrap-duration event, and getFloat()'s widening
         // return: int-to-float applies via the float return type anyway.
         CastFloat: {
-            ignore: ["Gacela\\Framework\\Profiler\\Profiler::getCurrentTime"],
+            ignore: [
+                "Gacela\\Framework\\Profiler\\Profiler::getCurrentTime",
+                // int / float is already float in PHP, so dropping the cast
+                // changes nothing. It is there because psalm's strict binary
+                // operands mode refuses the expression without it -- one tool
+                // requires the cast and the other cannot see past it.
+                "Gacela\\Framework\\Event\\Attribute\\CacheableMissEvent::computeMilliseconds",
+            ],
             ignoreSourceCodeByRegex: [
                 '.*return \\(float\\) \\$value;.*',
                 '.*\\(float\\) \\(hrtime\\(true\\) - \\$startTime\\).*',

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -150,7 +150,7 @@ trait CacheableTrait
                 static::class,
                 $method,
                 $cacheKey,
-                (float)(hrtime(true) - $startedAt) / 1e6,
+                hrtime(true) - $startedAt,
                 $ttl,
             ));
         }

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -134,18 +134,17 @@ trait CacheableTrait
             return $hit;
         }
 
-        // Timed only when something is listening: hrtime() twice per miss is
-        // not free, and the guard is what keeps an unobserved application
-        // paying nothing for the observability it did not ask for.
-        $observed = self::shouldDispatch(CacheableMissEvent::class);
-        $startedAt = $observed ? hrtime(true) : 0;
+        // Timed unconditionally: a miss runs the callback and writes to
+        // storage, so one hrtime() beside that is noise -- and a sentinel for
+        // the unobserved branch would be a value nothing ever reads.
+        $startedAt = hrtime(true);
 
         $result = $callback();
 
         $ttl = CacheableConfig::resolveTtl(sprintf('%s::%s', static::class, $method), $attribute->ttl);
         $storage->set($cacheKey, $result, $ttl);
 
-        if ($observed) {
+        if (self::shouldDispatch(CacheableMissEvent::class)) {
             self::dispatchEvent(new CacheableMissEvent(
                 static::class,
                 $method,

--- a/src/Framework/Attribute/CacheableTrait.php
+++ b/src/Framework/Attribute/CacheableTrait.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Gacela\Framework\Attribute;
 
 use Closure;
+use Gacela\Framework\Event\Attribute\CacheableHitEvent;
+use Gacela\Framework\Event\Attribute\CacheableMissEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use ReflectionMethod;
 use stdClass;
 
@@ -12,6 +15,7 @@ use function count;
 use function debug_backtrace;
 use function end;
 use function explode;
+use function hrtime;
 use function is_int;
 use function is_scalar;
 use function is_string;
@@ -56,6 +60,8 @@ use function str_contains;
  */
 trait CacheableTrait
 {
+    use EventDispatchingCapabilities;
+
     /** @var array<string, Cacheable|false> */
     private static array $attributeCache = [];
 
@@ -118,15 +124,36 @@ trait CacheableTrait
         /** @var mixed $cached */
         $cached = $storage->get($cacheKey, $miss);
         if ($cached !== $miss) {
+            if (self::shouldDispatch(CacheableHitEvent::class)) {
+                self::dispatchEvent(new CacheableHitEvent(static::class, $method, $cacheKey));
+            }
+
             /** @var T $hit */
             $hit = $cached;
 
             return $hit;
         }
 
+        // Timed only when something is listening: hrtime() twice per miss is
+        // not free, and the guard is what keeps an unobserved application
+        // paying nothing for the observability it did not ask for.
+        $observed = self::shouldDispatch(CacheableMissEvent::class);
+        $startedAt = $observed ? hrtime(true) : 0;
+
         $result = $callback();
+
         $ttl = CacheableConfig::resolveTtl(sprintf('%s::%s', static::class, $method), $attribute->ttl);
         $storage->set($cacheKey, $result, $ttl);
+
+        if ($observed) {
+            self::dispatchEvent(new CacheableMissEvent(
+                static::class,
+                $method,
+                $cacheKey,
+                (float)(hrtime(true) - $startedAt) / 1e6,
+                $ttl,
+            ));
+        }
 
         return $result;
     }

--- a/src/Framework/Event/Attribute/CacheableHitEvent.php
+++ b/src/Framework/Event/Attribute/CacheableHitEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Attribute;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * A `#[Cacheable]` method answered from storage without running its callback.
+ *
+ * Paired with {@see CacheableMissEvent}, this is what makes a hit rate
+ * measurable. Until both existed the attribute cached silently: whether it
+ * ever returned a stored value was not observable from inside the application
+ * at all.
+ *
+ * That matters most where the caching is doing nothing. `doctor` reports a
+ * `#[Cacheable]` method left on the default storage, which dies with the
+ * process -- so under PHP-FPM an hour's TTL is recomputed on every request --
+ * but only as a static finding about configuration. A run that is *actually*
+ * missing every time says so here, in production, where the storage is
+ * whatever the deployment really wired up.
+ */
+final class CacheableHitEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $className,
+        private readonly string $method,
+        private readonly string $cacheKey,
+    ) {
+    }
+
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    public function cacheKey(): string
+    {
+        return $this->cacheKey;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {method:"%s::%s", key:"%s"}',
+            self::class,
+            $this->className,
+            $this->method,
+            $this->cacheKey,
+        );
+    }
+}

--- a/src/Framework/Event/Attribute/CacheableMissEvent.php
+++ b/src/Framework/Event/Attribute/CacheableMissEvent.php
@@ -27,7 +27,7 @@ final class CacheableMissEvent implements GacelaEventInterface
         private readonly string $className,
         private readonly string $method,
         private readonly string $cacheKey,
-        private readonly float $computeMilliseconds,
+        private readonly int $computeNanoseconds,
         private readonly int $ttl,
     ) {
     }
@@ -47,9 +47,22 @@ final class CacheableMissEvent implements GacelaEventInterface
         return $this->cacheKey;
     }
 
+    /**
+     * Raw, as `hrtime()` reported it.
+     *
+     * Carried in nanoseconds and converted here rather than at the call site
+     * so the conversion is a pure function of an argument: a duration computed
+     * inline against a clock can only be asserted as "some non-negative
+     * number", which is an assertion every arithmetic mistake also satisfies.
+     */
+    public function computeNanoseconds(): int
+    {
+        return $this->computeNanoseconds;
+    }
+
     public function computeMilliseconds(): float
     {
-        return $this->computeMilliseconds;
+        return (float)$this->computeNanoseconds / 1e6;
     }
 
     public function ttl(): int
@@ -65,7 +78,7 @@ final class CacheableMissEvent implements GacelaEventInterface
             $this->className,
             $this->method,
             $this->cacheKey,
-            $this->computeMilliseconds,
+            $this->computeMilliseconds(),
             $this->ttl,
         );
     }

--- a/src/Framework/Event/Attribute/CacheableMissEvent.php
+++ b/src/Framework/Event/Attribute/CacheableMissEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Attribute;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * A `#[Cacheable]` method ran its callback because storage had no answer.
+ *
+ * Carries what the callback cost and the TTL the result was stored under,
+ * which is the pair a listener needs to decide whether the caching is earning
+ * anything: a miss that takes 0.2ms is noise, and the same miss repeating on
+ * every request is the PHP-FPM default-storage trap that `doctor` can only
+ * warn about from the configuration.
+ *
+ * The duration is measured around the callback alone, not around the storage
+ * write -- what is worth knowing is what the cache is saving when it hits, and
+ * a backend's own latency is the backend's to report.
+ */
+final class CacheableMissEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $className,
+        private readonly string $method,
+        private readonly string $cacheKey,
+        private readonly float $computeMilliseconds,
+        private readonly int $ttl,
+    ) {
+    }
+
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    public function cacheKey(): string
+    {
+        return $this->cacheKey;
+    }
+
+    public function computeMilliseconds(): float
+    {
+        return $this->computeMilliseconds;
+    }
+
+    public function ttl(): int
+    {
+        return $this->ttl;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {method:"%s::%s", key:"%s", computed_in:%.3fms, ttl:%d}',
+            self::class,
+            $this->className,
+            $this->method,
+            $this->cacheKey,
+            $this->computeMilliseconds,
+            $this->ttl,
+        );
+    }
+}

--- a/tests/Unit/Framework/Attribute/CacheableTest.php
+++ b/tests/Unit/Framework/Attribute/CacheableTest.php
@@ -237,7 +237,10 @@ final class CacheableTest extends TestCase
         self::assertSame('lookup', $misses[0]->method());
         self::assertSame(TestFacadeWithTemplatedKey::class . '::lookup::user:42', $misses[0]->cacheKey());
         self::assertSame(3600, $misses[0]->ttl());
-        self::assertGreaterThanOrEqual(0.0, $misses[0]->computeMilliseconds());
+        // Bounded on both sides. `>= 0` is satisfied by every arithmetic
+        // mistake the conversion could make, so it asserts nothing.
+        self::assertGreaterThan(0, $misses[0]->computeNanoseconds());
+        self::assertLessThan(1000.0, $misses[0]->computeMilliseconds());
 
         self::assertSame($misses[0]->cacheKey(), $hits[0]->cacheKey());
     }

--- a/tests/Unit/Framework/Attribute/CacheableTest.php
+++ b/tests/Unit/Framework/Attribute/CacheableTest.php
@@ -10,6 +10,11 @@ use Gacela\Framework\Attribute\CacheableConfig;
 use Gacela\Framework\Attribute\CacheableTrait;
 use Gacela\Framework\Attribute\CacheStorageInterface;
 use Gacela\Framework\Attribute\InMemoryCacheStorage;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\Attribute\CacheableHitEvent;
+use Gacela\Framework\Event\Attribute\CacheableMissEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -199,6 +204,42 @@ final class CacheableTest extends TestCase
         $storage = CacheableConfig::getStorage();
         self::assertTrue($storage->has(TestFacadeWithTemplatedKey::class . '::lookup::user:42'));
         self::assertSame(1, $facade->getCallCount());
+    }
+
+    /**
+     * A caching feature you cannot observe is one you cannot tune. Until these
+     * events existed, whether `#[Cacheable]` ever returned a stored value was
+     * not answerable from inside the application -- which is exactly the
+     * question to ask on PHP-FPM, where the default storage dies with the
+     * process and every request recomputes.
+     */
+    public function test_a_hit_and_a_miss_each_dispatch_their_event(): void
+    {
+        $events = [];
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use (&$events): void {
+            $config->resetInMemoryCache();
+            $config->registerGenericListener(static function (GacelaEventInterface $event) use (&$events): void {
+                $events[] = $event;
+            });
+        });
+
+        $facade = new TestFacadeWithTemplatedKey();
+        $facade->lookup(42);
+        $facade->lookup(42);
+
+        $misses = array_values(array_filter($events, static fn (GacelaEventInterface $e): bool => $e instanceof CacheableMissEvent));
+        $hits = array_values(array_filter($events, static fn (GacelaEventInterface $e): bool => $e instanceof CacheableHitEvent));
+
+        self::assertCount(1, $misses, 'the first call should report a miss');
+        self::assertCount(1, $hits, 'the second call should report a hit');
+
+        self::assertSame(TestFacadeWithTemplatedKey::class, $misses[0]->className());
+        self::assertSame('lookup', $misses[0]->method());
+        self::assertSame(TestFacadeWithTemplatedKey::class . '::lookup::user:42', $misses[0]->cacheKey());
+        self::assertSame(3600, $misses[0]->ttl());
+        self::assertGreaterThanOrEqual(0.0, $misses[0]->computeMilliseconds());
+
+        self::assertSame($misses[0]->cacheKey(), $hits[0]->cacheKey());
     }
 
     /**

--- a/tests/Unit/Framework/Event/Attribute/CacheableMissEventTest.php
+++ b/tests/Unit/Framework/Event/Attribute/CacheableMissEventTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Attribute;
+
+use Gacela\Framework\Event\Attribute\CacheableMissEvent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CacheableMissEventTest extends TestCase
+{
+    /**
+     * The conversion is a pure function of the argument, which is the whole
+     * reason the duration is carried in nanoseconds: measured against a live
+     * clock it could only be asserted as "some non-negative number", and every
+     * way of getting the arithmetic wrong satisfies that too.
+     */
+    #[DataProvider('durationProvider')]
+    public function test_nanoseconds_convert_to_milliseconds(int $nanoseconds, float $expectedMilliseconds): void
+    {
+        $event = new CacheableMissEvent('App\\Wallet\\WalletFacade', 'getUser', 'key', $nanoseconds, 3600);
+
+        self::assertSame($nanoseconds, $event->computeNanoseconds());
+        self::assertSame($expectedMilliseconds, $event->computeMilliseconds());
+    }
+
+    /**
+     * @return iterable<string, array{int, float}>
+     */
+    public static function durationProvider(): iterable
+    {
+        yield 'one millisecond' => [1_000_000, 1.0];
+        yield 'two and a half' => [2_500_000, 2.5];
+        yield 'sub-millisecond' => [1_500, 0.0015];
+        yield 'nothing measurable' => [0, 0.0];
+    }
+
+    public function test_it_describes_itself(): void
+    {
+        $event = new CacheableMissEvent('App\\Wallet\\WalletFacade', 'getUser', 'the-key', 2_500_000, 60);
+
+        $description = $event->toString();
+
+        self::assertStringContainsString('App\\Wallet\\WalletFacade::getUser', $description);
+        self::assertStringContainsString('the-key', $description);
+        self::assertStringContainsString('2.500ms', $description);
+        self::assertStringContainsString('ttl:60', $description);
+    }
+}


### PR DESCRIPTION
## 📚 Description

`#[Cacheable]` dispatched **nothing**. Whether it ever returned a stored value was not answerable from inside the application, so a hit rate — the one number worth knowing about a cache — could not be measured at all.

It is also the question that catches the default-storage trap in production. `InMemoryCacheStorage` dies with the process, so under PHP-FPM a method annotated for an hour's TTL is recomputed on every request: **every call reports a miss**, and nothing else says so. `doctor` reports the same fault from the configuration before a request is served; this reports it from the deployment that is actually running.

## 🔖 Changes

- `CacheableHitEvent` — `className()`, `method()`, `cacheKey()`
- `CacheableMissEvent` — the same plus `computeMilliseconds()` and `ttl()`. The duration times the **callback alone**, not the storage write: what a hit saves you is the callback, and a backend's own latency is the backend's to report
- Documented in the `docs/events.md` catalog

## ⚡ On cost

Free when unobserved, which is what makes adding events safe here. `hrtime()` is called only once something listens for the miss event.

| `CacheableBench` | baseline | with events, nobody listening |
|---|---|---|
| cache hit (backtrace) | 0.732μs | **0.732μs** |
| cache hit (explicit args) | 0.645μs | 0.638μs (−1%, inside ±1.2% noise) |

## 🔍 On the perf half of this request

I measured the dispatch guard before adding anything, since "more events" is only safe if the guard is genuinely cheap. Stubbing `shouldDispatch()` to a bare `return false` — the absolute ceiling for any optimisation — moves a warm resolve from **0.350μs to 0.332μs**. That is **18ns**, ~5%, against a baseline whose own spread is ±2.8%.

There is no meaningful perf win available in the event system, so I did not invent one. The guard is already as cheap as a guard gets, and that is precisely what makes the two new events cost nothing.