### PR TITLE
fix(bootstrap): honour setAppModulePaths() declared in gacela.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Lists every event the framework can dispatch, which of them your project listens
 
 ### Fixed
 
+- **`setAppModulePaths()` written in `gacela.php` is honoured.** The setup merger carried 24 properties and not that one, so the value survived only from a bootstrap closure: every command walked the whole application root, and `doctor`'s own `module paths` check reported the list that was not in force
 - **`doctor` no longer reports a `#[Provides]` method that declares a `Container` parameter.** That is the shape the attribute documents, and the scanner reads the signature and passes the container through — a project writing it could not have a green `doctor --strict`
 - **A `#[Provides]` method that resolves the id it declares throws `CircularProvidesException`** naming the provider, the method and the id — instead of a stack overflow with a hundred thousand anonymous-closure frames. A loop through a second id names the whole chain
 - **Event listeners registered in a bootstrap closure and in `gacela.php` at the same time now all fire.** The merge replaced one side's generic listeners and the bootstrap memoized the pre-merge dispatcher, so one set was silently dead

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -28,6 +28,13 @@ final class SetupMerger
 
         $this->whenChanged($other, SetupGacela::externalServices, fn () => $this->original->mergeExternalServices($other->externalServices()));
         $this->whenChanged($other, SetupGacela::projectNamespaces, fn () => $this->original->mergeProjectNamespaces($other->getProjectNamespaces()));
+        // Replaced rather than merged, unlike the namespaces above: this is the
+        // list of directories to scan, and a source that names it is naming all
+        // of them. Missing entirely until now, so `setAppModulePaths()` written
+        // in `gacela.php` -- where a project naturally writes it, beside
+        // `setProjectNamespaces()` -- was silently ignored and every command
+        // walked the whole application root.
+        $this->whenChanged($other, SetupGacela::appModulePaths, fn (): SetupGacela => $this->original->setAppModulePaths($other->getAppModulePaths()));
         $this->whenChanged($other, SetupGacela::configDimensions, fn () => $this->original->mergeConfigDimensions($other->getConfigDimensions()));
         $this->whenChanged($other, SetupGacela::configKeyValues, fn () => $this->original->mergeConfigKeyValues($other->getConfigKeyValues()));
         $this->whenChanged($other, SetupGacela::configSchema, fn () => $this->original->mergeConfigSchema($other->getConfigSchema()));

--- a/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
+++ b/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
@@ -319,6 +319,55 @@ final class SetupMergerTest extends TestCase
         );
     }
 
+    /**
+     * `gacela.php` is where a project writes this, beside `setProjectNamespaces()`
+     * -- and until the merger carried it, writing it there did nothing: every
+     * command went on walking the whole application root, and `doctor` reported
+     * the closure's paths as the ones being scanned.
+     */
+    public function test_app_module_paths_declared_by_the_second_setup_are_the_ones_scanned(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('unrelated', true);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['src/Billing', 'src/Customer']);
+        });
+
+        self::assertSame(['src/Billing', 'src/Customer'], $setup1->merge($setup2)->getAppModulePaths());
+    }
+
+    /**
+     * Replaced, not appended: the list names every directory to scan, so a
+     * source that writes it is answering the whole question.
+     */
+    public function test_app_module_paths_replace_rather_than_accumulate(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['src/Legacy']);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['src/Billing']);
+        });
+
+        self::assertSame(['src/Billing'], $setup1->merge($setup2)->getAppModulePaths());
+    }
+
+    public function test_a_setup_that_declares_no_app_module_paths_does_not_drop_the_originals(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->setAppModulePaths(['src/Billing']);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('unrelated', true);
+        });
+
+        self::assertSame(['src/Billing'], $setup1->merge($setup2)->getAppModulePaths());
+    }
+
     public function test_merge_handler_registries_from_two_setups(): void
     {
         $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

`setAppModulePaths()` written in `gacela.php` — beside `setProjectNamespaces()`, where `bin/gacela init` scaffolds it — was silently ignored. `SetupMerger::merge()` carried 24 properties from the incoming setup and not that one, so the value survived only when written in the bootstrap closure, which is where every existing fixture wrote it. Every command walked the whole application root, and `doctor`'s own `module paths` check reported the list that was not in force.

Found while building the reference application (#876).

## 🔖 Changes

- `SetupMerger` carries `appModulePaths`, replacing rather than appending: the list names every directory to scan, so a source that writes it answers the whole question
- Three tests in `SetupMergerTest`: taken from the file when the closure has none, replaced when both name it, untouched when the file is silent
- CHANGELOG entry
