### PR TITLE
fix(doctor): accept a #[Provides] method that takes the Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Lists every event the framework can dispatch, which of them your project listens
 
 ### Fixed
 
+- **`doctor` no longer reports a `#[Provides]` method that declares a `Container` parameter.** That is the shape the attribute documents, and the scanner reads the signature and passes the container through — a project writing it could not have a green `doctor --strict`
 - **A `#[Provides]` method that resolves the id it declares throws `CircularProvidesException`** naming the provider, the method and the id — instead of a stack overflow with a hundred thousand anonymous-closure frames. A loop through a second id names the whole chain
 - **Event listeners registered in a bootstrap closure and in `gacela.php` at the same time now all fire.** The merge replaced one side's generic listeners and the bootstrap memoized the pre-merge dispatcher, so one set was silently dead
 - **A `#[Cacheable]` custom key is scoped to the class and method that produced it.** Two classes with the same template shared one entry, and custom-keyed entries were invisible to `clearMethodCacheFor()`. **Stored keys change shape** — see [UPGRADE.md](UPGRADE.md#23--24)

--- a/src/Console/Application/Doctor/Check/UnusableProvidesCheck.php
+++ b/src/Console/Application/Doctor/Check/UnusableProvidesCheck.php
@@ -8,6 +8,8 @@ use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\HealthCheck;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Attribute\ProvidesScanner;
+use Gacela\Framework\Container\Container;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -25,9 +27,11 @@ use function sprintf;
  *  - **not seen** -- `ProvidesScanner::entriesFor()` reads
  *    `getMethods(ReflectionMethod::IS_PUBLIC)`, so the attribute on a private
  *    or protected method is not there as far as the container is concerned;
- *  - **not callable** -- a method with a required parameter is registered and
- *    then invoked with none, so resolving the id raises `ArgumentCountError`
- *    at whatever point something first asks for it;
+ *  - **not callable** -- a method with a required parameter the scanner has no
+ *    value for is registered and then invoked without it, so resolving the id
+ *    raises `ArgumentCountError` at whatever point something first asks for it.
+ *    A `Container` parameter is not one of those: the scanner reads the
+ *    signature and passes the container through;
  *  - **nothing to supply** -- a method returning `void` or `never` registers
  *    an id whose value is `null`.
  *
@@ -133,10 +137,12 @@ final class UnusableProvidesCheck implements HealthCheck
             );
         }
 
-        if ($method->getNumberOfRequiredParameters() > 0) {
+        $unsupplied = $this->unsuppliedParameterCount($method);
+
+        if ($unsupplied > 0) {
             return sprintf(
                 'which requires %d argument(s) -- the scanner calls it with none, so resolving the id raises ArgumentCountError',
-                $method->getNumberOfRequiredParameters(),
+                $unsupplied,
             );
         }
 
@@ -150,6 +156,36 @@ final class UnusableProvidesCheck implements HealthCheck
         }
 
         return null;
+    }
+
+    /**
+     * Required parameters the scanner has no value for.
+     *
+     * A `Container` parameter is not one of them: {@see ProvidesScanner::scan()}
+     * reads the signature and passes the container through, which is the
+     * documented way for a provided method to reach the locator. Counting it as
+     * a fault reported every Provider written the way `#[Provides]`'s own
+     * example is -- the check contradicting the feature it checks.
+     */
+    private function unsuppliedParameterCount(ReflectionMethod $method): int
+    {
+        $count = 0;
+
+        foreach ($method->getParameters() as $parameter) {
+            if ($parameter->isOptional()) {
+                continue;
+            }
+
+            $type = $parameter->getType();
+
+            if ($type instanceof ReflectionNamedType && $type->getName() === Container::class) {
+                continue;
+            }
+
+            ++$count;
+        }
+
+        return $count;
     }
 
     private function visibilityOf(ReflectionMethod $method): string

--- a/tests/Unit/Console/Application/Doctor/Check/Fixtures/ContainerProvidesProvider.php
+++ b/tests/Unit/Console/Application/Doctor/Check/Fixtures/ContainerProvidesProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+
+/**
+ * The shape `#[Provides]`'s own documentation shows: a provided method that
+ * declares a `Container` parameter, which the scanner passes through.
+ *
+ * Working code, so the check must not report it -- and the method beside it,
+ * which asks for something the scanner cannot supply, must still be reported.
+ */
+final class ContainerProvidesProvider extends AbstractProvider
+{
+    public const FROM_CONTAINER = 'from-container';
+
+    public const CONTAINER_AND_MORE = 'container-and-more';
+
+    #[Provides(self::FROM_CONTAINER)]
+    public function fromContainer(Container $container): string
+    {
+        return $container::class;
+    }
+
+    #[Provides(self::CONTAINER_AND_MORE)]
+    public function containerAndMore(Container $container, string $unexpected): string
+    {
+        return $unexpected;
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/UnusableProvidesCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/UnusableProvidesCheckTest.php
@@ -7,6 +7,7 @@ namespace GacelaTest\Unit\Console\Application\Doctor\Check;
 use Gacela\Console\Application\Doctor\Check\UnusableProvidesCheck;
 use Gacela\Console\Application\Doctor\CheckStatus;
 use Gacela\Console\Domain\AllAppModules\AppModule;
+use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\ContainerProvidesProvider;
 use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\HiddenProvidesProvider;
 use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\StubFacade;
 use GacelaTest\Unit\Console\Application\Doctor\Check\Fixtures\UncallableProvidesProvider;
@@ -135,6 +136,36 @@ final class UnusableProvidesCheckTest extends TestCase
         $result = (new UnusableProvidesCheck([$this->module(UncallableProvidesProvider::class)]))->run();
 
         self::assertCount(2, $result->details);
+    }
+
+    /**
+     * A `Container` parameter is the one required parameter the scanner does
+     * supply: `ProvidesScanner::scan()` reads the signature and passes it
+     * through, which is the shape `#[Provides]`'s own example is written in.
+     * Counting it reported every Provider that reaches the locator.
+     */
+    public function test_a_container_parameter_is_not_a_fault(): void
+    {
+        $result = (new UnusableProvidesCheck([$this->module(ContainerProvidesProvider::class)]))->run();
+
+        foreach ($result->details as $detail) {
+            self::assertStringNotContainsString('fromContainer()', $detail);
+        }
+    }
+
+    /**
+     * And the parameter beside it still is: exempting the container must not
+     * exempt the method carrying it.
+     */
+    public function test_a_further_required_parameter_is_still_reported(): void
+    {
+        $result = (new UnusableProvidesCheck([$this->module(ContainerProvidesProvider::class)]))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString(
+            'requires 1 argument(s)',
+            $this->detailMentioning($result->details, 'containerAndMore()'),
+        );
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

`doctor --strict` reported every `#[Provides]` method that declares a `Container` parameter as "requires 1 argument(s) — the scanner calls it with none". That is the shape the attribute's own docblock shows, and `ProvidesScanner::scan()` reads the signature and passes the container through — so a project written the documented way could not have a green `doctor --strict`, and its only ways out were to stop taking the container or to stop running the check.

Found while building the reference application (#876).

## 🔖 Changes

- `UnusableProvidesCheck` counts only the required parameters the scanner has no value for; a `Container`-typed one is exempt. A further required parameter beside it is still a fault
- Two tests in `UnusableProvidesCheckTest` with a `ContainerProvidesProvider` fixture
- CHANGELOG entry
