### PR TITLE
feat(events): a project's own events, and PSR-14 in both directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### Added
 
+#### Your application's own events
+
+The dispatcher, the guard, the inheritance matching and the tooling were all scoped to the framework's own introspection events. A project can now dispatch its own through the same dispatcher, which is how one module reacts to another without depending on it.
+
+- The dispatcher is an ordinary dependency: `getProvidedDependency(EventDispatcherInterface::class)` in a Factory, resolved to whatever `setEventDispatcher()` installed. Nothing was added to `AbstractFacade`/`AbstractFactory` — that is the point. An application binding for the id still wins, and so does a module Provider registering its own
+- Registered on the module scope rather than the application container, so `debug:container` and `validate:config` keep describing the application
+- `debug:events` lists a project's events beside the framework's, marked `project`, with a `source` field in `--json` and a count in the summary. Found under the paths discovery already walks — never `vendor/` — by implementing `GacelaEventInterface` or being named `*Event`, narrowed by `setProjectNamespaces()`
+- `doctor` judges a listener target against that catalog: a listener registered on a class that forgot `implements GacelaEventInterface` can never fire, which nothing reported before
+- `GacelaTestCase::assertEventDispatched()` answers from the recording `bootstrapGacela()` already installs, for a project's events as readily as for Gacela's
+- `EventDispatchingCapabilities` is marked `@internal`: it is how the framework's own pre-injection classes dispatch, and an application injects the dispatcher instead
+- The reference application shows the module-to-module case: `Billing` announces `InvoiceIssuedEvent`, `Notification` handles it, and a test asserts Billing depends on `Customer` and nothing else. See [your own events](docs/events.md#your-own-events)
+
+#### PSR-14 interop
+
+- `setEventDispatcher()` accepts a `Psr\EventDispatcher\EventDispatcherInterface` — Symfony's, Laravel's, any of them — and wraps it, so a hosted application routes Gacela's events onto the bus it already has. `psr/event-dispatcher` is now a hard requirement; it is interface-only
+- PSR-14 cannot be asked what it listens to, so the adapter's `hasListeners()` answers true and every dispatch site allocates. The cost falls only on an application that supplied one: with none, the hot-path guard is the single array lookup it always was (`EventDispatchBench` unmoved). To answer narrowly, implement Gacela's interface directly
+- `Psr14EventDispatcher` goes the other way, for a library that expects PSR-14: it returns the event, honours `hasListeners()`, and does not dispatch one that arrives already stopped. `ConfigurableEventDispatcher` deliberately does not claim the interface itself — its `void` return satisfies the signature and breaks the contract
+
 #### A module can declare its public API
 
 A module's surface is wider than its Facade — DTOs, enums, value objects, events — and until now the only way to say so was an ignore list in `phpstan.neon`, repeated in `psalm.xml`, outside the module that owns the class.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -218,7 +218,7 @@ No signature to change — `skippedCount` is a third constructor argument defaul
 
 ## 2.3 → 2.4
 
-Five changes: `registerSpecificListener()`, if you ever pointed one at a parent class or an interface; `setEventDispatcher()`, if you supply your own dispatcher; `#[Cacheable]`, if you set a custom `key:` template; the two opt-in cross-module rules, if you have them enabled; and `addAppConfig()` with a wildcard, if a file in that directory is named after another one with a `-suffix`.
+Six changes: `registerSpecificListener()`, if you ever pointed one at a parent class or an interface; `setEventDispatcher()`, if you supply your own dispatcher; `#[Cacheable]`, if you set a custom `key:` template; the two opt-in cross-module rules, if you have them enabled; `addAppConfig()` with a wildcard, if a file in that directory is named after another one with a `-suffix`; and `doctor`, if you run it with `--strict` and register a listener against something that is not an event type.
 
 ### 1. A specific listener matches by inheritance
 
@@ -313,6 +313,25 @@ The base layer now excludes any match named after another match plus one or more
 If a file in that list is not an environment layer, rename it so it is not named after another one, or give it its own `addAppConfig()` path. The check is a pass, not a warning: for every project that uses `APP_ENV` or a dimension, this is what correct looks like.
 
 **Run `cache:clear` after deploying this** if you have `enableFileCache()` on. The merged-config cache is a file of *values*, invalidated by the mtimes of the files that produced them — and upgrading Gacela touches none of those, so a warm cache goes on serving the old merge and this change appears not to have happened.
+### 6. `doctor` reports a listener target that no event can be
+
+Only if you register specific listeners, and only a new **warning** — which fails the command under `--strict`, so a CI job running `vendor/bin/gacela doctor --strict` is where you would meet it.
+
+The check used to accept any target that named a real class or interface. It now also asks whether an event could ever match it, against the framework's events *and* your own, and reports a target that is neither an event type nor something a known event extends or implements:
+
+```
+⚠ event listeners
+  App\Billing\InvoiceIssued is not an event type, and no known event extends or
+  implements it -- so nothing can ever match it
+```
+
+Almost always this is the mistake it looks like: a class of your own that is missing `implements GacelaEventInterface`. The registration was accepted, the dispatcher could never match it, and nothing said so before. Adding the interface fixes both the report and the listener.
+
+The other way to meet it is an event of yours that Gacela does not know about, because the class sits outside the paths discovery walks. `vendor/bin/gacela debug:events` lists the events it found — if yours is missing from that listing, widen `appModulePaths` or `setProjectNamespaces()` rather than changing the listener. Nothing is reported when the catalog is empty, which is what keeps a scoped run from calling every target dead.
+
+A target that exists and *can* match is still left alone whether or not this deployment dispatches it: a listener waiting for an event nobody raises is waiting, not broken.
+
+Two additions come with it, neither of which can break anything: `debug:events` lists your own events beside the framework's with a `source` field in `--json`, and `setEventDispatcher()` now also accepts a PSR-14 dispatcher. If you already wrote an adapter around your bus to satisfy Gacela's interface, keep it — it answers `hasListeners()` for itself, which the built-in wrapper cannot.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require": {
         "php": ">=8.3",
-        "gacela-project/container": "^2.0.2"
+        "gacela-project/container": "^2.0.2",
+        "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb20d523fc90114aa971d563832a6e51",
+    "content-hash": "98dc8f50b1aa39b782798580ac4b3a16",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -134,6 +134,56 @@
                 "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
             "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
         }
     ],
     "packages-dev": [
@@ -6045,56 +6095,6 @@
                 "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
             "time": "2022-11-25T14:36:26+00:00"
-        },
-        {
-            "name": "psr/event-dispatcher",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\EventDispatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Standard interfaces for event handling.",
-            "keywords": [
-                "events",
-                "psr",
-                "psr-14"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
-            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/docs/events.md
+++ b/docs/events.md
@@ -4,7 +4,7 @@ Gacela dispatches domain events while it works: bootstrapping, reading config, r
 
 ## Dispatch model
 
-- Every event is a small immutable class implementing `GacelaEventInterface` (one `toString()` method).
+- Every event is a small immutable class implementing `GacelaEventInterface` (one `toString()` method) — the framework's, and [your own](#your-own-events).
 - By default nothing listens: the dispatcher is a `NullEventDispatcher`, and every dispatch site is guarded by `EventDispatcherInterface::hasListeners()`, so **no event object is even allocated** unless a listener is registered for it. Events are zero-cost when unused, including on the class-resolution hot path.
 - Registering any listener switches to a `ConfigurableEventDispatcher`. Listeners are plain callables receiving the event object; they are notify-only (events are immutable, there is no propagation stopping).
 - A specific listener matches **by inheritance**: it runs for the class it names and for every event that extends or implements it. `AbstractGacelaClassResolverEvent::class` covers all four resolver events, and `GacelaEventInterface::class` covers every event there is — the typed way to listen to everything. The applicable listeners are worked out **once per concrete event class** and kept, so past the first dispatch of a class the guard is a single array lookup, exactly as when matching was on the exact class.
@@ -64,6 +64,108 @@ first Facade/Factory/Config access (per module)
  └─ ServiceResolvedEvent             (per service, first `get()` on the container)
 ```
 
+## Your own events
+
+The dispatcher is not the framework's private property: a module can dispatch its own events through it, which is how one module reacts to another without depending on it. `InvoiceIssued` → Notification sends the mail, Reporting updates a projection, and Billing knows about none of them.
+
+Three pieces, and nothing else:
+
+**1. The event is a class implementing `GacelaEventInterface`.** One `toString()` method, immutable, carrying facts rather than a handle onto the module that raised it.
+
+```php
+namespace App\Billing\Event;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+final class InvoiceIssued implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $invoiceNumber,
+        private readonly string $customerName,
+    ) {
+    }
+
+    public function invoiceNumber(): string
+    {
+        return $this->invoiceNumber;
+    }
+
+    public function customerName(): string
+    {
+        return $this->customerName;
+    }
+
+    public function toString(): string
+    {
+        return 'Invoice issued: ' . $this->invoiceNumber;
+    }
+}
+```
+
+**2. The dispatcher is an ordinary dependency.** A Factory asks for it by interface, like a repository or a clock — there is no trait to mix in and no static call to make:
+
+```php
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+
+final class BillingFactory extends AbstractFactory
+{
+    public function createInvoiceIssuer(): InvoiceIssuer
+    {
+        return new InvoiceIssuer($this->getEventDispatcher());
+    }
+
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->getProvidedDependency(EventDispatcherInterface::class);
+    }
+}
+```
+
+Whatever `setEventDispatcher()` installed is what arrives — including a host framework's own bus. The id is a default rather than a reservation: an application that binds something else under `EventDispatcherInterface::class`, app-wide or in one module's Provider, gets what it declared.
+
+Then dispatch, behind the same guard the framework uses on its own dispatch sites:
+
+```php
+if ($this->events->hasListeners(InvoiceIssued::class)) {
+    $this->events->dispatch(new InvoiceIssued($number, $customerName));
+}
+```
+
+The guard is worth writing. With nothing listening the event object is never constructed, so an announcement costs a single array lookup — and a module keeps that property whether or not this deployment cares about the event.
+
+**3. The listener is registered where every listener is:** in the `Gacela::bootstrap()` closure or in `gacela.php`.
+
+```php
+use App\Billing\Event\InvoiceIssued;
+use App\Notification\NotificationFacade;
+use Gacela\Framework\Gacela;
+
+$config->registerSpecificListener(
+    InvoiceIssued::class,
+    static function (InvoiceIssued $event): void {
+        /** @var NotificationFacade $notifications */
+        $notifications = Gacela::getRequired(NotificationFacade::class);
+        $notifications->onInvoiceIssued($event);
+    },
+);
+```
+
+That line is the only place both modules are named, and `gacela.php` is the composition root — the one file allowed to know both sides. Resolve the facade through the locator rather than constructing it, so a test that replaces the module also replaces what the listener reaches.
+
+What this buys, and what it costs:
+
+- **The publisher names nobody.** `debug:graph --check --rules` draws no edge from Billing to Notification and the analysers' cross-module rules see nothing to complain about, because there is no import to see. A second reaction is another registration and no change to Billing.
+- **The subscriber names the event.** It has to: it type-hints it. Put the event in the module's `Event` sub-namespace — `App\Billing\Event\InvoiceIssued` — which is one of the namespaces a module publishes by convention, so a subscriber may name it while the rest of `App\Billing` stays private. See [module boundaries](module-boundaries.md).
+- **Nothing draws the wiring for you.** An event leaves no import behind, so no graph can tell you who listens. `debug:events` can, and it is the report to reach for.
+- **A Facade only delegates**, so reading an event is the Factory's job — the shipped `gacela.facadeOnlyDelegates` rule holds a project to that.
+
+Everything the framework's own events get applies unchanged: the typed `registerSpecificListener()`, matching by inheritance (a project's own base event covers the family below it, `GacelaEventInterface::class` covers everything), the per-class listener memo, and the `hasListeners()` guard.
+
+In tests, `GacelaTestCase::assertEventDispatched()` answers from the recording `bootstrapGacela()` installs, for a project's events as readily as for Gacela's — see [testing](testing.md).
+
+The [reference application](reference-app.md) does exactly this: `Billing` announces `InvoiceIssuedEvent`, `Notification` handles it, and a test asserts that Billing depends on `Customer` and nothing else.
+
 ## Seeing what listens
 
 ```bash
@@ -72,9 +174,11 @@ vendor/bin/gacela debug:events
 
 The same catalog as below, read off the classes rather than this page, with the listeners *your* project registered against each one. Because a specific listener matches by inheritance, an event can be covered by a registration that never names it — the listener column names the target that does, so one listener on `AbstractGacelaClassResolverEvent` reads as four covered events rather than four mysteries.
 
-`--listened` narrows to the events something watches, an optional argument narrows by class name, and `--json` reports the same thing as a document. It also says when `disableEventListeners()` is in effect, which is the state in which everything below is registered and none of it runs, and when a dispatcher was supplied through `setEventDispatcher()` — the listener table is what the *configuration* registered, and a supplied dispatcher carries every event on to a bus this command cannot see into.
+**Your own events are listed too**, under their own namespace and marked `project`. They are found under the paths module discovery walks — `appModulePaths`, or the application root — by implementing `GacelaEventInterface` or being named `*Event`, and narrowed to `setProjectNamespaces()` when you declared it. Nothing in `vendor/` is scanned. An event of yours that is *missing* from the listing is one no listener registration can be checked against, and the fix is usually the interface: a class that forgot `implements GacelaEventInterface` looks exactly like an event, is accepted by `registerSpecificListener()`, and never fires. `doctor` reports that target as one nothing can ever match.
 
-Where `doctor` answers "is this listener target a thing an event can be", this answers "what does the framework offer, and what am I actually watching".
+`--listened` narrows to the events something watches, an optional argument narrows by class name — `debug:events App\` for your own, if they share a prefix — and `--json` reports the same thing as a document, with a `source` field per event and a `projectEvents` count in the summary. It also says when `disableEventListeners()` is in effect, which is the state in which everything below is registered and none of it runs, and when a dispatcher was supplied through `setEventDispatcher()` — the listener table is what the *configuration* registered, and a supplied dispatcher carries every event on to a bus this command cannot see into.
+
+Where `doctor` answers "is this listener target a thing an event can be", this answers "what does the framework offer, what do I offer, and what am I actually watching".
 
 ## Event catalog
 
@@ -243,9 +347,51 @@ Set it from the bootstrap closure, the same place everything else is configured:
 
 ```php
 Gacela::bootstrap($appRootDir, static function (GacelaConfig $config): void {
-    $config->setEventDispatcher(new Psr14Bridge($myBus));
+    $config->setEventDispatcher(new MyDispatcher($myBus));
 });
 ```
+
+### PSR-14, for a hosted application
+
+A Symfony or Laravel application already has a bus, and one event system per application is the point — so `setEventDispatcher()` also accepts a `Psr\EventDispatcher\EventDispatcherInterface` and wraps it for you. No adapter to write:
+
+```php
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+Gacela::bootstrap($appRootDir, static function (GacelaConfig $config) use ($dispatcher): void {
+    // Symfony's, Laravel's, or any other PSR-14 implementation.
+    $config->setEventDispatcher($dispatcher);
+});
+```
+
+Gacela's events then arrive on the host's bus, the listeners you registered beside it still run (see below), and your own events go to the same place — nothing is dispatched twice and there is no second event system beside the first.
+
+**One thing to know about the cost.** PSR-14 offers no way to ask what is subscribed, so the adapter's `hasListeners()` answers `true` for everything: every guarded dispatch site allocates its event and hands it over, including the ones on the class-resolution hot path. That is the price of routing events to a bus that cannot be asked, and it is paid only by an application that installed one — supply no dispatcher and the guard is the single array lookup it has always been. If you want a narrower answer, implement Gacela's `EventDispatcherInterface` yourself and say so in `hasListeners()`; that is exactly what this section's first paragraph is for.
+
+The other direction is a class rather than a parameter: a library that type-hints PSR-14 can be handed the dispatcher this application configured, listeners and all.
+
+```php
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\Psr14EventDispatcher;
+
+final class ReportingFactory extends AbstractFactory
+{
+    public function createLibrary(): SomeLibrary
+    {
+        return new SomeLibrary(new Psr14EventDispatcher(
+            $this->getProvidedDependency(EventDispatcherInterface::class),
+        ));
+    }
+}
+```
+
+Outside a module, `Config::getInstance()->getSetupGacela()->getEventDispatcher()` is the same object.
+
+It returns the event, as PSR-14 requires, and honours both halves of the contract Gacela's own dispatch sites honour: a dispatcher that declines the class in `hasListeners()` is not told, and an event that arrives already stopped is not dispatched. Gacela's listeners are notify-only, so propagation cannot be stopped *between* them.
+
+`ConfigurableEventDispatcher` deliberately does not implement PSR-14 itself. Its `dispatch()` returns `void`, which satisfies the signature — PSR-14 declares no return type — while breaking the contract, which says the event comes back. A class that is a PSR-14 dispatcher in name and returns nothing is worse than one that honestly is not, so the conversion is explicit.
 
 A dispatcher you supply **takes precedence over `disableEventListeners()`**: that switch governs the dispatcher Gacela would *build*, and this is one it does not build. To go quiet, return `false` from `hasListeners()` — which also skips allocating the events, where the switch would only stop them being delivered.
 

--- a/docs/reference-app.md
+++ b/docs/reference-app.md
@@ -22,10 +22,10 @@ The application root is
 | Module | What it is, and what it shows |
 |---|---|
 | `Customer` | The customer directory. A `#[Cacheable]` lookup with a per-reference key, and a shape declared with `declareDtoSchema()` whose generated class is committed. |
-| `Billing` | Issues invoices. Reaches `Customer` through `#[Provides]` + `getProvidedDependency()` and `Notification` through a `#[ServiceMap]` accessor; runs a plugin stack of tax rules and a tagged set of validators; reads typed configuration against a declared schema. |
+| `Billing` | Issues invoices. Reaches `Customer` through `#[Provides]` + `getProvidedDependency()`, and announces `Billing\Event\InvoiceIssuedEvent` through the injected event dispatcher without naming whoever reacts; runs a plugin stack of tax rules and a tagged set of validators; reads typed configuration against a declared schema. |
 | `Payment` | Takes the money. Declares a fifth resolvable kind, `Gateway`; dispatches by key through a handler registry; gets a stricter retry policy than the rest of the application through a contextual binding. Its four pillars carry the names it arrived with — `PaymentApi`, `PaymentBuilder`, `PaymentSettings`, `PaymentDependencyProvider` — which is what `addSuffixTypeFacade()` and its three siblings are for. |
-| `Notification` | Delivers. A plugin stack of channels, a header list the application extends with `extendService()`, and the resolver-event listener registered in `gacela.php`. |
-| `Reporting` | Reads. Billing's declared shapes and Customer's names, through their facades and nothing else — the module the boundary rules are written about. |
+| `Notification` | Delivers, and reacts. It handles Billing's `InvoiceIssuedEvent` — the subscriber names the event, the publisher names nobody — behind a plugin stack of channels, a header list the application extends with `extendService()`, and the resolver-event listener registered in `gacela.php`. |
+| `Reporting` | Reads. Billing's declared shapes through `#[Provides]` and Customer's names through a `#[ServiceMap]` accessor, and nothing else — the module the boundary rules are written about. |
 
 Beside them, `Shared/` is a shared kernel rather than a module: a clock the host
 supplies, a retry policy, the invokables that extend the configuration, and the
@@ -112,9 +112,15 @@ fixed. The loop:
 
 The module graph is built from `use` imports at module granularity, so
 `module-rules.json` can say that nothing may depend on `Reporting` and cannot
-say that Billing may reach only Notification's *facade*. That second rule is the
+say that Reporting may reach only Billing's *facade*. That second rule is the
 analysers' job, and it is why `CrossModuleViaFacadeRule` and its method-call half
 are both enabled in the configurations above.
+
+It also cannot say anything about `Notification` reacting to `Billing`. An event
+leaves no import behind in the module that dispatched it, so no graph and no rule
+can tell you who is listening — `debug:events` can, which is the report that
+answers it, and the registration in `gacela.php` is the one place it is written
+down.
 
 And the two generated shapes are excluded from both analysers. `dto:generate`
 writes a `@psalm-suppress` for the one thing Psalm objects to and nothing for

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,10 +31,13 @@ What it gives you:
 ```php
 $this->assertServiceResolved('checkout-gateway');       // ServiceResolvedEvent seen
 $this->assertBindingRegistered(PaymentGateway::class);  // BindingRegisteredEvent seen
+$this->assertEventDispatched(InvoiceIssued::class);     // any event, yours included
 
 $events = $this->recordedGacelaEvents();                              // all of them
 $resolved = $this->recordedGacelaEventsOf(ServiceResolvedEvent::class); // one type
 ```
+
+`assertEventDispatched()` and `recordedGacelaEventsOf()` answer about [your own events](events.md#your-own-events) as readily as about the framework's — one dispatcher, one recording — so a test of a module that announces something needs no listener of its own. Both match by inheritance, the way `registerSpecificListener()` does, so naming a base class or `GacelaEventInterface::class` asks about the whole family. To assert on a payload, read the events: `recordedGacelaEventsOf()` returns them typed and in dispatch order.
 
 If you only need the reset helpers inside an existing test hierarchy, use the [`ContainerFixture`](../src/Framework/Testing/ContainerFixture.php) trait directly — `GacelaTestCase` builds on it.
 

--- a/infection.json5
+++ b/infection.json5
@@ -289,6 +289,12 @@
         // to min(); shifting its origin by a constant changes no component.
         DecrementInteger: {
             ignore: [
+                // EventSource::order() exists to sort the framework's events
+                // before the project's. Only the *relation* between the two
+                // numbers is behaviour: 0/1, -1/1 and 0/2 order every listing
+                // identically, so no assertion on the output can tell them
+                // apart, and one that could would be asserting the constants.
+                "Gacela\\Console\\Application\\Debug\\EventSource::order",
                 // See the IncrementInteger note: an arbitrary but fixed slice
                 // of a digest.
                 "Gacela\\Framework\\Config\\MergedConfigCache::dimensionSuffix",
@@ -307,6 +313,9 @@
         // the digest, which pins the implementation rather than the behaviour.
         IncrementInteger: {
             ignore: [
+                // Same as the DecrementInteger entry: what orders a listing is
+                // framework < project, not the two integers that express it.
+                "Gacela\\Console\\Application\\Debug\\EventSource::order",
                 "Gacela\\Framework\\ClassResolver\\Cache\\AbstractPhpFileCache::absoluteFilename",
                 // Same arbitrary-slice reasoning as absoluteFilename above: the
                 // dimension suffix takes 12 hex characters out of a sha1 to
@@ -595,6 +604,18 @@
         },
         LogicalOr: {
             ignore: [
+                // The chain of guards that decides whether a scanned entry is
+                // worth opening -- unreadable path, not a file, not `.php`,
+                // hidden, vendored. Turning any `||` into `&&` lets an entry
+                // one guard would have refused reach the next, and the next
+                // refuses it for its own reason: a directory has no `.php`
+                // extension, a dotfile yields an empty class name, an
+                // unreadable path fails `file_get_contents()`. Every mutant
+                // therefore returns null exactly where the original does, and
+                // the only input that could tell them apart -- a directory
+                // named `Something.php` -- makes the mutant emit a warning
+                // rather than a different answer.
+                "Gacela\\Console\\Domain\\ProjectEvents\\ProjectEventFinder::eventClassIn",
                 "Gacela\\StaticAnalysis\\Rules\\FacadeOnlyDelegatesAnalyser::isCachedDelegation",
                 // Same redundancy as the MethodCallRemoval entry above: whatever
                 // this guard decides, the pillar swap right after it applies the

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -74,3 +74,10 @@ parameters:
         -
             identifier: classConstant.internalClass
             path: %currentWorkingDirectory%/tests/Unit/Framework/ClassResolver/GlobalInstance/AnonymousGlobalTest.php
+        # EventDispatchingCapabilities is @internal: an application injects the
+        # dispatcher instead of mixing the trait in. The trait's own test is the
+        # one place that has to mix it in, because the two methods are private
+        # and a `use` is the only way to reach them.
+        -
+            identifier: traitUse.internalTrait
+            path: %currentWorkingDirectory%/tests/Unit/Framework/Event/Dispatcher/EventDispatchingCapabilitiesTest.php

--- a/src/Console/Application/Debug/EventCatalog.php
+++ b/src/Console/Application/Debug/EventCatalog.php
@@ -31,6 +31,14 @@ use const DIRECTORY_SEPARATOR;
  * Read off the directory rather than listed here: a catalog restating the
  * classes is a second place to forget, which is the fault `docs/events.md`
  * already has -- two events were added in #867 and had to be remembered.
+ *
+ * {@see eventClasses()} stays the framework's own, and nothing else: it is what
+ * `EventCatalogDocsTest` compares `docs/events.md` against in both directions,
+ * and a project's events appearing in it would make that page's tables either
+ * wrong or impossible to satisfy. An application's events are found by
+ * {@see \Gacela\Console\Domain\ProjectEvents\ProjectEventFinder} and handed to
+ * {@see inspect()}, which marks each row with the {@see EventSource} it came
+ * from.
  */
 final class EventCatalog
 {
@@ -107,35 +115,71 @@ final class EventCatalog
      * @param list<class-string>  $eventClasses           what {@see eventClasses()} found
      * @param array<class-string, int> $specificListenerCounts registered target => how many listeners it carries
      * @param int                 $genericListenerCount   registerGenericListener() callables
+     * @param list<class-string>  $projectEventClasses    what the application declared, from
+     *   {@see \Gacela\Console\Domain\ProjectEvents\ProjectEventFinder}
      *
      * @return list<EventInspection>
      */
-    public function inspect(array $eventClasses, array $specificListenerCounts, int $genericListenerCount): array
-    {
+    public function inspect(
+        array $eventClasses,
+        array $specificListenerCounts,
+        int $genericListenerCount,
+        array $projectEventClasses = [],
+    ): array {
         $inspections = [];
 
         foreach ($eventClasses as $eventClass) {
-            $inspections[] = new EventInspection(
+            $inspections[] = $this->inspectOne(
                 $eventClass,
-                $this->groupOf($eventClass),
-                $this->isAbstract($eventClass),
-                in_array($eventClass, self::HOT_PATH_EVENTS, true),
-                $this->targetsCovering($eventClass, $specificListenerCounts),
+                EventSource::Framework,
+                $specificListenerCounts,
                 $genericListenerCount,
             );
         }
 
-        // By group first, so a namespace is one contiguous run. Sorting the
-        // class names instead splits `ClassResolver` around its own
-        // subdirectories -- `ClassResolver\Cache` sorts between the abstract
-        // parent and the four `ResolvedClass*` events beside it.
+        foreach ($projectEventClasses as $eventClass) {
+            $inspections[] = $this->inspectOne(
+                $eventClass,
+                EventSource::Project,
+                $specificListenerCounts,
+                $genericListenerCount,
+            );
+        }
+
+        // Source first, so the framework's catalog and the project's own events
+        // are two runs rather than one interleaved list -- a reader scanning for
+        // "my events" should not have to read the whole table. Then by group, so
+        // a namespace is contiguous: sorting the class names instead splits
+        // `ClassResolver` around its own subdirectories, with `ClassResolver\Cache`
+        // between the abstract parent and the four `ResolvedClass*` events.
         usort(
             $inspections,
-            static fn (EventInspection $a, EventInspection $b): int => [$a->group, $a->shortName()]
-                <=> [$b->group, $b->shortName()],
+            static fn (EventInspection $a, EventInspection $b): int => [$a->source->order(), $a->group, $a->shortName()]
+                <=> [$b->source->order(), $b->group, $b->shortName()],
         );
 
         return $inspections;
+    }
+
+    /**
+     * @param class-string $eventClass
+     * @param array<class-string, int> $specificListenerCounts
+     */
+    private function inspectOne(
+        string $eventClass,
+        EventSource $source,
+        array $specificListenerCounts,
+        int $genericListenerCount,
+    ): EventInspection {
+        return new EventInspection(
+            $eventClass,
+            $this->groupOf($eventClass, $source),
+            $this->isAbstract($eventClass),
+            in_array($eventClass, self::HOT_PATH_EVENTS, true),
+            $this->targetsCovering($eventClass, $specificListenerCounts),
+            $genericListenerCount,
+            $source,
+        );
     }
 
     /**
@@ -164,10 +208,17 @@ final class EventCatalog
     /**
      * The namespace below `Gacela\Framework\Event\`, empty for an event sitting
      * directly in it.
+     *
+     * A project's event is grouped by its own namespace instead, written out in
+     * full: there is no root to make it relative to, and the namespace is
+     * exactly what tells a reader which module the event belongs to.
      */
-    private function groupOf(string $eventClass): string
+    private function groupOf(string $eventClass, EventSource $source): string
     {
-        $relative = substr($eventClass, strlen(self::EVENT_NAMESPACE));
+        $relative = $source === EventSource::Framework
+            ? substr($eventClass, strlen(self::EVENT_NAMESPACE))
+            : $eventClass;
+
         $position = strrpos($relative, '\\');
 
         return $position === false ? '' : substr($relative, 0, $position);

--- a/src/Console/Application/Debug/EventInspection.php
+++ b/src/Console/Application/Debug/EventInspection.php
@@ -15,11 +15,12 @@ final class EventInspection
 {
     /**
      * @param class-string          $className
-     * @param string                $group                the namespace under `Gacela\Framework\Event\`, e.g. `ClassResolver\Cache`
+     * @param string                $group                the namespace under `Gacela\Framework\Event\`, e.g. `ClassResolver\Cache`; a project event carries its own namespace in full
      * @param bool                  $isAbstract           a target listeners can be registered against, never itself dispatched
      * @param bool                  $isHotPath            dispatched on every warm resolve
      * @param array<class-string, int> $matchedTargets    registered target => how many listeners it carries, for the targets that cover this event
      * @param int                   $genericListenerCount registerGenericListener() callables, which cover every event
+     * @param EventSource           $source               who declared it: the framework, or the application
      */
     public function __construct(
         public readonly string $className,
@@ -28,6 +29,7 @@ final class EventInspection
         public readonly bool $isHotPath,
         public readonly array $matchedTargets,
         public readonly int $genericListenerCount,
+        public readonly EventSource $source,
     ) {
     }
 

--- a/src/Console/Application/Debug/EventSource.php
+++ b/src/Console/Application/Debug/EventSource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+/**
+ * Who declared an event: the framework, or the application reading the report.
+ *
+ * Worth a column because the two answer different questions. A framework event
+ * is documented in `docs/events.md` and its payload is fixed; a project event
+ * is the reader's own, and seeing it listed is how they know Gacela found it --
+ * which is the difference between "no listener is registered" and "this class
+ * is not where discovery looks".
+ */
+enum EventSource: string
+{
+    case Framework = 'framework';
+
+    case Project = 'project';
+
+    /**
+     * Framework first in every report.
+     *
+     * Given as a number rather than left to the string values: `framework`
+     * sorting before `project` is an accident of the alphabet, and renaming a
+     * case would silently reorder every listing.
+     */
+    public function order(): int
+    {
+        return $this === self::Framework ? 0 : 1;
+    }
+}

--- a/src/Console/Application/Doctor/Check/EventListenerTargetCheck.php
+++ b/src/Console/Application/Doctor/Check/EventListenerTargetCheck.php
@@ -6,10 +6,12 @@ namespace Gacela\Console\Application\Doctor\Check;
 
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Framework\Event\GacelaEventInterface;
 
 use function class_exists;
 use function count;
 use function interface_exists;
+use function is_a;
 use function sprintf;
 
 /**
@@ -18,11 +20,19 @@ use function sprintf;
  *
  * The dispatcher matches by inheritance, so a parent class or an interface is a
  * legitimate target: it covers the whole family below it. What is left is the
- * name that is not a type at all -- a typo, or a class that moved. It is
- * accepted at bootstrap and simply never runs.
+ * name that is not a type at all -- a typo, or a class that moved -- and the
+ * name that is a type no event can ever be. Both are accepted at bootstrap and
+ * simply never run.
  *
- * Only names that can never equal, extend or implement a dispatched event are
- * reported. A type that exists is left alone whether or not it is ever
+ * The second case is what a project's own events made worth reporting. An event
+ * of Gacela's is a `GacelaEventInterface` by construction; an event of yours is
+ * one because you wrote `implements GacelaEventInterface`, and forgetting it
+ * leaves a class that looks exactly like an event, a registration that is
+ * accepted, and a listener that never fires. That is why the check is given the
+ * catalog -- the framework's events *and* the project's: a target neither an
+ * event type itself nor a supertype of any known event cannot match a dispatch.
+ *
+ * A type that exists and *can* match is left alone whether or not it is ever
  * dispatched: a listener for an event this deployment happens not to raise is
  * waiting, not broken.
  */
@@ -34,11 +44,16 @@ final class EventListenerTargetCheck implements HealthCheck
      *                                           they carry no target, so they are invisible to the checks below
      * @param bool         $dispatcherEnabled    false when `disableEventListeners()` was called, which
      *                                           builds no dispatcher at all. Defaults to Gacela's own default
+     * @param list<class-string> $knownEventClasses the catalog to judge a target against: the framework's
+     *                                           events and the project's. Empty means "do not judge" --
+     *                                           `doctor` skips the project scan when nothing is registered,
+     *                                           and a check with no catalog must not call every target dead
      */
     public function __construct(
         private readonly array $listenerTargets,
         private readonly int $genericListenerCount = 0,
         private readonly bool $dispatcherEnabled = true,
+        private readonly array $knownEventClasses = [],
     ) {
     }
 
@@ -98,7 +113,7 @@ final class EventListenerTargetCheck implements HealthCheck
             return 'remove disableEventListeners() to let them run, or drop the registrations -- nothing here can tell a deliberate kill switch from a forgotten one';
         }
 
-        return 'a specific listener runs for the event class named and everything below it -- pass `EventClass::class` rather than a hand-written string, so a rename cannot leave it behind';
+        return 'a specific listener runs for the event class named and everything below it -- pass `EventClass::class` rather than a hand-written string, so a rename cannot leave it behind, and check that an event of your own implements GacelaEventInterface (`debug:events` lists the ones Gacela found)';
     }
 
     private function whyItCanNeverFire(string $target): ?string
@@ -107,6 +122,25 @@ final class EventListenerTargetCheck implements HealthCheck
             return 'names no class or interface';
         }
 
-        return null;
+        if (is_a($target, GacelaEventInterface::class, true)) {
+            // An event type. Whether anything dispatches it is another
+            // question, and not one a health check should answer: a listener
+            // for an event this deployment does not raise is waiting.
+            return null;
+        }
+
+        if ($this->knownEventClasses === []) {
+            return null;
+        }
+
+        foreach ($this->knownEventClasses as $eventClass) {
+            if (is_a($eventClass, $target, true)) {
+                // A marker interface or a base class that events do implement,
+                // without being an event type itself. It matches, so it fires.
+                return null;
+            }
+        }
+
+        return 'is not an event type, and no known event extends or implements it -- so nothing can ever match it';
     }
 }

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -133,6 +133,23 @@ final class ConsoleFacade extends AbstractFacade
     }
 
     /**
+     * The event classes the application declares, as opposed to the ones the
+     * framework ships.
+     *
+     * Read by `debug:events`, which lists them beside Gacela's own, and by
+     * `doctor`, which cannot judge a listener target without knowing the events
+     * a project has. Found by walking the paths discovery walks -- see
+     * {@see \Gacela\Console\Domain\ProjectEvents\ProjectEventFinder} for what
+     * makes a file worth opening.
+     *
+     * @return list<class-string>
+     */
+    public function findProjectEventClasses(): array
+    {
+        return $this->getFactory()->createProjectEventFinder()->find();
+    }
+
+    /**
      * The `appModulePaths` entries discovery walked, for a report that found
      * nothing and has to say where it looked.
      *

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -38,6 +38,7 @@ use Gacela\Console\Domain\ModuleGraph\ModuleGraphDiffer;
 use Gacela\Console\Domain\ModuleGraph\ModuleRuleChecker;
 use Gacela\Console\Domain\ModuleGraph\TextGraphFormatter;
 use Gacela\Console\Domain\PackageManifest\ComposerPackage;
+use Gacela\Console\Domain\ProjectEvents\ProjectEventFinder;
 use Gacela\Console\Domain\ServiceMapMigration\ServiceMapMigrationRunner;
 use Gacela\Console\Domain\ServiceMapMigration\ServiceMapMigrator;
 use Gacela\Console\Infrastructure\FileContentIo;
@@ -192,6 +193,18 @@ final class ConsoleFactory extends AbstractFactory
         return new UndiscoveredFacadeFinder(
             $this->createModuleScanIterator(),
             $this->facadeSuffixes(),
+        );
+    }
+
+    /**
+     * The same file iterator the module finders take, so a project's events are
+     * looked for exactly where its modules are, and never in `vendor/`.
+     */
+    public function createProjectEventFinder(): ProjectEventFinder
+    {
+        return new ProjectEventFinder(
+            $this->createModuleScanIterator(),
+            Config::getInstance()->getSetupGacela()->getProjectNamespaces(),
         );
     }
 

--- a/src/Console/Domain/ProjectEvents/ProjectEventFinder.php
+++ b/src/Console/Domain/ProjectEvents/ProjectEventFinder.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Domain\ProjectEvents;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+use OuterIterator;
+use SplFileInfo;
+
+use function array_keys;
+use function file_get_contents;
+use function is_a;
+use function preg_match;
+use function sort;
+use function str_contains;
+use function str_ends_with;
+use function str_starts_with;
+use function strpos;
+use function substr;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * The events an application declares, as opposed to the ones Gacela ships.
+ *
+ * A project dispatching its own events through Gacela's dispatcher gets the
+ * same guard, matching and memo the framework's events get -- and, without
+ * this, none of the tooling that reports on them: `debug:events` listed only
+ * `Gacela\Framework\Event\*`, so a project event was invisible to the one
+ * command whose job is to answer "what is listening to what", and `doctor`
+ * could not judge a listener registered against one.
+ *
+ * Found by walking the directories discovery already walks -- the configured
+ * `appModulePaths`, or the application root -- rather than by a second scanner
+ * or a scan of `vendor/`. It is the same file iterator the module finders take,
+ * so a command that asks for both pays for the walks it starts, and `vendor/`
+ * is pruned before it is ever reached.
+ *
+ * ## Which files are opened, and which classes are loaded
+ *
+ * Every `.php` file under those paths is read, as the module finders already
+ * read them. A class is *loaded* only when the file looks like it could hold
+ * an event, because loading is what costs: a whole-project `class_exists()`
+ * sweep is 147ms on an application of 126 modules, and this runs inside
+ * `debug:events` and `doctor`.
+ *
+ * Two things make a file a candidate, and either is enough:
+ *
+ * - it names `GacelaEventInterface`, which an event implementing it directly
+ *   must do;
+ * - it is named `*Event.php`, which is the convention the framework's own
+ *   events follow and the one `docs/events.md` recommends.
+ *
+ * What that misses is an event that neither names the interface nor ends in
+ * `Event` -- `class InvoiceIssued extends DomainEvent`, where the parent
+ * carries the interface. The parent is found and reported (a listener target,
+ * exactly as an abstract framework event is), the child is not. Naming either
+ * the interface or the suffix is enough to be listed, and `debug:events` is
+ * where a project sees which of its events Gacela knows about.
+ */
+final class ProjectEventFinder
+{
+    private const string EVENT_FILE_SUFFIX = 'Event.php';
+
+    /**
+     * The framework's own events are catalogued from the installed package, so
+     * finding them again here would list every one of them twice in a project
+     * whose scan path happens to include Gacela's source -- which is exactly
+     * the shape of Gacela's own repository.
+     */
+    private const string FRAMEWORK_EVENT_NAMESPACE = 'Gacela\\Framework\\Event\\';
+
+    /**
+     * @param OuterIterator<array-key, SplFileInfo> $fileIterator
+     * @param list<string> $projectNamespaces the `setProjectNamespaces()` list, when the
+     *   application declared one: a class outside it is not the project's event
+     */
+    public function __construct(
+        private readonly OuterIterator $fileIterator,
+        private readonly array $projectNamespaces = [],
+    ) {
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public function find(): array
+    {
+        $classes = [];
+
+        /** @var SplFileInfo $fileInfo */
+        foreach ($this->fileIterator as $fileInfo) {
+            $class = $this->eventClassIn($fileInfo);
+
+            if ($class !== null) {
+                $classes[$class] = true;
+            }
+        }
+
+        $found = array_keys($classes);
+
+        // Sorted so two runs of one project agree, whatever order the
+        // filesystem hands the directories over in.
+        sort($found);
+
+        /** @var list<class-string> $found */
+        return $found;
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private function eventClassIn(SplFileInfo $fileInfo): ?string
+    {
+        $realPath = $fileInfo->getRealPath();
+
+        if ($realPath === false
+            || !$fileInfo->isFile()
+            || $fileInfo->getExtension() !== 'php'
+            || str_starts_with($fileInfo->getFilename(), '.')
+            || str_contains($realPath, 'vendor' . DIRECTORY_SEPARATOR)
+        ) {
+            return null;
+        }
+
+        $fileContent = file_get_contents($realPath);
+
+        if ($fileContent === false) {
+            return null;
+        }
+
+        if (!$this->looksLikeAnEvent($fileInfo, $fileContent)) {
+            return null;
+        }
+
+        $namespace = $this->namespaceOf($fileContent);
+
+        if ($namespace === '' || !$this->isProjectNamespace($namespace)) {
+            return null;
+        }
+
+        /** @var class-string $class */
+        $class = $namespace . '\\' . $this->classNameOf($fileInfo);
+
+        // The one load, and the one thing that actually decides: a file can
+        // name the interface for any reason -- a listener type-hints it, a
+        // service imports it -- and only the class itself says whether an event
+        // is what this is.
+        return is_a($class, GacelaEventInterface::class, true) ? $class : null;
+    }
+
+    private function looksLikeAnEvent(SplFileInfo $fileInfo, string $fileContent): bool
+    {
+        return str_ends_with($fileInfo->getFilename(), self::EVENT_FILE_SUFFIX)
+            || str_contains($fileContent, 'GacelaEventInterface');
+    }
+
+    /**
+     * A declared project namespace wins when there is one: it is what the
+     * application already told discovery its classes are called, so a fixture
+     * or a vendored path that slipped into a scan path is not mistaken for the
+     * project's own event.
+     *
+     * With none declared, everything outside the framework's event namespace
+     * counts -- `setProjectNamespaces()` is optional, and an application that
+     * skipped it still has events.
+     */
+    private function isProjectNamespace(string $namespace): bool
+    {
+        if (str_starts_with($namespace . '\\', self::FRAMEWORK_EVENT_NAMESPACE)) {
+            return false;
+        }
+
+        if ($this->projectNamespaces === []) {
+            return true;
+        }
+
+        foreach ($this->projectNamespaces as $projectNamespace) {
+            if (str_starts_with($namespace . '\\', $projectNamespace . '\\')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function namespaceOf(string $fileContent): string
+    {
+        preg_match('#namespace (.*);#', $fileContent, $matches);
+
+        return $matches[1] ?? '';
+    }
+
+    private function classNameOf(SplFileInfo $fileInfo): string
+    {
+        $filename = $fileInfo->getFilename();
+        $dotPosition = strpos($filename, '.');
+
+        return $dotPosition !== false ? substr($filename, 0, $dotPosition) : $filename;
+    }
+}

--- a/src/Console/Domain/ProjectEvents/ProjectEventFinder.php
+++ b/src/Console/Domain/ProjectEvents/ProjectEventFinder.php
@@ -8,7 +8,6 @@ use Gacela\Framework\Event\GacelaEventInterface;
 use OuterIterator;
 use SplFileInfo;
 
-use function array_keys;
 use function file_get_contents;
 use function is_a;
 use function preg_match;
@@ -94,18 +93,19 @@ final class ProjectEventFinder
             $class = $this->eventClassIn($fileInfo);
 
             if ($class !== null) {
-                $classes[$class] = true;
+                // Keyed by the class name so a file reached twice -- two
+                // configured paths overlapping -- is one entry.
+                $classes[$class] = $class;
             }
         }
 
-        $found = array_keys($classes);
-
         // Sorted so two runs of one project agree, whatever order the
-        // filesystem hands the directories over in.
-        sort($found);
+        // filesystem hands the directories over in; `sort()` drops the keys,
+        // which is what makes this a list.
+        sort($classes);
 
-        /** @var list<class-string> $found */
-        return $found;
+        /** @var list<class-string> $classes */
+        return $classes;
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DebugEventsCommand.php
+++ b/src/Console/Infrastructure/Command/DebugEventsCommand.php
@@ -334,13 +334,18 @@ final class DebugEventsCommand extends Command
         $output->writeln('');
     }
 
+    /**
+     * Both messages speak for the whole listing, the project's events included:
+     * "no Gacela event contains this" beside a table that also holds the
+     * reader's own events answers a narrower question than the one they asked.
+     */
     private function nothingToShow(string $filter, bool $listenedOnly): string
     {
         if ($listenedOnly) {
-            return '  <comment>Nothing listens to any Gacela event.</comment>';
+            return "  <comment>Nothing listens to any event, Gacela's or this project's.</comment>";
         }
 
-        return sprintf('  <comment>No Gacela event contains "%s".</comment>', $filter);
+        return sprintf('  <comment>No event contains "%s".</comment>', $filter);
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DebugEventsCommand.php
+++ b/src/Console/Infrastructure/Command/DebugEventsCommand.php
@@ -6,9 +6,13 @@ namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Debug\EventCatalog;
 use Gacela\Console\Application\Debug\EventInspection;
+use Gacela\Console\Application\Debug\EventSource;
+use Gacela\Console\ConsoleFacade;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,7 +38,8 @@ use const JSON_UNESCAPED_SLASHES;
 
 /**
  * Every event Gacela can dispatch, which of them anything listens to, and which
- * sit on the hot path.
+ * sit on the hot path -- and the same for the events the application declares
+ * itself.
  *
  * Until now the only way to know a listener is registered was that it fired,
  * and the only way to know one is dead was `doctor` -- which reports a target
@@ -45,13 +50,23 @@ use const JSON_UNESCAPED_SLASHES;
  * It reads as the counterpart to the matching rule. A listener registered
  * against `AbstractGacelaClassResolverEvent` covers four events, and this is
  * where you see the four.
+ *
+ * A project's own events are listed under their own heading, marked `project`.
+ * For those the question is often the other one -- not "what listens to this"
+ * but "does Gacela see my event at all" -- and a class missing from this table
+ * is one no `registerSpecificListener()` can be checked against.
+ *
+ * @method ConsoleFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: ConsoleFacade::class)]
 final class DebugEventsCommand extends Command
 {
+    use ServiceResolverAwareTrait;
+
     protected function configure(): void
     {
         $this->setName('debug:events')
-            ->setDescription('List every Gacela event, which have listeners, and which are on the hot path')
+            ->setDescription('List every Gacela and project event, which have listeners, and which are on the hot path')
             ->setHelp($this->getHelpText())
             ->addArgument('filter', InputArgument::OPTIONAL, 'Only events whose class name contains this text', '')
             ->addOption('listened', 'l', InputOption::VALUE_NONE, 'Only events something listens to')
@@ -69,6 +84,7 @@ final class DebugEventsCommand extends Command
             $catalog->eventClasses(),
             $this->specificListenerCounts(),
             $this->genericListenerCount(),
+            $this->getFacade()->findProjectEventClasses(),
         );
 
         $shown = $this->applyFilters($inspections, $filter, $listenedOnly);
@@ -134,6 +150,7 @@ final class DebugEventsCommand extends Command
             'status' => $listenersEnabled ? 'ok' : 'error',
             'summary' => [
                 'events' => count($all),
+                'projectEvents' => count($this->projectOf($all)),
                 'withListeners' => count($this->listenedOf($all)),
                 'hotPath' => count($this->hotPathOf($all)),
                 'listeners' => $listeners,
@@ -145,6 +162,7 @@ final class DebugEventsCommand extends Command
                 static fn (EventInspection $inspection): array => [
                     'class' => $inspection->className,
                     'group' => $inspection->group,
+                    'source' => $inspection->source->value,
                     'abstract' => $inspection->isAbstract,
                     'hotPath' => $inspection->isHotPath,
                     'listeners' => $inspection->listenerCount(),
@@ -205,7 +223,7 @@ final class DebugEventsCommand extends Command
         $name = $inspection->shortName();
         $padding = str_repeat(' ', $width - strlen($name));
 
-        // Trimmed: the hot-path column is padded so the listener note lines up,
+        // Trimmed: the source column is padded so the listener note lines up,
         // and a row with neither would otherwise carry the padding to the end
         // of the line, which every diff of captured output then argues about.
         return rtrim(sprintf(
@@ -213,9 +231,32 @@ final class DebugEventsCommand extends Command
             $marker,
             $name,
             $padding,
-            $inspection->isHotPath ? '<fg=yellow>hot path</>' : '        ',
+            $this->sourceColumn($inspection),
             $this->listenerNote($inspection),
         ));
+    }
+
+    /**
+     * One column carrying both facts, because they cannot both be true: the hot
+     * path is the framework's list of events dispatched on every warm resolve,
+     * and a project event is never on it.
+     *
+     * A project event is marked rather than left blank. The group heading above
+     * it is a namespace, which a reader may or may not recognise as their own,
+     * and the fact worth stating in a report of "every event there is" is which
+     * of them the application declared.
+     */
+    private function sourceColumn(EventInspection $inspection): string
+    {
+        if ($inspection->isHotPath) {
+            return '<fg=yellow>hot path</>';
+        }
+
+        if ($inspection->source === EventSource::Project) {
+            return '<fg=magenta>project </>';
+        }
+
+        return '        ';
     }
 
     /**
@@ -253,6 +294,7 @@ final class DebugEventsCommand extends Command
     private function writeSummary(OutputInterface $output, array $all): void
     {
         $listened = count($this->listenedOf($all));
+        $project = count($this->projectOf($all));
 
         $output->writeln(sprintf(
             '<fg=cyan>Summary:</> %d events, %d with listeners, %d on the hot path',
@@ -260,6 +302,17 @@ final class DebugEventsCommand extends Command
             $listened,
             count($this->hotPathOf($all)),
         ));
+
+        // Only when there are any: an application that dispatches none of its
+        // own should not be told about a number that is always zero, and a
+        // project that expected some and reads "0 declared by this project" is
+        // being told the scan found nothing -- which is the answer it needs.
+        if ($project > 0) {
+            $output->writeln(sprintf(
+                '<fg=cyan>Of these:</> %d declared by this project',
+                $project,
+            ));
+        }
 
         if (!$this->listenersEnabled()) {
             $output->writeln('<comment>disableEventListeners() is in effect, so none of these listeners runs.</comment>');
@@ -306,6 +359,24 @@ final class DebugEventsCommand extends Command
         }
 
         return $listened;
+    }
+
+    /**
+     * @param list<EventInspection> $inspections
+     *
+     * @return list<EventInspection>
+     */
+    private function projectOf(array $inspections): array
+    {
+        $project = [];
+
+        foreach ($inspections as $inspection) {
+            if ($inspection->source === EventSource::Project) {
+                $project[] = $inspection;
+            }
+        }
+
+        return $project;
     }
 
     /**
@@ -447,12 +518,18 @@ final class DebugEventsCommand extends Command
 Lists every event class the framework can dispatch, whether anything listens to
 it, and whether it is dispatched on the class-resolution hot path.
 
+The events this project declares are listed too, marked `project`. They are
+found under the paths module discovery walks -- `appModulePaths`, or the
+application root -- by implementing GacelaEventInterface or being named
+`*Event`. An event of yours that is missing is one no listener registration can
+be checked against.
+
 A specific listener matches by inheritance, so an event can be covered by a
 listener that never names it -- one registered against a parent class or against
 GacelaEventInterface. The listener column names the target that covers it.
 
 <info>Examples:</info>
-  # The whole catalog
+  # The whole catalog, the framework's events and yours
   bin/gacela debug:events
 
   # Only the events something listens to
@@ -460,6 +537,9 @@ GacelaEventInterface. The listener column names the target that covers it.
 
   # Only the class-resolution events
   bin/gacela debug:events ClassResolver
+
+  # Only your own, if they share a namespace
+  bin/gacela debug:events App\\
 
 <comment>Complements:</comment>
   bin/gacela doctor                names a listener target no event can ever be

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Console\Infrastructure\Command;
 
+use Gacela\Console\Application\Debug\EventCatalog;
 use Gacela\Console\Application\Doctor\Check\CacheableStorageCheck;
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
@@ -300,6 +301,7 @@ final class DoctorCommand extends Command
                 $this->specificListenerTargets(),
                 $this->genericListenerCount(),
                 $this->eventDispatcherCanBeBuilt(),
+                $this->knownEventClasses(),
             ),
             new ServiceExtensionTargetCheck(
                 $modules,
@@ -350,6 +352,29 @@ final class DoctorCommand extends Command
         $targets = array_keys($setup->getSpecificListeners() ?? []);
 
         return $targets;
+    }
+
+    /**
+     * The events a listener target can be judged against: the framework's
+     * catalog and the ones this project declares.
+     *
+     * Skipped entirely when no target is registered. The project half is a walk
+     * of the application's files, and `doctor` should not pay for it to answer a
+     * question nobody asked -- the check returns early on an empty target list
+     * anyway.
+     *
+     * @return list<class-string>
+     */
+    private function knownEventClasses(): array
+    {
+        if ($this->specificListenerTargets() === []) {
+            return [];
+        }
+
+        return [
+            ...(new EventCatalog())->eventClasses(),
+            ...$this->getFacade()->findProjectEventClasses(),
+        ];
     }
 
     /**

--- a/src/Framework/AbstractFactory.php
+++ b/src/Framework/AbstractFactory.php
@@ -9,6 +9,8 @@ use Gacela\Framework\ClassResolver\Provider\ProviderNotFoundException;
 use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
 use Gacela\Framework\Config\Config;
 use Gacela\Framework\Container\Container;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
 use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
 use Gacela\Framework\Exception\PluginStackException;
@@ -174,6 +176,7 @@ abstract class AbstractFactory
     private function createContainerWithProvidedDependencies(): Container
     {
         $container = $this->appContainer()->createScope();
+        $this->provideEventDispatcher($container);
         $this->scheduleAppWideExtensions($container);
 
         $resolver = (new ProviderResolver())->resolve($this);
@@ -198,6 +201,42 @@ abstract class AbstractFactory
         self::$providerless[static::class] = $resolver === null;
 
         return $container;
+    }
+
+    /**
+     * The event dispatcher, in the one place a module reads its dependencies
+     * from.
+     *
+     * This is what makes a project's own events ordinary: a Factory writes
+     * `getProvidedDependency(EventDispatcherInterface::class)` and dispatches
+     * through the same object the framework does -- no trait, no static
+     * provider, and no second event system beside Gacela's.
+     *
+     * On the module scope rather than on the application container, because the
+     * scope is where *provided dependencies* live. The application container is
+     * what `debug:container` and `validate:config` report, and it should
+     * describe the application: a framework service registered there would
+     * appear in every project's binding report, and would stop `debug:container`
+     * from ever saying "Container is empty" -- which is a diagnostic, and would
+     * be answering about Gacela rather than about the reader's wiring.
+     *
+     * Skipped when anything already provides the id, so an application that
+     * binds its own dispatcher app-wide keeps it; registered before the module's
+     * Provider runs, so a Provider registering one for its own module wins too.
+     * Resolved through {@see EventDispatcherProvider} on every `get()` rather
+     * than captured here, so a scope built early never hands out a dispatcher
+     * the setup has since replaced.
+     */
+    private function provideEventDispatcher(Container $scope): void
+    {
+        if ($scope->provides(EventDispatcherInterface::class)) {
+            return;
+        }
+
+        $scope->set(
+            EventDispatcherInterface::class,
+            $scope->factory(static fn (): EventDispatcherInterface => EventDispatcherProvider::get()),
+        );
     }
 
     /**

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -17,10 +17,12 @@ use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Dto\Schema\DtoType;
 use Gacela\Framework\Dto\Schema\MalformedDtoSchemaException;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\PsrEventDispatcherAdapter;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Health\HealthCheckRegistry;
 use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use InvalidArgumentException;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 
 use function array_key_exists;
 use function is_array;
@@ -531,9 +533,20 @@ final class GacelaConfig
     }
 
     /**
-     * Replace the dispatcher entirely -- to bridge Gacela's events onto a PSR-14
-     * bus, or to answer `hasListeners()` yourself so the framework skips
-     * allocating the events you do not want.
+     * Replace the dispatcher entirely -- to route Gacela's events onto the bus
+     * the application already has, or to answer `hasListeners()` yourself so
+     * the framework skips allocating the events you do not want.
+     *
+     * Either interface is accepted:
+     *
+     * - Gacela's `EventDispatcherInterface`, which also answers `hasListeners()`
+     *   and so decides for itself which events are worth allocating;
+     * - any `Psr\EventDispatcher\EventDispatcherInterface` -- Symfony's,
+     *   Laravel's, whatever a host framework installed -- which is wrapped in
+     *   {@see \Gacela\Framework\Event\Dispatcher\PsrEventDispatcherAdapter}.
+     *   PSR-14 cannot be asked what it listens to, so that adapter answers
+     *   `hasListeners()` with true and every dispatch site allocates its event;
+     *   the price is paid only by an application that installed a bus.
      *
      * `SetupGacela::setEventDispatcher()` has always accepted one; this is the
      * way to reach it from `Gacela::bootstrap()`, whose closure is handed a
@@ -544,9 +557,9 @@ final class GacelaConfig
      * application that hands over a dispatcher is the thing deciding what runs,
      * so decline in `hasListeners()` rather than reaching for the switch.
      */
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
+    public function setEventDispatcher(EventDispatcherInterface|PsrEventDispatcherInterface $eventDispatcher): self
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = PsrEventDispatcherAdapter::wrap($eventDispatcher);
 
         return $this;
     }

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -20,8 +20,9 @@ use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Dto\Schema\DtoType;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
+use Gacela\Framework\Event\Dispatcher\PsrEventDispatcherAdapter;
 use Override;
-
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use RuntimeException;
 
 use function is_callable;
@@ -609,11 +610,18 @@ final class SetupGacela extends AbstractSetupGacela
      * application made. With any listener registered, the two are composed --
      * see {@see \Gacela\Framework\Event\Dispatcher\CompositeEventDispatcher}.
      *
+     * A `Psr\EventDispatcher\EventDispatcherInterface` is accepted too and
+     * wrapped in {@see \Gacela\Framework\Event\Dispatcher\PsrEventDispatcherAdapter},
+     * so a host framework's own bus can be handed over as it is. Everything
+     * downstream of this line sees one interface.
+     *
      * Takes precedence over `disableEventListeners()`: that switch governs the
      * dispatcher Gacela would *build*, and this is one it does not build.
      */
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
+    public function setEventDispatcher(EventDispatcherInterface|PsrEventDispatcherInterface $eventDispatcher): self
     {
+        $eventDispatcher = PsrEventDispatcherAdapter::wrap($eventDispatcher);
+
         if ($eventDispatcher === $this->properties->eventDispatcher) {
             // Handing back the dispatcher Gacela derived for this very setup is
             // not a handover. Recording it would compose it with the listeners

--- a/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
+++ b/src/Framework/Event/Dispatcher/EventDispatchingCapabilities.php
@@ -6,6 +6,20 @@ namespace Gacela\Framework\Event\Dispatcher;
 
 use Gacela\Framework\Event\GacelaEventInterface;
 
+/**
+ * How the *framework* dispatches: a static reach into
+ * {@see EventDispatcherProvider}, because the classes below the resolver have
+ * nowhere to inject a dependency from -- they are what the injection is built
+ * out of.
+ *
+ * @internal An application dispatches its own events through the dispatcher
+ *   instead, injected like any other dependency:
+ *   `getProvidedDependency(EventDispatcherInterface::class)`. That is the
+ *   documented seam (`docs/events.md`, "Your own events"), it is testable
+ *   without global state, and it is the one this trait is deliberately not.
+ *   Both `use` sites and both methods are private to the framework and may
+ *   change with any release.
+ */
 trait EventDispatchingCapabilities
 {
     /**

--- a/src/Framework/Event/Dispatcher/Psr14EventDispatcher.php
+++ b/src/Framework/Event/Dispatcher/Psr14EventDispatcher.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Dispatcher;
+
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+
+/**
+ * Gacela's dispatcher, seen as a PSR-14 one.
+ *
+ * The direction {@see PsrEventDispatcherAdapter} does not cover: a library that
+ * type-hints `Psr\EventDispatcher\EventDispatcherInterface` can be handed the
+ * dispatcher this application configured, listeners and all.
+ *
+ * ```php
+ * $psr = new Psr14EventDispatcher(Config::getInstance()->getSetupGacela()->getEventDispatcher());
+ * $library = new SomeLibrary($psr);
+ * ```
+ *
+ * `ConfigurableEventDispatcher` deliberately does not implement PSR-14 itself.
+ * Its `dispatch()` returns `void`, which satisfies the *signature* -- PSR-14
+ * declares no return type -- while breaking the *contract*, which says the
+ * event comes back. A class that is a PSR-14 dispatcher in name and returns
+ * nothing is worse than one that is honestly not a PSR-14 dispatcher, so the
+ * conversion is explicit and lives here.
+ */
+final class Psr14EventDispatcher implements PsrEventDispatcherInterface
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    /**
+     * Returns the event it was given, as PSR-14 requires. It is the same
+     * object: Gacela's events are immutable and its listeners are notify-only,
+     * so there is nothing for a listener to have replaced.
+     *
+     * Two conditions keep it from being dispatched at all:
+     *
+     * - `hasListeners()` says no. That is the promise `docs/events.md` makes
+     *   about a dispatcher an application supplied -- declining a class is how
+     *   it goes quiet -- and it holds whoever is doing the dispatching.
+     * - PSR-14 says a dispatcher handed an already-stopped event must return
+     *   immediately. Propagation cannot be stopped *between* Gacela's own
+     *   listeners, which are notify-only; honouring an event that arrives
+     *   stopped is the part that costs nothing and is simply correct.
+     */
+    public function dispatch(object $event): object
+    {
+        if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
+            return $event;
+        }
+
+        if ($this->dispatcher->hasListeners($event::class)) {
+            $this->dispatcher->dispatch($event);
+        }
+
+        return $event;
+    }
+}

--- a/src/Framework/Event/Dispatcher/PsrEventDispatcherAdapter.php
+++ b/src/Framework/Event/Dispatcher/PsrEventDispatcherAdapter.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Dispatcher;
+
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+
+/**
+ * A PSR-14 dispatcher, seen as a Gacela one.
+ *
+ * This is what lets `setEventDispatcher()` accept the bus a host application
+ * already has -- Symfony's, Laravel's, or any other PSR-14 implementation --
+ * without the application writing an adapter of its own: the parameter accepts
+ * either interface and wraps a PSR-14 dispatcher in this.
+ *
+ * The two interfaces are kept apart rather than merged. PSR-14's
+ * `dispatch(object $event)` declares no return type and its contract says the
+ * event comes back; Gacela's declares `: void`. A single class can satisfy both
+ * signatures, and would still be a broken PSR-14 implementation -- returning
+ * nothing where callers are told to expect their event. Widening Gacela's
+ * interface to `: object` instead would break every custom dispatcher already
+ * written against it. So each side keeps its own contract and this carries
+ * events across. {@see Psr14EventDispatcher} goes the other way.
+ *
+ * ## What `hasListeners()` answers, and why
+ *
+ * True, always.
+ *
+ * PSR-14 offers no way to ask what is subscribed -- a bus is precisely the
+ * component that knows its listeners while its callers do not.
+ * `ListenerProviderInterface` cannot help either: it resolves listeners from an
+ * event *instance*, and the guard's whole purpose is to answer before one is
+ * allocated.
+ *
+ * That leaves two possible answers. `false` would make every guarded dispatch
+ * site skip, so a dispatcher the application deliberately handed over would
+ * receive nothing at all, and nothing would say so -- the failure #888 was, one
+ * level down. `true` costs one event allocation per dispatch site that fires,
+ * which is the ordinary price of listening to events, and it is paid only by an
+ * application that installed a bus. An application that supplies no dispatcher
+ * never constructs this class, so the hot-path guard stays the single array
+ * lookup it has always been (`EventDispatchBench` is unmoved).
+ *
+ * An application that wants a narrower answer than "everything" has it already:
+ * implement Gacela's `EventDispatcherInterface` directly and say so in
+ * `hasListeners()`. That is the seam `docs/events.md` documents, and this
+ * adapter is the convenience for everyone who does not need it.
+ */
+final class PsrEventDispatcherAdapter implements EventDispatcherInterface
+{
+    public function __construct(
+        private readonly PsrEventDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    /**
+     * The dispatcher an application supplied, as a Gacela one: its own if it
+     * wrote one against Gacela's interface, this adapter around it if it handed
+     * over a PSR-14 bus.
+     *
+     * A class carrying both interfaces is taken as the Gacela one. `void`
+     * satisfies PSR-14's untyped `dispatch()`, so writing both is possible, and
+     * Gacela's is the richer of the two -- it answers `hasListeners()` for
+     * itself, which is exactly what wrapping would throw away.
+     */
+    public static function wrap(EventDispatcherInterface|PsrEventDispatcherInterface $dispatcher): EventDispatcherInterface
+    {
+        return $dispatcher instanceof EventDispatcherInterface
+            ? $dispatcher
+            : new self($dispatcher);
+    }
+
+    /**
+     * True for every class -- see the class docblock for what PSR-14 makes
+     * knowable and what it does not.
+     */
+    public function hasListeners(string $eventClass): bool
+    {
+        return true;
+    }
+
+    /**
+     * PSR-14 hands back the event, possibly a different object; Gacela's
+     * interface returns nothing, so the value is dropped here rather than
+     * surfacing where no caller could use it.
+     */
+    public function dispatch(object $event): void
+    {
+        $this->dispatcher->dispatch($event);
+    }
+}

--- a/src/Framework/Preload/Preloader.php
+++ b/src/Framework/Preload/Preloader.php
@@ -44,8 +44,8 @@ use function trait_exists;
  * Composer's autoloader is deliberately not the one used: it runs every
  * installed package's `files` entries, and the preload context forbids the I/O
  * some of them do at load time -- one `fopen('php://stdout')` in a stream
- * library aborts the entire preload. Gacela's runtime closure is three
- * packages, so those prefixes are named below instead.
+ * library aborts the entire preload. Gacela's runtime closure is a handful of
+ * packages, so those prefixes are named in {@see autoloadPrefixes()} instead.
  */
 final class Preloader
 {
@@ -140,6 +140,11 @@ final class Preloader
 
         $prefixes['Gacela\\Container\\'] = $vendorDir . '/gacela-project/container/src/Container/';
         $prefixes['Psr\\Container\\'] = $vendorDir . '/psr/container/src/';
+        // Named for the same reason as the two above: `Psr14EventDispatcher`
+        // implements an interface from here, and a class whose interface is
+        // missing is dropped from the image with a startup warning rather than
+        // linked.
+        $prefixes['Psr\\EventDispatcher\\'] = $vendorDir . '/psr/event-dispatcher/src/';
 
         return $prefixes;
     }

--- a/src/Framework/Testing/GacelaTestCase.php
+++ b/src/Framework/Testing/GacelaTestCase.php
@@ -21,7 +21,6 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function array_filter;
-use function array_keys;
 use function array_map;
 use function array_values;
 use function class_exists;
@@ -535,9 +534,11 @@ abstract class GacelaTestCase extends TestCase
         $classes = [];
 
         foreach ($this->recordedGacelaEvents as $event) {
-            $classes[$event::class] = true;
+            // Keyed by the name and holding it: the key is what makes the list
+            // distinct, the value is what gets printed.
+            $classes[$event::class] = $event::class;
         }
 
-        return $classes === [] ? 'nothing' : implode(', ', array_keys($classes));
+        return $classes === [] ? 'nothing' : implode(', ', $classes);
     }
 }

--- a/src/Framework/Testing/GacelaTestCase.php
+++ b/src/Framework/Testing/GacelaTestCase.php
@@ -21,10 +21,12 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function array_filter;
+use function array_keys;
 use function array_map;
 use function array_values;
 use function class_exists;
 use function dirname;
+use function implode;
 use function interface_exists;
 use function is_object;
 use function is_string;
@@ -210,6 +212,40 @@ abstract class GacelaTestCase extends TestCase
         return array_values(array_filter(
             $this->recordedGacelaEvents,
             static fn (GacelaEventInterface $event): bool => $event instanceof $eventClass,
+        ));
+    }
+
+    /**
+     * Assert that an event of the given class was dispatched since the last
+     * bootstrap.
+     *
+     * Works for the events the application dispatches as readily as for the
+     * framework's own: `bootstrapGacela()` registers a generic listener, and a
+     * project event goes through the same dispatcher.
+     *
+     * ```php
+     * $this->bootstrapGacela(__DIR__);
+     *
+     * (new BillingFacade())->issueInvoice('acme', 10_000);
+     *
+     * $this->assertEventDispatched(InvoiceIssuedEvent::class);
+     * ```
+     *
+     * Matched by inheritance, the way `registerSpecificListener()` matches, so
+     * naming a parent class or an interface asserts about the whole family
+     * below it. To assert on a payload, read the events instead:
+     * {@see recordedGacelaEventsOf()} returns them typed and in dispatch order.
+     *
+     * @param class-string<GacelaEventInterface> $eventClass
+     */
+    protected function assertEventDispatched(string $eventClass): void
+    {
+        $this->assertGacelaEventsAreBeingRecorded();
+
+        self::assertNotSame([], $this->recordedGacelaEventsOf($eventClass), sprintf(
+            'No "%s" was dispatched. Dispatched: %s.',
+            $eventClass,
+            $this->dispatchedClassList(),
         ));
     }
 
@@ -483,5 +519,25 @@ abstract class GacelaTestCase extends TestCase
             MESSAGE;
 
         self::assertNotSame([], $this->recordedGacelaEvents, $message);
+    }
+
+    /**
+     * The distinct event classes recorded, in dispatch order.
+     *
+     * Named in the failure message because the useful answer to "my event was
+     * not dispatched" is usually another event that was -- a listener wired to
+     * the wrong class, or a flow that stopped earlier than the test assumed.
+     * Distinct, because the resolver events alone would otherwise fill the
+     * message hundreds of lines deep.
+     */
+    private function dispatchedClassList(): string
+    {
+        $classes = [];
+
+        foreach ($this->recordedGacelaEvents as $event) {
+            $classes[$event::class] = true;
+        }
+
+        return $classes === [] ? 'nothing' : implode(', ', array_keys($classes));
     }
 }

--- a/tests/Feature/Console/DebugEvents/DebugEventsCommandTest.php
+++ b/tests/Feature/Console/DebugEvents/DebugEventsCommandTest.php
@@ -125,7 +125,7 @@ final class DebugEventsCommandTest extends TestCase
         $tester = $this->runCommand(['filter' => 'NoSuchEvent']);
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        self::assertStringContainsString('No Gacela event contains "NoSuchEvent"', $tester->getDisplay());
+        self::assertStringContainsString('No event contains "NoSuchEvent"', $tester->getDisplay());
     }
 
     public function test_listened_with_nothing_registered_says_so(): void
@@ -134,7 +134,7 @@ final class DebugEventsCommandTest extends TestCase
 
         $display = $this->runCommand(['--listened' => true])->getDisplay();
 
-        self::assertStringContainsString('Nothing listens to any Gacela event.', $display);
+        self::assertStringContainsString("Nothing listens to any event, Gacela's or this project's.", $display);
     }
 
     /**

--- a/tests/Feature/Console/DebugEvents/DebugEventsCommandTest.php
+++ b/tests/Feature/Console/DebugEvents/DebugEventsCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Console\DebugEvents;
 
 use Gacela\Console\Application\Debug\EventCatalog;
+use Gacela\Console\ConsoleFacade;
 use Gacela\Console\Infrastructure\Command\DebugEventsCommand;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Event\ClassResolver\AbstractGacelaClassResolverEvent;
@@ -13,6 +14,7 @@ use Gacela\Framework\Event\Config\ConfigKeyReadEvent;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
 use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Console\DebugEvents\Fixture\StockRunLowEvent;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -249,9 +251,98 @@ final class DebugEventsCommandTest extends TestCase
         );
     }
 
+    /**
+     * The half of the report that used to be missing: an event the application
+     * declared. Listed under its own namespace and marked `project`, so a
+     * reader can tell what Gacela found from what Gacela ships -- and, when a
+     * class of theirs is absent, that no listener registration against it can
+     * be checked.
+     */
+    public function test_a_project_event_is_listed_and_marked_as_the_projects(): void
+    {
+        $this->bootstrapWithoutListeners();
+
+        $display = $this->runCommand([])->getDisplay();
+
+        self::assertStringContainsString('StockRunLowEvent', $display);
+        self::assertStringContainsString('project', $display);
+        // Grouped by its own namespace, written out in full: there is no
+        // framework root to make it relative to.
+        self::assertStringContainsString('GacelaTest\Feature\Console\DebugEvents\Fixture', $display);
+        self::assertStringContainsString('1 declared by this project', $display);
+    }
+
+    public function test_the_project_marker_is_absent_when_only_the_frameworks_events_are_shown(): void
+    {
+        $this->bootstrapWithoutListeners();
+
+        $display = $this->runCommand(['filter' => 'ClassResolver'])->getDisplay();
+
+        self::assertStringNotContainsString('StockRunLowEvent', $display);
+        // The summary still counts the whole catalog, so the project line stays.
+        self::assertStringContainsString('1 declared by this project', $display);
+    }
+
+    /**
+     * The doctor's counterpart to this: a listener on a project event is a
+     * listener like any other, and the table has to say so or `debug:events`
+     * cannot answer "is my listener registered" for the events a project cares
+     * about most.
+     */
+    public function test_a_listener_on_a_project_event_is_reported(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+            $config->registerSpecificListener(StockRunLowEvent::class, static function (): void {});
+        });
+
+        $display = $this->runCommand(['--listened' => true])->getDisplay();
+
+        self::assertStringContainsString('StockRunLowEvent', $display);
+        self::assertStringContainsString('1 listener via StockRunLowEvent', $display);
+        self::assertStringContainsString('1 with listeners', $display);
+    }
+
+    public function test_the_json_names_the_source_of_every_event(): void
+    {
+        $this->bootstrapWithoutListeners();
+
+        $document = $this->runAsJson([]);
+
+        self::assertSame('project', $this->eventNamed($document, StockRunLowEvent::class)['source']);
+        self::assertSame('framework', $this->eventNamed($document, ResolvedClassCachedEvent::class)['source']);
+        self::assertSame(1, $document['summary']['projectEvents']);
+    }
+
+    /**
+     * Framework first, then the project's -- two runs rather than one
+     * interleaved list, so "my events" is a place in the output and not a
+     * search.
+     */
+    public function test_the_frameworks_events_are_listed_before_the_projects(): void
+    {
+        $this->bootstrapWithoutListeners();
+
+        /** @var list<array<string, mixed>> $events */
+        $events = $this->runAsJson([])['events'];
+        $sources = [];
+
+        foreach ($events as $event) {
+            $sources[] = $event['source'];
+        }
+
+        self::assertSame('framework', $sources[0]);
+        self::assertSame('project', $sources[count($sources) - 1]);
+    }
+
+    /**
+     * Everything the command lists: the framework's catalog and the events of
+     * the fixture application it is pointed at.
+     */
     private function catalogSize(): int
     {
-        return count((new EventCatalog())->eventClasses());
+        return count((new EventCatalog())->eventClasses())
+            + count((new ConsoleFacade())->findProjectEventClasses());
     }
 
     private function bootstrapWithoutListeners(): void

--- a/tests/Feature/Console/DebugEvents/Fixture/StockRunLowEvent.php
+++ b/tests/Feature/Console/DebugEvents/Fixture/StockRunLowEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Console\DebugEvents\Fixture;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * An event of the "application" this command is run against: the fixture
+ * directory beside this test is its app root, so `debug:events` finds this the
+ * way it finds a project's own.
+ */
+final class StockRunLowEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $sku,
+    ) {
+    }
+
+    public function sku(): string
+    {
+        return $this->sku;
+    }
+
+    public function toString(): string
+    {
+        return sprintf('Stock run low: %s', $this->sku);
+    }
+}

--- a/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
+++ b/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
@@ -249,6 +249,10 @@ final class GacelaTestCaseTest extends GacelaTestCase
         );
 
         self::assertStringContainsString(Module\GreetedEvent::class, $message);
+        // And what did arrive, which is usually where the answer is: a listener
+        // wired to the wrong class, or a flow that stopped earlier than the
+        // test assumed.
+        self::assertStringContainsString(GacelaBootstrapFinishedEvent::class, $message);
         self::assertStringNotContainsString('No Gacela events were recorded', $message);
     }
 

--- a/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
+++ b/tests/Feature/Framework/Testing/GacelaTestCaseTest.php
@@ -6,7 +6,9 @@ namespace GacelaTest\Feature\Framework\Testing;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Config\Config;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
 use Gacela\Framework\Event\Container\BindingRegisteredEvent;
+use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Exception\GacelaNotBootstrappedException;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Testing\GacelaTestCase;
@@ -201,6 +203,84 @@ final class GacelaTestCaseTest extends GacelaTestCase
         self::assertTrue($seen);
         self::assertSame('yes', Config::getInstance()->getString('from-closure'));
         self::assertNotSame([], $this->recordedGacelaEvents());
+    }
+
+    public function test_assert_event_dispatched_passes_for_a_framework_event(): void
+    {
+        $this->bootstrapGacela(__DIR__);
+
+        $this->assertEventDispatched(GacelaBootstrapFinishedEvent::class);
+    }
+
+    /**
+     * The point of the assertion: an event the *application* dispatched, through
+     * the dispatcher its module was given. Nothing about the recording is
+     * framework-specific, and a test of a project's own events should not have
+     * to build its own listener to see them.
+     */
+    public function test_assert_event_dispatched_passes_for_a_project_event(): void
+    {
+        $this->bootstrapGacela(__DIR__);
+
+        (new Module\Facade())->announce('Ada');
+
+        $this->assertEventDispatched(Module\GreetedEvent::class);
+    }
+
+    /**
+     * The same inheritance rule the dispatcher matches by, so an assertion can
+     * name a family: `GacelaEventInterface::class` is every event there is.
+     */
+    public function test_assert_event_dispatched_matches_by_inheritance(): void
+    {
+        $this->bootstrapGacela(__DIR__);
+
+        (new Module\Facade())->announce('Ada');
+
+        $this->assertEventDispatched(GacelaEventInterface::class);
+    }
+
+    public function test_assert_event_dispatched_fails_naming_the_event_that_never_arrived(): void
+    {
+        $this->bootstrapGacela(__DIR__);
+
+        $message = $this->messageFromFailedAssertion(
+            fn (): mixed => $this->assertEventDispatched(Module\GreetedEvent::class),
+        );
+
+        self::assertStringContainsString(Module\GreetedEvent::class, $message);
+        self::assertStringNotContainsString('No Gacela events were recorded', $message);
+    }
+
+    /**
+     * Same guard as the other two assertions: a test that bootstrapped Gacela
+     * itself records nothing, and must be told that rather than that its event
+     * did not happen.
+     */
+    public function test_assert_event_dispatched_names_the_missing_recording_first(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->resetInMemoryCache();
+        });
+
+        $message = $this->messageFromFailedAssertion(
+            fn (): mixed => $this->assertEventDispatched(GacelaBootstrapFinishedEvent::class),
+        );
+
+        self::assertStringContainsString('No Gacela events were recorded', $message);
+        self::assertStringContainsString('bootstrapGacela', $message);
+    }
+
+    public function test_recorded_events_of_sees_a_project_event(): void
+    {
+        $this->bootstrapGacela(__DIR__);
+
+        (new Module\Facade())->announce('Grace');
+
+        $greeted = $this->recordedGacelaEventsOf(Module\GreetedEvent::class);
+
+        self::assertCount(1, $greeted);
+        self::assertSame('Grace', $greeted[0]->name());
     }
 
     /**

--- a/tests/Feature/Framework/Testing/Module/Facade.php
+++ b/tests/Feature/Framework/Testing/Module/Facade.php
@@ -15,4 +15,13 @@ final class Facade extends AbstractFacade
     {
         return $this->getFactory()->createGreeting();
     }
+
+    public function announce(string $name): void
+    {
+        $events = $this->getFactory()->getEventDispatcher();
+
+        if ($events->hasListeners(GreetedEvent::class)) {
+            $events->dispatch(new GreetedEvent($name));
+        }
+    }
 }

--- a/tests/Feature/Framework/Testing/Module/Factory.php
+++ b/tests/Feature/Framework/Testing/Module/Factory.php
@@ -5,11 +5,21 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\Framework\Testing\Module;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 
 final class Factory extends AbstractFactory
 {
     public function createGreeting(): string
     {
         return (string)$this->getProvidedDependency(Provider::GREETING);
+    }
+
+    /**
+     * The dispatcher as a provided dependency, which is how an application
+     * dispatches its own events.
+     */
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->getProvidedDependency(EventDispatcherInterface::class);
     }
 }

--- a/tests/Feature/Framework/Testing/Module/GreetedEvent.php
+++ b/tests/Feature/Framework/Testing/Module/GreetedEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\Testing\Module;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * An event of the application under test, dispatched through the dispatcher the
+ * module was given -- which is what the recording assertions have to see as
+ * readily as they see the framework's own.
+ */
+final class GreetedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $name,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function toString(): string
+    {
+        return sprintf('Greeted: %s', $this->name);
+    }
+}

--- a/tests/Feature/ReferenceApp/Invoicing/Billing/BillingFactory.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Billing/BillingFactory.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\ReferenceApp\Invoicing\Billing;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Plugins\PluginStack;
-use Gacela\Framework\ServiceResolver\ServiceMap;
-use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\CountryRegistry;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\InvoiceIssuer;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\InvoiceNumbering;
@@ -15,26 +14,23 @@ use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\InvoiceRepository;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Tax\TaxCalculatorInterface;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Validation\InvoiceValidatorInterface;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
-use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Shared\Clock\ClockInterface;
 
 /**
- * Two ways of reaching another module sit side by side here on purpose.
+ * Two ways of depending on something else sit side by side here on purpose.
  *
  * The Customer facade comes through the Provider, because Billing depends on
  * customers for its whole reason to exist and that dependency is worth writing
- * down. The Notification facade comes through `#[ServiceMap]`, which is the
- * shorter path for the one call that only announces what already happened --
- * declared as an attribute rather than a `@method` docblock, so a rename moves
- * it and `migrate:service-map` has nothing left to report.
+ * down. The event dispatcher comes through the Provider as well -- it is a
+ * dependency like any other, which is the whole point of the arrangement: no
+ * trait, no static call, and a test can hand this Factory a dispatcher of its
+ * own. What Billing announces through it reaches whoever `gacela.php` says, and
+ * this module never learns who that is.
  *
  * @extends AbstractFactory<BillingConfig>
  */
-#[ServiceMap(method: 'getNotificationFacade', className: NotificationFacade::class)]
 final class BillingFactory extends AbstractFactory
 {
-    use ServiceResolverAwareTrait;
-
     public function __construct(
         private readonly ClockInterface $clock,
     ) {
@@ -42,9 +38,6 @@ final class BillingFactory extends AbstractFactory
 
     public function createInvoiceIssuer(): InvoiceIssuer
     {
-        /** @var NotificationFacade $notifications */
-        $notifications = $this->getNotificationFacade();
-
         return new InvoiceIssuer(
             $this->getInvoiceRepository(),
             $this->getInvoiceNumbering(),
@@ -52,11 +45,21 @@ final class BillingFactory extends AbstractFactory
             $this->getValidators(),
             $this->getCountryRegistry(),
             $this->getCustomerFacade(),
-            $notifications,
+            $this->getEventDispatcher(),
             $this->clock,
             $this->getNumberPrefix(),
             $this->getConfig()->currency(),
         );
+    }
+
+    /**
+     * The dispatcher the application is running with, asked for by its
+     * interface. Whatever `setEventDispatcher()` installed is what arrives
+     * here -- including a host framework's own PSR-14 bus.
+     */
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->getProvidedDependency(EventDispatcherInterface::class);
     }
 
     public function getInvoiceRepository(): InvoiceRepository

--- a/tests/Feature/ReferenceApp/Invoicing/Billing/Domain/InvoiceIssuer.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Billing/Domain/InvoiceIssuer.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain;
 
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Plugins\PluginStack;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Tax\TaxCalculatorInterface;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Validation\InvoiceValidatorInterface;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
-use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Shared\Clock\ClockInterface;
 use InvalidArgumentException;
 
@@ -17,9 +18,16 @@ use function sprintf;
 /**
  * The one place an invoice comes into existence.
  *
- * Two other modules are reached from here, and both through their Facade: the
- * customer directory to learn where the customer is, and notifications to say
- * the invoice exists. Nothing else of theirs is named.
+ * One other module is reached from here, through its Facade: the customer
+ * directory, to learn where the customer is. Billing depends on customers for
+ * its whole reason to exist, and that dependency is written down.
+ *
+ * Saying that the invoice exists is a different kind of thing, and it is done a
+ * different way: an event, dispatched through the dispatcher this class was
+ * given. Notification sends the mail and Reporting could update a projection
+ * without either of them appearing here -- which is what lets the announcement
+ * gain a second listener without this file changing, and what keeps `debug:graph`
+ * from ever drawing an edge from Billing to whoever is listening.
  */
 final class InvoiceIssuer
 {
@@ -34,7 +42,7 @@ final class InvoiceIssuer
         private readonly array $validators,
         private readonly CountryRegistry $countries,
         private readonly CustomerFacade $customers,
-        private readonly NotificationFacade $notifications,
+        private readonly EventDispatcherInterface $events,
         private readonly ClockInterface $clock,
         private readonly string $numberPrefix,
         private readonly string $currency,
@@ -62,12 +70,7 @@ final class InvoiceIssuer
         ]);
 
         $this->invoices->save($invoice);
-
-        $this->notifications->notifyInvoiceIssued(
-            $profile->getName(),
-            $number,
-            sprintf('%d %s due', $invoice->getGrossCents(), $this->currency),
-        );
+        $this->announce($invoice, $profile->getName());
 
         return $invoice;
     }
@@ -84,6 +87,26 @@ final class InvoiceIssuer
         }
 
         return $names;
+    }
+
+    /**
+     * Guarded like every dispatch site in the framework, and for the same
+     * reason: with nothing listening, the event is never built. An application
+     * that removes the listener from `gacela.php` pays nothing for the line
+     * below staying here.
+     */
+    private function announce(InvoiceRecord $invoice, string $customerName): void
+    {
+        if (!$this->events->hasListeners(InvoiceIssuedEvent::class)) {
+            return;
+        }
+
+        $this->events->dispatch(new InvoiceIssuedEvent(
+            $invoice->getNumber(),
+            $customerName,
+            $invoice->getGrossCents(),
+            $this->currency,
+        ));
     }
 
     private function refuseUnlessValid(string $customerReference, int $netCents): void

--- a/tests/Feature/ReferenceApp/Invoicing/Billing/Event/InvoiceIssuedEvent.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Billing/Event/InvoiceIssuedEvent.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * An invoice exists. Whoever cares about that is not Billing's business.
+ *
+ * This is the module's outward announcement, and the reason Billing names no
+ * other module in order to make it: it dispatches through the event dispatcher
+ * it was given, and `gacela.php` -- the composition root, the one place that is
+ * allowed to know both sides -- decides who hears it.
+ *
+ * In `Billing\Event`, which is one of the sub-namespaces a module publishes by
+ * convention, so a subscriber may name this class where it may not name
+ * anything under `Billing\Domain`. The direction of that permission is the
+ * point: a subscriber knows the event it subscribes to, and the publisher knows
+ * nobody.
+ *
+ * Immutable and self-describing, like every Gacela event: the listener gets
+ * facts, not a handle onto Billing.
+ */
+final class InvoiceIssuedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $invoiceNumber,
+        private readonly string $customerName,
+        private readonly int $grossCents,
+        private readonly string $currency,
+    ) {
+    }
+
+    public function invoiceNumber(): string
+    {
+        return $this->invoiceNumber;
+    }
+
+    public function customerName(): string
+    {
+        return $this->customerName;
+    }
+
+    public function grossCents(): int
+    {
+        return $this->grossCents;
+    }
+
+    public function currency(): string
+    {
+        return $this->currency;
+    }
+
+    /**
+     * What is owed, as a line a human can read.
+     *
+     * Written here rather than by the listener: the amount and the currency are
+     * Billing's facts, and a subscriber deciding how to phrase them would have
+     * to know that `grossCents` is minor units -- which is the kind of thing a
+     * module learns about another module and then depends on.
+     */
+    public function amountDue(): string
+    {
+        return sprintf('%d %s due', $this->grossCents, $this->currency);
+    }
+
+    public function toString(): string
+    {
+        return sprintf('Invoice %s issued: %s', $this->invoiceNumber, $this->amountDue());
+    }
+}

--- a/tests/Feature/ReferenceApp/Invoicing/Notification/NotificationFacade.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Notification/NotificationFacade.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\ReferenceApp\Invoicing\Notification;
 
 use Gacela\Framework\AbstractFacade;
-use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\NotificationMessage;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 
 /**
  * Not `final`, unlike every other class here: this is the one seam a caller is
@@ -22,12 +22,23 @@ use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\NotificationMe
 class NotificationFacade extends AbstractFacade
 {
     /**
+     * This module's reaction to an invoice being issued.
+     *
+     * The subscriber names the event; the publisher names nobody. Billing
+     * dispatches `InvoiceIssuedEvent` and has no idea this method exists --
+     * `gacela.php` is where the two are wired together, and a second reaction to
+     * the same event changes nothing in Billing.
+     *
+     * Reading the event is the Factory's job, like every other translation into
+     * this module's own shapes: a Facade only delegates, which the shipped
+     * `gacela.facadeOnlyDelegates` rule holds this application to.
+     *
      * @return list<string> one delivery receipt per channel
      */
-    public function notifyInvoiceIssued(string $recipient, string $invoiceNumber, string $body): array
+    public function onInvoiceIssued(InvoiceIssuedEvent $event): array
     {
         return $this->getFactory()->createDispatcher()->dispatch(
-            new NotificationMessage($recipient, $this->getFactory()->subjectFor($invoiceNumber), $body),
+            $this->getFactory()->messageForInvoiceIssued($event),
         );
     }
 

--- a/tests/Feature/ReferenceApp/Invoicing/Notification/NotificationFactory.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Notification/NotificationFactory.php
@@ -6,9 +6,11 @@ namespace GacelaTest\Feature\ReferenceApp\Invoicing\Notification;
 
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Plugins\PluginStack;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\Channel\NotificationChannelInterface;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\DeliveryLog;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\NotificationDispatcher;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\NotificationMessage;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Shared\Resilience\RetryPolicyInterface;
 
 /**
@@ -51,6 +53,23 @@ final class NotificationFactory extends AbstractFactory
     public function subjectFor(string $invoiceNumber): string
     {
         return $this->getConfig()->subjectPrefix() . ' ' . $invoiceNumber;
+    }
+
+    /**
+     * Billing's event, as this module's own message.
+     *
+     * The one place the two vocabularies meet, and it belongs here: the subject
+     * is Notification's (its prefix is this module's configuration), while the
+     * recipient and the amount are facts the event carried. Nothing else in the
+     * module knows an event was involved.
+     */
+    public function messageForInvoiceIssued(InvoiceIssuedEvent $event): NotificationMessage
+    {
+        return new NotificationMessage(
+            $event->customerName(),
+            $this->subjectFor($event->invoiceNumber()),
+            $event->amountDue(),
+        );
     }
 
     /**

--- a/tests/Feature/ReferenceApp/Invoicing/Reporting/ReportingFactory.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Reporting/ReportingFactory.php
@@ -5,20 +5,37 @@ declare(strict_types=1);
 namespace GacelaTest\Feature\ReferenceApp\Invoicing\Reporting;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Reporting\Domain\RevenueReportCalculator;
 
 /**
+ * Two ways of reaching another module sit side by side here on purpose.
+ *
+ * The Billing facade comes through the Provider, because the ledger is what a
+ * revenue report is *of* and that dependency is worth writing down. The
+ * Customer facade comes through `#[ServiceMap]`, which is the shorter path for
+ * the one call that turns a reference into a name -- declared as an attribute
+ * rather than a `@method` docblock, so a rename moves it and
+ * `migrate:service-map` has nothing left to report.
+ *
  * @extends AbstractFactory<ReportingConfig>
  */
+#[ServiceMap(method: 'getCustomerFacade', className: CustomerFacade::class)]
 final class ReportingFactory extends AbstractFactory
 {
+    use ServiceResolverAwareTrait;
+
     public function createRevenueReportCalculator(): RevenueReportCalculator
     {
+        /** @var CustomerFacade $customers */
+        $customers = $this->getCustomerFacade();
+
         return new RevenueReportCalculator(
             $this->getBillingFacade(),
-            $this->getCustomerFacade(),
+            $customers,
         );
     }
 
@@ -31,14 +48,6 @@ final class ReportingFactory extends AbstractFactory
     {
         /** @var BillingFacade $facade */
         $facade = $this->getProvidedDependency(ReportingProvider::BILLING_FACADE);
-
-        return $facade;
-    }
-
-    private function getCustomerFacade(): CustomerFacade
-    {
-        /** @var CustomerFacade $facade */
-        $facade = $this->getProvidedDependency(ReportingProvider::CUSTOMER_FACADE);
 
         return $facade;
     }

--- a/tests/Feature/ReferenceApp/Invoicing/Reporting/ReportingProvider.php
+++ b/tests/Feature/ReferenceApp/Invoicing/Reporting/ReportingProvider.php
@@ -8,7 +8,6 @@ use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingFacade;
-use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
 
 /**
  * @extends AbstractProvider<ReportingConfig>
@@ -17,22 +16,17 @@ final class ReportingProvider extends AbstractProvider
 {
     public const BILLING_FACADE = 'REPORTING_BILLING_FACADE';
 
-    public const CUSTOMER_FACADE = 'REPORTING_CUSTOMER_FACADE';
-
+    /**
+     * The whole of Reporting's declared dependency: the ledger a revenue report
+     * is a read of. The customer names it also reads come through the
+     * `#[ServiceMap]` accessor on {@see ReportingFactory}, which is the shorter
+     * path for a lookup that decorates the report rather than making it.
+     */
     #[Provides(self::BILLING_FACADE)]
     public function billingFacade(Container $container): BillingFacade
     {
         /** @var BillingFacade $facade */
         $facade = $container->getLocator()->get(BillingFacade::class);
-
-        return $facade;
-    }
-
-    #[Provides(self::CUSTOMER_FACADE)]
-    public function customerFacade(Container $container): CustomerFacade
-    {
-        /** @var CustomerFacade $facade */
-        $facade = $container->getLocator()->get(CustomerFacade::class);
 
         return $facade;
     }

--- a/tests/Feature/ReferenceApp/Invoicing/gacela.php
+++ b/tests/Feature/ReferenceApp/Invoicing/gacela.php
@@ -7,6 +7,7 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Config\Schema\ConfigType;
 use Gacela\Framework\Dto\Schema\DtoType;
 use Gacela\Framework\Event\ClassResolver\AbstractGacelaClassResolverEvent;
+use Gacela\Framework\Gacela;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingProvider;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\CountryRegistry;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\InvoiceNumbering;
@@ -16,11 +17,13 @@ use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Tax\TaxCalculatorIn
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Tax\TaxRateTable;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Validation\NonEmptyReferenceValidator;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Domain\Validation\PositiveAmountValidator;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Health\LedgerHealthCheck;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\Domain\CustomerProfile;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\Channel\EmailChannel;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\Channel\NotificationChannelInterface;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Infrastructure\ResolverActivityLog;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationProvider;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Payment\AbstractGateway;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Payment\Domain\AttemptId;
@@ -273,6 +276,30 @@ return static function (GacelaConfig $config): void {
         // Nothing from this file is captured: the log is process-wide, like the
         // resolver it watches.
         static fn (AbstractGacelaClassResolverEvent $event) => ResolverActivityLog::record($event),
+    );
+
+    // ------------------------------------------------------------------
+    // What reacts to what
+    // ------------------------------------------------------------------
+
+    // Billing announces that an invoice exists; Notification sends the mail.
+    // This line is the only place both modules are named, which is what lets
+    // `Billing` be written without knowing `Notification` exists -- `debug:graph`
+    // draws no edge between them, and the analysers agree.
+    //
+    // A second reaction -- Reporting updating a projection, an audit log -- is
+    // another registration here and no change to Billing at all.
+    //
+    // Resolved through the locator rather than constructed: that is the path a
+    // module double travels, so a test that replaces the Notification module
+    // replaces the thing this listener reaches.
+    $config->registerSpecificListener(
+        InvoiceIssuedEvent::class,
+        static function (InvoiceIssuedEvent $event): void {
+            /** @var NotificationFacade $notifications */
+            $notifications = Gacela::getRequired(NotificationFacade::class);
+            $notifications->onInvoiceIssued($event);
+        },
     );
 
     $config->addHealthCheck(LedgerHealthCheck::class);

--- a/tests/Feature/ReferenceApp/InvoicingFlowTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingFlowTest.php
@@ -11,12 +11,14 @@ use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Gacela;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingFacade;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Infrastructure\ResolverActivityLog;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Payment\PaymentApi;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Reporting\ReportingFacade;
 use GacelaTest\Feature\ReferenceApp\Support\RecordingEventDispatcher;
+use GacelaTest\Feature\ReferenceApp\Support\RecordingPsr14Bus;
 use GacelaTest\Feature\ReferenceApp\Support\ReferenceApp;
 use GacelaTest\Feature\ReferenceApp\Support\SilentNotificationFacade;
 use InvalidArgumentException;
@@ -190,8 +192,12 @@ final class InvoicingFlowTest extends TestCase
     }
 
     /**
-     * Swapping a whole module out at the seam Gacela provides for it. Billing
-     * reaches notifications through `#[ServiceMap]` and is not told.
+     * Swapping a whole module out at the seam Gacela provides for it.
+     *
+     * Billing is not told, and this time it could not be: it dispatches an event
+     * and never names the module that reacts. What the override replaces is what
+     * the listener in `gacela.php` resolves -- which is why that listener asks
+     * the locator for the facade instead of constructing one.
      */
     public function test_a_stub_notification_facade_takes_the_place_of_the_real_one(): void
     {
@@ -204,6 +210,87 @@ final class InvoicingFlowTest extends TestCase
         (new BillingFacade())->issueInvoice('acme-nl', 10_000);
 
         self::assertSame(['ACME-INV-01001'], $silent->suppressed());
+    }
+
+    /**
+     * The module-to-module acceptance criterion, from the outside.
+     *
+     * `Billing` announces that an invoice exists and `Notification` sends the
+     * mail, with no import, no injected facade and no name of `Notification`
+     * anywhere in `Billing` -- see
+     * {@see InvoicingSliceTest::test_billing_depends_on_customer_and_nothing_else},
+     * which asserts that half against the module graph the analysers and
+     * `debug:graph --check --rules` read.
+     *
+     * A second listener on the same event is a line in `gacela.php` and no
+     * change to `Billing` at all, which is what the decoupling buys.
+     */
+    public function test_the_module_that_reacts_to_an_invoice_is_never_named_by_the_one_that_issues_it(): void
+    {
+        $heard = [];
+
+        ReferenceApp::bootstrap(static function (GacelaConfig $config) use (&$heard): void {
+            $config->registerSpecificListener(
+                InvoiceIssuedEvent::class,
+                static function (InvoiceIssuedEvent $event) use (&$heard): void {
+                    $heard[] = $event->toString();
+                },
+            );
+        });
+
+        (new CustomerFacade())->registerCustomer('acme-nl', 'Acme BV', 'NL');
+        (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        // The listener this test added, beside the one `gacela.php` registers:
+        // both ran, and neither is known to Billing.
+        self::assertSame(['Invoice ACME-INV-01001 issued: 12100 EUR due'], $heard);
+        self::assertSame(
+            ['email:Acme BV:Invoice ACME-INV-01001'],
+            (new NotificationFacade())->deliveries(),
+        );
+    }
+
+    /**
+     * The other side of the guard: an application that registers no listener at
+     * all pays nothing for the announcement, because the event is never built.
+     * `disableEventListeners()` is the bluntest way to arrange that.
+     */
+    public function test_an_invoice_is_issued_with_no_listener_and_nothing_is_announced(): void
+    {
+        ReferenceApp::bootstrap(static function (GacelaConfig $config): void {
+            $config->disableEventListeners();
+        });
+
+        (new CustomerFacade())->registerCustomer('acme-nl', 'Acme BV', 'NL');
+        $invoice = (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        self::assertSame('ACME-INV-01001', $invoice->getNumber());
+        self::assertSame([], (new NotificationFacade())->deliveries());
+    }
+
+    /**
+     * A project's own event, on the host's own bus: the application hands Gacela
+     * a PSR-14 dispatcher, and `InvoiceIssuedEvent` arrives on it beside the
+     * framework's events. Nothing in `Billing` changes -- it dispatches into
+     * whatever the application installed.
+     */
+    public function test_the_applications_own_event_reaches_a_supplied_psr14_bus(): void
+    {
+        $bus = new RecordingPsr14Bus();
+
+        ReferenceApp::bootstrap(static function (GacelaConfig $config) use ($bus): void {
+            $config->setEventDispatcher($bus);
+        });
+
+        (new CustomerFacade())->registerCustomer('acme-nl', 'Acme BV', 'NL');
+        (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        self::assertSame(
+            ['Invoice ACME-INV-01001 issued: 12100 EUR due'],
+            $bus->descriptionsOf(InvoiceIssuedEvent::class),
+        );
+        // The framework's events reach it too: one dispatcher, both kinds.
+        self::assertContains(GacelaBootstrapFinishedEvent::class, $bus->receivedClasses());
     }
 
     /**

--- a/tests/Feature/ReferenceApp/InvoicingSliceTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingSliceTest.php
@@ -11,6 +11,7 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
 use Gacela\Framework\Testing\GacelaTestCase;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingFacade;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\CustomerFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\Domain\CustomerDirectory;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Customer\Domain\CustomerProfile;
@@ -26,7 +27,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use function array_map;
 
 /**
- * The Billing module on its own, with the two modules it depends on replaced.
+ * The Billing module on its own, with its neighbours replaced.
  *
  * This is the test a team writes every day and the reason `bootstrapModule()`
  * exists: one call instead of a bootstrap, three override APIs and the question
@@ -34,6 +35,13 @@ use function array_map;
  * replaced two different ways on purpose -- Notification through its Facade,
  * which the module leaves open for exactly this, and Customer through its
  * Factory, because `CustomerFacade` is `final` and nothing can stand in for it.
+ *
+ * The two are not the same kind of neighbour. Customer is a dependency: Billing
+ * names its Facade and cannot issue an invoice without it. Notification only
+ * *reacts* -- Billing dispatches `InvoiceIssuedEvent` and `gacela.php` wires the
+ * reaction -- so doubling it replaces the module the announcement reaches, not
+ * something Billing asked for. Both are worth doubling, and only one of them is
+ * an edge in the module graph.
  *
  * What makes it a *slice* rather than a bootstrap with doubles is the last two
  * tests: the replaced modules are never built, and module discovery sees one
@@ -67,6 +75,11 @@ final class InvoicingSliceTest extends GacelaTestCase
     /**
      * The whole flow the module is for, with nothing behind it: the same
      * invoice number, tax and total the end-to-end test produces.
+     *
+     * The last assertion is the event arriving: Billing dispatched, the listener
+     * `gacela.php` registered ran, and it reached the double standing in for the
+     * Notification module -- three things a slice has to get right for the
+     * announcement to be observable at all.
      */
     public function test_billing_issues_an_invoice_with_both_neighbours_replaced(): void
     {
@@ -81,7 +94,10 @@ final class InvoicingSliceTest extends GacelaTestCase
         self::assertSame(ReferenceApp::FIXED_TODAY, $invoice->getIssuedOn());
 
         // The double was reached, rather than the module merely not complaining.
+        // It is reached through the event, so this is also the proof that the
+        // announcement survives a slice.
         self::assertSame(['ACME-INV-01001'], $notifications->suppressed());
+        $this->assertEventDispatched(InvoiceIssuedEvent::class);
     }
 
     /**
@@ -163,14 +179,19 @@ final class InvoicingSliceTest extends GacelaTestCase
      * Billing's own boundary, written where Billing's tests are. Reporting
      * reads the ledger, so nothing forbids Billing from reaching it except this
      * -- which is the decision worth stating next to the module.
+     *
+     * Customer and nothing else: Notification sends the mail when an invoice is
+     * issued, and is not in this list. Billing dispatches `InvoiceIssuedEvent`
+     * and `gacela.php` decides who hears it, so the module that reacts is not a
+     * module Billing depends on -- which is the whole claim of the arrangement,
+     * asserted here rather than described.
      */
-    public function test_billing_depends_on_customer_and_notification_and_nothing_else(): void
+    public function test_billing_depends_on_customer_and_nothing_else(): void
     {
         ReferenceApp::bootstrap();
 
         self::assertModuleDependsOnlyOn(BillingFacade::class, [
             CustomerFacade::class,
-            NotificationFacade::class,
         ]);
 
         self::assertModuleDependsOnlyOn(ReportingFacade::class, [

--- a/tests/Feature/ReferenceApp/InvoicingToolingTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingToolingTest.php
@@ -379,7 +379,7 @@ final class InvoicingToolingTest extends TestCase
         $display = $tester->getDisplay();
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $display);
-        self::assertStringNotContainsString('Nothing listens to any Gacela event.', $display);
+        self::assertStringNotContainsString('Nothing listens to any event', $display);
         // One registration against the abstract parent, so all four resolver
         // events are covered by it and the target is named on each row.
         self::assertStringContainsString('1 listener via AbstractGacelaClassResolverEvent', $display);

--- a/tests/Feature/ReferenceApp/InvoicingToolingTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingToolingTest.php
@@ -383,13 +383,44 @@ final class InvoicingToolingTest extends TestCase
         // One registration against the abstract parent, so all four resolver
         // events are covered by it and the target is named on each row.
         self::assertStringContainsString('1 listener via AbstractGacelaClassResolverEvent', $display);
-        self::assertStringContainsString('4 with listeners', $display);
+        // Those four and this application's own InvoiceIssuedEvent, which the
+        // command reports on the same terms as the framework's -- the report
+        // would otherwise contradict the very use it exists to support.
+        self::assertStringContainsString('5 with listeners', $display);
+        self::assertStringContainsString('1 listener via InvoiceIssuedEvent', $display);
+        self::assertStringContainsString('1 declared by this project', $display);
+    }
+
+    /**
+     * The module-to-module recipe, as the tooling sees it: Billing's event, in
+     * Billing's namespace, marked as this application's own and carrying the
+     * listener that wires it to Notification.
+     */
+    public function test_debug_events_lists_the_applications_own_event(): void
+    {
+        ReferenceApp::bootstrap();
+
+        $tester = $this->execute(new DebugEventsCommand(), ['filter' => 'InvoiceIssued']);
+        $display = $tester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $display);
+        self::assertStringContainsString('InvoiceIssuedEvent', $display);
+        self::assertStringContainsString('project', $display);
+        self::assertStringContainsString(
+            'GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event',
+            $display,
+        );
     }
 
     /**
      * The other half of #887: `doctor`'s event-listener check reported "no
      * specific listeners registered" for an application whose `gacela.php`
      * registers one -- and could therefore never judge its target either.
+     *
+     * Two targets now: a framework event and one of this application's own. The
+     * second is the case the check needs the project's catalog for -- a listener
+     * on a class that forgot `implements GacelaEventInterface` can never fire,
+     * and a listener on one that has it must not be called dead.
      */
     public function test_doctor_reports_the_listener_registered_in_the_gacela_file(): void
     {
@@ -399,8 +430,9 @@ final class InvoicingToolingTest extends TestCase
         $display = $tester->getDisplay();
 
         self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $display);
-        self::assertStringContainsString('1 listener target(s) name a known event type', $display);
+        self::assertStringContainsString('2 listener target(s) name a known event type', $display);
         self::assertStringNotContainsString('no specific listeners registered', $display);
+        self::assertStringNotContainsString('nothing can ever match it', $display);
     }
 
     /**

--- a/tests/Feature/ReferenceApp/Support/RecordingPsr14Bus.php
+++ b/tests/Feature/ReferenceApp/Support/RecordingPsr14Bus.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\ReferenceApp\Support;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+use function array_map;
+
+/**
+ * The bus a hosted application already has: PSR-14 and nothing else.
+ *
+ * Unlike {@see RecordingEventDispatcher} it implements no Gacela interface and
+ * has no `hasListeners()` to implement -- PSR-14 has no such method. Handing one
+ * of these to `setEventDispatcher()` is what a Symfony or Laravel project does,
+ * and Gacela wraps it.
+ */
+final class RecordingPsr14Bus implements EventDispatcherInterface
+{
+    /** @var list<object> */
+    private array $received = [];
+
+    public function dispatch(object $event): object
+    {
+        $this->received[] = $event;
+
+        return $event;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public function receivedClasses(): array
+    {
+        return array_map(static fn (object $event): string => $event::class, $this->received);
+    }
+
+    /**
+     * What the events of one class said about themselves, in dispatch order.
+     *
+     * `toString()` rather than the object, so an assertion reads as the fact the
+     * event carried instead of an identity nothing else in the test holds.
+     *
+     * @param class-string $eventClass
+     *
+     * @return list<string>
+     */
+    public function descriptionsOf(string $eventClass): array
+    {
+        $descriptions = [];
+
+        foreach ($this->received as $event) {
+            if ($event instanceof $eventClass && $event instanceof GacelaEventInterface) {
+                $descriptions[] = $event->toString();
+            }
+        }
+
+        return $descriptions;
+    }
+}

--- a/tests/Feature/ReferenceApp/Support/SilentNotificationFacade.php
+++ b/tests/Feature/ReferenceApp/Support/SilentNotificationFacade.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GacelaTest\Feature\ReferenceApp\Support;
 
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
 use Override;
 
@@ -11,8 +12,14 @@ use Override;
  * The notification module, replaced.
  *
  * Handed to `Gacela::overrideExistingResolvedClass()`, this is what every
- * consumer of `NotificationFacade` gets -- including Billing, which reaches it
- * through a `#[ServiceMap]` accessor and never learns the difference.
+ * consumer of `NotificationFacade` gets -- including the listener in
+ * `gacela.php` that turns Billing's `InvoiceIssuedEvent` into a notification.
+ * That listener resolves the facade rather than constructing one for exactly
+ * this reason.
+ *
+ * Overriding the facade method is what keeps the real module out of the way
+ * entirely: no Factory, no channels, no delivery log -- which is what a slice
+ * test asserts when it says the replaced module was never built.
  */
 final class SilentNotificationFacade extends NotificationFacade
 {
@@ -23,9 +30,9 @@ final class SilentNotificationFacade extends NotificationFacade
      * @return list<string>
      */
     #[Override]
-    public function notifyInvoiceIssued(string $recipient, string $invoiceNumber, string $body): array
+    public function onInvoiceIssued(InvoiceIssuedEvent $event): array
     {
-        $this->suppressed[] = $invoiceNumber;
+        $this->suppressed[] = $event->invoiceNumber();
 
         return [];
     }

--- a/tests/Integration/Framework/Event/CustomDispatcherFromBootstrapTest.php
+++ b/tests/Integration/Framework/Event/CustomDispatcherFromBootstrapTest.php
@@ -11,8 +11,12 @@ use Gacela\Framework\Config\Config;
 use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
 use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
+use Gacela\Framework\Event\Dispatcher\Psr14EventDispatcher;
 use Gacela\Framework\Gacela;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+
+use function array_map;
 
 /**
  * `docs/events.md` documents replacing the dispatcher — "`SetupGacela::setEventDispatcher()`
@@ -132,6 +136,70 @@ final class CustomDispatcherFromBootstrapTest extends TestCase
         self::assertSame(2, $calls, 'once at bootstrap and once here -- any more is a listener registered twice');
     }
 
+    /**
+     * The host's own bus, handed over as-is. A Symfony or Laravel application
+     * has a PSR-14 dispatcher and no reason to write an adapter for it, so the
+     * parameter accepts one and Gacela wraps it.
+     */
+    public function test_a_psr14_dispatcher_is_accepted_and_receives_the_events(): void
+    {
+        $bus = new RecordingPsr14Bus();
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use ($bus): void {
+            $config->setEventDispatcher($bus);
+        });
+
+        self::assertContains(GacelaBootstrapFinishedEvent::class, $bus->receivedClasses());
+    }
+
+    /**
+     * Same composition as a Gacela dispatcher gets, because by the time the
+     * setup holds it there is no difference left: the wrapping happens at the
+     * setter, so everything downstream sees one `EventDispatcherInterface`.
+     */
+    public function test_a_psr14_dispatcher_composes_with_the_listeners_registered_beside_it(): void
+    {
+        $bus = new RecordingPsr14Bus();
+        $calls = 0;
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use ($bus, &$calls): void {
+            $config->setEventDispatcher($bus);
+            $config->registerSpecificListener(
+                GacelaBootstrapFinishedEvent::class,
+                static function () use (&$calls): void {
+                    ++$calls;
+                },
+            );
+        });
+
+        self::assertSame(1, $calls, 'the listener registered beside the bus never ran');
+        self::assertContains(GacelaBootstrapFinishedEvent::class, $bus->receivedClasses());
+    }
+
+    /**
+     * The other direction: a library that type-hints PSR-14 can be handed the
+     * dispatcher this application configured, listeners and all.
+     */
+    public function test_the_configured_dispatcher_can_be_handed_to_a_psr14_consumer(): void
+    {
+        $calls = 0;
+
+        $this->bootstrapWith(static function (GacelaConfig $config) use (&$calls): void {
+            $config->registerSpecificListener(
+                GacelaBootstrapFinishedEvent::class,
+                static function () use (&$calls): void {
+                    ++$calls;
+                },
+            );
+        });
+
+        $psr = new Psr14EventDispatcher(EventDispatcherProvider::get());
+        $event = new GacelaBootstrapFinishedEvent(1.0);
+
+        self::assertSame($event, $psr->dispatch($event));
+        self::assertSame(2, $calls, 'once at bootstrap, once through the PSR-14 view of the same dispatcher');
+    }
+
     private function bootstrapWith(callable $setup): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($setup): void {
@@ -160,5 +228,30 @@ final class CustomDispatcherFromBootstrapTest extends TestCase
                 ++$this->dispatched;
             }
         };
+    }
+}
+
+/**
+ * The shape a host application already has: PSR-14 and nothing else. No
+ * `hasListeners()`, because PSR-14 has no such method to implement.
+ */
+final class RecordingPsr14Bus implements PsrEventDispatcherInterface
+{
+    /** @var list<object> */
+    private array $received = [];
+
+    public function dispatch(object $event): object
+    {
+        $this->received[] = $event;
+
+        return $event;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public function receivedClasses(): array
+    {
+        return array_map(static fn (object $event): string => $event::class, $this->received);
     }
 }

--- a/tests/Integration/Framework/ProjectEvents/Ordering/Domain/OrderPlacedEvent.php
+++ b/tests/Integration/Framework/ProjectEvents/Ordering/Domain/OrderPlacedEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents\Ordering\Domain;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * A project's own event: nothing about it is framework-shaped except the one
+ * interface, which is what makes the typed listener registration, the
+ * inheritance matching and the `hasListeners()` guard apply to it unchanged.
+ */
+final class OrderPlacedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $reference,
+    ) {
+    }
+
+    public function reference(): string
+    {
+        return $this->reference;
+    }
+
+    public function toString(): string
+    {
+        return sprintf('Order placed: %s', $this->reference);
+    }
+}

--- a/tests/Integration/Framework/ProjectEvents/Ordering/Domain/OrderPlacer.php
+++ b/tests/Integration/Framework/ProjectEvents/Ordering/Domain/OrderPlacer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents\Ordering\Domain;
+
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+
+/**
+ * The dispatcher arrives as a constructor argument, like every other
+ * dependency: no trait, no static call, nothing to reset between tests.
+ */
+final class OrderPlacer
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $events,
+    ) {
+    }
+
+    public function place(string $reference): void
+    {
+        // The guard the framework's own dispatch sites use, for the same
+        // reason: with nothing listening, the event is never built.
+        if ($this->events->hasListeners(OrderPlacedEvent::class)) {
+            $this->events->dispatch(new OrderPlacedEvent($reference));
+        }
+    }
+}

--- a/tests/Integration/Framework/ProjectEvents/Ordering/OrderingConfig.php
+++ b/tests/Integration/Framework/ProjectEvents/Ordering/OrderingConfig.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents\Ordering;
+
+use Gacela\Framework\AbstractConfig;
+
+final class OrderingConfig extends AbstractConfig
+{
+}

--- a/tests/Integration/Framework/ProjectEvents/Ordering/OrderingFacade.php
+++ b/tests/Integration/Framework/ProjectEvents/Ordering/OrderingFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents\Ordering;
+
+use Gacela\Framework\AbstractFacade;
+
+/**
+ * @extends AbstractFacade<OrderingFactory>
+ */
+final class OrderingFacade extends AbstractFacade
+{
+    public function placeOrder(string $reference): void
+    {
+        $this->getFactory()->createOrderPlacer()->place($reference);
+    }
+}

--- a/tests/Integration/Framework/ProjectEvents/Ordering/OrderingFactory.php
+++ b/tests/Integration/Framework/ProjectEvents/Ordering/OrderingFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents\Ordering;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use GacelaTest\Integration\Framework\ProjectEvents\Ordering\Domain\OrderPlacer;
+
+/**
+ * @extends AbstractFactory<OrderingConfig>
+ */
+final class OrderingFactory extends AbstractFactory
+{
+    public function createOrderPlacer(): OrderPlacer
+    {
+        return new OrderPlacer($this->getEventDispatcher());
+    }
+
+    /**
+     * The dispatcher the application is running with, asked for by its
+     * interface like any other provided dependency.
+     */
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->getProvidedDependency(EventDispatcherInterface::class);
+    }
+}

--- a/tests/Integration/Framework/ProjectEvents/Ordering/OrderingProvider.php
+++ b/tests/Integration/Framework/ProjectEvents/Ordering/OrderingProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents\Ordering;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Container\Container;
+
+/**
+ * Empty, and still needed: `getProvidedDependency()` refuses to answer for a
+ * module that resolved no Provider at all, and the dispatcher is reached
+ * through the parent container rather than registered here.
+ */
+final class OrderingProvider extends AbstractProvider
+{
+    public function provideModuleDependencies(Container $container): void
+    {
+    }
+}

--- a/tests/Integration/Framework/ProjectEvents/ProjectEventsTest.php
+++ b/tests/Integration/Framework/ProjectEvents/ProjectEventsTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Integration\Framework\ProjectEvents;
+
+use Closure;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Container\Container;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherProvider;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use Gacela\Framework\Event\GacelaEventInterface;
+use Gacela\Framework\Gacela;
+use GacelaTest\Integration\Framework\ProjectEvents\Ordering\Domain\OrderPlacedEvent;
+use GacelaTest\Integration\Framework\ProjectEvents\Ordering\OrderingFacade;
+use GacelaTest\Integration\Framework\ProjectEvents\Ordering\OrderingFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+
+/**
+ * An application dispatching its own events through Gacela's dispatcher.
+ *
+ * The whole point of the arrangement is that nothing here is special: the
+ * dispatcher is a provided dependency like a repository or a clock, the event
+ * is a class implementing one interface, and the listener is registered where
+ * every other listener is. What the framework contributes is the guard -- an
+ * event nobody wants is never built -- and the inheritance matching.
+ */
+final class ProjectEventsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Gacela::resetCache();
+    }
+
+    public function test_a_factory_is_given_the_dispatcher_the_application_runs_with(): void
+    {
+        $this->bootstrap();
+
+        self::assertSame(
+            EventDispatcherProvider::get(),
+            (new OrderingFactory())->getEventDispatcher(),
+        );
+    }
+
+    /**
+     * The module's own container, which is what a Provider is handed and what
+     * `getProvidedDependency()` reads. The application container deliberately
+     * does not carry it: that one is what `debug:container` and
+     * `validate:config` describe, and it should describe the application.
+     */
+    public function test_the_dispatcher_resolves_from_the_module_container(): void
+    {
+        $this->bootstrap();
+
+        $factory = new OrderingFactory();
+
+        self::assertSame(EventDispatcherProvider::get(), $factory->getEventDispatcher());
+        self::assertFalse(
+            Gacela::container()->provides(EventDispatcherInterface::class),
+            'the application container should be about the application',
+        );
+    }
+
+    /**
+     * The id is a default, not a reservation: an application that binds
+     * something else under it gets what it asked for.
+     */
+    public function test_a_binding_the_application_declares_for_the_id_wins(): void
+    {
+        $own = new NullEventDispatcher();
+
+        $this->bootstrap(static function (GacelaConfig $config) use ($own): void {
+            $config->addBinding(EventDispatcherInterface::class, $own);
+        });
+
+        self::assertSame($own, (new OrderingFactory())->getEventDispatcher());
+    }
+
+    public function test_a_module_event_reaches_a_listener_registered_at_bootstrap(): void
+    {
+        $placed = [];
+
+        $this->bootstrap(static function (GacelaConfig $config) use (&$placed): void {
+            $config->registerSpecificListener(
+                OrderPlacedEvent::class,
+                static function (OrderPlacedEvent $event) use (&$placed): void {
+                    $placed[] = $event->reference();
+                },
+            );
+        });
+
+        (new OrderingFacade())->placeOrder('order-1');
+
+        self::assertSame(['order-1'], $placed);
+    }
+
+    /**
+     * The matching rule is the dispatcher's, so it covers a project's events on
+     * the same terms as the framework's: a listener on `GacelaEventInterface`
+     * hears everything, including events Gacela knows nothing about.
+     */
+    public function test_a_listener_on_the_event_interface_hears_a_project_event(): void
+    {
+        $heard = [];
+
+        $this->bootstrap(static function (GacelaConfig $config) use (&$heard): void {
+            $config->registerSpecificListener(
+                GacelaEventInterface::class,
+                static function (GacelaEventInterface $event) use (&$heard): void {
+                    $heard[] = $event::class;
+                },
+            );
+        });
+
+        (new OrderingFacade())->placeOrder('order-2');
+
+        self::assertContains(OrderPlacedEvent::class, $heard);
+    }
+
+    /**
+     * What the guard buys a project: with nothing listening for it, the event
+     * object is never constructed -- the same deal the framework's own dispatch
+     * sites get.
+     */
+    public function test_an_event_nothing_listens_to_is_never_built(): void
+    {
+        $this->bootstrap();
+
+        self::assertFalse(
+            (new OrderingFactory())->getEventDispatcher()->hasListeners(OrderPlacedEvent::class),
+        );
+    }
+
+    /**
+     * A project's own event, on the host's bus. Nothing in the module changes:
+     * it dispatches into the dispatcher the application installed.
+     */
+    public function test_a_project_event_reaches_a_supplied_psr14_bus(): void
+    {
+        $bus = new class() implements PsrEventDispatcherInterface {
+            /** @var list<object> */
+            public array $received = [];
+
+            public function dispatch(object $event): object
+            {
+                $this->received[] = $event;
+
+                return $event;
+            }
+        };
+
+        $this->bootstrap(static function (GacelaConfig $config) use ($bus): void {
+            $config->setEventDispatcher($bus);
+        });
+
+        (new OrderingFacade())->placeOrder('order-3');
+
+        $references = [];
+
+        foreach ($bus->received as $event) {
+            if ($event instanceof OrderPlacedEvent) {
+                $references[] = $event->reference();
+            }
+        }
+
+        self::assertSame(['order-3'], $references);
+    }
+
+    private function bootstrap(?Closure $configFn = null): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configFn): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+
+            if ($configFn instanceof Closure) {
+                $configFn($config);
+            }
+        });
+    }
+}

--- a/tests/Unit/Console/Application/Debug/EventCatalogTest.php
+++ b/tests/Unit/Console/Application/Debug/EventCatalogTest.php
@@ -6,6 +6,7 @@ namespace GacelaTest\Unit\Console\Application\Debug;
 
 use Gacela\Console\Application\Debug\EventCatalog;
 use Gacela\Console\Application\Debug\EventInspection;
+use Gacela\Console\Application\Debug\EventSource;
 use Gacela\Framework\Event\Bootstrap\GacelaBootstrapStartedEvent;
 use Gacela\Framework\Event\ClassResolver\AbstractGacelaClassResolverEvent;
 use Gacela\Framework\Event\ClassResolver\Cache\ClassNameCacheCachedEvent;
@@ -14,6 +15,7 @@ use Gacela\Framework\Event\ClassResolver\ResolvedClassCreatedEvent;
 use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
 use Gacela\Framework\Event\GacelaEventInterface;
 use Gacela\Framework\Event\Provider\ProviderRegisteredEvent;
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\SomethingHappenedEvent;
 use PHPUnit\Framework\TestCase;
 
 use function array_map;
@@ -268,6 +270,104 @@ final class EventCatalogTest extends TestCase
     public function test_inspecting_nothing_returns_nothing(): void
     {
         self::assertSame([], (new EventCatalog())->inspect([], [GacelaEventInterface::class => 1], 1));
+    }
+
+    public function test_an_events_source_says_who_declared_it(): void
+    {
+        $inspections = (new EventCatalog())->inspect(
+            [ProviderRegisteredEvent::class],
+            [],
+            0,
+            [SomethingHappenedEvent::class],
+        );
+
+        self::assertSame(EventSource::Framework, $inspections[0]->source);
+        self::assertSame(EventSource::Project, $inspections[1]->source);
+    }
+
+    /**
+     * Written out in full, unlike a framework event's: there is no root to make
+     * it relative to, and the namespace is what tells a reader which of their
+     * modules the event belongs to.
+     */
+    public function test_a_project_event_is_grouped_by_its_own_namespace(): void
+    {
+        $inspections = (new EventCatalog())->inspect([], [], 0, [SomethingHappenedEvent::class]);
+
+        self::assertSame(
+            'GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture',
+            $inspections[0]->group,
+        );
+    }
+
+    /**
+     * Two runs rather than one interleaved list. Ordering by the namespace
+     * alone would scatter a project's events through the framework's, and
+     * "which of these are mine" is the first question a project asks of this
+     * report.
+     */
+    public function test_the_frameworks_events_come_before_the_projects(): void
+    {
+        $inspections = (new EventCatalog())->inspect(
+            // A project namespace sorting before `Provider` on its own.
+            [ProviderRegisteredEvent::class],
+            [],
+            0,
+            [SomethingHappenedEvent::class],
+        );
+
+        self::assertSame([
+            ProviderRegisteredEvent::class,
+            SomethingHappenedEvent::class,
+        ], array_map(
+            static fn (EventInspection $inspection): string => $inspection->className,
+            $inspections,
+        ));
+    }
+
+    /**
+     * The hot path is a property of the framework's own dispatch sites, and the
+     * list of them is written in this class. Nothing a project declares can be
+     * on it.
+     */
+    public function test_a_project_event_is_never_on_the_hot_path(): void
+    {
+        $inspections = (new EventCatalog())->inspect([], [], 0, [SomethingHappenedEvent::class]);
+
+        self::assertFalse($inspections[0]->isHotPath);
+    }
+
+    /**
+     * The listener matching does not care where an event came from, so neither
+     * does the report: a project event registered against by name, by a parent
+     * or by the interface reads exactly like a framework one.
+     */
+    public function test_a_listener_target_covers_a_project_event_the_same_way(): void
+    {
+        $inspections = (new EventCatalog())->inspect(
+            [],
+            [GacelaEventInterface::class => 1, SomethingHappenedEvent::class => 2],
+            0,
+            [SomethingHappenedEvent::class],
+        );
+
+        self::assertSame([
+            GacelaEventInterface::class => 1,
+            SomethingHappenedEvent::class => 2,
+        ], $inspections[0]->matchedTargets);
+        self::assertTrue($inspections[0]->isWatched());
+    }
+
+    /**
+     * `eventClasses()` is what `docs/events.md` is compared against in both
+     * directions. A project's events must not leak into it: the page could then
+     * neither be complete nor stay right.
+     */
+    public function test_the_shipped_catalog_holds_only_the_frameworks_own_events(): void
+    {
+        foreach ((new EventCatalog())->eventClasses() as $class) {
+            self::assertStringStartsWith('Gacela\Framework\Event\\', $class);
+        }
     }
 
     /**

--- a/tests/Unit/Console/Application/Doctor/Check/EventListenerTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/EventListenerTargetCheckTest.php
@@ -206,6 +206,24 @@ final class EventListenerTargetCheckTest extends TestCase
 
         self::assertSame(CheckStatus::Ok, $result->status);
     }
+
+    /**
+     * The catalog is what the scan found, not the whole world: an event of the
+     * project's that lives outside the scanned paths is missing from it. Being
+     * an event type is enough on its own, so that listener is not reported --
+     * the check would otherwise turn a gap in `appModulePaths` into a warning
+     * about code that is perfectly correct.
+     */
+    public function test_an_event_type_the_catalog_does_not_know_is_not_reported(): void
+    {
+        $result = (new EventListenerTargetCheck(
+            [ProjectEvent::class],
+            knownEventClasses: [GacelaBootstrapStartedEvent::class],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['1 listener target(s) name a known event type'], $result->details);
+    }
 }
 
 /**

--- a/tests/Unit/Console/Application/Doctor/Check/EventListenerTargetCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/EventListenerTargetCheckTest.php
@@ -125,8 +125,8 @@ final class EventListenerTargetCheckTest extends TestCase
     }
 
     /**
-     * A type that exists is waiting, not broken, whether it is concrete,
-     * abstract or an interface: only names that are no type at all are reported.
+     * A type that exists and can match is waiting, not broken, whether it is
+     * concrete, abstract or an interface.
      */
     public function test_every_unfireable_target_is_named_and_the_valid_ones_are_not(): void
     {
@@ -138,5 +138,99 @@ final class EventListenerTargetCheckTest extends TestCase
 
         self::assertSame(CheckStatus::Warn, $result->status);
         self::assertSame(['App\Event\Mispelled names no class or interface'], $result->details);
+    }
+
+    /**
+     * A project's own event is an event because it says
+     * `implements GacelaEventInterface`. Without that it is an ordinary class:
+     * the registration is accepted, the dispatcher can never match it, and
+     * nothing said so until the catalog was here to judge against.
+     */
+    public function test_a_target_that_is_not_an_event_type_is_reported(): void
+    {
+        $result = (new EventListenerTargetCheck(
+            [NotAnEvent::class],
+            knownEventClasses: [GacelaBootstrapStartedEvent::class],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            [NotAnEvent::class . ' is not an event type, and no known event extends or implements it'
+                . ' -- so nothing can ever match it'],
+            $result->details,
+        );
+        self::assertStringContainsString('GacelaEventInterface', $result->remediation);
+    }
+
+    /**
+     * The project's events are in the catalog too, so a listener on one is a
+     * listener like any other -- the tooling must not contradict the very use
+     * it is there to support.
+     */
+    public function test_a_target_that_is_a_project_event_passes(): void
+    {
+        $result = (new EventListenerTargetCheck(
+            [ProjectEvent::class],
+            knownEventClasses: [GacelaBootstrapStartedEvent::class, ProjectEvent::class],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['1 listener target(s) name a known event type'], $result->details);
+    }
+
+    /**
+     * A marker interface an event implements is a legitimate target: it is not
+     * an event type itself, and the dispatcher matches it by inheritance all
+     * the same. Answering from `GacelaEventInterface` alone would report every
+     * one of those as dead.
+     */
+    public function test_a_marker_interface_a_known_event_implements_passes(): void
+    {
+        $result = (new EventListenerTargetCheck(
+            [AuditableInterface::class],
+            knownEventClasses: [AuditedProjectEvent::class],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+    }
+
+    /**
+     * With no catalog to judge against, the old answer stands: only a name that
+     * is no type at all is reported. `doctor` skips the project scan when
+     * nothing is registered, and a check with an empty catalog must not start
+     * calling every target dead.
+     */
+    public function test_without_a_catalog_a_type_that_exists_is_left_alone(): void
+    {
+        $result = (new EventListenerTargetCheck([NotAnEvent::class]))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+    }
+}
+
+/**
+ * A real class that is not an event: the shape of forgetting the interface.
+ */
+final class NotAnEvent
+{
+}
+
+interface AuditableInterface
+{
+}
+
+final class ProjectEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return 'a project event';
+    }
+}
+
+final class AuditedProjectEvent implements AuditableInterface, GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return 'an audited project event';
     }
 }

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/Nested/NestedProjectEvent.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/Nested/NestedProjectEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\Nested;
+
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\ProjectBaseEvent;
+
+/**
+ * Two things at once: an event a directory deeper than the scan root, and one
+ * that gets the interface from its parent while still being named for it.
+ */
+final class NestedProjectEvent extends ProjectBaseEvent
+{
+    public function toString(): string
+    {
+        return 'nested project event';
+    }
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/Nested/QuietOne.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/Nested/QuietOne.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\Nested;
+
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\ProjectBaseEvent;
+
+/**
+ * An event that says so nowhere: no `Event` in the name, and the interface
+ * comes from the parent rather than from this file.
+ *
+ * The documented limit of the finder, pinned as a test rather than left as a
+ * sentence: it is not found, and the class named on the `extends` line is --
+ * which is the family target a listener would register against anyway.
+ */
+final class QuietOne extends ProjectBaseEvent
+{
+    public function toString(): string
+    {
+        return 'a quiet one';
+    }
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/NotReallyAnEvent.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/NotReallyAnEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture;
+
+/**
+ * Named like an event, implementing nothing. The name is what makes it a
+ * candidate and the interface is what refuses it -- which is the whole reason
+ * the finder loads the class instead of trusting the filename.
+ */
+final class NotReallyAnEvent
+{
+    public function toString(): string
+    {
+        return 'not an event at all';
+    }
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/OrderShipped.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/OrderShipped.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+/**
+ * No `Event` suffix: a project grouping its events in an `Event` namespace
+ * names them after what happened, and the interface is what says it is one.
+ */
+final class OrderShipped implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return 'order shipped';
+    }
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/ProjectBaseEvent.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/ProjectBaseEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+/**
+ * A project's own family parent: never dispatched, and a listener target that
+ * covers everything below it -- the same role `AbstractGacelaClassResolverEvent`
+ * plays for the framework's resolver events.
+ */
+abstract class ProjectBaseEvent implements GacelaEventInterface
+{
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/RecordingListener.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/RecordingListener.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+/**
+ * Names the interface without being one: a listener type-hints the events it
+ * receives, and so does anything else that handles them. The pre-filter cannot
+ * tell the difference, and is not supposed to.
+ */
+final class RecordingListener
+{
+    /** @var list<string> */
+    private array $recorded = [];
+
+    public function __invoke(GacelaEventInterface $event): void
+    {
+        $this->recorded[] = $event->toString();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function recorded(): array
+    {
+        return $this->recorded;
+    }
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/Fixture/SomethingHappenedEvent.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/Fixture/SomethingHappenedEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+/**
+ * The ordinary shape: named after the convention and implementing the one
+ * interface.
+ */
+final class SomethingHappenedEvent implements GacelaEventInterface
+{
+    public function toString(): string
+    {
+        return 'something happened';
+    }
+}

--- a/tests/Unit/Console/Domain/ProjectEvents/ProjectEventFinderTest.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/ProjectEventFinderTest.php
@@ -25,6 +25,44 @@ final class ProjectEventFinderTest extends TestCase
 {
     private const string FIXTURE_NAMESPACE = 'GacelaTest\\Unit\\Console\\Domain\\ProjectEvents\\Fixture';
 
+    /** The prefix of every directory this test builds, and of nothing else. */
+    private const string TEMPORARY_PREFIX = 'gacela-project-events-';
+
+    private string $temporaryRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->temporaryRoot = sys_get_temp_dir() . '/' . self::TEMPORARY_PREFIX . bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        $root = $this->temporaryRoot;
+
+        // Removing a tree, so the root it walks is asserted to be the one this
+        // test built and nothing above it, before anything is unlinked.
+        self::assertNotSame('', $root);
+        self::assertStringStartsWith(sys_get_temp_dir() . '/' . self::TEMPORARY_PREFIX, $root);
+
+        $this->temporaryRoot = '';
+
+        if (!is_dir($root)) {
+            return;
+        }
+
+        $entries = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var SplFileInfo $entry */
+        foreach ($entries as $entry) {
+            $entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+        }
+
+        rmdir($root);
+    }
+
     public function test_it_finds_the_events_under_the_scanned_path(): void
     {
         $found = (new ProjectEventFinder($this->fixtureIterator()))->find();
@@ -119,9 +157,94 @@ final class ProjectEventFinderTest extends TestCase
         self::assertSame([], $found);
     }
 
+    /**
+     * The documented limit, pinned so it stays a decision rather than becoming
+     * a surprise: an event that neither names the interface nor ends in `Event`
+     * is not found. Its parent is -- and registering against the parent is what
+     * covers the family anyway.
+     */
+    public function test_an_event_that_says_so_nowhere_in_its_own_file_is_not_found(): void
+    {
+        $found = (new ProjectEventFinder($this->fixtureIterator()))->find();
+
+        self::assertNotContains(self::FIXTURE_NAMESPACE . '\\Nested\\QuietOne', $found);
+        self::assertContains(ProjectBaseEvent::class, $found);
+    }
+
+    /**
+     * Never `vendor/`. A dependency's events are not the project's, and loading
+     * every candidate class in an installed package to find that out is exactly
+     * the cost this finder is shaped to avoid.
+     *
+     * Built here rather than committed: `vendor/` is in this repository's
+     * `.gitignore`, so a fixture directory by that name would not survive a
+     * clone.
+     */
+    public function test_nothing_under_a_vendor_directory_is_scanned(): void
+    {
+        $this->writeEventFileIn($this->temporaryRoot . '/vendor/acme/events/src');
+
+        $found = (new ProjectEventFinder($this->iteratorFor($this->temporaryRoot)))->find();
+
+        self::assertSame([], $found);
+    }
+
+    /**
+     * The counterpart, so the test above proves the `vendor/` rule rather than
+     * a temporary directory the finder cannot read at all: the same file, one
+     * directory to the side, is found.
+     */
+    public function test_the_same_file_outside_vendor_is_found(): void
+    {
+        $this->writeEventFileIn($this->temporaryRoot . '/src');
+
+        $found = (new ProjectEventFinder($this->iteratorFor($this->temporaryRoot)))->find();
+
+        self::assertSame([SomethingHappenedEvent::class], $found);
+    }
+
+    /**
+     * The directory is `vendor`, not any name starting with it. A project with
+     * a `Vendored/` or `vendors/` module of its own keeps its events: matching
+     * the bare word would take those away, and matching `/vendor` without the
+     * trailing separator is the same mistake spelled differently.
+     */
+    public function test_a_directory_whose_name_merely_starts_with_vendor_is_scanned(): void
+    {
+        $this->writeEventFileIn($this->temporaryRoot . '/vendored/src');
+
+        $found = (new ProjectEventFinder($this->iteratorFor($this->temporaryRoot)))->find();
+
+        self::assertSame([SomethingHappenedEvent::class], $found);
+    }
+
     public function test_scanning_nothing_finds_nothing(): void
     {
         self::assertSame([], (new ProjectEventFinder(new AppendIterator()))->find());
+    }
+
+    /**
+     * A file the finder accepts by every rule it has: the right filename, and a
+     * namespace declaration that makes the class it derives an event this
+     * process can already load -- the one in the fixture directory.
+     *
+     * It is never included, only read: the finder derives a name from the path
+     * and the `namespace` line, and asks `is_a()` about it. So the only thing
+     * the two tests below differ in is where the file sits.
+     */
+    private function writeEventFileIn(string $directory): void
+    {
+        mkdir($directory, 0o777, true);
+
+        file_put_contents($directory . '/SomethingHappenedEvent.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture;
+
+            // Body deliberately absent: this file is read, never loaded.
+            PHP);
     }
 
     /**

--- a/tests/Unit/Console/Domain/ProjectEvents/ProjectEventFinderTest.php
+++ b/tests/Unit/Console/Domain/ProjectEvents/ProjectEventFinderTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Domain\ProjectEvents;
+
+use AppendIterator;
+use FilesystemIterator;
+use Gacela\Console\Domain\ProjectEvents\ProjectEventFinder;
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\Nested\NestedProjectEvent;
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\OrderShipped;
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\ProjectBaseEvent;
+use GacelaTest\Unit\Console\Domain\ProjectEvents\Fixture\SomethingHappenedEvent;
+use OuterIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * The fixture directory holds one of each shape the finder has to get right,
+ * and two it has to leave alone.
+ */
+final class ProjectEventFinderTest extends TestCase
+{
+    private const string FIXTURE_NAMESPACE = 'GacelaTest\\Unit\\Console\\Domain\\ProjectEvents\\Fixture';
+
+    public function test_it_finds_the_events_under_the_scanned_path(): void
+    {
+        $found = (new ProjectEventFinder($this->fixtureIterator()))->find();
+
+        self::assertContains(SomethingHappenedEvent::class, $found);
+        self::assertContains(NestedProjectEvent::class, $found);
+        self::assertContains(ProjectBaseEvent::class, $found);
+    }
+
+    /**
+     * The name is a convention, not the rule: what makes a class an event is
+     * the interface, and `App\Billing\Event\InvoiceIssued` is how a project
+     * that groups its events in a namespace writes one.
+     */
+    public function test_an_event_that_does_not_end_in_event_is_found_by_its_interface(): void
+    {
+        $found = (new ProjectEventFinder($this->fixtureIterator()))->find();
+
+        self::assertContains(OrderShipped::class, $found);
+    }
+
+    /**
+     * A class named like an event and implementing nothing is not one, and a
+     * file naming the interface for another reason -- a listener type-hinting
+     * it -- is not one either. Both are candidates the pre-filter lets through
+     * on purpose, and both are rejected by the only question that decides.
+     */
+    public function test_a_class_that_is_not_an_event_is_left_out(): void
+    {
+        $found = (new ProjectEventFinder($this->fixtureIterator()))->find();
+
+        self::assertNotContains(self::FIXTURE_NAMESPACE . '\\NotReallyAnEvent', $found);
+        self::assertNotContains(self::FIXTURE_NAMESPACE . '\\RecordingListener', $found);
+    }
+
+    public function test_the_classes_come_back_sorted_and_unique(): void
+    {
+        $found = (new ProjectEventFinder($this->fixtureIterator()))->find();
+        $sorted = $found;
+        sort($sorted);
+
+        self::assertSame($sorted, $found);
+        self::assertSame($found, array_values(array_unique($found)));
+    }
+
+    /**
+     * The application said what its namespaces are, so a class outside them is
+     * somebody else's -- a fixture, or something vendored into a scanned path.
+     */
+    public function test_a_declared_project_namespace_excludes_everything_else(): void
+    {
+        $found = (new ProjectEventFinder(
+            $this->fixtureIterator(),
+            [self::FIXTURE_NAMESPACE . '\\Nested'],
+        ))->find();
+
+        self::assertSame([NestedProjectEvent::class], $found);
+    }
+
+    public function test_a_project_namespace_that_matches_nothing_finds_nothing(): void
+    {
+        $found = (new ProjectEventFinder($this->fixtureIterator(), ['App\\Somewhere\\Else']))->find();
+
+        self::assertSame([], $found);
+    }
+
+    /**
+     * A prefix has to end at a namespace separator: `App\Billing` does not own
+     * `App\BillingReports`, whatever `str_starts_with` alone would say.
+     */
+    public function test_a_namespace_prefix_does_not_claim_a_longer_neighbour(): void
+    {
+        $found = (new ProjectEventFinder(
+            $this->fixtureIterator(),
+            [self::FIXTURE_NAMESPACE . '\\Nest'],
+        ))->find();
+
+        self::assertSame([], $found);
+    }
+
+    /**
+     * Gacela's own events are catalogued from the installed package. A project
+     * whose scan path includes them -- this repository, for one -- must not see
+     * them reported twice.
+     */
+    public function test_the_frameworks_own_events_are_never_reported_as_the_projects(): void
+    {
+        $found = (new ProjectEventFinder($this->iteratorFor(
+            __DIR__ . '/../../../../../src/Framework/Event',
+        )))->find();
+
+        self::assertSame([], $found);
+    }
+
+    public function test_scanning_nothing_finds_nothing(): void
+    {
+        self::assertSame([], (new ProjectEventFinder(new AppendIterator()))->find());
+    }
+
+    /**
+     * @return OuterIterator<array-key, SplFileInfo>
+     */
+    private function fixtureIterator(): OuterIterator
+    {
+        return $this->iteratorFor(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return OuterIterator<array-key, SplFileInfo>
+     */
+    private function iteratorFor(string $directory): OuterIterator
+    {
+        /** @var OuterIterator<array-key, SplFileInfo> $iterator */
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+        );
+
+        return $iterator;
+    }
+}

--- a/tests/Unit/Framework/Event/Dispatcher/Psr14EventDispatcherTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/Psr14EventDispatcherTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Dispatcher;
+
+use Gacela\Framework\Event\Dispatcher\ConfigurableEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\Psr14EventDispatcher;
+use Gacela\Framework\Event\GacelaEventInterface;
+use GacelaTest\Unit\Framework\Config\GacelaFileConfig\Factory\FakeEvent;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+
+final class Psr14EventDispatcherTest extends TestCase
+{
+    public function test_it_is_a_psr14_dispatcher(): void
+    {
+        $dispatcher = new Psr14EventDispatcher(new NullEventDispatcher());
+
+        self::assertInstanceOf(PsrEventDispatcherInterface::class, $dispatcher);
+    }
+
+    public function test_the_listeners_of_the_wrapped_dispatcher_run(): void
+    {
+        $received = [];
+
+        $configured = new ConfigurableEventDispatcher();
+        $configured->registerSpecificListener(
+            FakeEvent::class,
+            static function (FakeEvent $event) use (&$received): void {
+                $received[] = $event;
+            },
+        );
+
+        $event = new FakeEvent();
+        (new Psr14EventDispatcher($configured))->dispatch($event);
+
+        self::assertSame([$event], $received);
+    }
+
+    /**
+     * PSR-14: "returns the Event that was passed". Gacela's own interface
+     * returns nothing, which is why this class exists rather than the interface
+     * being widened -- a caller holding a `Psr\EventDispatcher\EventDispatcherInterface`
+     * writes `$event = $dispatcher->dispatch($event)` and must get its event.
+     */
+    public function test_it_returns_the_event_it_was_given(): void
+    {
+        $event = new FakeEvent();
+
+        $returned = (new Psr14EventDispatcher(new NullEventDispatcher()))->dispatch($event);
+
+        self::assertSame($event, $returned);
+    }
+
+    /**
+     * The guard `docs/events.md` promises: a dispatcher that declines a class
+     * in `hasListeners()` is not told about it. Gacela's dispatch sites ask
+     * before allocating, and a library dispatching through this adapter gets
+     * the same answer honoured.
+     */
+    public function test_a_dispatcher_that_wants_nothing_is_not_told(): void
+    {
+        $refusing = new RefusingDispatcher();
+
+        $returned = (new Psr14EventDispatcher($refusing))->dispatch(new FakeEvent());
+
+        self::assertSame([], $refusing->received());
+        self::assertInstanceOf(FakeEvent::class, $returned, 'the event is still returned');
+    }
+
+    /**
+     * PSR-14 requires a dispatcher to return immediately when the event it is
+     * handed is already stopped. Gacela's dispatcher is notify-only and does
+     * not stop between its own listeners; refusing an already-stopped event is
+     * the part that costs nothing and is simply correct.
+     */
+    public function test_an_already_stopped_event_is_not_dispatched(): void
+    {
+        $received = [];
+
+        $configured = new ConfigurableEventDispatcher();
+        $configured->registerGenericListeners([static function (object $event) use (&$received): void {
+            $received[] = $event;
+        }]);
+
+        $event = new StoppedEvent();
+        $returned = (new Psr14EventDispatcher($configured))->dispatch($event);
+
+        self::assertSame([], $received);
+        self::assertSame($event, $returned);
+    }
+
+    public function test_an_unstopped_stoppable_event_is_dispatched(): void
+    {
+        $received = [];
+
+        $configured = new ConfigurableEventDispatcher();
+        $configured->registerGenericListeners([static function (object $event) use (&$received): void {
+            $received[] = $event;
+        }]);
+
+        $event = new UnstoppedEvent();
+        (new Psr14EventDispatcher($configured))->dispatch($event);
+
+        self::assertSame([$event], $received);
+    }
+}
+
+final class RefusingDispatcher implements EventDispatcherInterface
+{
+    /** @var list<object> */
+    private array $received = [];
+
+    public function dispatch(object $event): void
+    {
+        $this->received[] = $event;
+    }
+
+    public function hasListeners(string $eventClass): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function received(): array
+    {
+        return $this->received;
+    }
+}
+
+final class StoppedEvent implements GacelaEventInterface, StoppableEventInterface
+{
+    public function toString(): string
+    {
+        return 'stopped event';
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return true;
+    }
+}
+
+final class UnstoppedEvent implements GacelaEventInterface, StoppableEventInterface
+{
+    public function toString(): string
+    {
+        return 'unstopped event';
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Framework/Event/Dispatcher/PsrEventDispatcherAdapterTest.php
+++ b/tests/Unit/Framework/Event/Dispatcher/PsrEventDispatcherAdapterTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Event\Dispatcher;
+
+use Gacela\Framework\Event\Dispatcher\EventDispatcherInterface;
+use Gacela\Framework\Event\Dispatcher\NullEventDispatcher;
+use Gacela\Framework\Event\Dispatcher\PsrEventDispatcherAdapter;
+use GacelaTest\Unit\Framework\Config\GacelaFileConfig\Factory\FakeEvent;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+
+final class PsrEventDispatcherAdapterTest extends TestCase
+{
+    public function test_the_event_reaches_the_psr_dispatcher(): void
+    {
+        $psr = new RecordingPsrDispatcher();
+        $event = new FakeEvent();
+
+        (new PsrEventDispatcherAdapter($psr))->dispatch($event);
+
+        self::assertSame([$event], $psr->received());
+    }
+
+    /**
+     * PSR-14 has no way to ask what is subscribed: a bus is precisely the thing
+     * that knows its listeners while its caller does not. Answering `false`
+     * would make every dispatch site skip, and the dispatcher an application
+     * deliberately handed over would receive nothing at all -- silently.
+     */
+    public function test_it_answers_that_anything_may_have_a_listener(): void
+    {
+        $adapter = new PsrEventDispatcherAdapter(new RecordingPsrDispatcher());
+
+        self::assertTrue($adapter->hasListeners(FakeEvent::class));
+        self::assertTrue($adapter->hasListeners('Some\Event\Nobody\Registered'));
+    }
+
+    /**
+     * The price of the answer above, stated as a test: every guarded dispatch
+     * site allocates its event once a PSR-14 bus is installed. It is paid only
+     * by an application that installed one, and there is no cheaper honest
+     * answer -- see the class docblock.
+     */
+    public function test_every_event_dispatched_after_the_handover_arrives(): void
+    {
+        $psr = new RecordingPsrDispatcher();
+        $adapter = new PsrEventDispatcherAdapter($psr);
+
+        $first = new FakeEvent();
+        $second = new FakeEvent();
+        $adapter->dispatch($first);
+        $adapter->dispatch($second);
+
+        self::assertSame([$first, $second], $psr->received());
+    }
+
+    /**
+     * PSR-14 says the dispatcher returns the event, and permits it to be a
+     * different object. Gacela's returns nothing, so whatever the bus hands
+     * back is dropped here rather than leaking somewhere no caller could use
+     * it -- and the dispatch itself still happened, which is the part that
+     * matters to the framework.
+     */
+    public function test_a_bus_answering_with_another_object_changes_nothing(): void
+    {
+        $psr = new RecordingPsrDispatcher(new FakeEvent());
+        $event = new FakeEvent();
+
+        (new PsrEventDispatcherAdapter($psr))->dispatch($event);
+
+        self::assertSame([$event], $psr->received());
+    }
+
+    public function test_wrapping_a_psr_dispatcher_adapts_it(): void
+    {
+        $psr = new RecordingPsrDispatcher();
+
+        $wrapped = PsrEventDispatcherAdapter::wrap($psr);
+        $event = new FakeEvent();
+        $wrapped->dispatch($event);
+
+        self::assertInstanceOf(PsrEventDispatcherAdapter::class, $wrapped);
+        self::assertSame([$event], $psr->received());
+    }
+
+    /**
+     * A dispatcher that already speaks Gacela's interface is installed as it
+     * is. Wrapping it would throw away the `hasListeners()` it answers for
+     * itself -- the one thing an adapter around a PSR-14 bus cannot know --
+     * and every guarded dispatch site would start allocating.
+     */
+    public function test_wrapping_a_gacela_dispatcher_hands_back_the_same_object(): void
+    {
+        $gacela = new NullEventDispatcher();
+
+        self::assertSame($gacela, PsrEventDispatcherAdapter::wrap($gacela));
+    }
+
+    /**
+     * `void` satisfies PSR-14's untyped `dispatch()`, so one class can carry
+     * both interfaces. Gacela's is the richer contract of the two, and taking
+     * it keeps such a dispatcher's own `hasListeners()` in charge.
+     */
+    public function test_a_dispatcher_that_is_both_is_taken_as_the_gacela_one(): void
+    {
+        $both = new BothInterfacesDispatcher();
+
+        self::assertSame($both, PsrEventDispatcherAdapter::wrap($both));
+    }
+}
+
+final class RecordingPsrDispatcher implements PsrEventDispatcherInterface
+{
+    /** @var list<object> */
+    private array $received = [];
+
+    /**
+     * @param object|null $answer what `dispatch()` hands back instead of the
+     *   event, which PSR-14 permits: it declares no return type at all
+     */
+    public function __construct(
+        private readonly ?object $answer = null,
+    ) {
+    }
+
+    public function dispatch(object $event): object
+    {
+        $this->received[] = $event;
+
+        return $this->answer ?? $event;
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function received(): array
+    {
+        return $this->received;
+    }
+}
+
+/**
+ * Both contracts at once: `void` satisfies PSR-14's untyped `dispatch()`,
+ * whatever the prose around it says the return value means.
+ */
+final class BothInterfacesDispatcher implements EventDispatcherInterface, PsrEventDispatcherInterface
+{
+    public function dispatch(object $event): void
+    {
+    }
+
+    public function hasListeners(string $eventClass): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Framework/Preload/PreloaderTest.php
+++ b/tests/Unit/Framework/Preload/PreloaderTest.php
@@ -168,6 +168,7 @@ final class PreloaderTest extends TestCase
         self::assertArrayHasKey('Gacela\\Framework\\', $prefixes);
         self::assertArrayHasKey('Gacela\\Container\\', $prefixes);
         self::assertArrayHasKey('Psr\\Container\\', $prefixes);
+        self::assertArrayHasKey('Psr\\EventDispatcher\\', $prefixes);
     }
 
     public function test_every_prefix_points_at_a_directory_that_exists(): void
@@ -190,6 +191,7 @@ final class PreloaderTest extends TestCase
             'Gacela\\Framework\\' => $root . '/src/Framework/',
             'Gacela\\Container\\' => $root . '/vendor/gacela-project/container/src/Container/',
             'Psr\\Container\\' => $root . '/vendor/psr/container/src/',
+            'Psr\\EventDispatcher\\' => $root . '/vendor/psr/event-dispatcher/src/',
         ], Preloader::autoloadPrefixes($root));
     }
 
@@ -205,12 +207,14 @@ final class PreloaderTest extends TestCase
 
         mkdir($installed . '/src/Framework', 0o777, true);
         mkdir($vendor . '/psr/container/src', 0o777, true);
+        mkdir($vendor . '/psr/event-dispatcher/src', 0o777, true);
         mkdir($vendor . '/gacela-project/container/src/Container', 0o777, true);
 
         self::assertSame([
             'Gacela\\Framework\\' => $installed . '/src/Framework/',
             'Gacela\\Container\\' => $vendor . '/gacela-project/container/src/Container/',
             'Psr\\Container\\' => $vendor . '/psr/container/src/',
+            'Psr\\EventDispatcher\\' => $vendor . '/psr/event-dispatcher/src/',
         ], Preloader::autoloadPrefixes($installed));
     }
 


### PR DESCRIPTION
## 📚 Description

Modules in a modular monolith need to react to each other without depending on each other. Gacela had a fast dispatcher, a listener registry, `debug:events`, a doctor check and a benchmark for it — all scoped to the framework's own introspection events. A project could not cleanly dispatch its own: the dispatch API was a trait of two `private static` methods over an internal provider, `EventCatalog` was hard-scoped to `Gacela\Framework\Event\`, and `EventListenerTargetCheck` would call a listener on a project event a target no event can be. The tooling actively contradicted the use.

Builds directly on #896.

Closes #880

## 🔖 Changes

- **The dispatcher is an ordinary dependency.** A Factory injects it through `#[Provides]` / `getProvidedDependency()` instead of reaching for the static trait. Nothing was added to `AbstractFacade`/`AbstractFactory` — that events are a dependency like any other *is* the design
- **PSR-14 in both directions**, as two thin adapters rather than one class pretending to be both interfaces. PSR-14's `dispatch()` declares no return type and its contract returns the event; Gacela's declares `: void`. One class can satisfy both signatures and would still be a broken PSR-14 implementation, and widening Gacela's to `: object` would break every custom dispatcher already written. So `setEventDispatcher()` now accepts either interface and wraps when needed, and `Psr14EventDispatcher` hands Gacela's dispatcher to a library that wants PSR-14
- **What the PSR-14 adapter answers from `hasListeners()`: `true`, always** — and the docblock argues it. PSR-14 offers no way to ask what is subscribed, and `ListenerProviderInterface` resolves from an event *instance*, while the guard exists to answer before one is allocated. `false` would make every guarded site skip, so a bus the application deliberately handed over would receive nothing and nothing would say so — #888 one level down. `true` costs one event allocation per firing dispatch site, paid only by an application that installed a bus
- **A project's own events are first-class in the tooling.** `EventCatalog` reads the project's namespaces as well as the framework's, `debug:events` gains a source column, `doctor`'s listener-target check consults the widened catalog, and `GacelaTestCase::assertEventDispatched()` sees project events
- **The acceptance criterion, in the reference application:** `Billing` announces an invoice and `Notification` listens, and `Billing` imports nothing from `Notification` — verified, the only occurrence of the word in that module is prose in a docblock. `debug:graph --check --rules` and both analysers stay green over `module-rules.json`, so the decoupling is real rather than claimed. A second test hands over a PSR-14 dispatcher and asserts Gacela's events arrive on it
- `psr/event-dispatcher` moves into `require`. It was in `vendor/` only transitively through dev dependencies, which is not good enough for code in `src/`; it is interface-only and about three kilobytes

**Not built, deliberately:** async, an outbox, priorities, or stoppable propagation beyond what PSR-14's `StoppableEventInterface` gives for free — a project that needs Messenger has Messenger. No `#[AsListener]`; that is #881.

`EventDispatchBench` (the ±10% gate): 0.323μs / 0.338μs / 0.493μs against a ~0.35 / 0.39 / 0.56 baseline — unmoved. An application that supplies no dispatcher never constructs an adapter, so the hot-path guard stays the single array lookup it has always been.
