### PR TITLE
feat(testing): bootstrap one module with its neighbours doubled, and assert boundaries from a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ Lists every event the framework can dispatch, which of them your project listens
 - **Paths skipped** — an `appModulePaths` entry that is not a directory is reported as `Not scanned, not a directory: …`, and by a new `module paths` doctor check so `--strict` can fail on it
 - **The filter** — `doctor` names it and how many modules it matched, including none, which used to end in `All checks passed`
 
+#### Module test slices
+
+`GacelaTestCase::bootstrapModule($appRoot, InvoiceFacade::class, doubles: [...])` bootstraps one module with its neighbours replaced — the everyday test of a modular application, which needed a bootstrap plus three override APIs and the question of which one applies to which kind of dependency.
+
+- Narrows module discovery to that module's directory, so `doctor`, `list:modules` and `debug:graph` answer about one module
+- Routes each double by what it is: a pillar instance to `swapModule*()`, a class or interface to a binding, a lazy service and a resolved-class override, a container id to a service extension — the only reach a bootstrap has into a module's own Provider
+- Refuses a double that is not an instance of the class it is registered under; a Facade left `final` cannot be doubled by anyone, so replace that module's Factory instead
+
+#### Module boundaries in PHPUnit
+
+`Gacela\Console\Testing\ModuleAssertions` is a standalone trait with `assertModuleDependsOnlyOn()`, `assertNoModuleCycles()` and `assertModuleRulesHold()`.
+
+- Reads the graph, allowed-cycles file and `module-rules.json` that `debug:graph --check` reads, so a boundary holds in the test and in CI or in neither
+- Every failure names the offending edge and the `use` statement behind it, as `file:line`
+- In the `Gacela\Console` namespace because the graph is built by scanning source files, and `Gacela\Framework` must not depend on `Gacela\Console`
+
 #### Reference application
 
 An invoicing SaaS under `tests/Feature/ReferenceApp/`, wired with every feature at once and run on every pull request. Five modules, a three-layer harness — behaviour, every shipped command, and a guard that fails when a new `GacelaConfig` method, attribute or command is not used by it — and both analysers over the application with the opt-in architecture rules turned on. See [docs/reference-app.md](docs/reference-app.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 - [Module health checks](module-health-checks.md) — report module operational status
 - [Profiling](profiling.md) — instrument code with the in-memory `Profiler` and read it back with `profile:report`
 - [Events](events.md) — listen to Gacela internals: dispatch model, event catalog, cookbook
-- [Testing](testing.md) — `GacelaTestCase`: bootstrap isolation, config overrides, container assertions
+- [Testing](testing.md) — `GacelaTestCase`: bootstrap isolation, module slices with doubles, container and boundary assertions
 - [Caching](caching.md) — overview of Gacela's three caching layers and when to reach for each
 - [Cacheable methods](cacheable-methods.md) — cache facade method results with `#[Cacheable]`
 - [FileCache and ScopedCache](file-cache.md) — cache arbitrary application data with atomic writes and cascading invalidation

--- a/docs/module-boundaries.md
+++ b/docs/module-boundaries.md
@@ -1,6 +1,6 @@
 # Module Boundaries
 
-Module A may only reach module B through B's Facade. This page collects everything that enforces that claim and the agreements built on top of it: two opt-in analyser rules, a dependency-cycle gate on `debug:graph`, a declared rules file both readers share, and a CI review for graph changes.
+Module A may only reach module B through B's Facade. This page collects everything that enforces that claim and the agreements built on top of it: two opt-in analyser rules, a dependency-cycle gate on `debug:graph`, a declared rules file the analysers, the command and the test suite all share, and a CI review for graph changes.
 
 The rules run under PHPStan and Psalm alike; [Static analysis](static-analysis.md) covers installing the analysers, the always-on pillar rules, and suppression.
 
@@ -214,7 +214,7 @@ services:
 </pluginClass>
 ```
 
-One file, two readers, on purpose: a boundary that holds in CI and not in the editor is a boundary nobody trusts.
+One file, several readers, on purpose: a boundary that holds in CI and not in the editor is a boundary nobody trusts. A [test method reads it too](#enforcing-the-same-file-from-a-test-method).
 
 The rules are **self-invalidating**, like the cycle allow list. A `from`, `allow` or `deny` naming a namespace that matches no module fails the check — a rule about a module nobody has any more still reads as a boundary being watched. A `deny` that never fires is not an error; that is the rule doing its job.
 
@@ -240,6 +240,18 @@ Neither analyser can. They are handed one class at a time and asked whether *thi
     "unknownRuleNamespaces": []
 }
 ```
+
+## Enforcing the same file from a test method
+
+The rules file has a third reader. `Gacela\Console\Testing\ModuleAssertions` puts the same graph, cycle detector, allow list and rule checker behind three PHPUnit assertions, so a boundary decision can live next to the module's own tests rather than only in CI configuration:
+
+```php
+self::assertModuleDependsOnlyOn(InvoiceFacade::class, [BillingFacade::class, CustomerFacade::class]);
+self::assertNoModuleCycles(__DIR__ . '/allowed-cycles.json');
+self::assertModuleRulesHold(__DIR__ . '/module-rules.json');
+```
+
+Failures name the offending edge and the `use` statement that writes it, as `file:line`. See [Testing](testing.md#module-boundaries-in-a-test-method).
 
 ## Reviewing graph changes in CI
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,6 +79,53 @@ Gacela::bootstrap($dir, static function (GacelaConfig $config): void {
 
 `GacelaTestCase` and both framework bridges call it on every boot for exactly this reason. It is opt-in rather than automatic because a process that re-bootstraps with the *same* wiring pays to resolve everything again.
 
+## Testing one module: `bootstrapModule()`
+
+The everyday test of a modular application is one module with its neighbours replaced. That is one call:
+
+```php
+$this->bootstrapModule(__DIR__, InvoiceFacade::class, doubles: [
+    BillingFacade::class => $this->createStub(BillingFacade::class),
+    PaymentGatewayInterface::class => new FakeGateway(),
+]);
+
+$invoice = (new InvoiceFacade())->issue('acme-nl', 10_000);
+```
+
+Two things happen.
+
+**Discovery is narrowed** to the directory the Facade lives in — the slice. `doctor`, `list:modules`, `debug:graph` and the [boundary assertions](#module-boundaries-in-a-test-method) then answer about that module instead of about the whole application. The narrowing is applied after `gacela.php` has been read, so an application that declares its own `setAppModulePaths()` does not silently un-narrow it.
+
+**Each double is applied through the seam that fits it**, so the test does not have to know which of three a given dependency arrives on:
+
+| The double is | It becomes |
+|---|---|
+| an `AbstractFactory` / `AbstractConfig` / `AbstractProvider` instance | that pillar of the module its key's **Facade** names — the `swapModule*()` calls below |
+| any other object, keyed by a class or interface | a container binding, a lazy service, and a resolved-class override — the last is the path a neighbour Facade reached through `getProvidedDependency()` or `#[ServiceMap]` travels |
+| a `Closure` or a class-string, keyed by a class or interface | a container binding and a lazy service |
+| anything, keyed by a **container id** | a replacement for that id wherever it is registered, including in the module's own Provider — which nothing written at application level can otherwise reach |
+
+The third argument is a `GacelaConfig` closure, composed with the narrowing rather than replacing it, for a slice that still has to configure the application it is a slice of:
+
+```php
+$this->bootstrapModule(__DIR__, InvoiceFacade::class,
+    doubles: [BillingFacade::class => $billing],
+    configFn: static fn (GacelaConfig $config) => $config->addExternalService('clock', $frozenClock),
+);
+```
+
+Like `bootstrapGacela()`, it bootstraps once per test, and `tearDown()` drops everything it registered.
+
+### A neighbour has to leave its Facade open
+
+A consumer that type-hints a **`final`** Facade cannot be handed a stand-in for it by anyone — not PHPUnit, not a hand-written subclass. A module meant to be replaceable from its neighbours' tests declares its Facade non-`final`; where that is not an option, replace the neighbour's **Factory** instead, which needs nothing from the class it replaces.
+
+### What it checks, and what it cannot
+
+A double registered under a class or interface it is **not an instance of** is refused with a `ModuleDoubleException`, because it would otherwise reach a consumer that type-hints the real one and fail there instead. Naming a module by anything but its Facade is refused for the same reason `swapModuleFactory()` refuses it.
+
+What is **not** checked is whether the module actually depends on what is being doubled. Reflection can see a module's `#[Provides]` ids and return types, its `#[ServiceMap]` accessors and its pillar constructors — and that misses a plugin-stack interface named only as a call argument, an app-wide binding autowired into a nested constructor, and anything a Provider registers from inside a method body. On the [reference application](reference-app.md) those are four of nine legitimate doubles, so such a check would refuse real tests rather than catch typos.
+
 ## Replacing another module
 
 Testing module A in isolation means replacing module B. A container binding only works when B's Facade arrives through a Provider, and a consumer that writes `new BlogFacade()` leaves nothing to bind — so the seam is the **Factory** every Facade resolves:
@@ -118,6 +165,48 @@ $this->swapModuleFactory(BlogFacade::class, new class() extends BlogFactory {   
 Naming a class that is not a Facade — the Factory itself, or a typo — throws a `ModuleDoubleException` rather than registering a double nothing would ever read.
 
 This replaces reaching into `AnonymousGlobal::overrideExistingResolvedClass()`, which needed the resolver's key format and left the Facade's memoised Factory in place.
+
+## Module boundaries in a test method
+
+A boundary decision that lives only in CI configuration is one a module's own tests cannot state. `Gacela\Console\Testing\ModuleAssertions` is a standalone trait, so it goes into whatever base test class a project already has:
+
+```php
+use Gacela\Console\Testing\ModuleAssertions;
+
+final class InvoiceBoundaryTest extends TestCase
+{
+    use ModuleAssertions;
+
+    public function test_invoice_reaches_billing_and_customer_and_nothing_else(): void
+    {
+        Gacela::bootstrap(__DIR__);
+
+        self::assertModuleDependsOnlyOn(InvoiceFacade::class, [BillingFacade::class, CustomerFacade::class]);
+        self::assertNoModuleCycles(__DIR__ . '/allowed-cycles.json');
+        self::assertModuleRulesHold(__DIR__ . '/module-rules.json');
+    }
+}
+```
+
+- `assertModuleDependsOnlyOn()` takes the module — any class inside it, its Facade by convention, or its namespace — and the modules it may reach. An allowance may name a namespace covering several modules. Naming a module the running configuration does not scan **fails**, listing the modules it did find, rather than passing on an empty dependency list.
+- `assertNoModuleCycles()` reads the same allowed-cycles file `debug:graph --check --allowed-cycles` reads, and is as self-invalidating: an allowance whose cycle has since been broken fails too.
+- `assertModuleRulesHold()` reads the same [`module-rules.json`](module-boundaries.md) the CLI and the PHPStan/Psalm rules read. One file, enforced from wherever you happen to be looking.
+
+Every failure names the offending edge **and the `use` statement behind it**, as `file:line`:
+
+```
+"App\Invoice" may depend only on:
+  - App\Customer
+
+✗ App\Invoice -> App\Billing
+    /app/src/Invoice/Domain/InvoiceIssuer.php:12  use App\Billing\BillingFacade;
+```
+
+The line is where the `use` statement opens, so every name of a grouped import reports the same one. A dependency that arrives without an import — a fully qualified name written inline, a class-string in configuration — has no evidence to show, because the graph does not see it either: nothing is reported that the check did not find.
+
+The application must be bootstrapped, since these read the modules the running configuration declares. That is also what makes `bootstrapModule()`'s narrowing meaningful here: inside a slice, these assertions answer about one module.
+
+**These live in the `Gacela\Console` namespace, not on `GacelaTestCase`.** The module graph is built by scanning source files, which is console work, and `Gacela\Framework` references `Gacela\Console` in no file. A framework that sells module boundaries must not invert its own to ship a test helper — so `bootstrapModule()`, which needs only framework primitives, stayed on `GacelaTestCase`, and this came here. A test class writes `use ModuleAssertions;` and has both.
 
 ## Scaffolding a testable module
 

--- a/infection.json5
+++ b/infection.json5
@@ -117,8 +117,28 @@
         UnwrapFinally: {
             ignore: ["Gacela\\Framework\\Cache\\FileCache::commitBatch"],
         },
+        // A trait's method is flattened into the class that uses it, so a test
+        // case calling `self::assertModuleDependsOnlyOn()` reaches it whether it
+        // is declared protected or private. Only a consumer *outside* the using
+        // class could tell the two apart, and there is no such caller to write:
+        // these are the trait's public surface for a project's own test case.
+        ProtectedVisibility: {
+            ignore: [
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertModuleDependsOnlyOn",
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertNoModuleCycles",
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertModuleRulesHold",
+            ],
+        },
         MethodCallRemoval: {
             ignore: [
+                // The guard is followed immediately by swapModuleFactory/Config/
+                // Provider, which perform the identical class_exists +
+                // is_subclass_of check and throw the identical
+                // ModuleDoubleException. So removing it changes which line
+                // raises, never whether one does. It is here to narrow the key
+                // to class-string<AbstractFacade> for the analysers, which is
+                // the one thing the swap's own guard cannot do for its caller.
+                "Gacela\\Framework\\Testing\\GacelaTestCase::swapModulePillarDouble",
                 // Registering the preload autoloader only changes anything in a
                 // process that has no other one -- which a test suite, running
                 // under composer's, never is. What it guards is asserted by
@@ -206,15 +226,36 @@
         // WritableDirectory::probe() / containerTempDir(): mkdir-failure paths only
         // reachable through filesystem races (TOCTOU) or an unwritable system temp dir.
         Throw_: {
-            ignore: ["Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir"],
+            ignore: [
+                "Gacela\\Framework\\Testing\\ContainerFixture::containerTempDir",
+                // Swallowing this throw only defers it: the pillar swap on the
+                // next line builds and throws the same exception for the same
+                // key. See the MethodCallRemoval entry above.
+                "Gacela\\Framework\\Testing\\GacelaTestCase::assertNamesAFacade",
+            ],
         },
         PregQuote: {
             ignore: ["Gacela\\Framework\\Cache\\FileCache::normalizeDirectory"],
         },
         // Random tmp-file suffix shape and the per-class attribute memo key are
         // internal formats with no observable behavior of their own.
+        // The module-boundary failure messages. What each one *says* is
+        // asserted -- the edge, the file and line behind it, the rule's reason,
+        // the modules the scan found, the sentence telling the reader what to do
+        // -- and every finding line has exactly one definition, shared by the
+        // findings list and the report, so a mutant that mangles it is caught by
+        // those assertions. What is exempt here is the layout around them: the
+        // newline between a finding and its evidence, the order two whole
+        // sentences appear in, and the "  - " that indents a list. Pinning those
+        // is a golden master over whitespace.
         Concat: {
             ignore: [
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertModuleDependsOnlyOn",
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertNoModuleCycles",
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertModuleRulesHold",
+                "Gacela\\Console\\Testing\\ModuleAssertions::gacelaUnknownModuleReport",
+                "Gacela\\Console\\Testing\\ModuleAssertions::gacelaBulletList",
+                "Gacela\\Framework\\Testing\\ModuleDoubleException::notAnInstanceOf",
                 // keyFor() is the internal `operation:subject` key and nothing
                 // reads it back. It used to be written out in both start() and
                 // stop(), where mutating one copy desynchronised the two and
@@ -229,6 +270,12 @@
         },
         ConcatOperandRemoval: {
             ignore: [
+                // See the Concat note above: the separator between a finding and
+                // the imports listed under it, and the indent in front of a
+                // listed item. Every operand that carries a value is asserted.
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertModuleDependsOnlyOn",
+                "Gacela\\Console\\Testing\\ModuleAssertions::assertNoModuleCycles",
+                "Gacela\\Console\\Testing\\ModuleAssertions::gacelaBulletList",
                 // Same as Concat above: one definition cannot disagree with
                 // itself, so dropping an operand still keys start and stop
                 // identically.
@@ -330,6 +377,11 @@
             ignore: [
                 "Gacela\\Framework\\Plugins\\LazyHandlerRegistry::get",
                 "Gacela\\Console\\Domain\\PackageManifest\\NamespacePackageMap::from",
+                // The map only puts "  - " in front of each item. Which items
+                // are listed is asserted -- the allowed modules, the modules the
+                // scan found -- and the indent is not: pinning it would be a
+                // golden master over two spaces and a dash.
+                "Gacela\\Console\\Testing\\ModuleAssertions::gacelaBulletList",
             ],
         },
         // affectedModules() keys its accumulator by module name to deduplicate;
@@ -515,7 +567,16 @@
             ],
         },
         TrueValue: {
-            ignore: ["Gacela\\StaticAnalysis\\Rules\\FacadeOnlyDelegatesAnalyser::isDelegateStatement"],
+            ignore: [
+                "Gacela\\StaticAnalysis\\Rules\\FacadeOnlyDelegatesAnalyser::isDelegateStatement",
+                // The one-entry map is a *set*: owningModulesOf() reads it with
+                // isset(), which answers the same for `false` as for `true`.
+                // Only the key is ever looked at. Same shape as the `$seen[...]`
+                // and `$provided[...]` bookkeeping ignored by regex above; it is
+                // built as a map rather than a list so that the evidence and the
+                // graph share one matching rule instead of two.
+                "Gacela\\Console\\Domain\\ModuleGraph\\ModuleGraphBuilder::importsPointingInto",
+            ],
         },
         // PHP 8.4 reports a return type with the casing the source wrote, so
         // `: SELF` arrives as 'SELF' there and as the resolved class on 8.5 --
@@ -529,6 +590,11 @@
         LogicalOr: {
             ignore: [
                 "Gacela\\StaticAnalysis\\Rules\\FacadeOnlyDelegatesAnalyser::isCachedDelegation",
+                // Same redundancy as the MethodCallRemoval entry above: whatever
+                // this guard decides, the pillar swap right after it applies the
+                // identical condition and throws the identical exception, so no
+                // input can tell || from && at this call site.
+                "Gacela\\Framework\\Testing\\GacelaTestCase::assertNamesAFacade",
             ],
         },
         // warmAttributeCache() breaks out of the prefix scan after the first

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,6 +43,14 @@ parameters:
             identifier: trait.unused
             path: src/Framework/DeclaredTypeResolverAwareTrait.php
             count: 1
+        # The module boundary assertions, for the same reason: a project writes
+        # `use ModuleAssertions;` in its own test case. GacelaTestCase cannot use
+        # it -- that class is in src/Framework, and the graph these assertions
+        # read is built by src/Console, which Framework must not depend on.
+        -
+            identifier: trait.unused
+            path: src/Console/Testing/ModuleAssertions.php
+            count: 1
         # Building a MethodReflection is unavoidable for a methodsClassReflectionExtension,
         # and PHPStan covers no way of doing it under its BC promise -- neither implementing
         # ExtendedMethodReflection nor constructing its own implementation of it. The class

--- a/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
+++ b/src/Console/Domain/ModuleGraph/ModuleGraphBuilder.php
@@ -15,6 +15,9 @@ use function file_get_contents;
 use function is_string;
 use function sort;
 
+/**
+ * @psalm-type ImportEvidence = array{file: string, line: int, import: string}
+ */
 final class ModuleGraphBuilder
 {
     public function __construct(
@@ -45,6 +48,47 @@ final class ModuleGraphBuilder
         }
 
         return $graph;
+    }
+
+    /**
+     * Where one edge of the graph was written: every import in the module that
+     * points into `$dependencyNamespace`, with the file and the line declaring
+     * it.
+     *
+     * The graph answers whether a dependency exists; a reader who has just been
+     * told it does needs the line to go and look at. Both answers come from the
+     * same parse and the same namespace matching, so evidence cannot name an
+     * edge the graph does not report, nor go missing for one it does.
+     *
+     * @return list<ImportEvidence> in the order the module's files are walked,
+     *                              and within a file in declaration order
+     */
+    public function importsPointingInto(AppModule $module, string $dependencyNamespace): array
+    {
+        $ownName = $module->fullModuleName();
+        if ($dependencyNamespace === $ownName) {
+            return [];
+        }
+
+        $moduleDir = $this->moduleDirectory($module);
+        if ($moduleDir === null) {
+            return [];
+        }
+
+        $owner = [$dependencyNamespace => true];
+        $evidence = [];
+
+        foreach ($this->phpSourcesIn($moduleDir) as $file => $source) {
+            foreach ($this->importParser->importsWithLinesIn($source) as $import) {
+                if ($this->owningModulesOf($import['name'], $owner) === []) {
+                    continue;
+                }
+
+                $evidence[] = ['file' => $file, 'line' => $import['line'], 'import' => $import['name']];
+            }
+        }
+
+        return $evidence;
     }
 
     /**
@@ -124,13 +168,13 @@ final class ModuleGraphBuilder
     }
 
     /**
-     * The contents of every php file under a directory.
+     * The contents of every php file under a directory, keyed by its path.
      *
      * Separated so the method above is about imports rather than about
      * traversal: which files are read is one question, what is read out of them
      * is another.
      *
-     * @return iterable<string>
+     * @return iterable<string, string>
      */
     private function phpSourcesIn(string $directory): iterable
     {
@@ -148,9 +192,10 @@ final class ModuleGraphBuilder
                 continue;
             }
 
-            $contents = file_get_contents($fileInfo->getPathname());
+            $path = $fileInfo->getPathname();
+            $contents = file_get_contents($path);
             if (is_string($contents)) {
-                yield $contents;
+                yield $path => $contents;
             }
         }
     }

--- a/src/Console/Domain/ModuleGraph/PhpImportParser.php
+++ b/src/Console/Domain/ModuleGraph/PhpImportParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Domain\ModuleGraph;
 
+use function array_column;
 use function count;
 use function explode;
 use function is_array;
@@ -21,6 +22,8 @@ use function trim;
  * correct it. Everything after that is text handling, because the body of a use
  * statement is a comma-separated list with an optional `prefix{...}` group and
  * optional `as` aliases -- and nothing else.
+ *
+ * @psalm-type ImportedName = array{name: string, line: int}
  */
 final class PhpImportParser
 {
@@ -29,13 +32,33 @@ final class PhpImportParser
      */
     public function importsIn(string $phpSource): array
     {
+        return array_column($this->importsWithLinesIn($phpSource), 'name');
+    }
+
+    /**
+     * The same imports, each with the line its `use` statement opens on.
+     *
+     * Split from {@see importsIn()} for whoever has to point a reader at the
+     * import rather than merely count it: a boundary violation is a fact about
+     * one line of one file, and "somewhere in this module" is the difference
+     * between a finding somebody fixes and one they go looking for.
+     *
+     * Every name in a statement carries that statement's line, so the entries of
+     * a group spanning five lines all report the `use`. That is the line worth
+     * showing anyway, and pinning each entry to its own would mean tokenizing
+     * the group body a second time for a distinction no reader needs.
+     *
+     * @return list<ImportedName> in declaration order
+     */
+    public function importsWithLinesIn(string $phpSource): array
+    {
         $imports = [];
 
         foreach ($this->topLevelUseStatements($phpSource) as $statement) {
-            foreach ($this->namesIn($statement) as $name) {
+            foreach ($this->namesIn($statement['text']) as $name) {
                 // `use \App\Billing\Invoice;` is legal and means the same import;
                 // the leading separator is not part of the name modules match on.
-                $imports[] = ltrim($name, '\\');
+                $imports[] = ['name' => ltrim($name, '\\'), 'line' => $statement['line']];
             }
         }
 
@@ -43,12 +66,13 @@ final class PhpImportParser
     }
 
     /**
-     * The text between each top-level `use` and its `;`.
+     * The text between each top-level `use` and its `;`, and the line the `use`
+     * itself sits on.
      *
      * A grouped import's own braces are part of that text, so they are consumed
      * here rather than counted as a class body.
      *
-     * @return list<string>
+     * @return list<array{text: string, line: int}>
      */
     private function topLevelUseStatements(string $phpSource): array
     {
@@ -64,13 +88,14 @@ final class PhpImportParser
             } elseif ($token === '}') {
                 --$depth;
             } elseif ($depth === 0 && is_array($token) && $token[0] === T_USE) {
+                $line = $token[2];
                 $statement = '';
                 for (++$index; $index < $total && $tokens[$index] !== ';'; ++$index) {
                     $current = $tokens[$index];
                     $statement .= is_array($current) ? $current[1] : $current;
                 }
 
-                $statements[] = $statement;
+                $statements[] = ['text' => $statement, 'line' => $line];
             }
         }
 

--- a/src/Console/Testing/ModuleAssertionException.php
+++ b/src/Console/Testing/ModuleAssertionException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Testing;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * The test's own setup being wrong, rather than a boundary being broken.
+ *
+ * Kept apart from an assertion failure on purpose: a missing rules file
+ * reported as a violation sends the reader to look at the application, which is
+ * the one place the problem is not.
+ */
+final class ModuleAssertionException extends RuntimeException
+{
+    public static function unreadableFile(string $path, string $label): self
+    {
+        return new self(sprintf('Cannot read the %s: "%s".', $label, $path));
+    }
+
+    public static function invalidJson(string $path, string $label, string $reason): self
+    {
+        return new self(sprintf('The %s "%s" is not valid JSON: %s', $label, $path, $reason));
+    }
+
+    public static function notAListOfEntries(string $path, string $label): self
+    {
+        return new self(sprintf('The %s "%s" must contain a JSON array.', $label, $path));
+    }
+}

--- a/src/Console/Testing/ModuleAssertions.php
+++ b/src/Console/Testing/ModuleAssertions.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Testing;
+
+use Gacela\Console\ConsoleFacade;
+use Gacela\Console\Domain\AllAppModules\AppModule;
+use Gacela\Console\Domain\ModuleGraph\CycleAllowList;
+use Gacela\Console\Domain\ModuleGraph\ModuleGraphBuilder;
+use Gacela\StaticAnalysis\ModuleRules\ModuleRuleSet;
+use Gacela\StaticAnalysis\NamespaceMatch;
+use JsonException;
+use PHPUnit\Framework\Assert;
+use ReflectionClass;
+
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_values;
+use function class_exists;
+use function count;
+use function file_get_contents;
+use function implode;
+use function in_array;
+use function interface_exists;
+use function is_array;
+use function is_file;
+use function json_decode;
+use function ltrim;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * The module boundary assertions, for a PHPUnit test of any base class.
+ *
+ * ```php
+ * self::assertModuleDependsOnlyOn(InvoiceFacade::class, [BillingFacade::class]);
+ * self::assertNoModuleCycles(__DIR__ . '/allowed-cycles.json');
+ * self::assertModuleRulesHold(__DIR__ . '/module-rules.json');
+ * ```
+ *
+ * Every answer here comes from the graph `debug:graph --check` reads, through
+ * the same {@see ModuleGraphBuilder}, cycle detector, allow list and rule
+ * checker. That is the whole point: a boundary decision that held in CI and not
+ * in the test suite -- or the other way round -- is a decision nobody can act
+ * on, so the two are the same code rather than two readings of one idea.
+ *
+ * **Why this lives in the Console namespace.** The module graph is built by
+ * scanning source files, which is console work, and `Gacela\Framework` does not
+ * reference `Gacela\Console` in a single file. A framework that sells module
+ * boundaries inverting its own would be a poor advertisement, so the slice
+ * helper -- {@see \Gacela\Framework\Testing\GacelaTestCase::bootstrapModule()},
+ * which needs only framework primitives -- stayed there and this came here. A
+ * project with its own base test class writes `use ModuleAssertions;` and has
+ * both.
+ *
+ * The application must be bootstrapped: these read the modules the running
+ * configuration declares, which is what makes a filtered `setAppModulePaths()`
+ * mean the same thing here as it does on the command line.
+ */
+trait ModuleAssertions
+{
+    /**
+     * Assert that a module's dependencies are all covered by the given list.
+     *
+     * A module is named by any class inside it -- its Facade, by convention --
+     * or by its namespace. An allowance may name a namespace that holds several
+     * modules, which is how a decision about a whole area of an application is
+     * written; naming a module the running configuration does not scan fails
+     * rather than passing on an empty dependency list.
+     *
+     * @param list<string> $allowedModules facade classes or module namespaces
+     */
+    protected static function assertModuleDependsOnlyOn(string $module, array $allowedModules): void
+    {
+        $modules = self::gacelaAppModules();
+        $graph = (new ModuleGraphBuilder())->build($modules);
+        $namespace = self::gacelaNamespaceOf($module);
+
+        if (!isset($graph[$namespace])) {
+            Assert::fail(self::gacelaUnknownModuleReport($module, $namespace, array_keys($graph)));
+        }
+
+        $allowed = array_map(self::gacelaNamespaceOf(...), $allowedModules);
+
+        $forbidden = array_values(array_filter(
+            $graph[$namespace],
+            static fn (string $dependency): bool => !NamespaceMatch::anyCovers($allowed, $dependency),
+        ));
+
+        Assert::assertSame(
+            [],
+            array_map(static fn (string $dependency): string => $namespace . ' -> ' . $dependency, $forbidden),
+            self::gacelaForbiddenDependencyReport($modules, $namespace, $forbidden, $allowed),
+        );
+    }
+
+    /**
+     * Assert that the module graph holds no dependency cycle nobody reviewed.
+     *
+     * The optional file has the shape `debug:graph --check --allowed-cycles`
+     * reads -- a list of entries, each with a `modules` list and a `reason` --
+     * and is as self-invalidating here as it is there: an allowance whose cycle
+     * has since been broken fails, because an allow list that outlives what it
+     * allows is only a way to keep the check quiet.
+     */
+    protected static function assertNoModuleCycles(string $allowedCyclesFile = ''): void
+    {
+        $modules = self::gacelaAppModules();
+        $graph = (new ModuleGraphBuilder())->build($modules);
+
+        $cycles = self::gacelaConsole()->detectModuleCycles($graph);
+        $result = self::gacelaCycleAllowList($allowedCyclesFile)->check($cycles);
+
+        $findings = [];
+        foreach ($result->undeclaredCycles as $cycle) {
+            $findings[] = 'Dependency cycle: ' . implode(' -> ', $cycle);
+        }
+
+        foreach ($result->staleAllowances as $cycle) {
+            $findings[] = 'Allowed cycle no longer exists: ' . implode(' -> ', $cycle);
+        }
+
+        Assert::assertSame([], $findings, self::gacelaCycleReport($modules, $graph, $result->undeclaredCycles, $result->staleAllowances));
+    }
+
+    /**
+     * Assert that the declared module rules hold against the graph the
+     * application actually has.
+     *
+     * The file is the one `debug:graph --check --rules` reads, and the one the
+     * PHPStan and Psalm rules read: a project keeps a single `module-rules.json`
+     * and enforces it from wherever it is looking.
+     */
+    protected static function assertModuleRulesHold(string $rulesFile): void
+    {
+        $modules = self::gacelaAppModules();
+        $graph = (new ModuleGraphBuilder())->build($modules);
+
+        $result = self::gacelaConsole()->checkModuleRules($graph, ModuleRuleSet::fromFile($rulesFile));
+
+        $findings = [];
+        foreach ($result->violations as $violation) {
+            $findings[] = sprintf('Forbidden dependency: %s -> %s', $violation->from, $violation->to);
+        }
+
+        foreach ($result->unknownNamespaces as $namespace) {
+            $findings[] = sprintf('Module rule governs nothing: %s', $namespace);
+        }
+
+        Assert::assertSame([], $findings, self::gacelaRuleReport($modules, $result->violations, $result->unknownNamespaces));
+    }
+
+    /**
+     * The modules the running configuration declares, exactly as the console
+     * finds them.
+     *
+     * @return list<AppModule>
+     */
+    private static function gacelaAppModules(): array
+    {
+        return self::gacelaConsole()->findAllAppModules();
+    }
+
+    private static function gacelaConsole(): ConsoleFacade
+    {
+        return new ConsoleFacade();
+    }
+
+    /**
+     * The module a caller named: the namespace of the class, when it is one,
+     * and otherwise the string itself.
+     *
+     * Any class inside a module names it, so a Factory or a domain service in
+     * the module's own namespace works as well as the Facade. A class in a
+     * *sub*namespace does not, and that mistake is caught by the module not
+     * being in the graph rather than by guessing which ancestor was meant.
+     */
+    private static function gacelaNamespaceOf(string $module): string
+    {
+        $name = ltrim($module, '\\');
+
+        return class_exists($name) || interface_exists($name)
+            ? (new ReflectionClass($name))->getNamespaceName()
+            : $name;
+    }
+
+    /**
+     * @param list<string> $knownModules
+     */
+    private static function gacelaUnknownModuleReport(string $module, string $namespace, array $knownModules): string
+    {
+        return sprintf(
+            "\"%s\" is not a module of the bootstrapped application: no module has the namespace \"%s\".\n"
+            . "Name a module by its Facade class or by its namespace, and check the bootstrap's setAppModulePaths().\n"
+            . "The scan found:\n%s",
+            $module,
+            $namespace,
+            self::gacelaBulletList($knownModules),
+        );
+    }
+
+    /**
+     * @param list<AppModule> $modules
+     * @param list<string>    $forbidden
+     * @param list<string>    $allowed
+     */
+    private static function gacelaForbiddenDependencyReport(array $modules, string $namespace, array $forbidden, array $allowed): string
+    {
+        $report = sprintf(
+            "\"%s\" may depend only on:\n%s\n",
+            $namespace,
+            $allowed === [] ? '  (nothing)' : self::gacelaBulletList($allowed),
+        );
+
+        foreach ($forbidden as $dependency) {
+            $report .= sprintf("\n✗ %s -> %s\n", $namespace, $dependency);
+            $report .= self::gacelaImportsBehind($modules, $namespace, $dependency);
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param list<AppModule>             $modules
+     * @param array<string, list<string>> $graph
+     * @param list<list<string>>          $undeclared
+     * @param list<list<string>>          $stale
+     */
+    private static function gacelaCycleReport(array $modules, array $graph, array $undeclared, array $stale): string
+    {
+        $report = sprintf(
+            "%d undeclared module dependency cycle(s), %d allowance(s) that no longer apply.\n",
+            count($undeclared),
+            count($stale),
+        );
+
+        foreach ($undeclared as $cycle) {
+            $report .= sprintf("\n✗ Dependency cycle: %s\n", implode(' -> ', $cycle));
+
+            foreach ($cycle as $from) {
+                foreach ($graph[$from] ?? [] as $to) {
+                    if (in_array($to, $cycle, true)) {
+                        $report .= self::gacelaImportsBehind($modules, $from, $to);
+                    }
+                }
+            }
+        }
+
+        foreach ($stale as $cycle) {
+            $report .= sprintf(
+                "\n✗ Allowed cycle no longer exists: %s. Remove it from the allow list.\n",
+                implode(' -> ', $cycle),
+            );
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param list<AppModule>           $modules
+     * @param list<ModuleRuleViolation> $violations
+     * @param list<string>              $unknownNamespaces
+     */
+    private static function gacelaRuleReport(array $modules, array $violations, array $unknownNamespaces): string
+    {
+        $report = sprintf(
+            "%d forbidden dependency(ies), %d rule(s) governing nothing.\n",
+            count($violations),
+            count($unknownNamespaces),
+        );
+
+        foreach ($violations as $violation) {
+            $report .= sprintf("\n✗ Forbidden dependency: %s -> %s (%s)\n", $violation->from, $violation->to, $violation->reason);
+            $report .= self::gacelaImportsBehind($modules, $violation->from, $violation->to);
+        }
+
+        foreach ($unknownNamespaces as $namespace) {
+            $report .= sprintf(
+                "\n✗ Module rule governs nothing: %s matches no module. Remove the rule, or fix the namespace.\n",
+                $namespace,
+            );
+        }
+
+        return $report;
+    }
+
+    /**
+     * The `use` statements that write one edge, each as `file:line`.
+     *
+     * The line is where the statement opens; a grouped import reaching two
+     * modules is one statement and reports one line for both. What is *not*
+     * here is a dependency that arrives without an import -- a fully qualified
+     * name written inline, or a class-string in configuration -- because the
+     * graph does not see those either, so nothing can be reported that the
+     * check did not find.
+     *
+     * @param list<AppModule> $modules
+     */
+    private static function gacelaImportsBehind(array $modules, string $from, string $to): string
+    {
+        $module = self::gacelaModuleNamed($modules, $from);
+        if (!$module instanceof AppModule) {
+            return '';
+        }
+
+        $lines = '';
+        foreach ((new ModuleGraphBuilder())->importsPointingInto($module, $to) as $import) {
+            $lines .= sprintf("    %s:%d  use %s;\n", $import['file'], $import['line'], $import['import']);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param list<AppModule> $modules
+     */
+    private static function gacelaModuleNamed(array $modules, string $namespace): ?AppModule
+    {
+        foreach ($modules as $module) {
+            if ($module->fullModuleName() === $namespace) {
+                return $module;
+            }
+        }
+
+        return null;
+    }
+
+    private static function gacelaCycleAllowList(string $path): CycleAllowList
+    {
+        if ($path === '') {
+            return CycleAllowList::empty();
+        }
+
+        $contents = is_file($path) ? file_get_contents($path) : false;
+        if ($contents === false) {
+            throw ModuleAssertionException::unreadableFile($path, 'allowed cycles');
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw ModuleAssertionException::invalidJson($path, 'allowed cycles', $jsonException->getMessage());
+        }
+
+        if (!is_array($decoded)) {
+            throw ModuleAssertionException::notAListOfEntries($path, 'allowed cycles');
+        }
+
+        return CycleAllowList::fromDecodedJson($decoded);
+    }
+
+    /**
+     * @param list<string> $items
+     */
+    private static function gacelaBulletList(array $items): string
+    {
+        return implode("\n", array_map(static fn (string $item): string => '  - ' . $item, $items));
+    }
+}

--- a/src/Console/Testing/ModuleAssertions.php
+++ b/src/Console/Testing/ModuleAssertions.php
@@ -14,10 +14,8 @@ use JsonException;
 use PHPUnit\Framework\Assert;
 use ReflectionClass;
 
-use function array_filter;
 use function array_keys;
 use function array_map;
-use function array_values;
 use function class_exists;
 use function count;
 use function file_get_contents;
@@ -85,16 +83,24 @@ trait ModuleAssertions
 
         $allowed = array_map(self::gacelaNamespaceOf(...), $allowedModules);
 
-        $forbidden = array_values(array_filter(
-            $graph[$namespace],
-            static fn (string $dependency): bool => !NamespaceMatch::anyCovers($allowed, $dependency),
-        ));
-
-        Assert::assertSame(
-            [],
-            array_map(static fn (string $dependency): string => $namespace . ' -> ' . $dependency, $forbidden),
-            self::gacelaForbiddenDependencyReport($modules, $namespace, $forbidden, $allowed),
+        $findings = [];
+        $report = sprintf(
+            "\"%s\" may depend only on:\n%s\n",
+            $namespace,
+            $allowed === [] ? '  (nothing)' : self::gacelaBulletList($allowed),
         );
+
+        foreach ($graph[$namespace] as $dependency) {
+            if (NamespaceMatch::anyCovers($allowed, $dependency)) {
+                continue;
+            }
+
+            $finding = $namespace . ' -> ' . $dependency;
+            $findings[] = $finding;
+            $report .= "\n✗ " . $finding . "\n" . self::gacelaImportsBehind($modules, $namespace, $dependency);
+        }
+
+        Assert::assertSame([], $findings, $report);
     }
 
     /**
@@ -115,15 +121,25 @@ trait ModuleAssertions
         $result = self::gacelaCycleAllowList($allowedCyclesFile)->check($cycles);
 
         $findings = [];
+        $report = sprintf(
+            "%d undeclared module dependency cycle(s), %d allowance(s) that no longer apply.\n",
+            count($result->undeclaredCycles),
+            count($result->staleAllowances),
+        );
+
         foreach ($result->undeclaredCycles as $cycle) {
-            $findings[] = 'Dependency cycle: ' . implode(' -> ', $cycle);
+            $finding = 'Dependency cycle: ' . implode(' -> ', $cycle);
+            $findings[] = $finding;
+            $report .= "\n✗ " . $finding . "\n" . self::gacelaImportsWithin($modules, $graph, $cycle);
         }
 
         foreach ($result->staleAllowances as $cycle) {
-            $findings[] = 'Allowed cycle no longer exists: ' . implode(' -> ', $cycle);
+            $finding = 'Allowed cycle no longer exists: ' . implode(' -> ', $cycle);
+            $findings[] = $finding;
+            $report .= "\n✗ " . $finding . ". Remove it from the allow list.\n";
         }
 
-        Assert::assertSame([], $findings, self::gacelaCycleReport($modules, $graph, $result->undeclaredCycles, $result->staleAllowances));
+        Assert::assertSame([], $findings, $report);
     }
 
     /**
@@ -142,15 +158,26 @@ trait ModuleAssertions
         $result = self::gacelaConsole()->checkModuleRules($graph, ModuleRuleSet::fromFile($rulesFile));
 
         $findings = [];
+        $report = sprintf(
+            "%d forbidden dependency(ies), %d rule(s) governing nothing.\n",
+            count($result->violations),
+            count($result->unknownNamespaces),
+        );
+
         foreach ($result->violations as $violation) {
-            $findings[] = sprintf('Forbidden dependency: %s -> %s', $violation->from, $violation->to);
+            $finding = sprintf('Forbidden dependency: %s -> %s', $violation->from, $violation->to);
+            $findings[] = $finding;
+            $report .= sprintf("\n✗ %s (%s)\n", $finding, $violation->reason)
+                . self::gacelaImportsBehind($modules, $violation->from, $violation->to);
         }
 
         foreach ($result->unknownNamespaces as $namespace) {
-            $findings[] = sprintf('Module rule governs nothing: %s', $namespace);
+            $finding = sprintf('Module rule governs nothing: %s', $namespace);
+            $findings[] = $finding;
+            $report .= sprintf("\n✗ %s matches no module. Remove the rule, or fix the namespace.\n", $finding);
         }
 
-        Assert::assertSame([], $findings, self::gacelaRuleReport($modules, $result->violations, $result->unknownNamespaces));
+        Assert::assertSame([], $findings, $report);
     }
 
     /**
@@ -203,88 +230,26 @@ trait ModuleAssertions
     }
 
     /**
-     * @param list<AppModule> $modules
-     * @param list<string>    $forbidden
-     * @param list<string>    $allowed
-     */
-    private static function gacelaForbiddenDependencyReport(array $modules, string $namespace, array $forbidden, array $allowed): string
-    {
-        $report = sprintf(
-            "\"%s\" may depend only on:\n%s\n",
-            $namespace,
-            $allowed === [] ? '  (nothing)' : self::gacelaBulletList($allowed),
-        );
-
-        foreach ($forbidden as $dependency) {
-            $report .= sprintf("\n✗ %s -> %s\n", $namespace, $dependency);
-            $report .= self::gacelaImportsBehind($modules, $namespace, $dependency);
-        }
-
-        return $report;
-    }
-
-    /**
+     * The imports that write the edges *inside* one cycle -- every module of it
+     * reaching every other one, which is what a cycle is.
+     *
      * @param list<AppModule>             $modules
      * @param array<string, list<string>> $graph
-     * @param list<list<string>>          $undeclared
-     * @param list<list<string>>          $stale
+     * @param list<string>                $cycle
      */
-    private static function gacelaCycleReport(array $modules, array $graph, array $undeclared, array $stale): string
+    private static function gacelaImportsWithin(array $modules, array $graph, array $cycle): string
     {
-        $report = sprintf(
-            "%d undeclared module dependency cycle(s), %d allowance(s) that no longer apply.\n",
-            count($undeclared),
-            count($stale),
-        );
+        $lines = '';
 
-        foreach ($undeclared as $cycle) {
-            $report .= sprintf("\n✗ Dependency cycle: %s\n", implode(' -> ', $cycle));
-
-            foreach ($cycle as $from) {
-                foreach ($graph[$from] ?? [] as $to) {
-                    if (in_array($to, $cycle, true)) {
-                        $report .= self::gacelaImportsBehind($modules, $from, $to);
-                    }
+        foreach ($cycle as $from) {
+            foreach ($graph[$from] ?? [] as $to) {
+                if (in_array($to, $cycle, true)) {
+                    $lines .= self::gacelaImportsBehind($modules, $from, $to);
                 }
             }
         }
 
-        foreach ($stale as $cycle) {
-            $report .= sprintf(
-                "\n✗ Allowed cycle no longer exists: %s. Remove it from the allow list.\n",
-                implode(' -> ', $cycle),
-            );
-        }
-
-        return $report;
-    }
-
-    /**
-     * @param list<AppModule>           $modules
-     * @param list<ModuleRuleViolation> $violations
-     * @param list<string>              $unknownNamespaces
-     */
-    private static function gacelaRuleReport(array $modules, array $violations, array $unknownNamespaces): string
-    {
-        $report = sprintf(
-            "%d forbidden dependency(ies), %d rule(s) governing nothing.\n",
-            count($violations),
-            count($unknownNamespaces),
-        );
-
-        foreach ($violations as $violation) {
-            $report .= sprintf("\n✗ Forbidden dependency: %s -> %s (%s)\n", $violation->from, $violation->to, $violation->reason);
-            $report .= self::gacelaImportsBehind($modules, $violation->from, $violation->to);
-        }
-
-        foreach ($unknownNamespaces as $namespace) {
-            $report .= sprintf(
-                "\n✗ Module rule governs nothing: %s matches no module. Remove the rule, or fix the namespace.\n",
-                $namespace,
-            );
-        }
-
-        return $report;
+        return $lines;
     }
 
     /**

--- a/src/Framework/Testing/GacelaTestCase.php
+++ b/src/Framework/Testing/GacelaTestCase.php
@@ -301,13 +301,10 @@ abstract class GacelaTestCase extends TestCase
      */
     private function assertDoubleIsUsableAs(string $id, mixed $double): void
     {
-        if (self::isPillarDouble($double)) {
-            $this->assertNamesAFacade($id);
-
-            return;
-        }
-
-        if (!is_object($double) || $double instanceof Closure) {
+        // A pillar double is checked where it is applied: the swap derives the
+        // module from the Facade and refuses anything else, with this same
+        // exception, so a second check here would only move the throw earlier.
+        if (self::isPillarDouble($double) || !is_object($double) || $double instanceof Closure) {
             return;
         }
 
@@ -317,11 +314,30 @@ abstract class GacelaTestCase extends TestCase
     }
 
     /**
+     * The three pillar swaps, behind the one guard they share.
+     *
      * A pillar double is registered under the key its module's own class would
      * have taken, and the resolver derives that key from the Facade. Anything
      * else names no module, so the double would be registered where nothing
-     * ever reads it.
+     * ever reads it -- which is what the guard refuses, and what narrows the
+     * key to the type the swaps are declared for.
      *
+     * @param AbstractConfig|AbstractFactory|AbstractProvider $double
+     */
+    private function swapModulePillarDouble(string $id, object $double): void
+    {
+        $this->assertNamesAFacade($id);
+
+        if ($double instanceof AbstractFactory) {
+            $this->swapModuleFactory($id, $double);
+        } elseif ($double instanceof AbstractConfig) {
+            $this->swapModuleConfig($id, $double);
+        } else {
+            $this->swapModuleProvider($id, $double);
+        }
+    }
+
+    /**
      * @phpstan-assert class-string<AbstractFacade<AbstractFactory>> $className
      *
      * @psalm-assert class-string<AbstractFacade<AbstractFactory>> $className
@@ -409,37 +425,31 @@ abstract class GacelaTestCase extends TestCase
      * resets the resolver's global instances, so an override registered before
      * one is an override that never happened.
      *
+     * Nothing is re-reset afterwards. The bootstrap this runs behind has just
+     * cleared the Facade and Factory memos, and the pillar swaps clear them
+     * again themselves -- a third clear here would be a call no test could tell
+     * from its absence.
+     *
      * @param array<string, object|Closure|class-string> $doubles
      */
     private function applyResolvedClassDoubles(array $doubles): void
     {
         foreach ($doubles as $id => $double) {
-            // The guard runs again on each pillar branch -- it already ran
-            // before the bootstrap -- so that the key is *known* to name a
-            // Facade at the call the swaps are typed for.
-            if ($double instanceof AbstractFactory) {
-                $this->assertNamesAFacade($id);
-                $this->swapModuleFactory($id, $double);
-            } elseif ($double instanceof AbstractConfig) {
-                $this->assertNamesAFacade($id);
-                $this->swapModuleConfig($id, $double);
-            } elseif ($double instanceof AbstractProvider) {
-                $this->assertNamesAFacade($id);
-                $this->swapModuleProvider($id, $double);
-            } elseif (is_object($double) && !$double instanceof Closure
-                && (class_exists($id) || interface_exists($id))
-            ) {
+            if (self::isPillarDouble($double)) {
+                /** @var AbstractConfig|AbstractFactory|AbstractProvider $double */
+                $this->swapModulePillarDouble($id, $double);
+            } elseif (is_object($double) && !$double instanceof Closure) {
                 // The path a neighbour Facade travels: the Locator consults the
                 // resolver's global instances before the container, which is how
                 // `getProvidedDependency()` and `#[ServiceMap]` both reach one.
+                //
+                // Registered whatever the key is. A key that names no class
+                // takes a slot nothing ever looks up -- the Locator is only ever
+                // asked for a class -- so testing for one would be a branch with
+                // the same outcome on both sides.
                 Gacela::overrideExistingResolvedClass($id, $double);
             }
         }
-
-        // A Facade resolved earlier in this process holds its Factory in a
-        // static, and a Factory holds the container built from its Provider.
-        AbstractFacade::resetCache();
-        AbstractFactory::resetCache();
     }
 
     private static function isPillarDouble(mixed $double): bool

--- a/src/Framework/Testing/GacelaTestCase.php
+++ b/src/Framework/Testing/GacelaTestCase.php
@@ -5,16 +5,30 @@ declare(strict_types=1);
 namespace Gacela\Framework\Testing;
 
 use Closure;
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
 use Gacela\Framework\Event\Container\BindingRegisteredEvent;
 use Gacela\Framework\Event\Container\ServiceResolvedEvent;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 use function array_filter;
 use function array_map;
 use function array_values;
+use function class_exists;
+use function dirname;
+use function interface_exists;
+use function is_object;
+use function is_string;
+use function is_subclass_of;
 use function sprintf;
 
 /**
@@ -74,6 +88,88 @@ abstract class GacelaTestCase extends TestCase
                 $configFn($config);
             }
         });
+    }
+
+    /**
+     * Bootstrap one module with its neighbours replaced -- the everyday test of
+     * a modular application.
+     *
+     * ```php
+     * $this->bootstrapModule(__DIR__, InvoiceFacade::class, doubles: [
+     *     BillingFacade::class => $this->createStub(BillingFacade::class),
+     *     PaymentGatewayInterface::class => new FakeGateway(),
+     * ]);
+     * ```
+     *
+     * Two things happen. Module discovery is narrowed to the module the Facade
+     * names, so `doctor`, `list:modules` and the boundary assertions answer
+     * about that module rather than about the whole application -- the slice.
+     * And each double is applied through the primitive that fits it, so a
+     * caller does not have to know which of three seams a given dependency
+     * arrives on:
+     *
+     * - an `AbstractFactory`, `AbstractConfig` or `AbstractProvider` instance
+     *   replaces that pillar of the module its key's Facade names, exactly as
+     *   {@see ContainerFixture::swapModuleFactory()} does -- and with the same
+     *   guard, so a key that is not a Facade fails rather than registering a
+     *   double nothing reads;
+     * - anything else keyed by a **class or interface** answers wherever that
+     *   type is asked for: a pillar constructor argument, a `Container::get()`,
+     *   and -- for an object -- the resolver's global instances, which is the
+     *   path a neighbour Facade reached through `getProvidedDependency()` or
+     *   `#[ServiceMap]` travels;
+     * - anything keyed by a **container id** replaces that id wherever it is
+     *   registered, including in the module's own Provider, which nothing
+     *   written at application level can otherwise reach.
+     *
+     * A neighbour worth doubling has to leave its Facade non-`final`: a
+     * consumer that type-hints a `final` class cannot be handed a stand-in for
+     * it by anyone. Where that is not an option, replace the neighbour's
+     * Factory instead -- which is the pillar double above, and needs nothing
+     * from the class it replaces.
+     *
+     * **What this cannot check.** That the module actually depends on what is
+     * being doubled. From the framework side, reflection sees a module's
+     * `#[Provides]` ids and return types, its `#[ServiceMap]` accessors and its
+     * pillar constructors -- and that misses a plugin-stack interface named
+     * only as a call argument, an app-wide binding autowired into a nested
+     * constructor, and anything a Provider registers from inside a method body.
+     * On the reference application that is four of nine legitimate doubles, so
+     * a "this module does not depend on X" check would refuse real tests. What
+     * *is* checked is precise: an object registered under a class or interface
+     * it is not an instance of would reach a consumer that type-hints the real
+     * one, and that fails here instead of at the call site.
+     *
+     * Bootstraps once, like {@see bootstrapGacela()}; `tearDown()` drops it.
+     *
+     * @param class-string                                $facadeClass the module under test
+     * @param array<string, object|Closure|class-string> $doubles     class, interface or container id => its replacement
+     * @param null|Closure(GacelaConfig):void             $configFn    composed with the narrowing, not instead of it
+     */
+    protected function bootstrapModule(
+        string $appRootDir,
+        string $facadeClass,
+        array $doubles = [],
+        ?Closure $configFn = null,
+    ): void {
+        $moduleDir = $this->moduleDirectoryOf($facadeClass, $appRootDir);
+
+        foreach ($doubles as $id => $double) {
+            $this->assertDoubleIsUsableAs($id, $double);
+        }
+
+        $this->bootstrapGacela($appRootDir, static function (GacelaConfig $config) use ($doubles, $configFn): void {
+            foreach ($doubles as $id => $double) {
+                self::registerDoubleIn($config, $id, $double);
+            }
+
+            if ($configFn instanceof Closure) {
+                $configFn($config);
+            }
+        });
+
+        $this->narrowModulePathsTo($moduleDir);
+        $this->applyResolvedClassDoubles($doubles);
     }
 
     /**
@@ -151,6 +247,206 @@ abstract class GacelaTestCase extends TestCase
             ),
             sprintf('Binding "%s" was not registered in the container.', $id),
         );
+    }
+
+    /**
+     * The directory the module under test lives in -- the slice.
+     *
+     * Derived from the Facade the same way the pillar swaps derive a module, so
+     * naming anything else fails with the message that already explains why the
+     * Facade is the name a module answers to.
+     *
+     * @param class-string $facadeClass
+     */
+    private function moduleDirectoryOf(string $facadeClass, string $appRootDir): string
+    {
+        if (!class_exists($facadeClass) || !is_subclass_of($facadeClass, AbstractFacade::class)) {
+            throw ModuleDoubleException::notAFacade($facadeClass);
+        }
+
+        $file = (new ReflectionClass($facadeClass))->getFileName();
+
+        // A Facade is a userland class and always has a file; reflection cannot
+        // say so, and narrowing to a path derived from `false` would point
+        // discovery at the working directory. Not narrowing at all is the
+        // honest fallback.
+        return is_string($file) ? dirname($file) : $appRootDir;
+    }
+
+    /**
+     * Point module discovery at the module under test, and nowhere else.
+     *
+     * After the bootstrap rather than inside it, because `gacela.php` merges
+     * *onto* the closure: an application that declares its own module paths --
+     * which is the only kind that has more than one module to narrow away --
+     * would overwrite a narrowing written in the closure, and the slice would
+     * silently be the whole application.
+     */
+    private function narrowModulePathsTo(string $moduleDir): void
+    {
+        $setup = Config::getInstance()->getSetupGacela();
+
+        if ($setup instanceof SetupGacela) {
+            $setup->setAppModulePaths([$moduleDir]);
+        }
+    }
+
+    /**
+     * The one thing about a double that can be checked without guessing.
+     *
+     * A double registered under a class or an interface is handed to whoever
+     * asked for that type. One that is not an instance of it gets all the way
+     * to the call site before failing, with a TypeError naming neither the test
+     * nor the id.
+     */
+    private function assertDoubleIsUsableAs(string $id, mixed $double): void
+    {
+        if (self::isPillarDouble($double)) {
+            $this->assertNamesAFacade($id);
+
+            return;
+        }
+
+        if (!is_object($double) || $double instanceof Closure) {
+            return;
+        }
+
+        if ((class_exists($id) || interface_exists($id)) && !$double instanceof $id) {
+            throw ModuleDoubleException::notAnInstanceOf($id, $double);
+        }
+    }
+
+    /**
+     * A pillar double is registered under the key its module's own class would
+     * have taken, and the resolver derives that key from the Facade. Anything
+     * else names no module, so the double would be registered where nothing
+     * ever reads it.
+     *
+     * @phpstan-assert class-string<AbstractFacade<AbstractFactory>> $className
+     *
+     * @psalm-assert class-string<AbstractFacade<AbstractFactory>> $className
+     */
+    private function assertNamesAFacade(string $className): void
+    {
+        if (!class_exists($className) || !is_subclass_of($className, AbstractFacade::class)) {
+            throw ModuleDoubleException::notAFacade($className);
+        }
+    }
+
+    /**
+     * Everything a double needs from the configuration, which is everything
+     * except the pillar swaps and the resolved-class overrides: both of those
+     * are dropped by the reset that a bootstrap begins with.
+     *
+     * Which registration depends on what the key is, because the two answers an
+     * application gives are reached differently and the registrations do not
+     * compose -- a lazy service registered here satisfies a pending extension
+     * at application level, and the module's Provider then overwrites the
+     * result, so asking for both gets neither.
+     *
+     * A **class or interface** is answered by a binding and a lazy service.
+     * The binding is what the class resolver reads when it builds a pillar's
+     * constructor arguments -- it consults bindings and nothing else. The lazy
+     * service is what `Container::get()` consults first, and it is the only one
+     * of the two that survives `gacela.php`: the application file merges *onto*
+     * the bootstrap closure, so a binding written here loses to one the file
+     * declares for the same class.
+     *
+     * A **container id** is answered by an extension, because a Provider
+     * registers its own ids on the module's container after the application's
+     * services -- so nothing written at application level wins one, and
+     * `extendService()` is the single reach a bootstrap has into a module's own
+     * container. An id nothing registers anywhere is left alone: there is
+     * nothing in the module for the double to stand in for.
+     */
+    private static function registerDoubleIn(GacelaConfig $config, string $id, mixed $double): void
+    {
+        if (self::isPillarDouble($double)) {
+            return;
+        }
+
+        $factory = self::doubleFactory($double);
+
+        if (!class_exists($id) && !interface_exists($id)) {
+            // The extension is handed the service it replaces and the module's
+            // own container, in that order.
+            $config->extendService($id, static fn (mixed $current, Container $container): mixed => $factory($container));
+
+            return;
+        }
+
+        /**
+         * @var class-string $id
+         * @var class-string|object $double
+         */
+        $config->addBinding($id, $double);
+        $config->addLazy($id, $factory);
+    }
+
+    /**
+     * The double as something the container can call for a value.
+     *
+     * A class-string is a recipe rather than a value, so it is resolved the way
+     * the same string in `addBinding()` would be -- handing the string itself
+     * back as the service is never what a caller meant.
+     */
+    private static function doubleFactory(mixed $double): Closure
+    {
+        if ($double instanceof Closure) {
+            return $double;
+        }
+
+        if (is_object($double)) {
+            return static fn (): object => $double;
+        }
+
+        /** @var class-string $double */
+        return static fn (Container $container): mixed => $container->get($double);
+    }
+
+    /**
+     * The doubles that only exist once Gacela has been bootstrapped: a bootstrap
+     * resets the resolver's global instances, so an override registered before
+     * one is an override that never happened.
+     *
+     * @param array<string, object|Closure|class-string> $doubles
+     */
+    private function applyResolvedClassDoubles(array $doubles): void
+    {
+        foreach ($doubles as $id => $double) {
+            // The guard runs again on each pillar branch -- it already ran
+            // before the bootstrap -- so that the key is *known* to name a
+            // Facade at the call the swaps are typed for.
+            if ($double instanceof AbstractFactory) {
+                $this->assertNamesAFacade($id);
+                $this->swapModuleFactory($id, $double);
+            } elseif ($double instanceof AbstractConfig) {
+                $this->assertNamesAFacade($id);
+                $this->swapModuleConfig($id, $double);
+            } elseif ($double instanceof AbstractProvider) {
+                $this->assertNamesAFacade($id);
+                $this->swapModuleProvider($id, $double);
+            } elseif (is_object($double) && !$double instanceof Closure
+                && (class_exists($id) || interface_exists($id))
+            ) {
+                // The path a neighbour Facade travels: the Locator consults the
+                // resolver's global instances before the container, which is how
+                // `getProvidedDependency()` and `#[ServiceMap]` both reach one.
+                Gacela::overrideExistingResolvedClass($id, $double);
+            }
+        }
+
+        // A Facade resolved earlier in this process holds its Factory in a
+        // static, and a Factory holds the container built from its Provider.
+        AbstractFacade::resetCache();
+        AbstractFactory::resetCache();
+    }
+
+    private static function isPillarDouble(mixed $double): bool
+    {
+        return $double instanceof AbstractFactory
+            || $double instanceof AbstractConfig
+            || $double instanceof AbstractProvider;
     }
 
     /**

--- a/src/Framework/Testing/ModuleDoubleException.php
+++ b/src/Framework/Testing/ModuleDoubleException.php
@@ -22,4 +22,21 @@ final class ModuleDoubleException extends RuntimeException
             AbstractFacade::class,
         ));
     }
+
+    /**
+     * The double is registered under an id the application resolves by type, so
+     * a consumer receives it where it asked for the real class. An object of
+     * another type gets there and fails at the call site, naming neither the
+     * test that registered it nor the id it was registered under.
+     */
+    public static function notAnInstanceOf(string $id, object $double): self
+    {
+        return new self(sprintf(
+            'The double for "%s" is a %s, which is not an instance of it. '
+            . 'A double registered under a class or interface is handed to whoever asks for that type, '
+            . 'so it has to be one -- a stub of it, a subclass, or another implementation.',
+            $id,
+            $double::class,
+        ));
+    }
 }

--- a/src/StaticAnalysis/ModuleRules/ModuleRuleSet.php
+++ b/src/StaticAnalysis/ModuleRules/ModuleRuleSet.php
@@ -25,9 +25,11 @@ use const JSON_THROW_ON_ERROR;
  * and nothing more -- lived in prose, where the tooling cannot see it and a
  * violation is one more import in a diff. This is that agreement, machine-read.
  *
- * The same file feeds `debug:graph --check`, which sees whole modules, and the
- * PHPStan/Psalm rules, which see one class at a time. Two readers, one decision:
- * a rule that held in CI and not in the editor would be a rule nobody trusts.
+ * The same file feeds `debug:graph --check`, which sees whole modules, the
+ * PHPStan/Psalm rules, which see one class at a time, and
+ * {@see \Gacela\Console\Testing\ModuleAssertions}, which reads it from a test
+ * method. One decision, however you happen to be looking: a rule that held in
+ * CI and not in the editor would be a rule nobody trusts.
  */
 final class ModuleRuleSet
 {

--- a/tests/Feature/ReferenceApp/InvoicingSliceTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingSliceTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\ReferenceApp;
+
+use Gacela\Console\Infrastructure\Command\ListModulesCommand;
+use Gacela\Console\Testing\ModuleAssertions;
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
+use Gacela\Framework\Testing\GacelaTestCase;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingFacade;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\Domain\CustomerDirectory;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\Domain\CustomerProfile;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\Domain\CustomerRepository;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Reporting\ReportingFacade;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Shared\Clock\FixedClock;
+use GacelaTest\Feature\ReferenceApp\Support\ReferenceApp;
+use GacelaTest\Feature\ReferenceApp\Support\SilentNotificationFacade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_map;
+
+/**
+ * The Billing module on its own, with the two modules it depends on replaced.
+ *
+ * This is the test a team writes every day and the reason `bootstrapModule()`
+ * exists: one call instead of a bootstrap, three override APIs and the question
+ * of which one applies to which kind of dependency. The two neighbours are
+ * replaced two different ways on purpose -- Notification through its Facade,
+ * which the module leaves open for exactly this, and Customer through its
+ * Factory, because `CustomerFacade` is `final` and nothing can stand in for it.
+ *
+ * What makes it a *slice* rather than a bootstrap with doubles is the last two
+ * tests: the replaced modules are never built, and module discovery sees one
+ * module.
+ */
+final class InvoicingSliceTest extends GacelaTestCase
+{
+    // Not on GacelaTestCase: the boundary assertions read a graph built by
+    // scanning source files, which is `Gacela\Console`, and `Gacela\Framework`
+    // does not depend on it. A project writes this one line and has both.
+    use ModuleAssertions;
+
+    private string $cacheDir = '';
+
+    protected function setUp(): void
+    {
+        // Owned by this test, so a warmed cache cannot be confused with one
+        // some other application on this machine left in the system temp dir.
+        $this->cacheDir = ReferenceApp::createTempDirectory('slice-cache');
+        putenv('GACELA_CACHE_DIR=' . $this->cacheDir);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        ReferenceApp::reset();
+        ReferenceApp::removeTempDirectory($this->cacheDir);
+    }
+
+    /**
+     * The whole flow the module is for, with nothing behind it: the same
+     * invoice number, tax and total the end-to-end test produces.
+     */
+    public function test_billing_issues_an_invoice_with_both_neighbours_replaced(): void
+    {
+        $notifications = new SilentNotificationFacade();
+        $this->bootstrapBillingSlice($notifications);
+
+        $invoice = (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        self::assertSame('ACME-INV-01001', $invoice->getNumber());
+        self::assertSame(2_100, $invoice->getTaxCents());
+        self::assertSame(12_100, $invoice->getGrossCents());
+        self::assertSame(ReferenceApp::FIXED_TODAY, $invoice->getIssuedOn());
+
+        // The double was reached, rather than the module merely not complaining.
+        self::assertSame(['ACME-INV-01001'], $notifications->suppressed());
+    }
+
+    /**
+     * The acceptance criterion. Asserted from the resolver's own events rather
+     * than from the setup: a slice that quietly built the modules it replaced
+     * would pass every assertion above and still be no slice at all.
+     */
+    public function test_the_replaced_modules_never_have_their_pillars_built(): void
+    {
+        $this->bootstrapBillingSlice(new SilentNotificationFacade());
+
+        (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        $built = $this->modulesWhoseClassesWereBuilt();
+
+        self::assertContains('Billing', $built, 'the module under test was not built either');
+        self::assertNotContains('Customer', $built);
+        self::assertNotContains('Notification', $built);
+    }
+
+    /**
+     * A module never mentioned is never reached, which is what makes the
+     * remaining three modules irrelevant to this test rather than merely
+     * unasserted.
+     */
+    public function test_the_modules_outside_the_slice_are_never_reached(): void
+    {
+        $this->bootstrapBillingSlice(new SilentNotificationFacade());
+
+        (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        $built = $this->modulesWhoseClassesWereBuilt();
+
+        self::assertNotContains('Payment', $built);
+        self::assertNotContains('Reporting', $built);
+    }
+
+    /**
+     * The slice as the tooling sees it: `list:modules` reports the module under
+     * test and nothing else, so `doctor` and the boundary assertions answer
+     * about one module too.
+     */
+    public function test_module_discovery_reports_only_the_module_under_test(): void
+    {
+        $this->bootstrapBillingSlice(new SilentNotificationFacade());
+
+        $tester = new CommandTester(new ListModulesCommand());
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $display);
+        self::assertStringContainsString('ReferenceApp\\Invoicing\\Billing', $display);
+
+        foreach (['Customer', 'Notification', 'Payment', 'Reporting'] as $module) {
+            self::assertStringNotContainsString('ReferenceApp\\Invoicing\\' . $module, $display);
+        }
+    }
+
+    /**
+     * The boundaries the application declares, asserted from a test method
+     * rather than from a CI job -- against the same `module-rules.json` that
+     * {@see InvoicingToolingTest::test_the_module_graph_breaks_none_of_the_declared_rules}
+     * runs `debug:graph --check` on, and the analysers read.
+     *
+     * The whole application, not a slice: a graph narrowed to one module cannot
+     * tell a rule about a filtered-out module from a rule about one that no
+     * longer exists.
+     */
+    public function test_the_declared_module_boundaries_hold(): void
+    {
+        ReferenceApp::bootstrap();
+
+        self::assertNoModuleCycles();
+        self::assertModuleRulesHold(ReferenceApp::rulesFile());
+    }
+
+    /**
+     * Billing's own boundary, written where Billing's tests are. Reporting
+     * reads the ledger, so nothing forbids Billing from reaching it except this
+     * -- which is the decision worth stating next to the module.
+     */
+    public function test_billing_depends_on_customer_and_notification_and_nothing_else(): void
+    {
+        ReferenceApp::bootstrap();
+
+        self::assertModuleDependsOnlyOn(BillingFacade::class, [
+            CustomerFacade::class,
+            NotificationFacade::class,
+        ]);
+
+        self::assertModuleDependsOnlyOn(ReportingFacade::class, [
+            BillingFacade::class,
+            CustomerFacade::class,
+        ]);
+    }
+
+    /**
+     * Notification through its Facade, Customer through its Factory, and the
+     * clock the application asks its host for.
+     */
+    private function bootstrapBillingSlice(NotificationFacade $notifications): void
+    {
+        $this->bootstrapModule(
+            ReferenceApp::root(),
+            BillingFacade::class,
+            doubles: [
+                NotificationFacade::class => $notifications,
+                CustomerFacade::class => $this->customerFactoryDouble(),
+            ],
+            configFn: static function (GacelaConfig $config): void {
+                $config->addExternalService('clock', new FixedClock(ReferenceApp::FIXED_TODAY));
+            },
+        );
+    }
+
+    /**
+     * `CustomerFacade` is `final`, so no object can stand in for it and the
+     * seam is the Factory every Facade resolves. A standalone `AbstractFactory`
+     * carrying the one accessor Billing's calls reach, over a store this test
+     * seeded -- no `CustomerConfig`, no `CustomerProvider`, no repository the
+     * module would have registered.
+     */
+    private function customerFactoryDouble(): AbstractFactory
+    {
+        $repository = new CustomerRepository();
+        $repository->save(CustomerProfile::fromArray([
+            'reference' => 'acme-nl',
+            'name' => 'Acme BV',
+            'countryCode' => 'NL',
+            'tier' => 'standard',
+        ]));
+
+        return new class($repository) extends AbstractFactory {
+            public function __construct(
+                private readonly CustomerRepository $repository,
+            ) {
+            }
+
+            public function createCustomerDirectory(): CustomerDirectory
+            {
+                return new CustomerDirectory($this->repository, 'standard');
+            }
+        };
+    }
+
+    /**
+     * The names of the modules whose pillars the resolver built since the
+     * bootstrap.
+     *
+     * @return list<string>
+     */
+    private function modulesWhoseClassesWereBuilt(): array
+    {
+        return array_map(
+            static fn (ResolvedClassCreatedEvent $event): string => $event->classInfo()->getModuleName(),
+            $this->recordedGacelaEventsOf(ResolvedClassCreatedEvent::class),
+        );
+    }
+}

--- a/tests/Integration/Console/Testing/ModuleAssertionsTest.php
+++ b/tests/Integration/Console/Testing/ModuleAssertionsTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\Testing;
+
+use Closure;
+use Gacela\Console\Testing\ModuleAssertionException;
+use Gacela\Console\Testing\ModuleAssertions;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Alpha\AlphaFacade;
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Beta\BetaFacade;
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Gamma\GammaFacade;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * A boundary that holds in CI and not in the test suite is a boundary nobody
+ * trusts, so these assertions read the graph `debug:graph --check` reads, with
+ * the parser, the cycle detector and the rule checker that command uses.
+ *
+ * The fixture application has its problems on purpose: Alpha and Beta import
+ * each other, Gamma is a leaf. Every failure below is a real finding about a
+ * real graph rather than a hand-written array.
+ */
+final class ModuleAssertionsTest extends TestCase
+{
+    use ModuleAssertions;
+
+    private const FIXTURE_DIR = __DIR__ . DIRECTORY_SEPARATOR . 'ModuleBoundaryFixture';
+
+    private const ALPHA = 'GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Alpha';
+
+    private const BETA = 'GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Beta';
+
+    private const GAMMA = 'GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Gamma';
+
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(self::FIXTURE_DIR, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_a_leaf_module_depends_on_nothing(): void
+    {
+        self::assertModuleDependsOnlyOn(GammaFacade::class, []);
+    }
+
+    public function test_a_module_within_its_allowed_list_holds(): void
+    {
+        self::assertModuleDependsOnlyOn(AlphaFacade::class, [BetaFacade::class, GammaFacade::class]);
+    }
+
+    /**
+     * The acceptance criterion: the same edge `debug:graph --check` fails on,
+     * named together with the file and line that write it.
+     */
+    public function test_a_dependency_outside_the_allowed_list_names_the_edge_and_where_it_is_written(): void
+    {
+        $failure = $this->failureOf(
+            static fn () => self::assertModuleDependsOnlyOn(AlphaFacade::class, [GammaFacade::class]),
+        );
+
+        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString(
+            self::FIXTURE_DIR . DIRECTORY_SEPARATOR . 'Alpha' . DIRECTORY_SEPARATOR . 'AlphaFacade.php:8',
+            $failure,
+        );
+        self::assertStringContainsString(BetaFacade::class, $failure);
+    }
+
+    /**
+     * A dependency the list does allow must not be reported alongside one it
+     * does not, or the reader is sent to two files to fix one problem.
+     */
+    public function test_only_the_dependencies_outside_the_list_are_reported(): void
+    {
+        $failure = $this->failureOf(
+            static fn () => self::assertModuleDependsOnlyOn(AlphaFacade::class, [BetaFacade::class]),
+        );
+
+        self::assertStringContainsString(self::ALPHA . ' -> ' . self::GAMMA, $failure);
+        self::assertStringNotContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+    }
+
+    /**
+     * A module and its allowances can be named by namespace, which is how a
+     * decision about a whole area of the application is written -- and the only
+     * form available for a namespace that holds several modules.
+     */
+    public function test_a_module_and_its_allowances_can_be_named_by_namespace(): void
+    {
+        self::assertModuleDependsOnlyOn(self::ALPHA, [
+            'GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture',
+        ]);
+    }
+
+    /**
+     * The mistake that would otherwise pass silently: an assertion about a
+     * module the scan never saw has nothing to check, and its empty dependency
+     * list reads exactly like a boundary holding.
+     */
+    public function test_a_module_the_scan_did_not_find_fails_naming_the_modules_it_did(): void
+    {
+        $failure = $this->failureOf(
+            static fn () => self::assertModuleDependsOnlyOn('App\Nope', []),
+        );
+
+        self::assertStringContainsString('App\Nope', $failure);
+        self::assertStringContainsString(self::ALPHA, $failure);
+        self::assertStringContainsString(self::GAMMA, $failure);
+    }
+
+    public function test_an_undeclared_cycle_is_reported_with_the_imports_that_create_it(): void
+    {
+        $failure = $this->failureOf(static fn () => self::assertNoModuleCycles());
+
+        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString(
+            self::FIXTURE_DIR . DIRECTORY_SEPARATOR . 'Beta' . DIRECTORY_SEPARATOR . 'BetaFacade.php:8',
+            $failure,
+        );
+    }
+
+    public function test_a_reviewed_cycle_in_the_allow_list_holds(): void
+    {
+        self::assertNoModuleCycles($this->fixtureFile('allowed-cycles.json'));
+    }
+
+    /**
+     * Self-invalidating, exactly as the CLI is: an allowance that outlives its
+     * cycle is the check having quietly stopped watching.
+     */
+    public function test_an_allowance_for_a_cycle_that_no_longer_exists_fails(): void
+    {
+        $failure = $this->failureOf(
+            fn () => self::assertNoModuleCycles($this->fixtureFile('allowed-cycles-stale.json')),
+        );
+
+        self::assertStringContainsString('no longer exists', $failure);
+        self::assertStringContainsString(self::GAMMA, $failure);
+    }
+
+    public function test_declared_rules_the_graph_respects_hold(): void
+    {
+        self::assertModuleRulesHold($this->fixtureFile('module-rules.json'));
+    }
+
+    public function test_a_forbidden_dependency_names_the_rules_reason_and_the_import(): void
+    {
+        $failure = $this->failureOf(
+            fn () => self::assertModuleRulesHold($this->fixtureFile('module-rules-violated.json')),
+        );
+
+        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString('alpha owns the decision', $failure);
+        self::assertStringContainsString('AlphaFacade.php:8', $failure);
+    }
+
+    public function test_a_rule_that_governs_no_module_fails(): void
+    {
+        $failure = $this->failureOf(
+            fn () => self::assertModuleRulesHold($this->fixtureFile('module-rules-governing-nothing.json')),
+        );
+
+        self::assertStringContainsString('governs nothing', $failure);
+        self::assertStringContainsString('Delta', $failure);
+    }
+
+    /**
+     * A file that cannot be read is the test's own setup being wrong, and a
+     * boundary failure would send the reader looking at the application.
+     */
+    public function test_an_unreadable_allowed_cycles_file_is_a_setup_error_not_a_finding(): void
+    {
+        $missing = $this->fixtureFile('there-is-no-such-file.json');
+
+        $this->expectException(ModuleAssertionException::class);
+        $this->expectExceptionMessage($missing);
+
+        self::assertNoModuleCycles($missing);
+    }
+
+    private function fixtureFile(string $name): string
+    {
+        return self::FIXTURE_DIR . DIRECTORY_SEPARATOR . $name;
+    }
+
+    /**
+     * The failure message of an assertion that was expected to fail.
+     *
+     * `RuntimeException` rather than PHPUnit's own `AssertionFailedError`: that
+     * class is `@internal`, and a test suite that catches it is coupled to a
+     * hierarchy PHPUnit does not promise. Every failure these assertions raise
+     * descends from `RuntimeException`, so the wider catch loses nothing -- and
+     * a {@see ModuleAssertionException} arriving here instead would fail on the
+     * message it carries, which names the file it could not read.
+     *
+     * @param Closure():void $assertion
+     */
+    private function failureOf(Closure $assertion): string
+    {
+        try {
+            $assertion();
+        } catch (RuntimeException $runtimeException) {
+            return $runtimeException->getMessage();
+        }
+
+        self::fail('The assertion was expected to fail, and passed.');
+    }
+}

--- a/tests/Integration/Console/Testing/ModuleAssertionsTest.php
+++ b/tests/Integration/Console/Testing/ModuleAssertionsTest.php
@@ -36,6 +36,8 @@ final class ModuleAssertionsTest extends TestCase
 
     private const GAMMA = 'GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Gamma';
 
+    private const DELTA = 'GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Delta';
+
     protected function setUp(): void
     {
         Gacela::bootstrap(self::FIXTURE_DIR, static function (GacelaConfig $config): void {
@@ -68,12 +70,51 @@ final class ModuleAssertionsTest extends TestCase
             static fn () => self::assertModuleDependsOnlyOn(AlphaFacade::class, [GammaFacade::class]),
         );
 
-        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString('"' . self::ALPHA . '" may depend only on', $failure);
+        self::assertStringContainsString('✗ ' . self::ALPHA . ' -> ' . self::BETA, $failure);
         // The separator the path is written with is the platform's; the file
         // and the line are what the message has to carry.
         self::assertStringContainsString('ModuleBoundaryFixture', $failure);
-        self::assertStringContainsString('AlphaFacade.php:8', $failure);
         self::assertStringContainsString(BetaFacade::class, $failure);
+    }
+
+    /**
+     * One edge written in two files. A reader told only about the first fixes
+     * one import and finds the check still red, so every import behind the edge
+     * has to be listed -- not the first one, and not a count.
+     */
+    public function test_every_file_behind_one_edge_is_named(): void
+    {
+        $failure = $this->failureOf(
+            static fn () => self::assertModuleDependsOnlyOn(AlphaFacade::class, [GammaFacade::class]),
+        );
+
+        self::assertStringContainsString('AlphaFacade.php:8', $failure);
+        self::assertStringContainsString('AlphaReporter.php:7', $failure);
+    }
+
+    /**
+     * A module may be named with the leading separator a `::class` constant
+     * never carries but a hand-written namespace string often does.
+     */
+    public function test_a_leading_namespace_separator_names_the_same_module(): void
+    {
+        self::assertModuleDependsOnlyOn('\\' . self::ALPHA, ['\\' . self::BETA, '\\' . self::GAMMA]);
+    }
+
+    /**
+     * A module allowed to depend on nothing at all says so, rather than
+     * printing an empty list under a heading.
+     */
+    public function test_an_empty_allowance_list_is_reported_as_nothing(): void
+    {
+        $failure = $this->failureOf(
+            static fn () => self::assertModuleDependsOnlyOn(AlphaFacade::class, []),
+        );
+
+        self::assertStringContainsString("may depend only on:\n  (nothing)", $failure);
+        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString(self::ALPHA . ' -> ' . self::GAMMA, $failure);
     }
 
     /**
@@ -114,6 +155,9 @@ final class ModuleAssertionsTest extends TestCase
         );
 
         self::assertStringContainsString('App\Nope', $failure);
+        // The half that says what to do about it.
+        self::assertStringContainsString('Name a module by its Facade class or by its namespace', $failure);
+        self::assertStringContainsString('The scan found:', $failure);
         self::assertStringContainsString(self::ALPHA, $failure);
         self::assertStringContainsString(self::GAMMA, $failure);
     }
@@ -122,7 +166,11 @@ final class ModuleAssertionsTest extends TestCase
     {
         $failure = $this->failureOf(static fn () => self::assertNoModuleCycles());
 
-        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString('1 undeclared module dependency cycle(s)', $failure);
+        self::assertStringContainsString('✗ Dependency cycle: ' . self::ALPHA . ' -> ' . self::BETA, $failure);
+        // Both directions: a cycle is made of every edge inside it, and a
+        // reader shown one of them fixes half a problem.
+        self::assertStringContainsString('AlphaFacade.php:8', $failure);
         self::assertStringContainsString('BetaFacade.php:8', $failure);
     }
 
@@ -141,8 +189,13 @@ final class ModuleAssertionsTest extends TestCase
             fn () => self::assertNoModuleCycles($this->fixtureFile('allowed-cycles-stale.json')),
         );
 
-        self::assertStringContainsString('no longer exists', $failure);
-        self::assertStringContainsString(self::GAMMA, $failure);
+        self::assertStringContainsString('1 allowance(s) that no longer apply', $failure);
+        self::assertStringContainsString(
+            '✗ Allowed cycle no longer exists: ' . self::ALPHA . ' -> ' . self::GAMMA,
+            $failure,
+        );
+        // The half that says what to do about it.
+        self::assertStringContainsString('Remove it from the allow list', $failure);
     }
 
     public function test_declared_rules_the_graph_respects_hold(): void
@@ -156,7 +209,11 @@ final class ModuleAssertionsTest extends TestCase
             fn () => self::assertModuleRulesHold($this->fixtureFile('module-rules-violated.json')),
         );
 
-        self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
+        self::assertStringContainsString('1 forbidden dependency(ies)', $failure);
+        self::assertStringContainsString(
+            '✗ Forbidden dependency: ' . self::ALPHA . ' -> ' . self::BETA,
+            $failure,
+        );
         self::assertStringContainsString('alpha owns the decision', $failure);
         self::assertStringContainsString('AlphaFacade.php:8', $failure);
     }
@@ -167,8 +224,8 @@ final class ModuleAssertionsTest extends TestCase
             fn () => self::assertModuleRulesHold($this->fixtureFile('module-rules-governing-nothing.json')),
         );
 
-        self::assertStringContainsString('governs nothing', $failure);
-        self::assertStringContainsString('Delta', $failure);
+        self::assertStringContainsString('1 rule(s) governing nothing', $failure);
+        self::assertStringContainsString('✗ Module rule governs nothing: ' . self::DELTA, $failure);
     }
 
     /**

--- a/tests/Integration/Console/Testing/ModuleAssertionsTest.php
+++ b/tests/Integration/Console/Testing/ModuleAssertionsTest.php
@@ -69,10 +69,10 @@ final class ModuleAssertionsTest extends TestCase
         );
 
         self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
-        self::assertStringContainsString(
-            self::FIXTURE_DIR . DIRECTORY_SEPARATOR . 'Alpha' . DIRECTORY_SEPARATOR . 'AlphaFacade.php:8',
-            $failure,
-        );
+        // The separator the path is written with is the platform's; the file
+        // and the line are what the message has to carry.
+        self::assertStringContainsString('ModuleBoundaryFixture', $failure);
+        self::assertStringContainsString('AlphaFacade.php:8', $failure);
         self::assertStringContainsString(BetaFacade::class, $failure);
     }
 
@@ -123,10 +123,7 @@ final class ModuleAssertionsTest extends TestCase
         $failure = $this->failureOf(static fn () => self::assertNoModuleCycles());
 
         self::assertStringContainsString(self::ALPHA . ' -> ' . self::BETA, $failure);
-        self::assertStringContainsString(
-            self::FIXTURE_DIR . DIRECTORY_SEPARATOR . 'Beta' . DIRECTORY_SEPARATOR . 'BetaFacade.php:8',
-            $failure,
-        );
+        self::assertStringContainsString('BetaFacade.php:8', $failure);
     }
 
     public function test_a_reviewed_cycle_in_the_allow_list_holds(): void

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/Alpha/AlphaFacade.php
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/Alpha/AlphaFacade.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Alpha;
+
+use Gacela\Framework\AbstractFacade;
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Beta\BetaFacade;
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Gamma\GammaFacade;
+
+/**
+ * The Beta import on line 8 is the edge every failure message in
+ * {@see \GacelaTest\Integration\Console\Testing\ModuleAssertionsTest} points at,
+ * so the two imports below are ordered rather than alphabetical by accident.
+ *
+ * The names are returned rather than merely imported because cs-fixer removes
+ * an import nothing uses, which would take the edge with it.
+ */
+final class AlphaFacade extends AbstractFacade
+{
+    public function neighbours(): string
+    {
+        return BetaFacade::class . GammaFacade::class;
+    }
+}

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/Alpha/Domain/AlphaReporter.php
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/Alpha/Domain/AlphaReporter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Alpha\Domain;
+
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Beta\BetaFacade;
+
+/**
+ * A second file in Alpha reaching into Beta.
+ *
+ * One edge written twice, which is what a boundary failure normally looks like:
+ * a reader told only about the first file fixes one import and finds the check
+ * still red. The evidence has to list both.
+ *
+ * The name is returned rather than merely imported because cs-fixer removes an
+ * import nothing uses, which would take the second edge with it.
+ */
+final class AlphaReporter
+{
+    public function neighbour(): string
+    {
+        return BetaFacade::class;
+    }
+}

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/Beta/BetaFacade.php
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/Beta/BetaFacade.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Beta;
+
+use Gacela\Framework\AbstractFacade;
+use GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Alpha\AlphaFacade;
+
+/**
+ * The import back into Alpha, which is what makes the pair a cycle.
+ */
+final class BetaFacade extends AbstractFacade
+{
+    public function neighbour(): string
+    {
+        return AlphaFacade::class;
+    }
+}

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/Gamma/GammaFacade.php
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/Gamma/GammaFacade.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture\Gamma;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * The leaf: it imports no sibling, so it is the module every "depends only on"
+ * assertion can hold for with an empty list.
+ */
+final class GammaFacade extends AbstractFacade
+{
+    public function name(): string
+    {
+        return self::class;
+    }
+}

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/allowed-cycles-stale.json
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/allowed-cycles-stale.json
@@ -1,0 +1,16 @@
+[
+    {
+        "modules": [
+            "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Alpha",
+            "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Beta"
+        ],
+        "reason": "reviewed: alpha and beta were one module and are being split"
+    },
+    {
+        "modules": [
+            "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Alpha",
+            "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Gamma"
+        ],
+        "reason": "reviewed, and then the cycle it allows was broken"
+    }
+]

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/allowed-cycles.json
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/allowed-cycles.json
@@ -1,0 +1,9 @@
+[
+    {
+        "modules": [
+            "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Alpha",
+            "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Beta"
+        ],
+        "reason": "reviewed: alpha and beta were one module and are being split"
+    }
+]

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/gacela.php
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/gacela.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+/**
+ * A three-module application with a boundary problem in it on purpose.
+ *
+ * Alpha and Beta import each other, so the graph has one cycle; Gamma is a leaf
+ * nothing reaches back into. That is the smallest shape in which every finding
+ * `ModuleAssertions` can report has something real to report about.
+ */
+return static function (GacelaConfig $config): void {
+    $config->setProjectNamespaces(['GacelaTest\Integration\Console\Testing\ModuleBoundaryFixture']);
+    $config->setAppModulePaths(['Alpha', 'Beta', 'Gamma']);
+};

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/module-rules-governing-nothing.json
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/module-rules-governing-nothing.json
@@ -1,0 +1,11 @@
+{
+    "rules": [
+        {
+            "from": "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Delta",
+            "deny": [
+                "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Alpha"
+            ],
+            "reason": "delta was deleted, and this rule outlived it"
+        }
+    ]
+}

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/module-rules-violated.json
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/module-rules-violated.json
@@ -1,0 +1,11 @@
+{
+    "rules": [
+        {
+            "from": "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Alpha",
+            "deny": [
+                "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Beta"
+            ],
+            "reason": "alpha owns the decision and beta only carries it out"
+        }
+    ]
+}

--- a/tests/Integration/Console/Testing/ModuleBoundaryFixture/module-rules.json
+++ b/tests/Integration/Console/Testing/ModuleBoundaryFixture/module-rules.json
@@ -1,0 +1,12 @@
+{
+    "rules": [
+        {
+            "from": "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Gamma",
+            "deny": [
+                "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Alpha",
+                "GacelaTest\\Integration\\Console\\Testing\\ModuleBoundaryFixture\\Beta"
+            ],
+            "reason": "gamma is a leaf: it is read from and reads nothing back"
+        }
+    ]
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/Domain/Quote.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/Domain/Quote.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\Domain;
 
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money\CurrencyInterface;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping\ShippingFacade;
 
@@ -16,6 +17,7 @@ final class Quote
         private readonly PricingFacade $pricing,
         private readonly ShippingFacade $shipping,
         private readonly TaxRateInterface $taxRate,
+        private readonly CurrencyInterface $currency,
     ) {
     }
 
@@ -26,10 +28,11 @@ final class Quote
     public function describe(string $article): string
     {
         return sprintf(
-            'price:%d shipping:%d tax:%d',
+            'price:%d shipping:%d tax:%d currency:%s',
             $this->pricing->priceOf($article),
             $this->shipping->costOf($article),
             $this->taxRate->basisPoints(),
+            $this->currency->code(),
         );
     }
 }

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/Domain/Quote.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/Domain/Quote.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\Domain;
+
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping\ShippingFacade;
+
+use function sprintf;
+
+final class Quote
+{
+    public function __construct(
+        private readonly PricingFacade $pricing,
+        private readonly ShippingFacade $shipping,
+        private readonly TaxRateInterface $taxRate,
+    ) {
+    }
+
+    /**
+     * Every number the slice can replace, in one string: what the article
+     * costs, what shipping it costs, and the rate applied on top.
+     */
+    public function describe(string $article): string
+    {
+        return sprintf(
+            'price:%d shipping:%d tax:%d',
+            $this->pricing->priceOf($article),
+            $this->shipping->costOf($article),
+            $this->taxRate->basisPoints(),
+        );
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingFacade.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingFacade.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * The module under test in every slice below.
+ *
+ * @extends AbstractFacade<OrderingFactory>
+ */
+final class OrderingFacade extends AbstractFacade
+{
+    public function quote(string $article): string
+    {
+        return $this->getFactory()->createQuote()->describe($article);
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingFactory.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingFactory.php
@@ -9,6 +9,7 @@ use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\Domain\Quote;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money\CurrencyInterface;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping\ShippingFacade;
 
@@ -21,12 +22,21 @@ final class OrderingFactory extends AbstractFactory
 {
     use ServiceResolverAwareTrait;
 
+    /**
+     * A constructor argument, which the class resolver fills from the
+     * bindings and from nothing else.
+     */
+    public function __construct(
+        private readonly CurrencyInterface $currency,
+    ) {
+    }
+
     public function createQuote(): Quote
     {
         /** @var ShippingFacade $shipping */
         $shipping = $this->getShippingFacade();
 
-        return new Quote($this->getPricingFacade(), $shipping, $this->getTaxRate());
+        return new Quote($this->getPricingFacade(), $shipping, $this->getTaxRate(), $this->currency);
     }
 
     private function getPricingFacade(): PricingFacade

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingFactory.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\Domain\Quote;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping\ShippingFacade;
+
+/**
+ * Two neighbours reached two ways, as a real module does it: Pricing through
+ * the Provider, Shipping through the shorter `#[ServiceMap]` path.
+ */
+#[ServiceMap(method: 'getShippingFacade', className: ShippingFacade::class)]
+final class OrderingFactory extends AbstractFactory
+{
+    use ServiceResolverAwareTrait;
+
+    public function createQuote(): Quote
+    {
+        /** @var ShippingFacade $shipping */
+        $shipping = $this->getShippingFacade();
+
+        return new Quote($this->getPricingFacade(), $shipping, $this->getTaxRate());
+    }
+
+    private function getPricingFacade(): PricingFacade
+    {
+        /** @var PricingFacade $facade */
+        $facade = $this->getProvidedDependency(OrderingProvider::PRICING_FACADE);
+
+        return $facade;
+    }
+
+    private function getTaxRate(): TaxRateInterface
+    {
+        /** @var TaxRateInterface $rate */
+        $rate = $this->getProvidedDependency(OrderingProvider::TAX_RATE);
+
+        return $rate;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingProvider.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Ordering/OrderingProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
+
+final class OrderingProvider extends AbstractProvider
+{
+    public const PRICING_FACADE = 'ORDERING_PRICING_FACADE';
+
+    public const TAX_RATE = 'ORDERING_TAX_RATE';
+
+    /**
+     * Ordering's declared dependency on Pricing: through the locator, which is
+     * the path a Facade double has to be visible on.
+     */
+    #[Provides(self::PRICING_FACADE)]
+    public function pricingFacade(Container $container): PricingFacade
+    {
+        /** @var PricingFacade $facade */
+        $facade = $container->getLocator()->get(PricingFacade::class);
+
+        return $facade;
+    }
+
+    /**
+     * Answered by the composition root rather than by a module, which is the
+     * dependency a container binding replaces.
+     */
+    #[Provides(self::TAX_RATE)]
+    public function taxRate(Container $container): TaxRateInterface
+    {
+        /** @var TaxRateInterface $rate */
+        $rate = $container->get(TaxRateInterface::class);
+
+        return $rate;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/Domain/PriceList.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/Domain/PriceList.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\Domain;
+
+final class PriceList
+{
+    /**
+     * @param array<string, int> $pricesByArticle
+     */
+    public function __construct(
+        private readonly array $pricesByArticle,
+    ) {
+    }
+
+    public function priceOf(string $article): int
+    {
+        return $this->pricesByArticle[$article] ?? 0;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingConfig.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing;
+
+use Gacela\Framework\AbstractConfig;
+
+/**
+ * Not final, so a test can double it with an anonymous subclass -- the shape
+ * {@see \GacelaTest\Integration\Framework\Testing\ModuleDoublesTest} pins for
+ * `swapModuleConfig()` and that a slice has to route to unchanged.
+ */
+class PricingConfig extends AbstractConfig
+{
+    public function currency(): string
+    {
+        return 'EUR';
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingFacade.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingFacade.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * Not final, and that is the point rather than an oversight: a consumer that
+ * type-hints a *final* Facade cannot be handed a double of it by anyone --
+ * neither PHPUnit nor a hand-written subclass can produce one. A module meant
+ * to be replaceable from its neighbours' tests leaves its Facade open, which is
+ * what the reference application does with its Notification module.
+ *
+ * @extends AbstractFacade<PricingFactory>
+ */
+class PricingFacade extends AbstractFacade
+{
+    public function priceOf(string $article): int
+    {
+        return $this->getFactory()->createPriceList()->priceOf($article);
+    }
+
+    public function currency(): string
+    {
+        return $this->getFactory()->currency();
+    }
+
+    public function catalogueName(): string
+    {
+        return $this->getFactory()->catalogueName();
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingFactory.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing;
+
+use Gacela\Framework\AbstractFactory;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\Domain\PriceList;
+
+/**
+ * Final, like everything `make:module` generates -- which is what makes a
+ * standalone `AbstractFactory` the only shape a double of it can take.
+ *
+ * @extends AbstractFactory<PricingConfig>
+ */
+final class PricingFactory extends AbstractFactory
+{
+    public function createPriceList(): PriceList
+    {
+        return new PriceList(['widget' => 1_000]);
+    }
+
+    public function currency(): string
+    {
+        return $this->getConfig()->currency();
+    }
+
+    public function catalogueName(): string
+    {
+        /** @var string $name */
+        $name = $this->getProvidedDependency(PricingProvider::CATALOGUE_NAME);
+
+        return $name;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingProvider.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Pricing/PricingProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Not final, for the same reason {@see PricingConfig} is not.
+ */
+class PricingProvider extends AbstractProvider
+{
+    public const CATALOGUE_NAME = 'PRICING_CATALOGUE_NAME';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $container->set(self::CATALOGUE_NAME, 'the real catalogue');
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Money/CurrencyInterface.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Money/CurrencyInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money;
+
+/**
+ * Asked for in a pillar's *constructor*, which is the one seam the class
+ * resolver fills and the container's lazy registry does not reach.
+ */
+interface CurrencyInterface
+{
+    public function code(): string;
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Money/EuroCurrency.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Money/EuroCurrency.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money;
+
+final class EuroCurrency implements CurrencyInterface
+{
+    public function code(): string
+    {
+        return 'EUR';
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Money/PoundCurrency.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Money/PoundCurrency.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money;
+
+/**
+ * What a slice puts in place of {@see EuroCurrency}.
+ */
+final class PoundCurrency implements CurrencyInterface
+{
+    public function code(): string
+    {
+        return 'GBP';
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Tax/StandardTaxRate.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Tax/StandardTaxRate.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax;
+
+final class StandardTaxRate implements TaxRateInterface
+{
+    public function basisPoints(): int
+    {
+        return 2100;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Tax/TaxRateInterface.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Tax/TaxRateInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax;
+
+interface TaxRateInterface
+{
+    public function basisPoints(): int;
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Tax/ZeroTaxRate.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shared/Tax/ZeroTaxRate.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax;
+
+/**
+ * The replacement a slice binds in place of {@see StandardTaxRate}, and -- when
+ * a test registers it under a class it is not -- the bogus double
+ * `bootstrapModule()` refuses.
+ */
+final class ZeroTaxRate implements TaxRateInterface
+{
+    public function basisPoints(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shipping/ShippingFacade.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shipping/ShippingFacade.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * Open for the same reason PricingFacade is: a consumer that type-hints a
+ * `final` Facade cannot be handed a double of it by anyone.
+ *
+ * @extends AbstractFacade<ShippingFactory>
+ */
+class ShippingFacade extends AbstractFacade
+{
+    public function costOf(string $article): int
+    {
+        return $this->getFactory()->costOf($article);
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/Shipping/ShippingFactory.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/Shipping/ShippingFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping;
+
+use Gacela\Framework\AbstractFactory;
+
+final class ShippingFactory extends AbstractFactory
+{
+    public function costOf(string $article): int
+    {
+        return $article === '' ? 0 : 500;
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/gacela.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/gacela.php
@@ -19,4 +19,10 @@ return static function (GacelaConfig $config): void {
     $config->setProjectNamespaces(['GacelaTest\Integration\Framework\Testing\ModuleSliceFixture']);
     $config->setAppModulePaths(['Ordering', 'Pricing', 'Shipping']);
     $config->addBinding(TaxRateInterface::class, StandardTaxRate::class);
+
+    // CurrencyInterface is deliberately *not* bound here. It is asked for in
+    // OrderingFactory's constructor, which the class resolver fills from the
+    // bindings and from nothing else, so the module cannot be built until
+    // somebody answers it -- the same contract the reference application has
+    // with its host over the clock. A slice answers it with a double.
 };

--- a/tests/Integration/Framework/Testing/ModuleSliceFixture/gacela.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceFixture/gacela.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\StandardTaxRate;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
+
+/**
+ * A three-module application shaped like a real one: Ordering reaches Pricing
+ * through its Provider and Shipping through `#[ServiceMap]`, and the tax rate
+ * is an interface the composition root answers -- the three ways a slice has to
+ * be able to replace a dependency.
+ *
+ * `Shared` is deliberately not in the module paths: it is a kernel, not a
+ * module, which is what makes narrowing to one module a meaningful change.
+ */
+return static function (GacelaConfig $config): void {
+    $config->setProjectNamespaces(['GacelaTest\Integration\Framework\Testing\ModuleSliceFixture']);
+    $config->setAppModulePaths(['Ordering', 'Pricing', 'Shipping']);
+    $config->addBinding(TaxRateInterface::class, StandardTaxRate::class);
+};

--- a/tests/Integration/Framework/Testing/ModuleSliceTest.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\Testing;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
+use Gacela\Framework\Testing\GacelaTestCase;
+use Gacela\Framework\Testing\ModuleDoubleException;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\OrderingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\OrderingFactory;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Ordering\OrderingProvider;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\Domain\PriceList;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingConfig;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingProvider;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\ZeroTaxRate;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping\ShippingFacade;
+use ReflectionClass;
+
+use function array_map;
+use function dirname;
+
+/**
+ * Testing one module with its neighbours replaced is the everyday test of a
+ * modular application. Every primitive for it already existed; what did not was
+ * one call that picks the right one per double and narrows the application to
+ * the module under test.
+ */
+final class ModuleSliceTest extends GacelaTestCase
+{
+    private const FIXTURE_DIR = __DIR__ . DIRECTORY_SEPARATOR . 'ModuleSliceFixture';
+
+    public function test_the_module_answers_with_its_real_neighbours_when_nothing_is_doubled(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class);
+
+        self::assertSame('price:1000 shipping:500 tax:2100', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * The slice: discovery sees the module under test and nothing else, so
+     * `doctor`, `list:modules` and the boundary assertions answer about one
+     * module instead of about the whole application.
+     */
+    public function test_the_slice_narrows_module_discovery_to_the_module_under_test(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class);
+
+        self::assertSame(
+            [dirname((string)(new ReflectionClass(OrderingFacade::class))->getFileName())],
+            Config::getInstance()->getSetupGacela()->getAppModulePaths(),
+        );
+    }
+
+    /**
+     * A neighbour the module reaches through its Provider, which resolves it
+     * from the locator.
+     */
+    public function test_a_facade_double_answers_where_the_provider_reaches_for_the_module(): void
+    {
+        $pricing = $this->createStub(PricingFacade::class);
+        $pricing->method('priceOf')->willReturn(7);
+
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            PricingFacade::class => $pricing,
+        ]);
+
+        self::assertSame('price:7 shipping:500 tax:2100', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * The other way a module reaches a neighbour. Both go through the locator,
+     * so one primitive covers them -- which is exactly what a caller should not
+     * have to know.
+     */
+    public function test_a_facade_double_answers_where_a_service_map_accessor_reaches_for_the_module(): void
+    {
+        $shipping = $this->createStub(ShippingFacade::class);
+        $shipping->method('costOf')->willReturn(42);
+
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            ShippingFacade::class => $shipping,
+        ]);
+
+        self::assertSame('price:1000 shipping:42 tax:2100', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * An interface the composition root answers rather than a module: the
+     * container is the seam, and the double has to become a binding.
+     */
+    public function test_an_interface_double_becomes_a_container_binding(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            TaxRateInterface::class => new class() implements TaxRateInterface {
+                public function basisPoints(): int
+                {
+                    return 0;
+                }
+            },
+        ]);
+
+        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+        $this->assertBindingRegistered(TaxRateInterface::class);
+    }
+
+    /**
+     * A container id is a string nobody can reflect on, and it is how a Provider
+     * names what it provides -- which is also the one thing an application-level
+     * binding cannot reach, because the Provider registers after it.
+     */
+    public function test_a_container_id_double_replaces_what_the_provider_registers(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            OrderingProvider::TAX_RATE => new class() implements TaxRateInterface {
+                public function basisPoints(): int
+                {
+                    return 1;
+                }
+            },
+        ]);
+
+        self::assertSame('price:1000 shipping:500 tax:1', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * A class-string value is a binding rather than an instance override: the
+     * container is what turns it into an object.
+     */
+    public function test_a_class_string_double_becomes_a_container_binding(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            TaxRateInterface::class => ZeroTaxRate::class,
+        ]);
+
+        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+    }
+
+    public function test_a_callable_double_becomes_a_container_binding(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            TaxRateInterface::class => static fn (): TaxRateInterface => new ZeroTaxRate(),
+        ]);
+
+        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * A Factory double is keyed by the Facade whose module it replaces, and the
+     * value's own type is what says which pillar is meant. `PricingFactory` is
+     * final, so the double is a standalone `AbstractFactory`.
+     */
+    public function test_a_factory_double_replaces_the_neighbours_factory(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            PricingFacade::class => new class() extends AbstractFactory {
+                public function createPriceList(): PriceList
+                {
+                    return new PriceList(['widget' => 3]);
+                }
+            },
+        ]);
+
+        self::assertSame('price:3 shipping:500 tax:2100', (new OrderingFacade())->quote('widget'));
+    }
+
+    public function test_a_config_double_replaces_the_neighbours_config(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            PricingFacade::class => new class() extends PricingConfig {
+                public function currency(): string
+                {
+                    return 'CHF';
+                }
+            },
+        ]);
+
+        self::assertSame('CHF', (new PricingFacade())->currency());
+    }
+
+    public function test_a_provider_double_replaces_the_neighbours_provider(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            PricingFacade::class => new class() extends PricingProvider {
+                public function provideModuleDependencies(Container $container): void
+                {
+                    $container->set(self::CATALOGUE_NAME, 'the doubled catalogue');
+                }
+            },
+        ]);
+
+        self::assertSame('the doubled catalogue', (new PricingFacade())->catalogueName());
+    }
+
+    /**
+     * The acceptance criterion, at the framework level: a neighbour that is
+     * doubled is never built. The events say so; trusting the setup would not.
+     */
+    public function test_a_doubled_neighbour_never_has_its_pillars_built(): void
+    {
+        $pricing = $this->createStub(PricingFacade::class);
+        $pricing->method('priceOf')->willReturn(7);
+
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            PricingFacade::class => $pricing,
+        ]);
+
+        (new OrderingFacade())->quote('widget');
+
+        self::assertNotContains('Pricing', $this->modulesWhoseClassesWereBuilt());
+        self::assertContains('Ordering', $this->modulesWhoseClassesWereBuilt());
+    }
+
+    /**
+     * Composed with the narrowing rather than replacing it, so a slice can still
+     * configure the application it is a slice of.
+     */
+    public function test_the_bootstrap_closure_runs_and_keeps_the_narrowing(): void
+    {
+        $this->bootstrapModule(
+            self::FIXTURE_DIR,
+            OrderingFacade::class,
+            configFn: static function (GacelaConfig $config): void {
+                $config->addLazy(TaxRateInterface::class, static fn (): TaxRateInterface => new ZeroTaxRate());
+            },
+        );
+
+        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+        self::assertCount(1, Config::getInstance()->getSetupGacela()->getAppModulePaths());
+    }
+
+    /**
+     * The same guard `swapModuleFactory()` has, for the same reason: a pillar
+     * double is registered under the key its module's own class would take, and
+     * only a Facade names a module.
+     */
+    public function test_a_pillar_double_keyed_by_something_that_is_not_a_facade_fails_loudly(): void
+    {
+        $this->expectException(ModuleDoubleException::class);
+        $this->expectExceptionMessage(OrderingFactory::class);
+
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            OrderingFactory::class => new class() extends AbstractFactory {},
+        ]);
+    }
+
+    /**
+     * The bogus double this *can* detect: an object that is not an instance of
+     * the class it is registered under would be handed to a consumer that
+     * type-hints the real one, and the resulting TypeError names neither the
+     * test nor the double.
+     */
+    public function test_a_double_that_is_not_an_instance_of_the_class_it_replaces_fails_loudly(): void
+    {
+        $this->expectException(ModuleDoubleException::class);
+        $this->expectExceptionMessage(PricingFacade::class);
+
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            PricingFacade::class => new ZeroTaxRate(),
+        ]);
+    }
+
+    /**
+     * The Facade is the name a consumer knows, and naming anything else leaves
+     * a double nothing would ever read.
+     */
+    public function test_slicing_a_module_that_is_not_named_by_a_facade_fails_loudly(): void
+    {
+        $this->expectException(ModuleDoubleException::class);
+        $this->expectExceptionMessage('There is no class');
+
+        /** @psalm-suppress ArgumentTypeCoercion,UndefinedClass a typo is the mistake under test */
+        $this->bootstrapModule(self::FIXTURE_DIR, 'App\Nope\NopeFacade');
+    }
+
+    /**
+     * The names of the modules whose classes the resolver built since the
+     * bootstrap.
+     *
+     * @return list<string>
+     */
+    private function modulesWhoseClassesWereBuilt(): array
+    {
+        return array_map(
+            static fn (ResolvedClassCreatedEvent $event): string => $event->classInfo()->getModuleName(),
+            $this->recordedGacelaEventsOf(ResolvedClassCreatedEvent::class),
+        );
+    }
+}

--- a/tests/Integration/Framework/Testing/ModuleSliceTest.php
+++ b/tests/Integration/Framework/Testing/ModuleSliceTest.php
@@ -18,6 +18,9 @@ use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\Domain\P
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingConfig;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingFacade;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Pricing\PricingProvider;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money\CurrencyInterface;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money\EuroCurrency;
+use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Money\PoundCurrency;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\TaxRateInterface;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shared\Tax\ZeroTaxRate;
 use GacelaTest\Integration\Framework\Testing\ModuleSliceFixture\Shipping\ShippingFacade;
@@ -38,9 +41,37 @@ final class ModuleSliceTest extends GacelaTestCase
 
     public function test_the_module_answers_with_its_real_neighbours_when_nothing_is_doubled(): void
     {
-        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class);
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [CurrencyInterface::class => new EuroCurrency()]);
 
-        self::assertSame('price:1000 shipping:500 tax:2100', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:500 tax:2100 currency:EUR', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * A pillar's *constructor* argument, which is the one seam the container's
+     * lazy registry cannot fill: the class resolver builds a pillar from the
+     * bindings and from nothing else. `gacela.php` binds no currency, so the
+     * module cannot be built at all unless the double becomes one.
+     */
+    public function test_a_double_becomes_the_binding_a_pillar_constructor_is_built_from(): void
+    {
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new PoundCurrency(),
+        ]);
+
+        self::assertSame('price:1000 shipping:500 tax:2100 currency:GBP', (new OrderingFacade())->quote('widget'));
+    }
+
+    /**
+     * The other half of the same guard: naming a class that exists but is not a
+     * Facade has to fail as loudly as naming one that does not exist at all.
+     */
+    public function test_slicing_a_module_named_by_a_class_that_is_not_a_facade_fails_loudly(): void
+    {
+        $this->expectException(ModuleDoubleException::class);
+        $this->expectExceptionMessage(OrderingFactory::class);
+
+        /** @psalm-suppress ArgumentTypeCoercion the wrong pillar is exactly the mistake under test */
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFactory::class, doubles: [CurrencyInterface::class => new EuroCurrency()]);
     }
 
     /**
@@ -50,7 +81,7 @@ final class ModuleSliceTest extends GacelaTestCase
      */
     public function test_the_slice_narrows_module_discovery_to_the_module_under_test(): void
     {
-        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class);
+        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [CurrencyInterface::class => new EuroCurrency()]);
 
         self::assertSame(
             [dirname((string)(new ReflectionClass(OrderingFacade::class))->getFileName())],
@@ -68,10 +99,11 @@ final class ModuleSliceTest extends GacelaTestCase
         $pricing->method('priceOf')->willReturn(7);
 
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             PricingFacade::class => $pricing,
         ]);
 
-        self::assertSame('price:7 shipping:500 tax:2100', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:7 shipping:500 tax:2100 currency:EUR', (new OrderingFacade())->quote('widget'));
     }
 
     /**
@@ -85,10 +117,11 @@ final class ModuleSliceTest extends GacelaTestCase
         $shipping->method('costOf')->willReturn(42);
 
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             ShippingFacade::class => $shipping,
         ]);
 
-        self::assertSame('price:1000 shipping:42 tax:2100', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:42 tax:2100 currency:EUR', (new OrderingFacade())->quote('widget'));
     }
 
     /**
@@ -98,6 +131,7 @@ final class ModuleSliceTest extends GacelaTestCase
     public function test_an_interface_double_becomes_a_container_binding(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             TaxRateInterface::class => new class() implements TaxRateInterface {
                 public function basisPoints(): int
                 {
@@ -106,7 +140,7 @@ final class ModuleSliceTest extends GacelaTestCase
             },
         ]);
 
-        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:500 tax:0 currency:EUR', (new OrderingFacade())->quote('widget'));
         $this->assertBindingRegistered(TaxRateInterface::class);
     }
 
@@ -118,6 +152,7 @@ final class ModuleSliceTest extends GacelaTestCase
     public function test_a_container_id_double_replaces_what_the_provider_registers(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             OrderingProvider::TAX_RATE => new class() implements TaxRateInterface {
                 public function basisPoints(): int
                 {
@@ -126,7 +161,7 @@ final class ModuleSliceTest extends GacelaTestCase
             },
         ]);
 
-        self::assertSame('price:1000 shipping:500 tax:1', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:500 tax:1 currency:EUR', (new OrderingFacade())->quote('widget'));
     }
 
     /**
@@ -136,19 +171,21 @@ final class ModuleSliceTest extends GacelaTestCase
     public function test_a_class_string_double_becomes_a_container_binding(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             TaxRateInterface::class => ZeroTaxRate::class,
         ]);
 
-        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:500 tax:0 currency:EUR', (new OrderingFacade())->quote('widget'));
     }
 
     public function test_a_callable_double_becomes_a_container_binding(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             TaxRateInterface::class => static fn (): TaxRateInterface => new ZeroTaxRate(),
         ]);
 
-        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:500 tax:0 currency:EUR', (new OrderingFacade())->quote('widget'));
     }
 
     /**
@@ -159,6 +196,7 @@ final class ModuleSliceTest extends GacelaTestCase
     public function test_a_factory_double_replaces_the_neighbours_factory(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             PricingFacade::class => new class() extends AbstractFactory {
                 public function createPriceList(): PriceList
                 {
@@ -167,12 +205,13 @@ final class ModuleSliceTest extends GacelaTestCase
             },
         ]);
 
-        self::assertSame('price:3 shipping:500 tax:2100', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:3 shipping:500 tax:2100 currency:EUR', (new OrderingFacade())->quote('widget'));
     }
 
     public function test_a_config_double_replaces_the_neighbours_config(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             PricingFacade::class => new class() extends PricingConfig {
                 public function currency(): string
                 {
@@ -187,6 +226,7 @@ final class ModuleSliceTest extends GacelaTestCase
     public function test_a_provider_double_replaces_the_neighbours_provider(): void
     {
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             PricingFacade::class => new class() extends PricingProvider {
                 public function provideModuleDependencies(Container $container): void
                 {
@@ -208,6 +248,7 @@ final class ModuleSliceTest extends GacelaTestCase
         $pricing->method('priceOf')->willReturn(7);
 
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             PricingFacade::class => $pricing,
         ]);
 
@@ -226,12 +267,13 @@ final class ModuleSliceTest extends GacelaTestCase
         $this->bootstrapModule(
             self::FIXTURE_DIR,
             OrderingFacade::class,
+            doubles: [CurrencyInterface::class => new EuroCurrency()],
             configFn: static function (GacelaConfig $config): void {
                 $config->addLazy(TaxRateInterface::class, static fn (): TaxRateInterface => new ZeroTaxRate());
             },
         );
 
-        self::assertSame('price:1000 shipping:500 tax:0', (new OrderingFacade())->quote('widget'));
+        self::assertSame('price:1000 shipping:500 tax:0 currency:EUR', (new OrderingFacade())->quote('widget'));
         self::assertCount(1, Config::getInstance()->getSetupGacela()->getAppModulePaths());
     }
 
@@ -246,6 +288,7 @@ final class ModuleSliceTest extends GacelaTestCase
         $this->expectExceptionMessage(OrderingFactory::class);
 
         $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+            CurrencyInterface::class => new EuroCurrency(),
             OrderingFactory::class => new class() extends AbstractFactory {},
         ]);
     }
@@ -258,12 +301,24 @@ final class ModuleSliceTest extends GacelaTestCase
      */
     public function test_a_double_that_is_not_an_instance_of_the_class_it_replaces_fails_loudly(): void
     {
-        $this->expectException(ModuleDoubleException::class);
-        $this->expectExceptionMessage(PricingFacade::class);
+        try {
+            $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
+                CurrencyInterface::class => new EuroCurrency(),
+                PricingFacade::class => new ZeroTaxRate(),
+            ]);
+        } catch (ModuleDoubleException $moduleDoubleException) {
+            $message = $moduleDoubleException->getMessage();
 
-        $this->bootstrapModule(self::FIXTURE_DIR, OrderingFacade::class, doubles: [
-            PricingFacade::class => new ZeroTaxRate(),
-        ]);
+            // What was asked for, what arrived, and what to do about it.
+            self::assertStringContainsString(PricingFacade::class, $message);
+            self::assertStringContainsString(ZeroTaxRate::class, $message);
+            self::assertStringContainsString('a stub of it, a subclass, or another implementation', $message);
+            self::assertStringContainsString('handed to whoever asks for that type', $message);
+
+            return;
+        }
+
+        self::fail('A double that is not an instance of its key was accepted.');
     }
 
     /**

--- a/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphBuilderTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphBuilderTest.php
@@ -8,6 +8,9 @@ use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Console\Domain\ModuleGraph\ModuleGraphBuilder;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
+use function str_replace;
+
 final class ModuleGraphBuilderTest extends TestCase
 {
     private const NS = 'GacelaTest\Unit\Console\Domain\ModuleGraph\Fixture';
@@ -109,8 +112,9 @@ final class ModuleGraphBuilderTest extends TestCase
      */
     public function test_the_imports_behind_an_edge_name_the_file_and_the_line(): void
     {
-        $evidence = (new ModuleGraphBuilder())
-            ->importsPointingInto($this->module('Hub'), self::NS . '\Zebra');
+        $evidence = $this->withNormalisedPaths(
+            (new ModuleGraphBuilder())->importsPointingInto($this->module('Hub'), self::NS . '\Zebra'),
+        );
 
         self::assertSame(
             [[
@@ -133,12 +137,12 @@ final class ModuleGraphBuilderTest extends TestCase
 
         self::assertSame(
             [['file' => $groupedFile, 'line' => 8, 'import' => self::NS . '\Alpha\Facade']],
-            $builder->importsPointingInto($this->module('Grouped'), self::NS . '\Alpha'),
+            $this->withNormalisedPaths($builder->importsPointingInto($this->module('Grouped'), self::NS . '\Alpha')),
         );
 
         self::assertSame(
             [['file' => $groupedFile, 'line' => 8, 'import' => self::NS . '\Zebra\Facade']],
-            $builder->importsPointingInto($this->module('Grouped'), self::NS . '\Zebra'),
+            $this->withNormalisedPaths($builder->importsPointingInto($this->module('Grouped'), self::NS . '\Zebra')),
         );
     }
 
@@ -163,9 +167,31 @@ final class ModuleGraphBuilderTest extends TestCase
         );
     }
 
+    /**
+     * The evidence carries the path the traversal produced, which starts from
+     * the one the autoloader recorded -- and on Windows that is not necessarily
+     * written with the separator `__DIR__` uses. Both sides are normalised so
+     * the assertion is about the file rather than about how it is spelled.
+     *
+     * @param list<array{file: string, line: int, import: string}> $evidence
+     *
+     * @return list<array{file: string, line: int, import: string}>
+     */
+    private function withNormalisedPaths(array $evidence): array
+    {
+        return array_map(
+            static fn (array $entry): array => [
+                ...$entry,
+                'file' => str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $entry['file']),
+            ],
+            $evidence,
+        );
+    }
+
     private function fixtureFile(string $module): string
     {
-        return __DIR__ . DIRECTORY_SEPARATOR . 'Fixture' . DIRECTORY_SEPARATOR
+        return str_replace(['\\', '/'], DIRECTORY_SEPARATOR, __DIR__)
+            . DIRECTORY_SEPARATOR . 'Fixture' . DIRECTORY_SEPARATOR
             . $module . DIRECTORY_SEPARATOR . 'Facade.php';
     }
 

--- a/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphBuilderTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/ModuleGraphBuilderTest.php
@@ -102,6 +102,73 @@ final class ModuleGraphBuilderTest extends TestCase
         );
     }
 
+    /**
+     * The graph says an edge exists; this says where it was written. Both read
+     * the same imports through the same parser, so a reported dependency always
+     * has evidence and the evidence always names a reported dependency.
+     */
+    public function test_the_imports_behind_an_edge_name_the_file_and_the_line(): void
+    {
+        $evidence = (new ModuleGraphBuilder())
+            ->importsPointingInto($this->module('Hub'), self::NS . '\Zebra');
+
+        self::assertSame(
+            [[
+                'file' => $this->fixtureFile('Hub'),
+                'line' => 9,
+                'import' => self::NS . '\Zebra\Facade',
+            ]],
+            $evidence,
+        );
+    }
+
+    /**
+     * The whole statement is the evidence for every module it reaches, so both
+     * entries of a group point at the `use` rather than at their own entry.
+     */
+    public function test_a_grouped_import_is_evidence_for_each_module_it_reaches(): void
+    {
+        $builder = new ModuleGraphBuilder();
+        $groupedFile = $this->fixtureFile('Grouped');
+
+        self::assertSame(
+            [['file' => $groupedFile, 'line' => 8, 'import' => self::NS . '\Alpha\Facade']],
+            $builder->importsPointingInto($this->module('Grouped'), self::NS . '\Alpha'),
+        );
+
+        self::assertSame(
+            [['file' => $groupedFile, 'line' => 8, 'import' => self::NS . '\Zebra\Facade']],
+            $builder->importsPointingInto($this->module('Grouped'), self::NS . '\Zebra'),
+        );
+    }
+
+    /**
+     * `Fixture\Alpha` is a plain-string prefix of the `Fixture\AlphaExtra`
+     * import Hub declares. Evidence for a dependency the graph does not report
+     * would send a reader to a line that is not the problem.
+     */
+    public function test_a_module_whose_name_prefixes_an_import_has_no_evidence(): void
+    {
+        self::assertSame(
+            [],
+            (new ModuleGraphBuilder())->importsPointingInto($this->module('Hub'), self::NS . '\Alpha'),
+        );
+    }
+
+    public function test_a_module_with_no_import_into_the_dependency_has_no_evidence(): void
+    {
+        self::assertSame(
+            [],
+            (new ModuleGraphBuilder())->importsPointingInto($this->module('Alpha'), self::NS . '\Zebra'),
+        );
+    }
+
+    private function fixtureFile(string $module): string
+    {
+        return __DIR__ . DIRECTORY_SEPARATOR . 'Fixture' . DIRECTORY_SEPARATOR
+            . $module . DIRECTORY_SEPARATOR . 'Facade.php';
+    }
+
     private function module(string $name): AppModule
     {
         /** @var class-string $facade */

--- a/tests/Unit/Console/Domain/ModuleGraph/PhpImportParserTest.php
+++ b/tests/Unit/Console/Domain/ModuleGraph/PhpImportParserTest.php
@@ -227,11 +227,118 @@ final class PhpImportParserTest extends TestCase
         self::assertSame([], $this->parse('<?php final class Foo {}'));
     }
 
+    public function test_an_import_carries_the_line_it_is_declared_on(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Reporting;
+
+            use App\Billing\Invoice;
+            use App\Orders\Order;
+            PHP;
+
+        self::assertSame(
+            [
+                ['name' => 'App\Billing\Invoice', 'line' => 7],
+                ['name' => 'App\Orders\Order', 'line' => 8],
+            ],
+            $this->parseWithLines($source),
+        );
+    }
+
+    /**
+     * Every name in one statement reports the line the statement starts on --
+     * the `use` keyword -- rather than the line its own entry sits on. A caller
+     * pointing a reader at the import has the statement to show them, and
+     * splitting the entries apart would mean re-tokenizing the group body for a
+     * distinction nobody reading a violation needs.
+     */
+    public function test_every_name_of_a_multi_line_group_reports_the_line_the_statement_opens_on(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            use App\{
+                Billing\Invoice,
+                Orders\Order,
+            };
+            PHP;
+
+        self::assertSame(
+            [
+                ['name' => 'App\Billing\Invoice', 'line' => 3],
+                ['name' => 'App\Orders\Order', 'line' => 3],
+            ],
+            $this->parseWithLines($source),
+        );
+    }
+
+    /**
+     * The trait `use` is skipped, so the import after the class body keeps its
+     * own line instead of inheriting the position of whatever was counted last.
+     */
+    public function test_a_skipped_trait_use_does_not_shift_the_lines_that_follow(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            use App\Billing\Invoice;
+
+            final class Foo
+            {
+                use App\Shared\SomeTrait;
+            }
+
+            use App\Orders\Order;
+            PHP;
+
+        self::assertSame(
+            [
+                ['name' => 'App\Billing\Invoice', 'line' => 3],
+                ['name' => 'App\Orders\Order', 'line' => 10],
+            ],
+            $this->parseWithLines($source),
+        );
+    }
+
+    /**
+     * The two methods answer the same question, so the names must not drift
+     * apart: one is the other with the positions dropped.
+     */
+    public function test_the_names_are_the_same_whether_or_not_the_lines_are_asked_for(): void
+    {
+        $source = <<<'PHP'
+            <?php
+
+            use App\{Billing\Invoice, function Orders\total};
+            use App\Orders\Order as SalesOrder;
+            use function App\Billing\calculate;
+            PHP;
+
+        $parser = new PhpImportParser();
+
+        self::assertSame(
+            $parser->importsIn($source),
+            array_column($parser->importsWithLinesIn($source), 'name'),
+        );
+    }
+
     /**
      * @return list<string>
      */
     private function parse(string $source): array
     {
         return (new PhpImportParser())->importsIn($source);
+    }
+
+    /**
+     * @return list<array{name: string, line: int}>
+     */
+    private function parseWithLines(string $source): array
+    {
+        return (new PhpImportParser())->importsWithLinesIn($source);
     }
 }


### PR DESCRIPTION
## 📚 Description

Testing one module with its neighbours stubbed is the everyday test of a modular monolith. Gacela had every primitive for it — `overrideExistingResolvedClass()`, `swapModuleFactory/Config/Provider()`, `setAppModulePaths()` — and no one call that puts them together, so every project assembled the slice by hand and had to remember which override API applies to which kind of dependency. Module boundaries were checkable too, but only from the CLI and the static analysers, never from a test method.

Closes #878

## 🔖 Changes

- **`GacelaTestCase::bootstrapModule(FacadeClass, doubles: [...])`** — bootstraps one module with its neighbours replaced. It derives the module from the Facade (same derivation and the same `ModuleDoubleException::notAFacade` guard the pillar doubles already use), narrows `setAppModulePaths()` to that module so discovery sees one, and routes each double through the right primitive by what it is: a pillar instance → the existing `swapModule*()`, anything the `Locator` resolves → `overrideExistingResolvedClass()`, an interface or container id → `addBinding()`. One lifecycle, the existing `tearDown` resets it
- **`Gacela\Console\Testing\ModuleAssertions`** — `assertModuleDependsOnlyOn()`, `assertNoModuleCycles()`, and the declared-rules assertion, over the same `ModuleGraphBuilder`/`ModuleRuleChecker`/`CycleAllowList` that `debug:graph --check` uses, so a boundary holds in the test and in CI or in neither
- **The import parser now carries the declaring line**, so a failure names the edge *and* the file and line that creates it rather than just the modules involved
- A setup mistake — an unreadable allowed-cycles file, a rule governing no module, a module the scan never found — raises `ModuleAssertionException` rather than a test failure, so "your fixture is wrong" never reads as "your architecture is wrong"
- Demonstrated in the reference application (`InvoicingSliceTest`): `Billing` bootstrapped with `Customer` and `Notification` doubled. That the replaced modules are never built is asserted from the recorded `ResolvedClassCreatedEvent`s, not from trusting the setup
- Docs: `docs/testing.md` gains the slice pattern and the boundary assertions

### One deviation from the issue

The issue put the boundary assertions on `GacelaTestCase`. They are a **standalone trait in the Console namespace** instead. `src/Framework/` references `Gacela\Console` in zero files, the graph engine lives in `src/Console/Domain/ModuleGraph/`, and this repo gates its own layering with `composer module-cycles`. Putting them on `GacelaTestCase` would have inverted Framework → Console — an architecture regression in the framework that sells module boundaries. A project uses them with `use ModuleAssertions;` in its own base test case, which is what the issue's "standalone trait" bullet asked for anyway. `bootstrapModule()` needs only Framework primitives, so it is on `GacelaTestCase` as proposed.
