### PR TITLE
fix(resolver): resolve against the current bootstrap's configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Lists every event the framework can dispatch, which of them your project listens
 
 ### Fixed
 
+- **A second bootstrap in one process resolves against its own bindings.** `AbstractClassResolver` memoized the merged `gacela.php` on the instance, and those instances are held by a trait static that no reset reaches — so an application that had used a `#[ServiceMap]` accessor went on resolving its pillars from the previous application's configuration, reported as "no concrete class was found" for a binding that was plainly there
 - **`setAppModulePaths()` written in `gacela.php` is honoured.** The setup merger carried 24 properties and not that one, so the value survived only from a bootstrap closure: every command walked the whole application root, and `doctor`'s own `module paths` check reported the list that was not in force
 - **`doctor` no longer reports a `#[Provides]` method that declares a `Container` parameter.** That is the shape the attribute documents, and the scanner reads the signature and passes the container through — a project writing it could not have a green `doctor --strict`
 - **A `#[Provides]` method that resolves the id it declares throws `CircularProvidesException`** naming the provider, the method and the id — instead of a stack overflow with a hundred thousand anonymous-closure frames. A loop through a second id names the whole chain

--- a/src/Framework/ClassResolver/AbstractClassResolver.php
+++ b/src/Framework/ClassResolver/AbstractClassResolver.php
@@ -35,8 +35,6 @@ abstract class AbstractClassResolver
      */
     private static ?Container $container = null;
 
-    private ?GacelaConfigFileInterface $gacelaFileConfig = null;
-
     /**
      * @internal remove all cached instances: facade, factory, config, dependency-provider
      */
@@ -181,14 +179,29 @@ abstract class AbstractClassResolver
         return $instance;
     }
 
+    /**
+     * Asked of the ConfigFactory every time rather than memoized here.
+     *
+     * A resolver instance can outlive the bootstrap that built it -- the ones
+     * held by `ServiceResolverAwareTrait::$docBlockServiceResolvers` are a trait
+     * static, which no reset can reach -- and a memo on this object was then a
+     * copy of the *previous* application's merged configuration, from which
+     * `createInstance()` built the shared container. A second bootstrap in one
+     * process therefore resolved its pillars against the first application's
+     * bindings: silently, and only for whoever had used a `#[ServiceMap]`
+     * accessor before.
+     *
+     * Nothing is re-derived by removing it. `ConfigFactory::createGacelaFileConfig()`
+     * memoizes the assembled file config itself, keyed by the app root and the
+     * setup identity -- which is exactly the pair that changes across a
+     * bootstrap, and exactly what this memo could not see. This is also the
+     * cold path: the callers are the class-name finder on a cache miss, and the
+     * one-time container build.
+     */
     private function getGacelaConfigFile(): GacelaConfigFileInterface
     {
-        if (!$this->gacelaFileConfig instanceof GacelaConfigFileInterface) {
-            $this->gacelaFileConfig = Config::getInstance()
-                ->getFactory()
-                ->createGacelaFileConfig();
-        }
-
-        return $this->gacelaFileConfig;
+        return Config::getInstance()
+            ->getFactory()
+            ->createGacelaFileConfig();
     }
 }

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/EnglishGreeter.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/EnglishGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting;
+
+final class EnglishGreeter implements GreeterInterface
+{
+    public function greet(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/GreeterInterface.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/GreeterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting;
+
+interface GreeterInterface
+{
+    public function greet(): string;
+}

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/GreetingService.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/GreetingService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting;
+
+/**
+ * Resolved through a `#[ServiceMap]` accessor, and built by the container from
+ * whichever bootstrap's bindings are in force.
+ */
+final class GreetingService
+{
+    public function __construct(
+        private readonly GreeterInterface $greeter,
+    ) {
+    }
+
+    public function greet(): string
+    {
+        return $this->greeter->greet();
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/SpanishGreeter.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Greeting/SpanishGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting;
+
+final class SpanishGreeter implements GreeterInterface
+{
+    public function greet(): string
+    {
+        return 'hola';
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Reader.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Reader.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting\GreetingService;
+
+/**
+ * A plain class reaching a service through `#[ServiceMap]`, the way a console
+ * command or an HTTP controller does.
+ *
+ * The resolver behind the accessor is held in a trait static, so it survives
+ * `Gacela::resetCache()` and the next bootstrap uses the same one -- which is
+ * why this class is what the regression beside it is written against.
+ */
+#[ServiceMap(method: 'getGreetingService', className: GreetingService::class)]
+final class Reader
+{
+    use ServiceResolverAwareTrait;
+
+    public function greet(): string
+    {
+        /** @var GreetingService $service */
+        $service = $this->getGreetingService();
+
+        return $service->greet();
+    }
+}

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Spanish/gacela.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/Spanish/gacela.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting\GreeterInterface;
+use GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting\SpanishGreeter;
+
+/**
+ * The second application: the same interface, bound to the other implementation.
+ */
+return static function (GacelaConfig $config): void {
+    $config->addBinding(GreeterInterface::class, SpanishGreeter::class);
+};

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/gacela.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfig/gacela.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting\EnglishGreeter;
+use GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Greeting\GreeterInterface;
+
+return static function (GacelaConfig $config): void {
+    $config->addBinding(GreeterInterface::class, EnglishGreeter::class);
+};

--- a/tests/Integration/Framework/ClassResolver/StaleBootstrapConfigTest.php
+++ b/tests/Integration/Framework/ClassResolver/StaleBootstrapConfigTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ClassResolver;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\ClassResolver\StaleBootstrapConfig\Reader;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A second bootstrap resolves against its own configuration, not the previous
+ * one's.
+ *
+ * The resolvers behind a `#[ServiceMap]` accessor are held in a trait static --
+ * one per using class, which no central reset can reach, and which the static
+ * coverage list already records as unclearable. That was safe only while those
+ * resolvers held pure memoization. They also held a copy of the merged
+ * `gacela.php` from the bootstrap that built them, and
+ * `AbstractClassResolver::createInstance()` builds the shared container out of
+ * it -- so an application that had used such an accessor once went on resolving
+ * every pillar against the previous application's bindings.
+ *
+ * Silent in every direction: no exception, no event, and the failure lands on
+ * whichever class the *new* application binds an interface for, as
+ * "no concrete class was found" for a binding that is plainly there.
+ */
+final class StaleBootstrapConfigTest extends TestCase
+{
+    private const string ENGLISH_ROOT = __DIR__ . '/StaleBootstrapConfig';
+
+    private const string SPANISH_ROOT = __DIR__ . '/StaleBootstrapConfig/Spanish';
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_the_second_bootstrap_resolves_with_its_own_bindings(): void
+    {
+        $this->bootstrap(self::ENGLISH_ROOT);
+        self::assertSame('hello', (new Reader())->greet());
+
+        $this->bootstrap(self::SPANISH_ROOT);
+        self::assertSame('hola', (new Reader())->greet(), 'the resolver served the first bootstrap’s bindings');
+    }
+
+    /**
+     * The other direction, so the test cannot pass by the two roots happening to
+     * agree: whichever ran first, the second one wins.
+     */
+    public function test_the_order_of_the_two_bootstraps_does_not_decide_the_answer(): void
+    {
+        $this->bootstrap(self::SPANISH_ROOT);
+        self::assertSame('hola', (new Reader())->greet());
+
+        $this->bootstrap(self::ENGLISH_ROOT);
+        self::assertSame('hello', (new Reader())->greet());
+    }
+
+    private function bootstrap(string $appRootDir): void
+    {
+        Gacela::bootstrap($appRootDir, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+        });
+    }
+}


### PR DESCRIPTION
## 📚 Description

A second `Gacela::bootstrap()` in one process resolved its pillars against the *first* application's bindings, reported as `DependencyNotFoundException: No concrete class was found that implements …` for an interface the second `gacela.php` plainly binds.

`AbstractClassResolver` memoized the merged `gacela.php` on the instance, and `createInstance()` builds the process-wide resolver container from it. Resolver instances are held by `ServiceResolverAwareTrait::$docBlockServiceResolvers` — a trait static no reset reaches, which `StaticStateCoverageTest::OUTLIVES_RESET` records as pure memoization. It was not: it carried one bootstrap's configuration into the next, for whoever had used a `#[ServiceMap]` accessor before. Every bridge, every functional suite and every `bin/console` that boots twice is in that shape.

Found while building the reference application (#876): `doctor --strict` passed on its own and failed inside the full feature suite.

## 🔖 Changes

- The instance memo is deleted; `getGacelaConfigFile()` asks `ConfigFactory::createGacelaFileConfig()`, which already memoizes keyed by app root **and setup identity** — the pair that changes across a bootstrap. Cold path only: the class-name finder on a cache miss and the one-time container build; the warm `resolveCached()` path is untouched
- `StaleBootstrapConfigTest`: two applications binding one interface to two implementations, asserted in both orders; fails on both without the fix
- CHANGELOG entry
