### PR TITLE
test(benchmark): stop the informational benches retrying until the CI timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ An invoicing SaaS under `tests/Feature/ReferenceApp/`, wired with every feature 
 - The `event listeners` doctor check no longer warns about an interface or abstract target, since those now fire
 - Every CI job declares `timeout-minutes` (10/20/45), so a stalled runner is a red check to re-run instead of a six-hour block. A test fails the build if a new job forgets one
 
+### Internal
+
+- Every `informational` benchmark carries `#[RetryThreshold(20)]`. `phpbench.json` sets a suite-wide threshold of 5 and a phpbench retry is **unbounded** — `setRetryLimit()` exists and nothing calls it — so a group whose numbers are reported and never asserted was paying open-ended CI time to stabilise a reading nothing reads. Measured on `ScopedCacheBench`, one machine, one commit: 34s at threshold 5 against 6.3s at 10. That is what made the performance guard's baseline step run 11–12 minutes and get killed by the job timeout while the gate step beside it passed in 15 seconds — a red check that was never a regression. The `gate` group keeps the strict 5, and a test fails if either side drifts
+
 ## [2.3.0](https://github.com/gacela-project/gacela/compare/2.2.0...2.3.0) - 2026-08-15
 
 ### Added

--- a/tests/Benchmark/Attribute/CacheableBench.php
+++ b/tests/Benchmark/Attribute/CacheableBench.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Attribute\InMemoryCacheStorage;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\RetryThreshold;
 use PhpBench\Attributes\Revs;
 
 /**
@@ -22,6 +23,7 @@ use PhpBench\Attributes\Revs;
  * well within CI timer noise, so it must not fail the performance regression guard.
  */
 #[BeforeMethods('setUp')]
+#[RetryThreshold(20)]
 #[Groups(['informational', 'cacheable'])]
 #[Revs(1000)]
 #[Iterations(5)]

--- a/tests/Benchmark/Cache/ScopedCacheBench.php
+++ b/tests/Benchmark/Cache/ScopedCacheBench.php
@@ -11,6 +11,7 @@ use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\RetryThreshold;
 use PhpBench\Attributes\Revs;
 
 use function bin2hex;
@@ -46,6 +47,7 @@ use function unlink;
 #[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
 #[BeforeMethods('setUp')]
 #[AfterMethods('tearDown')]
+#[RetryThreshold(20)]
 #[Groups(['informational', 'cache'])]
 #[Revs(50)]
 #[Iterations(5)]

--- a/tests/Benchmark/ClassResolver/ClassInfo/ClassInfoBench.php
+++ b/tests/Benchmark/ClassResolver/ClassInfo/ClassInfoBench.php
@@ -11,6 +11,7 @@ use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\RetryThreshold;
 use PhpBench\Attributes\Revs;
 
 /**
@@ -24,6 +25,7 @@ use PhpBench\Attributes\Revs;
  */
 #[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
 #[BeforeMethods('setUp')]
+#[RetryThreshold(20)]
 #[Groups(['informational', 'micro', 'resolve'])]
 #[Revs(1000)]
 #[Iterations(5)]

--- a/tests/Benchmark/Config/ConfigTypedAccessBench.php
+++ b/tests/Benchmark/Config/ConfigTypedAccessBench.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Gacela;
 use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\RetryThreshold;
 use PhpBench\Attributes\Revs;
 
 /**
@@ -28,6 +29,7 @@ use PhpBench\Attributes\Revs;
  * @BeforeMethods("setUp")
  */
 #[Assert('mode(variant.time.avg) <= mode(baseline.time.avg) +/- 1000%')]
+#[RetryThreshold(20)]
 #[Groups(['informational', 'micro', 'config'])]
 #[Revs(1000)]
 #[Iterations(5)]

--- a/tests/Benchmark/Container/SharedPlanCacheBench.php
+++ b/tests/Benchmark/Container/SharedPlanCacheBench.php
@@ -8,6 +8,7 @@ use Gacela\Container\Container;
 use Gacela\Container\PlanCache;
 use GacelaTest\Benchmark\Container\Fixtures\DeepD;
 use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\RetryThreshold;
 
 /**
  * Gacela's containers are sibling roots -- one per Factory class -- resolving
@@ -22,6 +23,7 @@ use PhpBench\Attributes\Groups;
  * Informational, not gated: the isolated subject is a deliberate slow path
  * kept for comparison, so gating it would gate a baseline nobody ships.
  */
+#[RetryThreshold(20)]
 #[Groups(['informational', 'container'])]
 final class SharedPlanCacheBench
 {

--- a/tests/Benchmark/README.md
+++ b/tests/Benchmark/README.md
@@ -21,6 +21,25 @@ Both sides of the comparison must run **the same group**. The baseline stores on
 
 Rule of thumb: if the subject's average time is below ~0.2μs, it belongs in `informational` and is tagged `micro` — at that scale timer quantization alone moves the mode by ~10%, which would false-fail the gate on unrelated PRs. Subjects in the 0.2–1μs range can stay gated when their `rstdev` holds below ~3% (e.g. the warm-resolve benches).
 
+## Retries: why the informational benches loosen the threshold
+
+`phpbench.json` sets `"runner.retry_threshold": 5` — phpbench re-runs an iteration set whenever its `rstdev` exceeds that, and **the retry is unbounded**: `SubjectMetadata::setRetryLimit()` exists in phpbench 1.7 but nothing ever calls it, so there is no cap and no config key for one. On a quiet machine that is invisible. On a loaded CI runner it is not.
+
+Measured here, same bench, same commit, one machine, varying only the threshold:
+
+| `--retry-threshold` | `ScopedCacheBench` |
+|---|---|
+| 0.5 | 256 s |
+| 5 (the global default) | 34 s |
+| 10 | 6.3 s |
+| 20 | 6.5 s |
+
+A 38× spread produced by nothing but the retry threshold. That is what made the CI guard's baseline step take 11–12 minutes and get killed by the job timeout while the gate step beside it passed in 15 seconds — a red check that was never a regression.
+
+So every `informational` class carries `#[RetryThreshold(20)]`. The gate group keeps the global 5, because a ±10% assertion is only meaningful when the reading under it is stable. The informational numbers are **reported and never asserted**, so buying a tighter `rstdev` for them with unbounded retries is cost without benefit — and the `rstdev` column is printed beside every number, so a reader can still see when one is noisy.
+
+20 rather than 10: both sit past the knee of the curve above, and CI runners are noisier than the machine those numbers came from.
+
 **`rstdev` is not sufficient on its own.** It measures spread *within* one run, but the gate compares two runs made at different moments. An I/O-bound subject can hold `rstdev` under 2% and still drift well past 10% run-to-run. Before gating a subject that touches the disk, network, or clock, run it twice against itself:
 
 ```bash

--- a/tests/Integration/Architecture/BenchmarkGroupsTest.php
+++ b/tests/Integration/Architecture/BenchmarkGroupsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Integration\Architecture;
 
 use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\RetryThreshold;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -16,6 +17,7 @@ use function array_values;
 use function count;
 use function dirname;
 use function implode;
+use function in_array;
 use function sprintf;
 use function str_replace;
 
@@ -36,6 +38,9 @@ use function str_replace;
 final class BenchmarkGroupsTest extends TestCase
 {
     private const array GATING_GROUPS = ['gate', 'informational'];
+
+    /** Kept in one place so the benches and this guard cannot disagree. */
+    private const int INFORMATIONAL_RETRY_THRESHOLD = 20;
 
     /**
      * @return iterable<string, array{class-string}>
@@ -86,6 +91,56 @@ final class BenchmarkGroupsTest extends TestCase
             implode(', ', $groups),
             implode(', ', self::GATING_GROUPS),
         ));
+    }
+
+    /**
+     * An `informational` class must loosen its retry threshold; a `gate` class
+     * must not.
+     *
+     * `phpbench.json` sets `runner.retry_threshold: 5` for the whole suite, and
+     * a retry is **unbounded** — phpbench 1.7 has `setRetryLimit()` and calls it
+     * from nowhere, so there is no cap and no config key for one. A group whose
+     * numbers are never asserted therefore pays an open-ended amount of CI time
+     * to stabilise a reading nothing reads: measured on `ScopedCacheBench`, one
+     * machine, one commit, 34s at threshold 5 against 6.3s at 10. That is what
+     * made the guard's baseline step run 11–12 minutes and get killed by the job
+     * timeout while the gate step beside it passed in 15 seconds.
+     *
+     * The gate group keeps the strict 5, because a ±10% assertion means nothing
+     * on top of an unstable reading. See tests/Benchmark/README.md.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('benchClassProvider')]
+    public function test_only_the_informational_benches_loosen_the_retry_threshold(string $class): void
+    {
+        $reflection = new ReflectionClass($class);
+
+        /** @var list<string> $groups */
+        $groups = $reflection->getAttributes(Groups::class)[0]->getArguments()[0];
+        $isInformational = in_array('informational', $groups, true);
+        $retry = $reflection->getAttributes(RetryThreshold::class);
+
+        if (!$isInformational) {
+            self::assertSame([], $retry, sprintf(
+                '%s is gated and declares #[RetryThreshold]. A gated subject keeps the strict '
+                . 'phpbench.json threshold: the ±10%% assertion is only meaningful on a stable reading.',
+                $class,
+            ));
+
+            return;
+        }
+
+        self::assertCount(1, $retry, sprintf(
+            '%s is informational and declares no #[RetryThreshold]. Retries are unbounded, so a '
+            . 'reading nothing asserts on can stall CI until the job timeout. Add #[RetryThreshold(%d)].',
+            $class,
+            self::INFORMATIONAL_RETRY_THRESHOLD,
+        ));
+
+        self::assertSame(
+            self::INFORMATIONAL_RETRY_THRESHOLD,
+            $retry[0]->getArguments()[0],
+            sprintf('%s should use the same threshold as every other informational bench.', $class),
+        );
     }
 
     public function test_the_suite_has_benches_to_check(): void


### PR DESCRIPTION
## 📚 Description

The `Performance regression guard` needed a manual re-run on three PRs in a row (#884, #891, #892), and the failure was never a regression: the **gate** step passed in ~15 seconds every time, and the job died because the *baseline* step — which runs on `origin/main`, without the change — took 11–12 minutes and hit the 20-minute job timeout.

The cause is measurable. `phpbench.json` sets `"runner.retry_threshold": 5` for the whole suite, and a phpbench retry is **unbounded**: `SubjectMetadata::setRetryLimit()` exists in phpbench 1.7 and nothing in the library ever calls it, so there is no cap and no configuration key for one. Same bench, same commit, one machine, varying only the threshold:

| `--retry-threshold` | `ScopedCacheBench` |
|---|---|
| 0.5 | 256 s |
| 5 (the suite default) | 34 s |
| 10 | 6.3 s |
| 20 | 6.5 s |

A 38× spread from the threshold alone. Under runner load `rstdev` rises, the retries multiply, and the I/O-bound half of the suite runs until something kills it.

The informational group's numbers are **reported and never asserted**, so buying a tighter `rstdev` for them with unbounded retries is cost with no benefit — and `rstdev` is printed beside every number, so a reader can still see when one is noisy.

Closes #893

## 🔖 Changes

- `#[RetryThreshold(20)]` on all five `informational` bench classes. The `gate` group keeps the strict 5, because a ±10% assertion is only meaningful on a stable reading
- `BenchmarkGroupsTest` gains the matching guard, in both directions: an informational class without the threshold fails, and a gated class *with* one fails too. Verified it bites by removing the attribute from `CacheableBench`
- `tests/Benchmark/README.md` documents the measurements and why the two groups differ

Locally the informational group now runs in 11 s against 34 s for `ScopedCacheBench` alone before; the gate group is untouched.

### What this does not fix

Retries are unbounded by construction, so a sufficiently pathological runner can still stall any threshold. The durable fix is that a slow *informational* bench must not be able to redden the gate at all — it is already labelled non-blocking, but a job timeout kills the whole job regardless of `continue-on-error`, so it would need to run as its own job. That is a change to `.github/workflows/phpbench.yml`, which this repo treats as a protected path, so I have left it out and noted it on the issue.
