### PR TITLE
feat(bootstrap): merge the Gacela config an installed package declares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ gacela-doctor-strict-*/
 # is the directory that broke every Windows job once already: the name is not a
 # valid path there, so `git checkout` fails outright if it is ever committed.
 [\\]*
+
+# The reference application ships a hand-written `vendor/composer/installed.json`:
+# it is what package discovery reads, and the demonstration needs one on disk.
+!tests/Feature/ReferenceApp/Invoicing/vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ An invoicing SaaS under `tests/Feature/ReferenceApp/`, wired with every feature 
 - **duplicate provided id** reports one id declared twice on the same Provider: the last method wins, every one before it is dead, and all of them read as live
 - **cacheable storage** reports `#[Cacheable]` on the default backend, which dies with the process, so under PHP-FPM an hour's TTL is recomputed every request
 - More inert declarations: an `extendService()` id no Provider `set()`s, a listener target no dispatched event can be, an `addAppConfig()` path matching no file, a tagged id nothing can answer, listeners registered under `disableEventListeners()`, an unwritable cache directory, a namespace a package's `composer.json` never mentions, and stale editor metadata
-- Print only the checks that found something with `doctor --only-problems`. Twenty-one checks is a lot of "✓" to read to find the one "⚠", and `--strict -q` fails a build without saying what failed
+- Print only the checks that found something with `doctor --only-problems`. Twenty-two checks is a lot of "✓" to read to find the one "⚠", and `--strict -q` fails a build without saying what failed
 
 #### Static analysis
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ Lists every event the framework can dispatch, which of them your project listens
 
 An invoicing SaaS under `tests/Feature/ReferenceApp/`, wired with every feature at once and run on every pull request. Five modules, a three-layer harness — behaviour, every shipped command, and a guard that fails when a new `GacelaConfig` method, attribute or command is not used by it — and both analysers over the application with the opt-in architecture rules turned on. See [docs/reference-app.md](docs/reference-app.md).
 
+#### Package discovery
+
+A Composer package can contribute to a Gacela application by being installed. It declares its own config file in `composer.json` — `extra.gacela.config`, returning the same `callable(GacelaConfig)` a project's `gacela.php` returns — and everything it declares is merged before the project's own, so the project always has the last word. Until now a package's listeners, plugin members, `#[Provides]` providers, suffix types, DTO schemas and doctor checks had to be pasted into every consuming project by hand and kept in sync by hand. See [shipping a Gacela package](docs/packages.md).
+
+- `vendor/composer/installed.json` is read once and the resolved list is cached; only packages declaring the key are considered, and `vendor/` is never scanned for config files
+- `dontDiscover(['vendor/pkg'])` opts a package out and `dontDiscover(['*'])` turns discovery off; opt-outs accumulate across the bootstrap closure and `gacela.php`
+- A `PackageConfigMergedEvent` per package makes the merge order observable, `debug:container` attributes what each package put in the container, and a `discovered packages` doctor check reports a declared config file that is missing or does not return a callable
+- A broken declaration never stops the boot — it is reported, not thrown
+
 ### Fixed
 
 - **The four pillars are built from the whole of `gacela.php`, not from `addBinding()` alone.** The container the class resolver constructs a Facade, Factory, Config or Provider from was seeded with bindings and contextual bindings and nothing else, so `loadDefinitions()`, `addAlias()`, `addFactory()`, `addProtected()`, `addLazy()`, tags, handler registries, plugin stacks, `extendService()` and `afterResolving()` reached every container except the one a project meets first: an interface declared in a definitions file resolved happily from `Gacela::container()` and threw `DependencyNotFoundException` the moment a Factory asked for it in its constructor. Both containers are now configured through one code path, in one order. The pillar container applies the configuration silently — `BindingRegisteredEvent` describes the configuration, which is walked once however many containers apply it, so listener counts and `assertBindingRegistered()` are unchanged

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,8 @@
         "psr-4": {
             "GacelaData\\": "data/",
             "GacelaTest\\": "tests/",
+            "GacelaTest\\Feature\\Framework\\PackageDiscovery\\Packages\\AuditTrail\\": "tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src",
+            "GacelaTest\\Feature\\ReferenceApp\\Packages\\InvoiceAudit\\": "tests/Feature/ReferenceApp/Packages/invoice-audit/src",
             "GacelaTest\\LaravelBridge\\": "laravel-bridge/tests/",
             "GacelaTest\\SymfonyBridge\\": "symfony-bridge/tests/"
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 - [Module boundaries](module-boundaries.md) — the cross-module rules, dependency-cycle gate, declared rules file, and CI graph review
 - [Module health checks](module-health-checks.md) — report module operational status
 - [Profiling](profiling.md) — instrument code with the in-memory `Profiler` and read it back with `profile:report`
+- [Shipping a Gacela package](packages.md) — let an installed Composer package contribute its own configuration, and control what a project discovers
 - [Events](events.md) — listen to Gacela internals: dispatch model, event catalog, cookbook
 - [Testing](testing.md) — `GacelaTestCase`: bootstrap isolation, module slices with doubles, container and boundary assertions
 - [Caching](caching.md) — overview of Gacela's three caching layers and when to reach for each

--- a/docs/events.md
+++ b/docs/events.md
@@ -52,6 +52,7 @@ Listeners can be registered in the `Gacela::bootstrap()` closure and in `gacela.
 ```
 Gacela::bootstrap()
  ├─ GacelaBootstrapStartedEvent
+ ├─ PackageConfigMergedEvent         (per discovered package, in merge order)
  ├─ ReadPhpConfigEvent               (per config file)
  ├─ ConfigInitializedEvent
  └─ GacelaBootstrapFinishedEvent
@@ -189,6 +190,7 @@ All classes live under `Gacela\Framework\Event\`. "Hot path" marks events fired 
 | Event | Fires when | Payload | Hot path |
 |---|---|---|---|
 | `GacelaBootstrapStartedEvent` | `Gacela::bootstrap()` begins (after the setup is processed) | `appRootDir()` | no |
+| `PackageConfigMergedEvent` | an installed package's `extra.gacela.config` was read and merged — one per package, in merge order | `packageName()`, `configFile()`, `position()` | no |
 | `GacelaBootstrapFinishedEvent` | bootstrap completed | `durationMs()` | no |
 
 ### Config (`Event\Config`, `Event\ConfigReader`)

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,234 @@
+# Shipping a Gacela package
+
+A Composer package can contribute to a Gacela application by being installed.
+It declares its configuration in its own `composer.json`:
+
+```json
+{
+    "name": "acme/invoice-audit",
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}
+```
+
+and that file returns the same thing a project's own `gacela.php` returns — a
+`callable(GacelaConfig): void`:
+
+```php
+<?php // config/gacela.php, in the package
+
+declare(strict_types=1);
+
+use Acme\InvoiceAudit\AuditChannel;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->addPluginStack(NotificationChannelInterface::class, [AuditChannel::class]);
+};
+```
+
+There is no second config format and no registration API to learn. The
+consuming application writes nothing:
+
+```bash
+composer require acme/invoice-audit
+```
+
+## Read the security note first
+
+**A discovered config is arbitrary PHP, executed inside `Gacela::bootstrap()`,
+in your application's process, with everything your application can reach.**
+
+That is the same bargain a Laravel service provider registered through
+`extra.laravel.providers` already asks for, and the same one a Composer install
+script asks for — but it is worth saying plainly rather than leaving it to be
+inferred, because `composer require` is the whole of the installation step.
+
+`GacelaConfig::dontDiscover()` is the control:
+
+```php
+// gacela.php, in the application
+return static function (GacelaConfig $config): void {
+    // Named packages: the file is never opened.
+    $config->dontDiscover(['acme/legacy-invoicing']);
+
+    // Everything, installed now or later: no package's file is opened at all.
+    $config->dontDiscover(['*']);
+};
+```
+
+Naming a package means its config is never *read*, not that its effects are
+undone afterwards. `dontDiscover(['*'])` is checked before the manifest is
+touched, so a project that wants nothing but its own `gacela.php` deciding what
+runs at boot pays nothing for the feature and reads nothing from `vendor/`.
+
+Both forms are read from the bootstrap closure and from `gacela.php`, and they
+accumulate across the two — a closure and a `gacela.php` that each refuse a
+package are refusing both. **They cannot be read from `gacela-{APP_ENV}.php`**:
+an environment file is merged *after* the packages, so an opt-out written there
+would arrive once the code it refuses had already run. `doctor` reports one
+written there rather than letting it look effective.
+
+## What a package can contribute
+
+Everything on `GacelaConfig`, which is the point of not inventing a second
+format. In practice:
+
+| | |
+|---|---|
+| bindings | `addBinding()`, `addFactory()`, `addLazy()`, `addProtected()`, `addAlias()` |
+| extension points | `addPluginStack()`, `addHandlerRegistry()`, `tag()`, `extendService()`, `extendProviderService()` |
+| behaviour at boot | `addPlugin()`, `registerSpecificListener()`, `registerGenericListener()` |
+| declarations | `declareConfigSchema()`, `declareDtoSchema()`, `addResolvableType()`, `addSuffixType*()` |
+| configuration values | `addAppConfigKeyValue()` |
+| health | `addHealthCheck()` |
+
+Two things a package should not reach for:
+
+- **`addAppConfig()`** — a config path resolves against the *application* root,
+  which the package knows nothing about. Ship `addAppConfigKeyValue()` defaults
+  instead, and let the application's own config layers override them.
+- **`setProjectNamespaces()` / `setAppModulePaths()`** — these describe the
+  application, and the merger *replaces* the module paths rather than appending,
+  so a package setting them would take the application's own list away.
+
+## Merge order
+
+```
+bootstrap closure  →  package 1  →  package 2  →  …  →  gacela.php  →  gacela-{APP_ENV}.php
+```
+
+Packages are merged in **Composer's installed order**, and the project's own
+configuration is merged after all of them — so **the project always has the last
+word**. Overriding a default a package set is one line in `gacela.php`:
+
+```php
+$config->addBinding(AuditSinkInterface::class, OurOwnSink::class);
+```
+
+Between two packages that declare the same thing, the later-installed one wins.
+**Do not rely on that.** Installed order is Composer's, decided by the dependency
+graph and by when things were added to `composer.json`; no application controls
+it, and it can change under a `composer update` that touches neither package. A
+package that needs to win should give the consuming project something to call
+instead.
+
+For anything *appended* rather than replaced — a plugin stack, a tag, a listener
+list — being merged first means being **first in the list**. A package's channel
+runs before the application's own:
+
+```
+$ vendor/bin/gacela debug:container --stats
+…
+Discovered packages:
+  1. acme/invoice-audit
+     /app/vendor/acme/invoice-audit/config/gacela.php
+     plugin stacks: NotificationChannelInterface => AuditChannel
+```
+
+## A broken declaration does not stop the boot
+
+`composer require` must never be able to stop an application from booting, so a
+declaration that cannot do what it says is skipped rather than fatal:
+
+- the file named by `extra.gacela.config` is not there;
+- the file is there and does not return a `callable(GacelaConfig)`.
+
+Both are silent at boot and reported by `doctor`:
+
+```
+$ vendor/bin/gacela doctor
+⚠ discovered packages
+    acme/invoice-audit declares /app/vendor/acme/invoice-audit/config/gacela.php, which file not found
+    → fix the `extra.gacela.config` path in the package, or drop the key; …
+```
+
+The same check reports an opt-out that refuses nothing — one written in an
+environment file, and one naming a package that declares no config — because a
+`dontDiscover()` entry that looks like it is working is worse than none.
+
+An application root with no `vendor/composer/installed.json` discovers nothing,
+silently. That is a checkout with no install, or a fixture directory used as an
+app root, and it is not a fault.
+
+## Seeing what a boot picked up
+
+Three reports, and one event.
+
+`debug:container --stats` names each discovered package, the file that ran, and
+what that file declared — the one source in an application a reader cannot find
+by searching it, because nothing in the project names the package. It names the
+refused ones too, so "opted out" is distinguishable from "not installed".
+`--json` carries the same under a `packages` key.
+
+`debug:events` lists a listener a package registered on the same terms as one the
+application registered: the listener registry is read off the configuration, so
+there is no blind spot for code nothing in the project names.
+
+`doctor` gives the verdict, from the same capture `debug:container` describes.
+
+And [`PackageConfigMergedEvent`](events.md) fires once per discovered package,
+carrying `packageName()`, `configFile()` and `position()` — the 1-based place in
+the merge order:
+
+```php
+$config->registerSpecificListener(
+    PackageConfigMergedEvent::class,
+    static fn (PackageConfigMergedEvent $event) => $logger->info($event->toString()),
+);
+```
+
+It is dispatched *after* the whole configuration is assembled rather than as each
+package is merged. The dispatcher is derived from the merged listeners, so firing
+during the merge would fire before the project's own listeners exist — and
+`gacela.php` is the natural place to write down what a boot picked up.
+
+## What it costs
+
+`vendor/composer/installed.json` is a few hundred kilobytes of JSON in a real
+application, and decoding it on every boot to find out that nothing declares
+anything is the cost worth avoiding. So the resolved list of config files is
+cached in the cache directory, keyed by that file's own size and modification
+time: a `composer install` moves the key and the previous answer stops being an
+answer. Nothing else has to invalidate it.
+
+The warm path is therefore a `stat` and an `include` of a small PHP array. An
+application where **no** package declares the key pays one `stat`, and one whose
+root was never `composer install`ed pays one `is_file`.
+
+Two things switch the cache off, both deliberately:
+
+- `setFileCache(false)` — the same trade a project already makes for class
+  resolution: every boot re-reads the manifest, and nothing is written to disk.
+- `dontDiscover(['*'])` — nothing is read, so there is nothing to cache.
+
+`cache:warm` and `cache:clear` treat the file like every other cache file.
+
+## Checklist for a package author
+
+1. `extra.gacela.config` in `composer.json`, pointing at a file that returns
+   `callable(GacelaConfig): void`.
+2. `require` on `gacela-project/gacela`, so the package declares what it imports
+   (`doctor` checks this too).
+3. Publish your extension points as interfaces and declare the stacks yourself:
+   `addPluginStack(YourContract::class, [YourDefault::class])`. A consuming
+   application appends to the same stack by naming the interface, which is then
+   the only thing it has to know about your package.
+4. Bind defaults, do not enforce them. The application is merged last; write the
+   documentation that says which binding to override.
+5. Keep the config file declarative. It runs during `Gacela::bootstrap()`, in
+   somebody else's process, before their application exists — read no
+   configuration, touch no network, write no files.
+6. Say in your README that installing the package runs code at boot, and that
+   `dontDiscover(['your/package'])` is how a consumer declines.
+
+## See also
+
+- [Getting started](getting-started.md) — the configuration surface a package shares with an application
+- [Container configuration](container-configuration.md) — plugin stacks, handler registries, tags
+- [Events](events.md) — `PackageConfigMergedEvent`, and the dispatch model a package's listener joins
+- [CLI commands](cli.md) — `debug:container`, `doctor`
+- [Reference application](reference-app.md) — two packages installed against it, one kept and one refused

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -162,7 +162,9 @@ Three reports, and one event.
 what that file declared — the one source in an application a reader cannot find
 by searching it, because nothing in the project names the package. It names the
 refused ones too, so "opted out" is distinguishable from "not installed".
-`--json` carries the same under a `packages` key.
+`--json` carries the same under a `packages` key, and the `dontDiscover()` list
+that decided it under `optedOut` — including an entry that refused nothing,
+which appears in neither of the other two lists.
 
 `debug:events` lists a listener a package registered on the same terms as one the
 application registered: the listener registry is read off the configuration, so

--- a/docs/rfc/0003-bootstrap-configuration-surface.md
+++ b/docs/rfc/0003-bootstrap-configuration-surface.md
@@ -78,6 +78,7 @@ Every public method, its bucket, and its verdict. **This table is a gate**: `tes
 | `declareConfigSchema()` | `declare*` | conforms |
 | `declareDtoSchema()` | `declare*` | conforms |
 | `disableEventListeners()` | — | exception: `enable*`'s negative twin; the grammar deliberately has no `disable*` row because most toggles default off, and this one defaults on |
+| `dontDiscover()` | — | exception: refuses the configuration named packages declare in `composer.json`, and a refusal is not a setting. `setDontDiscover()` conforms and reads as configuring a list, which is the opposite of what the call is for — it is the security control over code an install would otherwise run at boot, and it is named after the `extra.laravel.dont-discover` key every reader already knows |
 | `enableFileCache()` | `enable*` | conforms — sugar over `setFileCache(true)` |
 | `extendGacelaConfig()` | `extend*` | exception in meaning: composes another configuration surface into this one rather than wrapping a registered service; predates the grammar |
 | `extendGacelaConfigs()` | `extend*` | same as `extendGacelaConfig()`, plural variant |
@@ -98,7 +99,8 @@ Every public method, its bucket, and its verdict. **This table is a gate**: `tes
 | `validateConfigSchemaOnBoot()` | — | exception: semantically `enable*` (`enableConfigSchemaValidationOnBoot()` conforms and says less); recorded rather than renamed |
 | `when()` | — | exception: the head of the contextual-binding DSL (`when(X)->needs(Y)->give(Z)`); a prefix would break the sentence it starts |
 
-Eleven exceptions, each with the reason it stays. A twelfth needs a reason this table can hold.
+Every exception carries the reason it stays. A new one needs a reason this table
+can hold — the count is not the gate, the reason is.
 
 ## Non-goals
 

--- a/infection.json5
+++ b/infection.json5
@@ -489,7 +489,6 @@
                 // one prefix twice) and restores the list shape the return type
                 // declares. Every consumer foreaches the result, so the key shape is
                 // not observable.
-                "Gacela\\Console\\Application\\Doctor\\Check\\PackageManifestCheck::installedPackages",
                 "Gacela\\Console\\Domain\\PackageManifest\\NamespacePackageMap::from",
                 "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::undeclaredImportsOf",
                 "Gacela\\Console\\Domain\\PackageManifest\\PackageManifestChecker::autoloadedFilesOf",
@@ -659,11 +658,6 @@
         // return as behaviour. These two are allocation guards, not behaviour.
         ReturnRemoval: {
             ignore: [
-                // Same shape one level up: with no installed.json the guard
-                // returns null, and falling through reads an offset off null,
-                // which is null, which fails the is_array() below and returns
-                // null anyway. The guard is what keeps a php warning out of it.
-                "Gacela\\Console\\Application\\Doctor\\Check\\PackageManifestCheck::installedPackages",
                 // The early return for a non-object `autoload` is a guard, not a branch:
                 // falling through leaves the accumulator empty and returns the same [].
                 "Gacela\\Console\\Domain\\PackageManifest\\ComposerPackage::prefixesOf",

--- a/infection.json5
+++ b/infection.json5
@@ -162,6 +162,17 @@
                 // kept as the documented override convention, not as behavior.
                 "Gacela\\SymfonyBridge\\GacelaBundle::build",
             ],
+            ignoreSourceCodeByRegex: [
+                // Not an untested line: `composer test` fails on
+                // ResetCacheCoverageTest with this call removed, which is the
+                // test that exists to catch a reset nothing calls. It asserts by
+                // reading the source of Gacela::resetCache() rather than by
+                // executing it, so it covers none of that method's lines and a
+                // coverage-driven run never selects it for a mutant of them.
+                // Scoped to this one call by regex rather than to the method,
+                // because the resets around it are pinned by tests that do run.
+                '.*PackageContribution::resetCache\\(\\);.*',
+            ],
         },
         IfNegation: {
             ignore: [

--- a/infection.json5
+++ b/infection.json5
@@ -211,7 +211,34 @@
             ],
         },
         ArrayItemRemoval: {
-            ignore: ["Gacela\\Framework\\Cache\\FileCache::normalizeDirectory"],
+            ignore: [
+                "Gacela\\Framework\\Cache\\FileCache::normalizeDirectory",
+                // normalize() folds `['/', '\\']` to the local separator. Dropping
+                // `'/'` is the identity on POSIX, where DIRECTORY_SEPARATOR is
+                // already "/" -- the same reason as the
+                // `str_replace('/', DIRECTORY_SEPARATOR` regex above, which does
+                // not match this two-element call. Dropping `'\\'` *is* killed
+                // here, by the windows-drive install path in
+                // PackageConfigFinderTest, and the windows matrix is what
+                // enforces the other half.
+                "Gacela\\Framework\\Bootstrap\\Package\\PackageConfigFinder::normalize",
+            ],
+        },
+        // normalize() splits a windows drive off the front of the path before
+        // resolving the segments. Without the caret the pattern still matches at
+        // offset 0 for every path that has a drive, and for one that does not it
+        // takes the first two characters as the "drive" and the rest as the path
+        // -- which are then concatenated back together, byte for byte, because
+        // the split lands inside the first segment's name. Only a path whose
+        // first segment is a single character *and* whose second is `..` *and*
+        // which carries a drive-letter sequence further along could tell the two
+        // apart, and this method is only ever given an absolute directory
+        // followed by a declared relative path. The caret in isAbsolute(), where
+        // dropping it does change the answer, is pinned by name.
+        PregMatchRemoveCaret: {
+            ignore: [
+                "Gacela\\Framework\\Bootstrap\\Package\\PackageConfigFinder::normalize",
+            ],
         },
         LogicalAnd: {
             ignore: [
@@ -621,6 +648,12 @@
                 // identical condition and throws the identical exception, so no
                 // input can tell || from && at this call site.
                 "Gacela\\Framework\\Testing\\GacelaTestCase::assertNamesAFacade",
+                // fingerprint() asks filemtime() and filesize() about a path the
+                // is_file() right above it just accepted, so neither can be
+                // false unless the file vanished in between -- a filesystem
+                // race. Both halves of the `||` are unreachable from a test, for
+                // the same reason the CastInt entries above are.
+                "Gacela\\Framework\\Bootstrap\\Package\\InstalledPackagesReader::fingerprint",
             ],
         },
         // warmAttributeCache() breaks out of the prefix scan after the first
@@ -652,6 +685,14 @@
                 // when that regresses, not a mutant.
                 "Gacela\\Framework\\Event\\Dispatcher\\ConfigurableEventDispatcher::hasListeners",
                 "Gacela\\Framework\\Event\\Dispatcher\\ConfigurableEventDispatcher::dispatch",
+                // resolvableKinds() memoizes what an *empty* setup assembles to,
+                // so that reporting on N discovered packages costs one assembly
+                // instead of N. Recomputing it per call -- what the mutant does
+                // -- is always at least as correct: it is the staleness the memo
+                // risks that PackageContribution::resetCache() exists to undo, so
+                // no assertion can see the memo being right. Only the work is
+                // observable, and BootstrapBench is what fails when it grows.
+                "Gacela\\Framework\\Bootstrap\\Package\\PackageContribution::resolvableKinds",
             ],
         },
         // ReturnRemoval arrived with infection 0.34 and reads every early
@@ -700,6 +741,26 @@
                 // list. Only the work is observable, and the generation stamp is
                 // what makes the memo safe to keep.
                 "Gacela\\Framework\\ClassResolver\\ResolvableTypes::matchOrder",
+                // The three guards that refuse a manifest, a cache entry or a
+                // package entry that is not the shape it has to be. Falling
+                // through reads an offset off the non-array with `??`, which is
+                // null without a warning, which fails the is_array()/is_string()
+                // below and returns the identical null. Same shape as
+                // ComposerPackage::prefixesOf above -- and the same reasoning the
+                // `PackageManifestCheck::installedPackages` entry carried before
+                // that method's reader moved down into the framework.
+                "Gacela\\Framework\\Bootstrap\\Package\\InstalledPackagesReader::read",
+                "Gacela\\Framework\\Bootstrap\\Package\\PackageConfigCache::read",
+                "Gacela\\Framework\\Bootstrap\\Package\\PackageConfigFinder::declarationOf",
+                // announceDiscoveredPackages() opens with the hasListeners()
+                // guard every framework dispatch site carries, so an event is
+                // only built when something is listening. Removing it dispatches
+                // to nobody, which the dispatcher already treats as a no-op: the
+                // guard is what keeps a boot from allocating one event per
+                // discovered package for nothing. What the events *say* when a
+                // listener is registered is pinned by PackageDiscoveryTest's
+                // merge-order test.
+                "Gacela\\Framework\\Config\\ConfigFactory::announceDiscoveredPackages",
             ],
         },
         LogicalOrSingleSubExprNegation: {

--- a/rector.php
+++ b/rector.php
@@ -78,6 +78,8 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/Console/Infrastructure/Command/DebugContainerCommand.php',
             __DIR__ . '/src/Framework/Attribute/CacheableTrait.php',
             __DIR__ . '/src/Framework/Bootstrap/GacelaConfig.php',
+            __DIR__ . '/src/Framework/Bootstrap/Package/PackageConfigCache.php',
+            __DIR__ . '/src/Framework/Bootstrap/Package/PackageConfigFinder.php',
             __DIR__ . '/src/Framework/Container/Container.php',
             __DIR__ . '/src/Framework/Health/HealthCheckRegistry.php',
             __DIR__ . '/src/Framework/Testing/ContainerFixture.php',

--- a/src/Console/Application/Debug/PackageDiscoveryReport.php
+++ b/src/Console/Application/Debug/PackageDiscoveryReport.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Debug;
+
+use Gacela\Framework\Bootstrap\Package\DiscoveredPackage;
+use Gacela\Framework\Bootstrap\Package\InstalledPackagesReader;
+use Gacela\Framework\Bootstrap\Package\PackageConfigDeclaration;
+use Gacela\Framework\Bootstrap\Package\PackageConfigFinder;
+use Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry;
+use Gacela\Framework\Bootstrap\Package\RefusedPackage;
+
+use function array_map;
+
+/**
+ * What package discovery did on this boot, and what it was asked to do.
+ *
+ * Read by `debug:container`, which describes it, and by the `doctor` check,
+ * which judges it -- one capture, so the description and the verdict cannot
+ * disagree about the same application.
+ *
+ * The declarations are re-read from `installed.json` rather than taken from the
+ * registry alone, because `dontDiscover(['*'])` means nothing was read and a
+ * report that then said "no packages declare a config" would be describing the
+ * switch instead of the application. Reading the manifest executes nothing: it
+ * is the *config files* that are code, and this never opens one.
+ */
+final class PackageDiscoveryReport
+{
+    /**
+     * @param list<PackageConfigDeclaration> $declarations every declaration on disk, in installed order
+     * @param list<DiscoveredPackage>        $discovered   those that were read and merged, in merge order
+     * @param list<RefusedPackage>           $refused      those that were not, and why
+     * @param list<string>                   $optedOut     the merged `dontDiscover()` list
+     */
+    public function __construct(
+        public readonly bool $hasInstalledJson,
+        public readonly bool $discoveryDisabled,
+        public readonly array $declarations,
+        public readonly array $discovered,
+        public readonly array $refused,
+        public readonly array $optedOut,
+    ) {
+    }
+
+    /**
+     * @param list<string> $optedOut
+     */
+    public static function capture(string $appRootDir, array $optedOut): self
+    {
+        $reader = new InstalledPackagesReader($appRootDir);
+
+        return new self(
+            $reader->read() !== null,
+            PackageDiscoveryRegistry::isDisabled(),
+            (new PackageConfigFinder($reader))->find(),
+            PackageDiscoveryRegistry::discovered(),
+            PackageDiscoveryRegistry::refused(),
+            $optedOut,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function declaredNames(): array
+    {
+        return array_map(
+            static fn (PackageConfigDeclaration $declaration): string => $declaration->name,
+            $this->declarations,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function discoveredNames(): array
+    {
+        return array_map(
+            static fn (DiscoveredPackage $package): string => $package->name,
+            $this->discovered,
+        );
+    }
+}

--- a/src/Console/Application/Doctor/Check/DiscoveredPackagesCheck.php
+++ b/src/Console/Application/Doctor/Check/DiscoveredPackagesCheck.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Debug\PackageDiscoveryReport;
+use Gacela\Console\Application\Doctor\CheckResult;
+use Gacela\Console\Application\Doctor\HealthCheck;
+use Gacela\Framework\Bootstrap\Package\PackageConfigDeclaration;
+use Gacela\Framework\Bootstrap\Package\PackageDiscovery;
+use Gacela\Framework\Bootstrap\Package\PackageRefusal;
+use Gacela\Framework\Bootstrap\Package\RefusedPackage;
+
+use function array_fill_keys;
+use function count;
+use function in_array;
+use function is_file;
+use function sprintf;
+
+/**
+ * Reports a package whose declared Gacela config cannot do what it says.
+ *
+ * Discovery is deliberately forgiving -- a broken declaration is skipped rather
+ * than fatal, because `composer require` must never be able to stop an
+ * application from booting. That forgiveness is only safe if something says so
+ * out loud afterwards, and this is that something: without it a package author
+ * ships a typo and every consumer sees a package that silently does nothing.
+ *
+ * It also reports the two ways an opt-out can be wrong, which are both invisible
+ * otherwise: one written where it arrives too late to have refused anything, and
+ * one naming a package that is not installed.
+ */
+final class DiscoveredPackagesCheck implements HealthCheck
+{
+    private const string REMEDIATION = 'fix the `extra.gacela.config` path in the package, or drop the key; '
+        . 'move an opt-out into `gacela.php` or the bootstrap closure, where it is read before any package runs';
+
+    public function __construct(
+        private readonly PackageDiscoveryReport $report,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'discovered packages';
+    }
+
+    public function run(): CheckResult
+    {
+        if (!$this->report->hasInstalledJson) {
+            return CheckResult::ok($this->name(), 'no vendor/composer/installed.json — nothing to discover');
+        }
+
+        if ($this->report->declarations === []) {
+            return CheckResult::ok($this->name(), 'no installed package declares `extra.gacela.config`');
+        }
+
+        $findings = [...$this->brokenDeclarations(), ...$this->uselessOptOuts()];
+
+        if ($findings !== []) {
+            return CheckResult::warn($this->name(), $findings, self::REMEDIATION);
+        }
+
+        if ($this->report->discoveryDisabled) {
+            return CheckResult::ok($this->name(), sprintf(
+                '%d package(s) declare a config and none was read — `dontDiscover([\'*\'])`',
+                count($this->report->declarations),
+            ));
+        }
+
+        return CheckResult::ok($this->name(), sprintf(
+            '%d of %d declared package config(s) merged',
+            count($this->report->discovered),
+            count($this->report->declarations),
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function brokenDeclarations(): array
+    {
+        $findings = [];
+
+        foreach ($this->report->refused as $refused) {
+            if ($refused->reason->isBroken()) {
+                $findings[] = sprintf(
+                    '%s declares %s, which %s',
+                    $refused->name,
+                    $refused->configFile,
+                    $refused->reason->value,
+                );
+            }
+        }
+
+        // Discovery deliberately never opened these, so nothing recorded a
+        // verdict on them. Whether the file is *there* is still answerable
+        // without running it, and it is the mistake worth catching: a package
+        // refused today was installed for its config, and a missing one would
+        // otherwise wait to surprise whoever removes the opt-out.
+        foreach ($this->unopenedDeclarations() as $declaration) {
+            if (!is_file($declaration->configFile)) {
+                $findings[] = sprintf(
+                    '%s declares %s, which %s (not read: this project opted out of it)',
+                    $declaration->name,
+                    $declaration->configFile,
+                    PackageRefusal::MissingFile->value,
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Refused by name, or never looked at because `dontDiscover(['*'])`
+     * stopped the manifest being read at all.
+     *
+     * @return list<PackageConfigDeclaration>
+     */
+    private function unopenedDeclarations(): array
+    {
+        $optedOutByName = [];
+
+        foreach ($this->report->refused as $refused) {
+            if (!$refused->reason->isBroken()) {
+                $optedOutByName[] = $refused->name;
+            }
+        }
+
+        $judged = [...$this->report->discoveredNames(), ...array_map(
+            static fn (RefusedPackage $refused): string => $refused->name,
+            $this->report->refused,
+        )];
+
+        $unopened = [];
+
+        foreach ($this->report->declarations as $declaration) {
+            if (in_array($declaration->name, $optedOutByName, true) || !in_array($declaration->name, $judged, true)) {
+                $unopened[] = $declaration;
+            }
+        }
+
+        return $unopened;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function uselessOptOuts(): array
+    {
+        $findings = [];
+        // Keyed rather than searched: two `in_array()` negations on one name in
+        // a row read to Psalm as the same question asked twice.
+        $declared = array_fill_keys($this->report->declaredNames(), true);
+        $discovered = array_fill_keys($this->report->discoveredNames(), true);
+
+        foreach ($this->report->optedOut as $name) {
+            if ($name === PackageDiscovery::EVERYTHING) {
+                continue;
+            }
+
+            if (isset($discovered[$name])) {
+                // The only way this happens: the opt-out is in
+                // `gacela-{APP_ENV}.php`, which is merged after the packages.
+                $findings[] = sprintf(
+                    'dontDiscover() names %s and its config was merged anyway — an environment file is read after the packages, so the opt-out arrived too late',
+                    $name,
+                );
+                continue;
+            }
+
+            if (!isset($declared[$name])) {
+                $findings[] = sprintf(
+                    'dontDiscover() names %s, which declares no `extra.gacela.config` — the entry refuses nothing',
+                    $name,
+                );
+            }
+        }
+
+        return $findings;
+    }
+}

--- a/src/Console/Application/Doctor/Check/PackageManifestCheck.php
+++ b/src/Console/Application/Doctor/Check/PackageManifestCheck.php
@@ -6,14 +6,13 @@ namespace Gacela\Console\Application\Doctor\Check;
 
 use Gacela\Console\Application\Doctor\CheckResult;
 use Gacela\Console\Application\Doctor\HealthCheck;
-use Gacela\Console\Domain\FileContent\JsonFile;
 use Gacela\Console\Domain\PackageManifest\ComposerPackageFinder;
 use Gacela\Console\Domain\PackageManifest\NamespacePackageMap;
 use Gacela\Console\Domain\PackageManifest\PackageManifestChecker;
 use Gacela\Console\Domain\PackageManifest\UndeclaredImport;
+use Gacela\Framework\Bootstrap\Package\InstalledPackagesReader;
 
 use function count;
-use function is_array;
 use function sprintf;
 
 /**
@@ -47,7 +46,7 @@ final class PackageManifestCheck implements HealthCheck
             return CheckResult::ok($this->name(), 'no named composer package to check');
         }
 
-        $installed = $this->installedPackages();
+        $installed = (new InstalledPackagesReader($this->appRootDir))->read();
 
         // Without installed.json an import cannot be attributed to a package,
         // and guessing would name the wrong manifest to fix.
@@ -79,23 +78,4 @@ final class PackageManifestCheck implements HealthCheck
         );
     }
 
-    /**
-     * @return list<mixed>|null
-     */
-    private function installedPackages(): ?array
-    {
-        $path = $this->appRootDir . DIRECTORY_SEPARATOR . 'vendor'
-            . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json';
-
-        $decoded = JsonFile::decode($path);
-
-        if ($decoded === null) {
-            return null;
-        }
-
-        /** @var mixed $packages */
-        $packages = $decoded['packages'] ?? $decoded;
-
-        return is_array($packages) ? array_values($packages) : null;
-    }
 }

--- a/src/Console/ConsoleFacade.php
+++ b/src/Console/ConsoleFacade.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gacela\Console;
 
+use Gacela\Console\Application\Debug\PackageDiscoveryReport;
 use Gacela\Console\Domain\AllAppModules\AppModule;
 use Gacela\Console\Domain\AllAppModules\UndiscoveredFacadeFile;
 use Gacela\Console\Domain\CommandArguments\CommandArguments;
@@ -328,6 +329,11 @@ final class ConsoleFacade extends AbstractFacade
     public function getContainerBindings(): array
     {
         return $this->getFactory()->getContainerBindings();
+    }
+
+    public function getPackageDiscoveryReport(): PackageDiscoveryReport
+    {
+        return $this->getFactory()->getPackageDiscoveryReport();
     }
 
     /**

--- a/src/Console/ConsoleFactory.php
+++ b/src/Console/ConsoleFactory.php
@@ -6,6 +6,7 @@ namespace Gacela\Console;
 
 use AppendIterator;
 use FilesystemIterator;
+use Gacela\Console\Application\Debug\PackageDiscoveryReport;
 use Gacela\Console\Application\DtoGenerate\DtoGenerator;
 use Gacela\Console\Application\IdeMeta\IdeMetadataGenerator;
 use Gacela\Console\Application\IdeMeta\IdeMetadataScanner;
@@ -44,6 +45,7 @@ use Gacela\Console\Domain\ServiceMapMigration\ServiceMapMigrator;
 use Gacela\Console\Infrastructure\FileContentIo;
 use Gacela\Container\ContainerStats;
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\ClassResolver\Config\ConfigResolver;
 use Gacela\Framework\ClassResolver\Factory\FactoryResolver;
 use Gacela\Framework\ClassResolver\Provider\ProviderResolver;
@@ -306,6 +308,22 @@ final class ConsoleFactory extends AbstractFactory
         }
 
         return $result;
+    }
+
+    /**
+     * What the packages installed against this application contributed.
+     *
+     * Same source as the `doctor` check that judges it, so a description and a
+     * verdict of one boot cannot disagree.
+     */
+    public function getPackageDiscoveryReport(): PackageDiscoveryReport
+    {
+        $setup = Config::getInstance()->getSetupGacela();
+
+        return PackageDiscoveryReport::capture(
+            Config::getInstance()->getAppRootDir(),
+            $setup instanceof SetupGacela ? $setup->getDontDiscover() : [],
+        );
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -121,6 +121,13 @@ final class DebugContainerCommand extends Command
             'installedJson' => $report->hasInstalledJson,
             'discoveryDisabled' => $report->discoveryDisabled,
             'declared' => $report->declaredNames(),
+            // The input, next to the outcomes: `dontDiscover()` is what decided
+            // which of the declared configs below ran, and it is the one part of
+            // that decision the human-readable section cannot show -- an entry
+            // naming a package nobody installed refuses nothing, so it appears
+            // in neither `discovered` nor `refused`. `doctor` judges those; this
+            // document is what an operator reads them out of.
+            'optedOut' => $report->optedOut,
             'discovered' => array_map(
                 static fn (DiscoveredPackage $package): array => [
                     'name' => $package->name,

--- a/src/Console/Infrastructure/Command/DebugContainerCommand.php
+++ b/src/Console/Infrastructure/Command/DebugContainerCommand.php
@@ -9,6 +9,8 @@ use Gacela\Console\Application\Debug\DependencyTreeNode;
 use Gacela\Console\Application\Debug\DependencyTreeRenderer;
 use Gacela\Console\ConsoleFacade;
 use Gacela\Container\ContainerStats;
+use Gacela\Framework\Bootstrap\Package\DiscoveredPackage;
+use Gacela\Framework\Bootstrap\Package\RefusedPackage;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Symfony\Component\Console\Command\Command;
@@ -100,9 +102,43 @@ final class DebugContainerCommand extends Command
             // and how a consumer looks one up. Empty stays `{}` rather than
             // becoming `[]`, so the shape does not change with the contents.
             'bindings' => (object)$this->getFacade()->getContainerBindings(),
+            // Additive: a consumer reading `stats` or `bindings` is unaffected,
+            // and one asking what an install put in the container has an answer.
+            'packages' => $this->packagesDocument(),
         ]));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function packagesDocument(): array
+    {
+        $report = $this->getFacade()->getPackageDiscoveryReport();
+
+        return [
+            'installedJson' => $report->hasInstalledJson,
+            'discoveryDisabled' => $report->discoveryDisabled,
+            'declared' => $report->declaredNames(),
+            'discovered' => array_map(
+                static fn (DiscoveredPackage $package): array => [
+                    'name' => $package->name,
+                    'configFile' => $package->configFile,
+                    'position' => $package->position,
+                    'contributed' => (object)$package->contribution->items(),
+                ],
+                $report->discovered,
+            ),
+            'refused' => array_map(
+                static fn (RefusedPackage $package): array => [
+                    'name' => $package->name,
+                    'configFile' => $package->configFile,
+                    'reason' => $package->reason->value,
+                ],
+                $report->refused,
+            ),
+        ];
     }
 
     private function reportDependencyTree(OutputInterface $output, string $className, bool $asJson): int
@@ -186,6 +222,8 @@ final class DebugContainerCommand extends Command
             $output->writeln('');
         }
 
+        $this->displayDiscoveredPackages($output);
+
         // Every counter, not just the services: a binding registers none, so
         // keying the hint on that one printed "Container is empty" directly
         // under "User Bindings: 1" -- and checking that a binding landed is the
@@ -200,6 +238,55 @@ final class DebugContainerCommand extends Command
         $output->writeln('');
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Who put what in here that this application never wrote down.
+     *
+     * A binding is printed above with no hint of where it came from, and a
+     * discovered package is the one source a reader cannot find by searching the
+     * project: nothing in it names the package. So this names the package, the
+     * file that ran, and what that file declared.
+     *
+     * Silent when no package declares a config, which is every application that
+     * has not installed one -- a section saying "none" on every project is a
+     * section people stop reading.
+     */
+    private function displayDiscoveredPackages(OutputInterface $output): void
+    {
+        $report = $this->getFacade()->getPackageDiscoveryReport();
+
+        if ($report->declarations === []) {
+            return;
+        }
+
+        $output->writeln('<fg=cyan>Discovered packages:</>');
+
+        if ($report->discoveryDisabled) {
+            $output->writeln(sprintf(
+                "  <comment>none read: dontDiscover(['*']) — %d package(s) declare one</comment>",
+                count($report->declarations),
+            ));
+        }
+
+        foreach ($report->discovered as $package) {
+            $output->writeln(sprintf('  %d. %s', $package->position, $package->name));
+            $output->writeln(sprintf('     %s', $package->configFile));
+
+            foreach ($package->contribution->items() as $kind => $labels) {
+                $output->writeln(sprintf('     %s: %s', $kind, implode(', ', $labels)));
+            }
+
+            if ($package->contribution->isEmpty()) {
+                $output->writeln('     declares nothing');
+            }
+        }
+
+        foreach ($report->refused as $package) {
+            $output->writeln(sprintf('  ✗ %s — %s', $package->name, $package->reason->value));
+        }
+
+        $output->writeln('');
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Debug\EventCatalog;
+use Gacela\Console\Application\Debug\PackageDiscoveryReport;
 use Gacela\Console\Application\Doctor\Check\CacheableStorageCheck;
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigEnvironmentLayerCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSchemaCheck;
 use Gacela\Console\Application\Doctor\Check\ConfigSourceCheck;
+use Gacela\Console\Application\Doctor\Check\DiscoveredPackagesCheck;
 use Gacela\Console\Application\Doctor\Check\DuplicateProvidedIdCheck;
 use Gacela\Console\Application\Doctor\Check\EventListenerTargetCheck;
 use Gacela\Console\Application\Doctor\Check\FilenameMismatchCheck;
@@ -319,6 +321,7 @@ final class DoctorCommand extends Command
             // namespace filter left behind would report every scoped run as
             // stale.
             new PackageManifestCheck($config->getAppRootDir()),
+            new DiscoveredPackagesCheck($this->packageDiscoveryReport()),
             new IdeMetadataStalenessCheck(
                 $config->getAppRootDir(),
                 fn (): IdeMetadataResult => $this->getFacade()->generateIdeMetadata(dryRun: true),
@@ -330,6 +333,20 @@ final class DoctorCommand extends Command
         }
 
         return $checks;
+    }
+
+    /**
+     * The opt-out list comes off the concrete setup, for the same reason the
+     * listener map below does.
+     */
+    private function packageDiscoveryReport(): PackageDiscoveryReport
+    {
+        $setup = Config::getInstance()->getSetupGacela();
+
+        return PackageDiscoveryReport::capture(
+            Config::getInstance()->getAppRootDir(),
+            $setup instanceof SetupGacela ? $setup->getDontDiscover() : [],
+        );
     }
 
     /**

--- a/src/Console/Infrastructure/Command/DoctorCommand.php
+++ b/src/Console/Infrastructure/Command/DoctorCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\Console\Infrastructure\Command;
 
 use Gacela\Console\Application\Debug\EventCatalog;
-use Gacela\Console\Application\Debug\PackageDiscoveryReport;
 use Gacela\Console\Application\Doctor\Check\CacheableStorageCheck;
 use Gacela\Console\Application\Doctor\Check\CacheStalenessCheck;
 use Gacela\Console\Application\Doctor\Check\CacheWritabilityCheck;
@@ -321,7 +320,11 @@ final class DoctorCommand extends Command
             // namespace filter left behind would report every scoped run as
             // stale.
             new PackageManifestCheck($config->getAppRootDir()),
-            new DiscoveredPackagesCheck($this->packageDiscoveryReport()),
+            // One capture, taken through the facade `debug:container` uses, so
+            // the verdict here and the description there cannot disagree about
+            // the same boot -- and there is one place that reads the opt-out
+            // list off the concrete setup instead of two.
+            new DiscoveredPackagesCheck($this->getFacade()->getPackageDiscoveryReport()),
             new IdeMetadataStalenessCheck(
                 $config->getAppRootDir(),
                 fn (): IdeMetadataResult => $this->getFacade()->generateIdeMetadata(dryRun: true),
@@ -333,20 +336,6 @@ final class DoctorCommand extends Command
         }
 
         return $checks;
-    }
-
-    /**
-     * The opt-out list comes off the concrete setup, for the same reason the
-     * listener map below does.
-     */
-    private function packageDiscoveryReport(): PackageDiscoveryReport
-    {
-        $setup = Config::getInstance()->getSetupGacela();
-
-        return PackageDiscoveryReport::capture(
-            Config::getInstance()->getAppRootDir(),
-            $setup instanceof SetupGacela ? $setup->getDontDiscover() : [],
-        );
     }
 
     /**

--- a/src/Framework/Bootstrap/AbstractSetupGacela.php
+++ b/src/Framework/Bootstrap/AbstractSetupGacela.php
@@ -29,6 +29,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
 
     public const string appModulePaths = 'appModulePaths';
 
+    public const string dontDiscover = 'dontDiscover';
+
     public const string configKeyValues = 'configKeyValues';
 
     public const string configSchema = 'configSchema';
@@ -78,6 +80,8 @@ abstract class AbstractSetupGacela implements SetupGacelaInterface
     protected const array DEFAULT_CONFIG_DIMENSIONS = [];
 
     protected const array DEFAULT_APP_MODULE_PATHS = [];
+
+    protected const array DEFAULT_DONT_DISCOVER = [];
 
     protected const array DEFAULT_CONFIG_KEY_VALUES = [];
 

--- a/src/Framework/Bootstrap/GacelaConfig.php
+++ b/src/Framework/Bootstrap/GacelaConfig.php
@@ -69,6 +69,9 @@ final class GacelaConfig
     /** @var list<string> */
     private ?array $appModulePaths = null;
 
+    /** @var list<string> */
+    private ?array $dontDiscover = null;
+
     /** @var ConfigKeyValues */
     private ?array $configKeyValues = null;
 
@@ -400,6 +403,41 @@ final class GacelaConfig
     public function setAppModulePaths(array $paths): self
     {
         $this->appModulePaths = $paths;
+
+        return $this;
+    }
+
+    /**
+     * Refuse the Gacela configuration an installed package declares in its
+     * `composer.json` under `extra.gacela.config`.
+     *
+     * A discovered config is arbitrary PHP, executed during
+     * `Gacela::bootstrap()` in the same process as the application -- exactly
+     * like a Laravel service provider registered through `extra.laravel`. This
+     * is the control over it. Naming a package here means its file is never
+     * read, not that its effects are undone afterwards.
+     *
+     * ```php
+     * $config->dontDiscover(['acme/legacy-invoicing']);
+     * $config->dontDiscover(['*']); // no package config is read at all
+     * ```
+     *
+     * Names are the Composer package names as `composer.json` writes them,
+     * matched exactly. `'*'` refuses every package, including ones installed
+     * later, and is the switch to reach for when a project wants nothing but
+     * its own `gacela.php` deciding what runs at boot.
+     *
+     * Read from the bootstrap closure and from `gacela.php`, and merged across
+     * both. It cannot be read from `gacela-{env}.php`: an environment file is
+     * merged *after* the packages, so an opt-out written there would arrive
+     * once the code it refuses had already run. `doctor` reports one written
+     * there rather than letting it look effective.
+     *
+     * @param list<string> $packages
+     */
+    public function dontDiscover(array $packages): self
+    {
+        $this->dontDiscover = $packages;
 
         return $this;
     }
@@ -1039,6 +1077,7 @@ final class GacelaConfig
             $this->projectNamespaces,
             $this->configDimensions,
             $this->appModulePaths,
+            $this->dontDiscover,
             $this->configKeyValues,
             $this->genericListeners,
             $this->specificListeners,

--- a/src/Framework/Bootstrap/Package/DiscoveredPackage.php
+++ b/src/Framework/Bootstrap/Package/DiscoveredPackage.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+/**
+ * A package whose declared Gacela config was read and merged.
+ */
+final class DiscoveredPackage
+{
+    /**
+     * @param int $position 1-based place in the merge order, which is Composer's
+     *                      installed order -- see {@see PackageDiscovery}
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $configFile,
+        public readonly int $position,
+        public readonly PackageContribution $contribution,
+    ) {
+    }
+}

--- a/src/Framework/Bootstrap/Package/InstalledPackagesReader.php
+++ b/src/Framework/Bootstrap/Package/InstalledPackagesReader.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+use function array_values;
+use function file_get_contents;
+use function filemtime;
+use function filesize;
+use function is_array;
+use function is_file;
+use function json_decode;
+use function sprintf;
+
+/**
+ * The one reader of `vendor/composer/installed.json`.
+ *
+ * Two things read that file -- package discovery at bootstrap, and the `doctor`
+ * check that reports on what packages declared -- and a second parser of the
+ * same file is how the two drift apart. It lives below the console because
+ * discovery runs during `Gacela::bootstrap()`, where nothing of the console is
+ * loaded.
+ *
+ * Absent, unreadable and malformed all collapse to null on purpose: this is a
+ * manifest nobody here owns, and for every caller the three are the same
+ * outcome -- there is nothing to read, so nothing is discovered.
+ *
+ * `installed.json` rather than `composer.lock`: the lock file says what should
+ * be installed, and this one says what is, which is what `--no-dev` leaves
+ * behind and what the running application actually has on disk.
+ */
+final class InstalledPackagesReader
+{
+    public function __construct(
+        private readonly string $appRootDir,
+    ) {
+    }
+
+    /**
+     * Where Composer writes it.
+     */
+    public function path(): string
+    {
+        return $this->appRootDir
+            . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'composer'
+            . DIRECTORY_SEPARATOR . 'installed.json';
+    }
+
+    /**
+     * Every installed package, as Composer recorded it.
+     *
+     * @return list<mixed>|null
+     */
+    public function read(): ?array
+    {
+        $path = $this->path();
+
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($contents, true);
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var mixed $packages */
+        $packages = $decoded['packages'] ?? $decoded;
+
+        // Keys dropped rather than preserved: every caller iterates, and
+        // Composer 1 wrote the list at the top level where Composer 2 writes it
+        // under `packages`.
+        return is_array($packages) ? array_values($packages) : null;
+    }
+
+    /**
+     * What the file is right now, cheap enough to ask on every boot.
+     *
+     * Size and modification time, not a hash of the contents: hashing means
+     * reading the whole file, and not reading it is the entire purpose of the
+     * cache this keys. A `composer install` rewrites the file, so both halves
+     * move together in practice -- but a reinstall of the same package set
+     * leaves the size alone, and swapping one package for another of the same
+     * name length leaves nothing but the size to notice.
+     *
+     * Null when there is no file, which is the same answer `read()` gives: a
+     * caller that gets null here has nothing to key a cache on and nothing to
+     * discover either.
+     */
+    public function fingerprint(): ?string
+    {
+        $path = $this->path();
+
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $modifiedAt = filemtime($path);
+        $size = filesize($path);
+
+        if ($modifiedAt === false || $size === false) {
+            return null;
+        }
+
+        return sprintf('%d-%d', $modifiedAt, $size);
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageConfigCache.php
+++ b/src/Framework/Bootstrap/Package/PackageConfigCache.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Cache\FileCache;
+
+use function array_map;
+use function is_array;
+use function is_file;
+use function is_string;
+
+/**
+ * Which packages declare a Gacela config, remembered between boots.
+ *
+ * `installed.json` is a few hundred kilobytes of JSON in a real application, and
+ * decoding it to find out that no package declares anything is the cost this
+ * cache exists to stop paying. The key is the file's own fingerprint, so a
+ * `composer install` invalidates it and nothing else has to.
+ *
+ * What is cached is the *declarations*, before any opt-out is applied. A project
+ * editing `dontDiscover()` must not have to clear a cache for the edit to take
+ * effect, and filtering a list of a handful of entries costs nothing.
+ */
+final class PackageConfigCache
+{
+    public const string FILENAME = 'gacela-discovered-packages.php';
+
+    public function __construct(
+        private readonly string $cacheDir,
+    ) {
+    }
+
+    public function path(): string
+    {
+        return $this->cacheDir . DIRECTORY_SEPARATOR . self::FILENAME;
+    }
+
+    /**
+     * The declarations this fingerprint was cached with, or null when there is
+     * no usable entry for it.
+     *
+     * A cache written for a different fingerprint is not stale data to be
+     * repaired -- it is an answer to a different question, and it is discarded
+     * without a word.
+     *
+     * @return list<PackageConfigDeclaration>|null
+     */
+    public function read(string $fingerprint): ?array
+    {
+        $path = $this->path();
+
+        if (!is_file($path)) {
+            return null;
+        }
+
+        /**
+         * Written by this class, through {@see FileCache::writeAtomically}.
+         *
+         * @var mixed $cached
+         */
+        $cached = require $path;
+
+        if (!is_array($cached)) {
+            return null;
+        }
+
+        $cachedFingerprint = $cached['fingerprint'] ?? null;
+
+        if (!is_string($cachedFingerprint) || $cachedFingerprint !== $fingerprint) {
+            return null;
+        }
+
+        $packages = $cached['packages'] ?? null;
+
+        if (!is_array($packages)) {
+            return null;
+        }
+
+        $declarations = [];
+
+        foreach ($packages as $row) {
+            if (!is_array($row)) {
+                return null;
+            }
+
+            $declaration = PackageConfigDeclaration::fromArray($row);
+
+            // One unreadable row makes the whole entry untrustworthy: a
+            // partially-read cache would boot an application with some of its
+            // packages, which is worse than reading `installed.json` again.
+            if (!$declaration instanceof PackageConfigDeclaration) {
+                return null;
+            }
+
+            $declarations[] = $declaration;
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * @param list<PackageConfigDeclaration> $declarations
+     */
+    public function write(string $fingerprint, array $declarations): void
+    {
+        FileCache::writeAtomically($this->path(), [
+            'fingerprint' => $fingerprint,
+            'packages' => array_map(
+                static fn (PackageConfigDeclaration $declaration): array => $declaration->toArray(),
+                $declarations,
+            ),
+        ]);
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageConfigDeclaration.php
+++ b/src/Framework/Bootstrap/Package/PackageConfigDeclaration.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+use function is_string;
+
+/**
+ * One `extra.gacela.config` declaration, resolved to a file on disk.
+ *
+ * Says nothing about whether that file exists or is usable. Discovery answers
+ * that when it reads it, and `doctor` answers it without booting -- both from
+ * this, so both are talking about the same declaration.
+ */
+final class PackageConfigDeclaration
+{
+    /**
+     * @param string $name         the Composer package name, as its manifest writes it
+     * @param string $declaredPath the path exactly as `extra.gacela.config` gives it,
+     *                             kept so a message can quote what the package author wrote
+     *                             rather than the absolute path it resolved to
+     * @param string $configFile   that path resolved against the package's install directory
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $declaredPath,
+        public readonly string $configFile,
+    ) {
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    public static function fromArray(array $row): ?self
+    {
+        $name = $row['name'] ?? null;
+        $declaredPath = $row['declaredPath'] ?? null;
+        $configFile = $row['configFile'] ?? null;
+
+        if (!is_string($name) || !is_string($declaredPath) || !is_string($configFile)) {
+            return null;
+        }
+
+        return new self($name, $declaredPath, $configFile);
+    }
+
+    /**
+     * @return array{name: string, declaredPath: string, configFile: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'declaredPath' => $this->declaredPath,
+            'configFile' => $this->configFile,
+        ];
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageConfigFinder.php
+++ b/src/Framework/Bootstrap/Package/PackageConfigFinder.php
@@ -158,9 +158,10 @@ final class PackageConfigFinder
             $path = substr($path, 2);
         }
 
+        // Not trimmed off the path: the loop below drops every empty segment,
+        // which is what a leading -- or doubled -- separator becomes.
         if (str_starts_with($path, DIRECTORY_SEPARATOR)) {
             $prefix .= DIRECTORY_SEPARATOR;
-            $path = ltrim($path, DIRECTORY_SEPARATOR);
         }
 
         $segments = [];

--- a/src/Framework/Bootstrap/Package/PackageConfigFinder.php
+++ b/src/Framework/Bootstrap/Package/PackageConfigFinder.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+use function array_pop;
+use function dirname;
+use function explode;
+use function implode;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function str_replace;
+use function str_starts_with;
+
+/**
+ * Which installed packages declare a Gacela config, and where that file is.
+ *
+ * Only packages carrying the key are considered. `vendor/` is never scanned for
+ * `gacela.php` files: that discovery has been measured in this repository and
+ * rejected -- it costs a directory walk of every installed package on every
+ * boot to answer a question one already-open file answers.
+ */
+final class PackageConfigFinder
+{
+    private const string EXTRA_KEY = 'gacela';
+
+    private const string CONFIG_KEY = 'config';
+
+    public function __construct(
+        private readonly InstalledPackagesReader $reader,
+    ) {
+    }
+
+    /**
+     * In Composer's installed order, which is the merge order.
+     *
+     * @return list<PackageConfigDeclaration>
+     */
+    public function find(): array
+    {
+        $installed = $this->reader->read();
+
+        if ($installed === null) {
+            return [];
+        }
+
+        // Composer records `install-path` relative to this directory.
+        $vendorComposerDir = dirname($this->reader->path());
+
+        $declarations = [];
+
+        foreach ($installed as $package) {
+            if (!is_array($package)) {
+                continue;
+            }
+
+            $declaration = $this->declarationOf($package, $vendorComposerDir);
+
+            if ($declaration instanceof PackageConfigDeclaration) {
+                $declarations[] = $declaration;
+            }
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * @param array<array-key, mixed> $package
+     */
+    private function declarationOf(array $package, string $vendorComposerDir): ?PackageConfigDeclaration
+    {
+        $name = $package['name'] ?? null;
+
+        if (!is_string($name) || $name === '') {
+            return null;
+        }
+
+        $extra = $package['extra'] ?? null;
+
+        if (!is_array($extra)) {
+            return null;
+        }
+
+        $gacela = $extra[self::EXTRA_KEY] ?? null;
+
+        if (!is_array($gacela)) {
+            return null;
+        }
+
+        $declaredPath = $gacela[self::CONFIG_KEY] ?? null;
+
+        if (!is_string($declaredPath) || $declaredPath === '') {
+            return null;
+        }
+
+        return new PackageConfigDeclaration(
+            $name,
+            $declaredPath,
+            $this->resolve($package, $name, $vendorComposerDir, $declaredPath),
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $package
+     */
+    private function resolve(array $package, string $name, string $vendorComposerDir, string $declaredPath): string
+    {
+        /** @var mixed $installPath */
+        $installPath = $package['install-path'] ?? null;
+
+        // Composer 2 records it; Composer 1 did not, and a package installed
+        // where its name says it is needs no record for this to be right.
+        $packageDir = is_string($installPath) && $installPath !== ''
+            ? $this->absolutize($installPath, $vendorComposerDir)
+            : dirname($vendorComposerDir) . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $name);
+
+        return $this->normalize($packageDir . DIRECTORY_SEPARATOR . $declaredPath);
+    }
+
+    private function absolutize(string $path, string $vendorComposerDir): string
+    {
+        return $this->isAbsolute($path)
+            ? $path
+            : $vendorComposerDir . DIRECTORY_SEPARATOR . $path;
+    }
+
+    /**
+     * A unix root, a windows drive, or a UNC share.
+     */
+    private function isAbsolute(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || str_starts_with($path, '\\\\')
+            || preg_match('#^[A-Za-z]:[\\\\/]#', $path) === 1;
+    }
+
+    /**
+     * Fold the separators and resolve `.` and `..` textually.
+     *
+     * Not `realpath()`: that answers false for a path that does not exist,
+     * which is exactly the declaration `doctor` has to be able to report, and
+     * it resolves symlinks -- so a package installed from a path repository
+     * would be named by wherever it really lives rather than by where the
+     * application's own `vendor/` says it is.
+     */
+    private function normalize(string $path): string
+    {
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+
+        // Whatever is in front of the first segment and is not one: a windows
+        // drive, a root, both, or neither.
+        $prefix = '';
+
+        if (preg_match('#^[A-Za-z]:#', $path) === 1) {
+            $prefix = substr($path, 0, 2);
+            $path = substr($path, 2);
+        }
+
+        if (str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            $prefix .= DIRECTORY_SEPARATOR;
+            $path = ltrim($path, DIRECTORY_SEPARATOR);
+        }
+
+        $segments = [];
+
+        foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+
+            if ($segment === '.') {
+                continue;
+            }
+
+            // A `..` with nothing above it stays: dropping it would silently
+            // turn a path pointing outside the vendor directory into one inside
+            // it, and name a file the package never declared.
+            $last = $segments === [] ? null : $segments[array_key_last($segments)];
+
+            if ($segment === '..' && $last !== null && $last !== '..') {
+                array_pop($segments);
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        return $prefix . implode(DIRECTORY_SEPARATOR, $segments);
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageContribution.php
+++ b/src/Framework/Bootstrap/Package/PackageContribution.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function count;
+use function is_string;
+use function sprintf;
+
+/**
+ * What one package's configuration declared, read off that package's own setup
+ * before it was merged into anything.
+ *
+ * Taken from the package's setup rather than reconstructed by diffing the merged
+ * configuration: a binding two packages both declare is one entry in the merged
+ * map, and a diff would credit it to whichever ran last.
+ *
+ * A fixed set of accessors would be a dozen methods and a dozen renderers, so
+ * this is a map of kind to labels. The kinds are the ones a package can
+ * meaningfully ship; `addAppConfig()` is deliberately not among them, because a
+ * config path resolves against the *application* root and a package cannot know
+ * what is there.
+ */
+final class PackageContribution
+{
+    /**
+     * @param array<string, list<string>> $items kind => what it declared, in declaration order
+     */
+    private function __construct(
+        private readonly array $items,
+    ) {
+    }
+
+    public static function of(SetupGacela $setup, GacelaConfigFileInterface $configFile): self
+    {
+        $items = [
+            'bindings' => self::stringKeys($configFile->getBindings()),
+            'resolvable kinds' => array_keys(array_filter($configFile->getSuffixTypes(), static fn (array $suffixes): bool => $suffixes !== [])),
+            'plugins' => array_map(self::label(), $setup->getPlugins()),
+            'plugin stacks' => self::pluginStacks($setup),
+            'listeners' => self::listeners($setup),
+            'factories' => self::stringKeys($setup->getFactories()),
+            'protected services' => self::stringKeys($setup->getProtectedServices()),
+            'lazy services' => self::stringKeys($setup->getLazyServices()),
+            'aliases' => self::stringKeys($setup->getAliases()),
+            'handler registries' => self::stringKeys($setup->getHandlerRegistries()),
+            'tags' => self::stringKeys($setup->getTags()),
+            'config keys' => self::stringKeys($setup->getConfigKeyValues()),
+            'config schema' => self::stringKeys($setup->getConfigSchema()),
+            'dto schema' => self::stringKeys($setup->getDtoSchema()),
+        ];
+
+        return new self(array_filter($items, static fn (array $labels): bool => $labels !== []));
+    }
+
+    /**
+     * @param array<string, list<string>> $items
+     */
+    public static function fromArray(array $items): self
+    {
+        return new self($items);
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function items(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * A package whose config file declares nothing. Worth saying out loud
+     * rather than rendering as a blank: it is either a mistake or a package that
+     * only registers things through a plugin at runtime.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->items === [];
+    }
+
+    /**
+     * One line, for a listing that has no room for the labels.
+     */
+    public function summary(): string
+    {
+        if ($this->items === []) {
+            return 'nothing';
+        }
+
+        $parts = [];
+
+        foreach ($this->items as $kind => $labels) {
+            $parts[] = sprintf('%d %s', count($labels), $kind);
+        }
+
+        return implode(', ', $parts);
+    }
+
+    /**
+     * @param array<array-key, mixed> $map
+     *
+     * @return list<string>
+     */
+    private static function stringKeys(array $map): array
+    {
+        $keys = [];
+
+        foreach (array_keys($map) as $key) {
+            $keys[] = is_string($key) ? $key : (string) $key;
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function pluginStacks(SetupGacela $setup): array
+    {
+        $labels = [];
+
+        foreach ($setup->getPluginStacks() as $contract => $plugins) {
+            foreach ($plugins as $plugin) {
+                $labels[] = sprintf('%s => %s', $contract, self::labelOf($plugin));
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function listeners(SetupGacela $setup): array
+    {
+        $labels = [];
+
+        foreach ($setup->getSpecificListeners() ?? [] as $event => $listeners) {
+            $labels[] = sprintf('%s (%d)', $event, count($listeners));
+        }
+
+        $generic = count($setup->getGenericListeners() ?? []);
+
+        if ($generic > 0) {
+            $labels[] = sprintf('every event (%d)', $generic);
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @return callable(mixed):string
+     */
+    private static function label(): callable
+    {
+        return self::labelOf(...);
+    }
+
+    /**
+     * A plugin is a class-string or a callable, and a callable has no name to
+     * print.
+     */
+    private static function labelOf(mixed $value): string
+    {
+        return is_string($value) ? $value : 'closure';
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageContribution.php
+++ b/src/Framework/Bootstrap/Package/PackageContribution.php
@@ -47,6 +47,28 @@ final class PackageContribution
     ) {
     }
 
+    /**
+     * Cleared by `Gacela::resetCache()`, rather than left to outlive it as a
+     * memo of something constant.
+     *
+     * It looks constant -- an *empty* setup assembled -- and it is not.
+     * `ResolvableTypes::syncFrom()` keeps the suffix-to-kind mapping in
+     * process-global state, so what an empty setup assembles to depends on what
+     * the last bootstrap declared. Memoized across two applications, a kind the
+     * first one added with `addResolvableType()` would be in the second's
+     * baseline, and a package declaring that same kind would be reported as
+     * having declared nothing.
+     *
+     * That is the fault #884 fixed one layer down, where a resolver memoized the
+     * merged `gacela.php` on an object outliving its bootstrap. Recomputing is
+     * one assembly of an empty setup, on a reporting path, and it is not worth
+     * being clever about.
+     */
+    public static function resetCache(): void
+    {
+        self::$baselineSuffixTypes = null;
+    }
+
     public static function of(SetupGacela $setup, GacelaConfigFileInterface $configFile): self
     {
         $items = [

--- a/src/Framework/Bootstrap/Package/PackageContribution.php
+++ b/src/Framework/Bootstrap/Package/PackageContribution.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Gacela\Framework\Bootstrap\Package;
 
 use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigFileAssembler;
 use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 
+use function array_diff;
 use function array_filter;
 use function array_keys;
 use function array_map;
@@ -31,6 +33,13 @@ use function sprintf;
 final class PackageContribution
 {
     /**
+     * What an empty setup assembles to, which is what nobody declared.
+     *
+     * @var ?array<string, list<string>>
+     */
+    private static ?array $baselineSuffixTypes = null;
+
+    /**
      * @param array<string, list<string>> $items kind => what it declared, in declaration order
      */
     private function __construct(
@@ -42,7 +51,7 @@ final class PackageContribution
     {
         $items = [
             'bindings' => self::stringKeys($configFile->getBindings()),
-            'resolvable kinds' => array_keys(array_filter($configFile->getSuffixTypes(), static fn (array $suffixes): bool => $suffixes !== [])),
+            'resolvable kinds' => self::resolvableKinds($configFile),
             'plugins' => array_map(self::label(), $setup->getPlugins()),
             'plugin stacks' => self::pluginStacks($setup),
             'listeners' => self::listeners($setup),
@@ -102,6 +111,32 @@ final class PackageContribution
         }
 
         return implode(', ', $parts);
+    }
+
+    /**
+     * The kinds and suffixes this package added, and not the four every
+     * assembled configuration carries.
+     *
+     * Diffed against an empty setup rather than read off the builder: the
+     * builder holds the four defaults and what a source added, with nothing to
+     * tell them apart, so a report taken from it credited every package with
+     * declaring Facade, Factory, Config and Provider.
+     *
+     * @return list<string>
+     */
+    private static function resolvableKinds(GacelaConfigFileInterface $configFile): array
+    {
+        $baseline = self::$baselineSuffixTypes ??= GacelaConfigFileAssembler::assemble(new SetupGacela())->getSuffixTypes();
+
+        $kinds = [];
+
+        foreach ($configFile->getSuffixTypes() as $kind => $suffixes) {
+            foreach (array_diff($suffixes, $baseline[$kind] ?? []) as $suffix) {
+                $kinds[] = sprintf('%s => %s', $kind, $suffix);
+            }
+        }
+
+        return $kinds;
     }
 
     /**

--- a/src/Framework/Bootstrap/Package/PackageDiscovery.php
+++ b/src/Framework/Bootstrap/Package/PackageDiscovery.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+use Closure;
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Bootstrap\SetupGacelaInterface;
+use Gacela\Framework\Config\FileIoInterface;
+use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigUsingGacelaPhpFileFactory;
+use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
+
+use function in_array;
+
+/**
+ * Merges the Gacela configuration installed packages declare.
+ *
+ * A package contributes to an application by being installed, the way a Laravel
+ * package registers a provider through `extra.laravel.providers`:
+ *
+ * ```json
+ * { "extra": { "gacela": { "config": "config/gacela.php" } } }
+ * ```
+ *
+ * That file returns a `callable(GacelaConfig): void` -- the same shape a
+ * project's own `gacela.php` returns, so there is one config format and a
+ * package author has nothing new to learn.
+ *
+ * ## Order
+ *
+ * Packages are merged in Composer's installed order, and the project's own
+ * configuration is merged after all of them, so the project always has the last
+ * word. Between two packages that declare the same thing, the later-installed
+ * one wins -- but installed order is Composer's, decided by the dependency
+ * graph and by when things were added to `composer.json`, and no application
+ * controls it. A package that needs to win must not rely on it; it should give
+ * the consuming project something to call.
+ *
+ * ## Trust
+ *
+ * A discovered config is arbitrary PHP, run inside `Gacela::bootstrap()`, in the
+ * application's own process, with everything the application can reach. That is
+ * the same bargain a Laravel provider or a Composer install script already asks
+ * for, and `GacelaConfig::dontDiscover()` is the control over it: naming a
+ * package there means its file is never opened, and `dontDiscover(['*'])` means
+ * no package's file is opened at all.
+ */
+final class PackageDiscovery
+{
+    /** Refuses every package, installed now or later. */
+    private const string EVERYTHING = '*';
+
+    /**
+     * @param ?Closure(): string $cacheDirProvider where to remember the resolved
+     *                                             list of declarations. A closure
+     *                                             rather than the directory,
+     *                                             because asking `Config` for it
+     *                                             memoizes it -- and an
+     *                                             application with no installed
+     *                                             packages must not end up with a
+     *                                             materialised cache directory it
+     *                                             never writes to. Null means the
+     *                                             answer is not remembered.
+     */
+    public function __construct(
+        private readonly string $appRootDir,
+        private readonly SetupGacelaInterface $setup,
+        private readonly FileIoInterface $fileIo,
+        private readonly ?Closure $cacheDirProvider = null,
+    ) {
+    }
+
+    /**
+     * Every discovered package's configuration, merged into the setup and
+     * assembled, in merge order.
+     *
+     * @param list<string> $dontDiscover Composer package names, matched exactly,
+     *                                   or `['*']` to read nothing
+     *
+     * @return list<GacelaConfigFileInterface>
+     */
+    public function discover(array $dontDiscover): array
+    {
+        PackageDiscoveryRegistry::reset();
+
+        // Checked before the disk is touched: `dontDiscover(['*'])` is a project
+        // saying it wants nothing but its own configuration deciding what runs
+        // at boot, and honouring it by reading every declaration first and then
+        // throwing them away would be a strange way to agree.
+        if (in_array(self::EVERYTHING, $dontDiscover, true)) {
+            PackageDiscoveryRegistry::disable();
+
+            return [];
+        }
+
+        $configFiles = [];
+        $position = 0;
+
+        foreach ($this->declarations() as $declaration) {
+            if (in_array($declaration->name, $dontDiscover, true)) {
+                PackageDiscoveryRegistry::refuse(RefusedPackage::optedOut($declaration));
+                continue;
+            }
+
+            // A package that names a file it did not ship contributes nothing
+            // and does not stop the boot. `doctor` is where that is reported:
+            // `composer require` must never be able to break an application.
+            if (!$this->fileIo->existsFile($declaration->configFile)) {
+                PackageDiscoveryRegistry::refuse(RefusedPackage::missingFile($declaration));
+                continue;
+            }
+
+            $factory = new GacelaConfigUsingGacelaPhpFileFactory(
+                $declaration->configFile,
+                $this->setup,
+                $this->fileIo,
+            );
+
+            $packageSetup = $factory->createSetup();
+
+            if (!$packageSetup instanceof SetupGacela) {
+                PackageDiscoveryRegistry::refuse(RefusedPackage::notCallable($declaration));
+                continue;
+            }
+
+            // Merges into the base setup and assembles from the memoized setup
+            // above, so the file is read once.
+            $configFile = $factory->createGacelaFileConfig();
+            $configFiles[] = $configFile;
+
+            PackageDiscoveryRegistry::record(new DiscoveredPackage(
+                $declaration->name,
+                $declaration->configFile,
+                ++$position,
+                PackageContribution::of($packageSetup, $configFile),
+            ));
+        }
+
+        return $configFiles;
+    }
+
+    /**
+     * @return list<PackageConfigDeclaration>
+     */
+    private function declarations(): array
+    {
+        $reader = new InstalledPackagesReader($this->appRootDir);
+        $fingerprint = $reader->fingerprint();
+
+        // No `installed.json` means nothing was installed through Composer
+        // against this root -- a fixture directory used as an application root,
+        // a checkout with no install. Silently nothing, exactly as the `doctor`
+        // check reading the same file already treats it.
+        if ($fingerprint === null) {
+            return [];
+        }
+
+        // Built here rather than in the constructor, so an application with no
+        // `installed.json` never asks where the cache directory is.
+        $cache = $this->cache();
+
+        $cached = $cache?->read($fingerprint);
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $declarations = (new PackageConfigFinder($reader))->find();
+
+        $cache?->write($fingerprint, $declarations);
+
+        return $declarations;
+    }
+
+    private function cache(): ?PackageConfigCache
+    {
+        $provider = $this->cacheDirProvider;
+
+        return $provider instanceof Closure ? new PackageConfigCache($provider()) : null;
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageDiscovery.php
+++ b/src/Framework/Bootstrap/Package/PackageDiscovery.php
@@ -48,8 +48,11 @@ use function in_array;
  */
 final class PackageDiscovery
 {
-    /** Refuses every package, installed now or later. */
-    private const string EVERYTHING = '*';
+    /**
+     * Refuses every package, installed now or later. Public because `doctor` has
+     * to know that this one entry names no package.
+     */
+    public const string EVERYTHING = '*';
 
     /**
      * @param ?Closure(): string $cacheDirProvider where to remember the resolved

--- a/src/Framework/Bootstrap/Package/PackageDiscoveryRegistry.php
+++ b/src/Framework/Bootstrap/Package/PackageDiscoveryRegistry.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+/**
+ * What the last discovery did, for whoever asks after the boot.
+ *
+ * A feature that runs a package's code during bootstrap has to be inspectable
+ * afterwards, and by then the setups it read are gone: `debug:container` and the
+ * `doctor` check both run against an already-booted application. This is where
+ * the answer waits for them.
+ *
+ * Static, like {@see \Gacela\Framework\Health\HealthCheckRegistry}, for the same
+ * reason: discovery runs below the container, so there is nothing to inject it
+ * into and nothing to inject into it.
+ *
+ * Reset by {@see PackageDiscovery} immediately before it discovers, not by
+ * `Gacela::bootstrap()`. The merged configuration is memoized, and a second
+ * bootstrap that hits the memo does no discovery at all -- clearing this then
+ * would leave the registry claiming nothing was discovered for a configuration
+ * that has packages in it.
+ *
+ * @internal
+ */
+final class PackageDiscoveryRegistry
+{
+    /** @var list<DiscoveredPackage> */
+    private static array $discovered = [];
+
+    /** @var list<RefusedPackage> */
+    private static array $refused = [];
+
+    private static bool $disabled = false;
+
+    public static function reset(): void
+    {
+        self::$discovered = [];
+        self::$refused = [];
+        self::$disabled = false;
+    }
+
+    /**
+     * `dontDiscover(['*'])`: no declaration was read, so there are no names to
+     * list as refused -- only the fact that nothing was looked at.
+     */
+    public static function disable(): void
+    {
+        self::$disabled = true;
+    }
+
+    public static function isDisabled(): bool
+    {
+        return self::$disabled;
+    }
+
+    public static function record(DiscoveredPackage $package): void
+    {
+        self::$discovered[] = $package;
+    }
+
+    public static function refuse(RefusedPackage $package): void
+    {
+        self::$refused[] = $package;
+    }
+
+    /**
+     * In merge order.
+     *
+     * @return list<DiscoveredPackage>
+     */
+    public static function discovered(): array
+    {
+        return self::$discovered;
+    }
+
+    /**
+     * @return list<RefusedPackage>
+     */
+    public static function refused(): array
+    {
+        return self::$refused;
+    }
+}

--- a/src/Framework/Bootstrap/Package/PackageRefusal.php
+++ b/src/Framework/Bootstrap/Package/PackageRefusal.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+/**
+ * Why a declared package config was not merged.
+ */
+enum PackageRefusal: string
+{
+    /**
+     * The project named it in `dontDiscover()`, so the file was never read.
+     */
+    case OptedOut = 'opted out';
+
+    /**
+     * The declaration names a file that is not there.
+     */
+    case MissingFile = 'file not found';
+
+    /**
+     * The file is there and does not return a `callable(GacelaConfig)`.
+     */
+    case NotCallable = 'does not return a callable';
+
+    /**
+     * Whether this is a broken declaration rather than a decision.
+     *
+     * An opt-out is the project getting what it asked for; the other two are a
+     * package that cannot contribute and does not know it.
+     */
+    public function isBroken(): bool
+    {
+        return $this !== self::OptedOut;
+    }
+}

--- a/src/Framework/Bootstrap/Package/RefusedPackage.php
+++ b/src/Framework/Bootstrap/Package/RefusedPackage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Bootstrap\Package;
+
+/**
+ * A package that declared a Gacela config which was not merged, and why.
+ *
+ * Both reasons are things an operator has to be able to see: an opt-out that is
+ * working looks exactly like a package that was never installed, and a
+ * declaration pointing at a file that is not there looks exactly like a package
+ * that contributes nothing.
+ */
+final class RefusedPackage
+{
+    private function __construct(
+        public readonly string $name,
+        public readonly string $configFile,
+        public readonly PackageRefusal $reason,
+    ) {
+    }
+
+    public static function optedOut(PackageConfigDeclaration $declaration): self
+    {
+        return new self($declaration->name, $declaration->configFile, PackageRefusal::OptedOut);
+    }
+
+    public static function missingFile(PackageConfigDeclaration $declaration): self
+    {
+        return new self($declaration->name, $declaration->configFile, PackageRefusal::MissingFile);
+    }
+
+    public static function notCallable(PackageConfigDeclaration $declaration): self
+    {
+        return new self($declaration->name, $declaration->configFile, PackageRefusal::NotCallable);
+    }
+}

--- a/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
+++ b/src/Framework/Bootstrap/Setup/GacelaConfigTransfer.php
@@ -39,6 +39,7 @@ final class GacelaConfigTransfer
      * @param ?ExternalServicesMap $externalServices
      * @param ?list<string> $projectNamespaces
      * @param ?list<string> $appModulePaths
+     * @param ?list<string> $dontDiscover
      * @param ?ConfigKeyValues $configKeyValues
      * @param ?list<callable> $genericListeners
      * @param ?SpecificListenersMap $specificListeners
@@ -71,6 +72,7 @@ final class GacelaConfigTransfer
         /** @var ?list<string> */
         public readonly ?array $configDimensions,
         public readonly ?array $appModulePaths,
+        public readonly ?array $dontDiscover,
         public readonly ?array $configKeyValues,
         public readonly ?array $genericListeners,
         public readonly ?array $specificListeners,

--- a/src/Framework/Bootstrap/Setup/Properties.php
+++ b/src/Framework/Bootstrap/Setup/Properties.php
@@ -69,6 +69,9 @@ final class Properties
     /** @var ?list<string> */
     public ?array $appModulePaths = null;
 
+    /** @var ?list<string> */
+    public ?array $dontDiscover = null;
+
     /** @var ?ConfigKeyValues */
     public ?array $configKeyValues = null;
 

--- a/src/Framework/Bootstrap/Setup/PropertyMerger.php
+++ b/src/Framework/Bootstrap/Setup/PropertyMerger.php
@@ -60,6 +60,19 @@ final class PropertyMerger
     }
 
     /**
+     * Accumulated, and deduplicated: two sources refusing the same package are
+     * agreeing, not refusing it twice, and the list is read back by `doctor`
+     * and by `debug:container` where a repeated name reads as a mistake.
+     *
+     * @param list<string> $list
+     */
+    public function mergeDontDiscover(array $list): void
+    {
+        $current = $this->setup->getDontDiscover();
+        $this->setup->setDontDiscover(array_values(array_unique(array_merge($current, $list))));
+    }
+
+    /**
      * Declaration order is the order of the chain, so a later source appends
      * dimensions rather than reordering the ones already declared.
      *

--- a/src/Framework/Bootstrap/Setup/SetupInitializer.php
+++ b/src/Framework/Bootstrap/Setup/SetupInitializer.php
@@ -29,6 +29,7 @@ final class SetupInitializer
             ->setProjectNamespaces($dto->projectNamespaces)
             ->setConfigDimensions($dto->configDimensions)
             ->setAppModulePaths($dto->appModulePaths)
+            ->setDontDiscover($dto->dontDiscover)
             ->setConfigKeyValues($dto->configKeyValues)
             ->setConfigSchema($dto->configSchema)
             ->setDtoSchema($dto->dtoSchema)

--- a/src/Framework/Bootstrap/Setup/SetupMerger.php
+++ b/src/Framework/Bootstrap/Setup/SetupMerger.php
@@ -35,6 +35,10 @@ final class SetupMerger
         // `setProjectNamespaces()` -- was silently ignored and every command
         // walked the whole application root.
         $this->whenChanged($other, SetupGacela::appModulePaths, fn (): SetupGacela => $this->original->setAppModulePaths($other->getAppModulePaths()));
+        // Accumulated rather than replaced: a bootstrap closure and a
+        // `gacela.php` that each refuse a package are refusing both, and the
+        // one that ran second is not overruling the other.
+        $this->whenChanged($other, SetupGacela::dontDiscover, fn () => $this->original->mergeDontDiscover($other->getDontDiscover()));
         $this->whenChanged($other, SetupGacela::configDimensions, fn () => $this->original->mergeConfigDimensions($other->getConfigDimensions()));
         $this->whenChanged($other, SetupGacela::configKeyValues, fn () => $this->original->mergeConfigKeyValues($other->getConfigKeyValues()));
         $this->whenChanged($other, SetupGacela::configSchema, fn () => $this->original->mergeConfigSchema($other->getConfigSchema()));

--- a/src/Framework/Bootstrap/SetupGacela.php
+++ b/src/Framework/Bootstrap/SetupGacela.php
@@ -343,6 +343,32 @@ final class SetupGacela extends AbstractSetupGacela
     }
 
     /**
+     * @internal Used by SetupInitializer - do not call directly
+     *
+     * @param ?list<string> $packages
+     */
+    public function setDontDiscover(?array $packages): self
+    {
+        $this->properties->dontDiscover = $this->setPropertyWithTracking(
+            self::dontDiscover,
+            $packages,
+            self::DEFAULT_DONT_DISCOVER,
+        );
+
+        return $this;
+    }
+
+    /**
+     * The packages whose declared Gacela config must not be read.
+     *
+     * @return list<string>
+     */
+    public function getDontDiscover(): array
+    {
+        return $this->properties->dontDiscover ?? self::DEFAULT_DONT_DISCOVER;
+    }
+
+    /**
      * @return ConfigKeyValues
      */
     public function getConfigKeyValues(): array
@@ -689,6 +715,16 @@ final class SetupGacela extends AbstractSetupGacela
     public function mergeProjectNamespaces(array $list): void
     {
         $this->propertyMerger->mergeProjectNamespaces($list);
+    }
+
+    /**
+     * @internal Used by SetupMerger - do not call directly
+     *
+     * @param list<string> $list
+     */
+    public function mergeDontDiscover(array $list): void
+    {
+        $this->propertyMerger->mergeDontDiscover($list);
     }
 
     /**

--- a/src/Framework/Config/Config.php
+++ b/src/Framework/Config/Config.php
@@ -395,6 +395,10 @@ final class Config implements ConfigInterface
             $this->configFactory = new ConfigFactory(
                 $this->getAppRootDir(),
                 $this->setup,
+                // A closure, so asking is what materializes it: an application
+                // with nothing to discover must not end up with a cache
+                // directory it never writes to.
+                fn (): string => $this->getCacheDir(),
             );
         }
 

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Gacela\Framework\Config;
 
+use Closure;
+use Gacela\Framework\Bootstrap\Package\PackageDiscovery;
+use Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\ClassResolver\ClassInfo;
@@ -15,6 +18,8 @@ use Gacela\Framework\Config\GacelaFileConfig\GacelaConfigFileInterface;
 use Gacela\Framework\Config\PathNormalizer\AbsolutePathNormalizer;
 use Gacela\Framework\Config\PathNormalizer\WithoutSuffixAbsolutePathStrategy;
 use Gacela\Framework\Config\PathNormalizer\WithSuffixAbsolutePathStrategy;
+use Gacela\Framework\Event\Bootstrap\PackageConfigMergedEvent;
+use Gacela\Framework\Event\Dispatcher\EventDispatchingCapabilities;
 
 use function sprintf;
 
@@ -27,6 +32,8 @@ use function sprintf;
  */
 final class ConfigFactory
 {
+    use EventDispatchingCapabilities;
+
     private const GACELA_PHP_CONFIG_FILENAME = 'gacela';
 
     private const GACELA_PHP_CONFIG_EXTENSION = '.php';
@@ -45,9 +52,20 @@ final class ConfigFactory
 
     private static ?string $memoizedAppRootDir = null;
 
+    /**
+     * @param ?Closure(): string $cacheDirProvider where the resolved list of
+     *                                             package config files is
+     *                                             remembered between boots.
+     *                                             Null means it is not: this
+     *                                             factory is also built directly,
+     *                                             and `Config` is the only thing
+     *                                             that knows where the cache
+     *                                             directory is.
+     */
     public function __construct(
         private readonly string $appRootDir,
         private readonly SetupGacelaInterface $setup,
+        private readonly ?Closure $cacheDirProvider = null,
     ) {
     }
 
@@ -89,13 +107,22 @@ final class ConfigFactory
         $alreadyInTheBase = $this->setup instanceof SetupGacela
             && $this->setup->wasBuiltFrom($gacelaPhpDefaultPath);
 
-        if (!$alreadyInTheBase && $fileIo->existsFile($gacelaPhpDefaultPath)) {
-            $factoryFromGacelaPhp = new GacelaConfigUsingGacelaPhpFileFactory(
-                $gacelaPhpDefaultPath,
-                $this->setup,
-                $fileIo,
-            );
-            $gacelaConfigFiles[] = $factoryFromGacelaPhp->createGacelaFileConfig();
+        $projectFactory = !$alreadyInTheBase && $fileIo->existsFile($gacelaPhpDefaultPath)
+            ? new GacelaConfigUsingGacelaPhpFileFactory($gacelaPhpDefaultPath, $this->setup, $fileIo)
+            : null;
+
+        // Read before anything is merged, and memoized there so the file is
+        // still read exactly once: the discovery below runs arbitrary PHP from
+        // every installed package that declares a config, and what a project
+        // refuses is written in this very file.
+        $projectSetup = $projectFactory?->createSetup();
+
+        // First, so the project has the last word: the fold below lets a later
+        // source win, and so does the setup merge each of these performs.
+        $gacelaConfigFiles = $this->discoverPackages($fileIo, $projectSetup);
+
+        if ($projectFactory instanceof GacelaConfigUsingGacelaPhpFileFactory) {
+            $gacelaConfigFiles[] = $projectFactory->createGacelaFileConfig();
         }
 
         $gacelaPhpPath = $this->getGacelaPhpPathFromEnv();
@@ -124,6 +151,8 @@ final class ConfigFactory
             ClassInfo::resetCache();
         }
 
+        $this->announceDiscoveredPackages();
+
         return $this->memoize($merged);
     }
 
@@ -135,6 +164,71 @@ final class ConfigFactory
     public function dimensions(): ConfigDimensions
     {
         return ConfigDimensions::fromEnvironment($this->setup->getConfigDimensions());
+    }
+
+    /**
+     * The configuration every installed package declared, merged before the
+     * project's own.
+     *
+     * The opt-out is read from both places a project can write it: the bootstrap
+     * closure, which built the base setup, and `gacela.php`, whose setup was
+     * built above without being merged yet. It cannot be read from
+     * `gacela-{APP_ENV}.php` -- that file is merged after this returns, by which
+     * time the code it would refuse has run. `doctor` reports an opt-out written
+     * there rather than letting it look effective.
+     *
+     * @return list<GacelaConfigFileInterface>
+     */
+    private function discoverPackages(FileIoInterface $fileIo, ?SetupGacela $projectSetup): array
+    {
+        $fromBootstrap = $this->setup instanceof SetupGacela ? $this->setup->getDontDiscover() : [];
+
+        $discovery = new PackageDiscovery(
+            $this->appRootDir,
+            $this->setup,
+            $fileIo,
+            $this->packageCacheDirProvider(),
+        );
+
+        return $discovery->discover([
+            ...$fromBootstrap,
+            ...($projectSetup?->getDontDiscover() ?? []),
+        ]);
+    }
+
+    /**
+     * Null when there is nowhere to remember the answer, which makes every boot
+     * read `installed.json` again. `setFileCache(false)` is a project asking for
+     * exactly that trade for class resolution, and this is the same trade.
+     *
+     * @return ?Closure(): string
+     */
+    private function packageCacheDirProvider(): ?Closure
+    {
+        return $this->setup->isFileCacheEnabled() ? $this->cacheDirProvider : null;
+    }
+
+    /**
+     * One event per discovered package, in merge order.
+     *
+     * After the merge rather than during it: the dispatcher is derived from the
+     * merged listeners, so a listener registered in `gacela.php` -- the natural
+     * place to log what a boot picked up -- does not exist yet while the packages
+     * are being merged.
+     */
+    private function announceDiscoveredPackages(): void
+    {
+        if (!self::shouldDispatch(PackageConfigMergedEvent::class)) {
+            return;
+        }
+
+        foreach (PackageDiscoveryRegistry::discovered() as $package) {
+            self::dispatchEvent(new PackageConfigMergedEvent(
+                $package->name,
+                $package->configFile,
+                $package->position,
+            ));
+        }
     }
 
     /**

--- a/src/Framework/Config/ConfigFactory.php
+++ b/src/Framework/Config/ConfigFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Framework\Config;
 
 use Closure;
+use Gacela\Framework\Bootstrap\Package\InstalledPackagesReader;
 use Gacela\Framework\Bootstrap\Package\PackageDiscovery;
 use Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry;
 use Gacela\Framework\Bootstrap\SetupGacela;
@@ -181,6 +182,23 @@ final class ConfigFactory
      */
     private function discoverPackages(FileIoInterface $fileIo, ?SetupGacela $projectSetup): array
     {
+        // One `is_file()` before anything at all is built, because for most
+        // applications the answer is "nothing to discover" and it should cost
+        // about that much. There is no manifest under a directory Composer never
+        // installed into -- a fixture used as an application root, a checkout
+        // with no `vendor/` of its own.
+        //
+        // Measured, not assumed: without this, `BootstrapBench` came to +12.24%
+        // warm on CI against a +/-10% gate, and every bit of it was spent finding
+        // out there was nothing to read. An application that does have a manifest
+        // still pays for the cached declaration list, which is the honest price
+        // of the feature.
+        if (!$fileIo->existsFile((new InstalledPackagesReader($this->appRootDir))->path())) {
+            PackageDiscoveryRegistry::reset();
+
+            return [];
+        }
+
         $fromBootstrap = $this->setup instanceof SetupGacela ? $this->setup->getDontDiscover() : [];
 
         $discovery = new PackageDiscovery(

--- a/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
+++ b/src/Framework/Config/GacelaFileConfig/Factory/GacelaConfigUsingGacelaPhpFileFactory.php
@@ -16,8 +16,29 @@ use function get_debug_type;
 use function is_callable;
 use function sprintf;
 
+/**
+ * The one reader of a file that returns a `callable(GacelaConfig)`.
+ *
+ * Three kinds of file have that shape -- a project's `gacela.php`, its
+ * `gacela-{APP_ENV}.php`, and the config an installed package declares in
+ * `extra.gacela.config` -- and they are read here, once each, so the shape has
+ * one definition.
+ *
+ * `createGacelaFileConfig()` merges into the bootstrap setup, so it is called
+ * once per instance. One instance per file.
+ */
 final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFactoryInterface
 {
+    private bool $wasRead = false;
+
+    private ?SetupGacela $setup = null;
+
+    /**
+     * What the file returned, when it was not a callable -- kept only to name it
+     * in the message below.
+     */
+    private mixed $returned = null;
+
     public function __construct(
         private readonly string $gacelaPhpPath,
         private readonly SetupGacelaInterface $bootstrapSetup,
@@ -25,10 +46,55 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
     ) {
     }
 
+    /**
+     * The setup this file declares, or null when the file does not return a
+     * `callable(GacelaConfig)`.
+     *
+     * Separate from `createGacelaFileConfig()`, and memoized, because package
+     * discovery has to know what the project opted out of before it runs any
+     * package's code -- and `dontDiscover()` is written in the very file this
+     * reads. Answering that by reading the file a second time would run a
+     * project's configuration twice, which is the fault this whole layer already
+     * documents at length.
+     *
+     * Null rather than an exception, because the two callers want opposite
+     * things from a file that returns nothing usable. For a project's own file
+     * it is fatal -- nothing works without it, and `createGacelaFileConfig()`
+     * below says so. For a package's it is not: installing a package must never
+     * be able to stop an application from booting, so discovery records the
+     * broken declaration and `doctor` reports it.
+     */
+    public function createSetup(): ?SetupGacela
+    {
+        if (!$this->wasRead) {
+            $this->wasRead = true;
+
+            $gacelaConfig = $this->createGacelaConfig();
+
+            $this->setup = $gacelaConfig instanceof GacelaConfig
+                ? SetupGacela::fromGacelaConfig($gacelaConfig)
+                : null;
+        }
+
+        return $this->setup;
+    }
+
     public function createGacelaFileConfig(): GacelaConfigFileInterface
     {
-        $projectGacelaConfig = $this->createGacelaConfig();
-        $projectSetupGacela = SetupGacela::fromGacelaConfig($projectGacelaConfig);
+        $projectSetupGacela = $this->createSetup();
+
+        if (!$projectSetupGacela instanceof SetupGacela) {
+            // Named, because this factory reads `gacela-{APP_ENV}.php` as well:
+            // saying "gacela.php" sent you to the file that was fine, in the one
+            // environment where the other one was read. What came back instead
+            // is named too -- `include` yields 1 for a file that returns
+            // nothing, which is unrecognisable otherwise.
+            throw new RuntimeException(sprintf(
+                'The file "%s" must return a `callable(GacelaConfig)`, it returned %s.',
+                $this->gacelaPhpPath,
+                get_debug_type($this->returned),
+            ));
+        }
 
         $this->bootstrapSetup->merge($projectSetupGacela);
 
@@ -38,7 +104,7 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         );
     }
 
-    private function createGacelaConfig(): GacelaConfig
+    private function createGacelaConfig(): ?GacelaConfig
     {
         $gacelaConfig = new GacelaConfig($this->bootstrapSetup->externalServices());
 
@@ -46,16 +112,9 @@ final class GacelaConfigUsingGacelaPhpFileFactory implements GacelaConfigFileFac
         $configFn = $this->fileIo->include($this->gacelaPhpPath);
 
         if (!is_callable($configFn)) {
-            // Named, because this factory reads `gacela-{APP_ENV}.php` as well:
-            // saying "gacela.php" sent you to the file that was fine, in the one
-            // environment where the other one was read. What came back instead
-            // is named too -- `include` yields 1 for a file that returns
-            // nothing, which is unrecognisable otherwise.
-            throw new RuntimeException(sprintf(
-                'The file "%s" must return a `callable(GacelaConfig)`, it returned %s.',
-                $this->gacelaPhpPath,
-                get_debug_type($configFn),
-            ));
+            $this->returned = $configFn;
+
+            return null;
         }
 
         $configFn($gacelaConfig);

--- a/src/Framework/Event/Bootstrap/PackageConfigMergedEvent.php
+++ b/src/Framework/Event/Bootstrap/PackageConfigMergedEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Framework\Event\Bootstrap;
+
+use Gacela\Framework\Event\GacelaEventInterface;
+
+use function sprintf;
+
+/**
+ * An installed package's declared Gacela config was read and merged.
+ *
+ * One per discovered package, dispatched in merge order, which is the order
+ * `position()` counts. Dispatched *after* the whole configuration is assembled
+ * rather than as each package is merged: the dispatcher is built from the merged
+ * listeners, so firing during the merge would fire before the project's own
+ * listeners exist, and a listener in `gacela.php` -- the natural place to log
+ * what a boot picked up -- would never see it.
+ *
+ * `configFile()` is the absolute path of the file that ran, so a boot that picked
+ * up something unexpected names it rather than describing it.
+ */
+final class PackageConfigMergedEvent implements GacelaEventInterface
+{
+    public function __construct(
+        private readonly string $packageName,
+        private readonly string $configFile,
+        private readonly int $position,
+    ) {
+    }
+
+    public function packageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function configFile(): string
+    {
+        return $this->configFile;
+    }
+
+    /**
+     * 1-based place in the merge order.
+     */
+    public function position(): int
+    {
+        return $this->position;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s {packageName:"%s", configFile:"%s", position:%d}',
+            self::class,
+            $this->packageName,
+            $this->configFile,
+            $this->position,
+        );
+    }
+}

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework;
 use Closure;
 use Composer\InstalledVersions;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\Package\PackageContribution;
 use Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
@@ -214,6 +215,9 @@ final class Gacela
         // configuration that memo holds, and one surviving the other would have
         // `debug:container` describing a configuration that is gone.
         PackageDiscoveryRegistry::reset();
+        // Same reason, one level along: the baseline it memoizes looks
+        // constant and is not. See PackageContribution::resetCache().
+        PackageContribution::resetCache();
         PathFinder::resetCache();
         ClassValidator::resetCache();
         // Dropping the shared plan cache is cheap -- one null assignment -- and

--- a/src/Framework/Gacela.php
+++ b/src/Framework/Gacela.php
@@ -7,6 +7,7 @@ namespace Gacela\Framework;
 use Closure;
 use Composer\InstalledVersions;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry;
 use Gacela\Framework\Bootstrap\SetupGacela;
 use Gacela\Framework\Bootstrap\SetupGacelaInterface;
 use Gacela\Framework\Cache\WritableDirectory;
@@ -209,6 +210,10 @@ final class Gacela
         DocBlockResolver::resetCache();
         ClassResolverCache::resetCache();
         ConfigFactory::resetCache();
+        // Kept in step with the line above: the registry describes the merged
+        // configuration that memo holds, and one surviving the other would have
+        // `debug:container` describing a configuration that is gone.
+        PackageDiscoveryRegistry::reset();
         PathFinder::resetCache();
         ClassValidator::resetCache();
         // Dropping the shared plan cache is cheap -- one null assignment -- and

--- a/tests/Feature/Console/DebugEvents/DebugEventsCommandTest.php
+++ b/tests/Feature/Console/DebugEvents/DebugEventsCommandTest.php
@@ -204,7 +204,16 @@ final class DebugEventsCommandTest extends TestCase
         $document = $this->runAsJson(['filter' => 'Bootstrap']);
 
         self::assertSame($this->catalogSize(), $document['summary']['events']);
-        self::assertCount(2, $document['events']);
+
+        // Described rather than counted: a literal here is a number a new
+        // bootstrap event breaks for no reason, and what the filter promises is
+        // that the listing is a proper subset of one group.
+        self::assertNotSame([], $document['events']);
+        self::assertLessThan($this->catalogSize(), count($document['events']));
+
+        foreach ($document['events'] as $event) {
+            self::assertSame('Bootstrap', $event['group']);
+        }
     }
 
     /**

--- a/tests/Feature/Console/Doctor/DoctorCommandTest.php
+++ b/tests/Feature/Console/Doctor/DoctorCommandTest.php
@@ -277,6 +277,10 @@ final class DoctorCommandTest extends TestCase
             '✓ service extensions',
             '✓ tagged services',
             '✓ package manifests',
+            // Beside the manifest check, because both read
+            // `vendor/composer/installed.json` -- one about what a package
+            // imports, this one about what it declares to Gacela.
+            '✓ discovered packages',
             '✓ IDE metadata',
             '✓ All checks passed',
         ], $this->statusLinesOf($tester));
@@ -671,7 +675,7 @@ final class DoctorCommandTest extends TestCase
         $words = [
             10 => 'Ten', 11 => 'Eleven', 12 => 'Twelve', 13 => 'Thirteen', 14 => 'Fourteen',
             15 => 'Fifteen', 16 => 'Sixteen', 17 => 'Seventeen', 18 => 'Eighteen',
-            19 => 'Nineteen', 20 => 'Twenty', 21 => 'Twenty-one',
+            19 => 'Nineteen', 20 => 'Twenty', 21 => 'Twenty-one', 22 => 'Twenty-two',
         ];
         self::assertArrayHasKey($actual, $words, 'the doctor grew past the words this test knows');
 

--- a/tests/Feature/Framework/PackageDiscovery/App/Auditing/AuditingFacade.php
+++ b/tests/Feature/Framework/PackageDiscovery/App/Auditing/AuditingFacade.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\App\Auditing;
+
+use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+
+/**
+ * The consuming application's one module.
+ *
+ * It names the package's interface, because that is the extension point the
+ * package publishes -- and nothing else about the package. There is no
+ * registration, no provider, and no line in the application's `gacela.php`.
+ *
+ * @method AuditingFactory getFactory()
+ */
+#[ServiceMap(method: 'getFactory', className: AuditingFactory::class)]
+final class AuditingFacade extends AbstractFacade
+{
+    public function announce(string $message): void
+    {
+        foreach ($this->getFactory()->createChannels() as $channel) {
+            $channel->write($message);
+        }
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/App/Auditing/AuditingFactory.php
+++ b/tests/Feature/Framework/PackageDiscovery/App/Auditing/AuditingFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\App\Auditing;
+
+use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Plugins\PluginStack;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditChannelInterface;
+
+final class AuditingFactory extends AbstractFactory
+{
+    /**
+     * @return PluginStack<AuditChannelInterface>
+     */
+    public function createChannels(): PluginStack
+    {
+        return $this->getPluginStack(AuditChannelInterface::class);
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/App/BootLog.php
+++ b/tests/Feature/Framework/PackageDiscovery/App/BootLog.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\App;
+
+use Gacela\Framework\Event\Bootstrap\PackageConfigMergedEvent;
+
+use function sprintf;
+
+/**
+ * What a listener in the application's `gacela.php` writes down about the boot.
+ *
+ * This is the reason `PackageConfigMergedEvent` is dispatched after the merge
+ * rather than during it: a listener registered here does not exist yet while the
+ * packages are being merged.
+ */
+final class BootLog
+{
+    /** @var list<string> */
+    private static array $lines = [];
+
+    public static function recordMerge(PackageConfigMergedEvent $event): void
+    {
+        self::$lines[] = sprintf('%d %s', $event->position(), $event->packageName());
+    }
+
+    public static function reset(): void
+    {
+        self::$lines = [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function lines(): array
+    {
+        return self::$lines;
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/App/ProjectAuditSink.php
+++ b/tests/Feature/Framework/PackageDiscovery/App/ProjectAuditSink.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\App;
+
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditSinkInterface;
+
+/**
+ * What the application binds instead of the package's default.
+ */
+final class ProjectAuditSink implements AuditSinkInterface
+{
+    public function label(): string
+    {
+        return 'the project decided';
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/PackageDiscoveryTest.php
+++ b/tests/Feature/Framework/PackageDiscovery/PackageDiscoveryTest.php
@@ -201,6 +201,26 @@ final class PackageDiscoveryTest extends TestCase
     }
 
     /**
+     * `Gacela::resetCache()` drops the merged configuration the registry
+     * describes, so the registry goes with it. One surviving the other is
+     * `debug:container` and `doctor` describing packages that are in no
+     * configuration this process still holds.
+     */
+    public function test_resetting_the_caches_forgets_what_was_discovered(): void
+    {
+        $this->installed->install(['MissingConfig', 'AuditTrail']);
+        $this->bootstrap();
+
+        self::assertSame(['gacela-fixture/audit-trail'], $this->discoveredNames());
+
+        Gacela::resetCache();
+
+        self::assertSame([], PackageDiscoveryRegistry::discovered());
+        self::assertSame([], PackageDiscoveryRegistry::refused());
+        self::assertFalse(PackageDiscoveryRegistry::isDisabled());
+    }
+
+    /**
      * The harder half: `gacela.php` is read *after* the packages are merged, so
      * an opt-out written there is only in time because the file is read for the
      * opt-out before any package's code runs.
@@ -334,6 +354,57 @@ final class PackageDiscoveryTest extends TestCase
     public function test_without_installed_json_nothing_is_discovered_and_nothing_complains(): void
     {
         $this->bootstrap();
+
+        self::assertSame([], $this->discoveredNames());
+        self::assertSame([], PackageDiscoveryRegistry::refused());
+        self::assertFalse(PackageDiscoveryRegistry::isDisabled());
+    }
+
+    /**
+     * A root with no manifest is the one path that never reaches discovery, so
+     * it is the one that has to clear the registry itself: without that, the
+     * packages of the *previous* application are still standing there, and
+     * `debug:container` under this one attributes bindings to packages it never
+     * installed.
+     */
+    public function test_an_application_with_no_manifest_forgets_the_previous_ones_packages(): void
+    {
+        $this->installed->install(['AuditTrail']);
+        Gacela::bootstrap($this->installed->appRoot, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+
+        self::assertSame(['gacela-fixture/audit-trail'], $this->discoveredNames());
+
+        $bare = new InstalledPackages();
+
+        try {
+            Gacela::bootstrap($bare->appRoot, static function (GacelaConfig $config): void {
+                $config->setFileCache(false);
+            });
+
+            self::assertSame([], $this->discoveredNames());
+        } finally {
+            $bare->remove();
+        }
+    }
+
+    /**
+     * The same root, with the switch thrown: no manifest is answered before the
+     * opt-out is even looked at, so nothing is read and nothing is reported as
+     * having been refused.
+     *
+     * `discoveryDisabled` stays false on purpose. It is what makes `doctor` say
+     * "%d package(s) declare a config and none was read" and `debug:container`
+     * print the same, both about declarations -- and there are none here. What
+     * happened to this application is that there was nothing to discover, which
+     * is what the report says instead.
+     */
+    public function test_refusing_everything_under_a_root_with_no_manifest_reports_nothing_to_discover(): void
+    {
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['*']);
+        });
 
         self::assertSame([], $this->discoveredNames());
         self::assertSame([], PackageDiscoveryRegistry::refused());

--- a/tests/Feature/Framework/PackageDiscovery/PackageDiscoveryTest.php
+++ b/tests/Feature/Framework/PackageDiscovery/PackageDiscoveryTest.php
@@ -107,6 +107,100 @@ final class PackageDiscoveryTest extends TestCase
     }
 
     /**
+     * The refusal applies to the package it names and stops there: the packages
+     * installed after it are read exactly as if the entry were not written.
+     */
+    public function test_refusing_the_first_installed_package_leaves_the_rest_discovered(): void
+    {
+        $this->installed->install(['AuditTrail', 'LegacyNumbering']);
+
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['gacela-fixture/audit-trail']);
+        });
+
+        self::assertSame(['gacela-fixture/legacy-numbering'], $this->discoveredNames());
+        self::assertSame('roman', Config::getInstance()->get('legacy.numbering'));
+        self::assertNull(Config::getInstance()->get('audit.enabled', null));
+    }
+
+    /**
+     * Two packages declaring the same thing: the later-installed one wins, and
+     * the project is still merged after both.
+     *
+     * Worth pinning because it is also the warning in `docs/packages.md` --
+     * installed order is Composer's, decided by the dependency graph and by when
+     * things were added to `composer.json`, and no application controls it. A
+     * package that needs to win must not rely on this.
+     */
+    public function test_between_two_packages_the_later_installed_one_wins(): void
+    {
+        $this->installed->install(['AuditTrail', 'AuditOverride']);
+
+        $this->bootstrap();
+
+        self::assertSame(
+            ['gacela-fixture/audit-trail', 'gacela-fixture/audit-override'],
+            $this->discoveredNames(),
+        );
+        self::assertFalse(Config::getInstance()->getBool('audit.enabled'));
+        self::assertSame(
+            'the later-installed package decided',
+            Gacela::getRequired(AuditSinkInterface::class)->label(),
+        );
+    }
+
+    public function test_installing_the_same_two_packages_the_other_way_round_reverses_the_answer(): void
+    {
+        $this->installed->install(['AuditOverride', 'AuditTrail']);
+
+        $this->bootstrap();
+
+        self::assertSame(
+            ['gacela-fixture/audit-override', 'gacela-fixture/audit-trail'],
+            $this->discoveredNames(),
+        );
+        self::assertTrue(Config::getInstance()->getBool('audit.enabled'));
+        self::assertSame(
+            'file (the package default)',
+            Gacela::getRequired(AuditSinkInterface::class)->label(),
+        );
+    }
+
+    /**
+     * The registry describes the boot that just discovered, not every boot the
+     * process has seen -- so a second application, with other packages installed
+     * against it, replaces the answer instead of appending to it. What `doctor`
+     * and `debug:container` read afterwards is one application's packages.
+     *
+     * Two roots rather than two bootstraps of one, because the merged
+     * configuration is memoized per root and a second bootstrap of the same one
+     * discovers nothing. And neither of them clears the in-memory caches, so the
+     * clearing under test is the one discovery does for itself: nothing may be
+     * left to a caller that a production bootstrap does not have to make.
+     */
+    public function test_discovering_for_another_application_replaces_the_answer(): void
+    {
+        $this->installed->install(['MissingConfig', 'AuditTrail']);
+        Gacela::bootstrap($this->installed->appRoot, static function (GacelaConfig $config): void {
+            $config->setFileCache(false);
+        });
+
+        $other = new InstalledPackages();
+
+        try {
+            $other->install(['LegacyNumbering']);
+            Gacela::bootstrap($other->appRoot, static function (GacelaConfig $config): void {
+                $config->setFileCache(false);
+            });
+
+            self::assertSame(['gacela-fixture/legacy-numbering'], $this->discoveredNames());
+            self::assertSame([], $this->refusalReasons());
+        } finally {
+            $other->remove();
+        }
+    }
+
+    /**
      * The harder half: `gacela.php` is read *after* the packages are merged, so
      * an opt-out written there is only in time because the file is read for the
      * opt-out before any package's code runs.

--- a/tests/Feature/Framework/PackageDiscovery/PackageDiscoveryTest.php
+++ b/tests/Feature/Framework/PackageDiscovery/PackageDiscoveryTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\Package\PackageConfigCache;
+use Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry;
+use Gacela\Framework\Bootstrap\Package\PackageRefusal;
+use Gacela\Framework\Config\Config;
+use Gacela\Framework\Gacela;
+use GacelaTest\Feature\Framework\PackageDiscovery\App\Auditing\AuditingFacade;
+use GacelaTest\Feature\Framework\PackageDiscovery\App\BootLog;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditRecorder;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditSinkInterface;
+use GacelaTest\Feature\Framework\PackageDiscovery\Support\InstalledPackages;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function is_file;
+
+/**
+ * A package contributes to an application by being installed.
+ *
+ * Every test here asserts something the application's own `gacela.php` never
+ * mentions the package to get -- which is the whole claim.
+ */
+final class PackageDiscoveryTest extends TestCase
+{
+    private InstalledPackages $installed;
+
+    protected function setUp(): void
+    {
+        $this->installed = new InstalledPackages();
+        AuditRecorder::reset();
+        BootLog::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->installed->remove();
+        Gacela::resetCache();
+    }
+
+    public function test_an_installed_package_contributes_without_the_project_naming_it(): void
+    {
+        $this->installed->install(['AuditTrail']);
+        $this->installed->writeGacelaPhp(<<<'PHP'
+            use Gacela\Framework\Bootstrap\GacelaConfig;
+
+            return static function (GacelaConfig $config): void {
+                // Nothing about any package. That is the point.
+                $config->setProjectNamespaces(['GacelaTest\Feature\Framework\PackageDiscovery\App']);
+            };
+            PHP);
+
+        $this->bootstrap();
+
+        // The plugin stack: the member the package put on its own extension
+        // point runs when the application's module reads the stack.
+        Gacela::getRequired(AuditingFacade::class)->announce('invoice issued');
+
+        // The listener: registered by the package's config, fired by the
+        // framework at the end of the same bootstrap.
+        self::assertSame(['booted', 'log: invoice issued'], AuditRecorder::records());
+
+        // A config key the package declared, readable like any other.
+        self::assertTrue(Config::getInstance()->getBool('audit.enabled'));
+
+        // The package's own default answers, so the test below -- where the
+        // project replaces it -- is about the project winning rather than about
+        // the project being the only one who ever bound anything.
+        self::assertSame('file (the package default)', Gacela::getRequired(AuditSinkInterface::class)->label());
+    }
+
+    public function test_the_project_has_the_last_word_on_a_binding_the_package_set(): void
+    {
+        $this->installed->install(['AuditTrail']);
+        $this->installed->writeGacelaPhp(<<<'PHP'
+            use Gacela\Framework\Bootstrap\GacelaConfig;
+            use GacelaTest\Feature\Framework\PackageDiscovery\App\ProjectAuditSink;
+            use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditSinkInterface;
+
+            return static function (GacelaConfig $config): void {
+                $config->addBinding(AuditSinkInterface::class, ProjectAuditSink::class);
+            };
+            PHP);
+
+        $this->bootstrap();
+
+        self::assertSame('the project decided', Gacela::getRequired(AuditSinkInterface::class)->label());
+    }
+
+    public function test_dont_discover_in_the_bootstrap_closure_refuses_a_package(): void
+    {
+        $this->installed->install(['AuditTrail', 'LegacyNumbering']);
+
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['gacela-fixture/legacy-numbering']);
+        });
+
+        self::assertTrue(Config::getInstance()->getBool('audit.enabled'));
+        self::assertNull(Config::getInstance()->get('legacy.numbering', null));
+        self::assertSame(['gacela-fixture/audit-trail'], $this->discoveredNames());
+        self::assertSame([PackageRefusal::OptedOut], $this->refusalReasons());
+    }
+
+    /**
+     * The harder half: `gacela.php` is read *after* the packages are merged, so
+     * an opt-out written there is only in time because the file is read for the
+     * opt-out before any package's code runs.
+     */
+    public function test_dont_discover_in_gacela_php_refuses_a_package(): void
+    {
+        $this->installed->install(['AuditTrail', 'LegacyNumbering']);
+        $this->installed->writeGacelaPhp(<<<'PHP'
+            use Gacela\Framework\Bootstrap\GacelaConfig;
+
+            return static function (GacelaConfig $config): void {
+                $config->dontDiscover(['gacela-fixture/legacy-numbering']);
+            };
+            PHP);
+
+        $this->bootstrap();
+
+        self::assertNull(Config::getInstance()->get('legacy.numbering', null));
+        self::assertSame(['gacela-fixture/audit-trail'], $this->discoveredNames());
+    }
+
+    public function test_dont_discover_everything_reads_no_package_at_all(): void
+    {
+        $this->installed->install(['AuditTrail', 'LegacyNumbering']);
+
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['*']);
+        });
+
+        self::assertSame([], $this->discoveredNames());
+        self::assertTrue(PackageDiscoveryRegistry::isDisabled());
+        // Nothing to list as refused: no declaration was read to name.
+        self::assertSame([], PackageDiscoveryRegistry::refused());
+        self::assertNull(Config::getInstance()->get('audit.enabled', null));
+    }
+
+    /**
+     * Two opt-outs from two sources are two refusals, not the later one winning.
+     */
+    public function test_opt_outs_accumulate_across_the_closure_and_gacela_php(): void
+    {
+        $this->installed->install(['AuditTrail', 'LegacyNumbering']);
+        $this->installed->writeGacelaPhp(<<<'PHP'
+            use Gacela\Framework\Bootstrap\GacelaConfig;
+
+            return static function (GacelaConfig $config): void {
+                $config->dontDiscover(['gacela-fixture/legacy-numbering']);
+            };
+            PHP);
+
+        $this->bootstrap(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['gacela-fixture/audit-trail']);
+        });
+
+        self::assertSame([], $this->discoveredNames());
+    }
+
+    public function test_a_declared_config_that_is_not_there_does_not_stop_the_boot(): void
+    {
+        $this->installed->install(['MissingConfig', 'AuditTrail']);
+
+        $this->bootstrap();
+
+        self::assertSame(['gacela-fixture/audit-trail'], $this->discoveredNames());
+        self::assertSame([PackageRefusal::MissingFile], $this->refusalReasons());
+    }
+
+    public function test_a_config_that_does_not_return_a_callable_does_not_stop_the_boot(): void
+    {
+        $this->installed->install(['NotCallable', 'AuditTrail']);
+
+        $this->bootstrap();
+
+        self::assertSame(['gacela-fixture/audit-trail'], $this->discoveredNames());
+        self::assertSame([PackageRefusal::NotCallable], $this->refusalReasons());
+    }
+
+    /**
+     * The merge order, seen from a listener the application registered -- which
+     * only works because the event is dispatched once the whole configuration is
+     * assembled.
+     */
+    public function test_the_merge_order_is_observable_from_the_projects_own_listener(): void
+    {
+        $this->installed->install(['AuditTrail', 'LegacyNumbering']);
+        $this->installed->writeGacelaPhp(<<<'PHP'
+            use Gacela\Framework\Bootstrap\GacelaConfig;
+            use Gacela\Framework\Event\Bootstrap\PackageConfigMergedEvent;
+            use GacelaTest\Feature\Framework\PackageDiscovery\App\BootLog;
+
+            return static function (GacelaConfig $config): void {
+                $config->registerSpecificListener(
+                    PackageConfigMergedEvent::class,
+                    static fn (PackageConfigMergedEvent $event): null => BootLog::recordMerge($event),
+                );
+            };
+            PHP);
+
+        $this->bootstrap();
+
+        self::assertSame(
+            ['1 gacela-fixture/audit-trail', '2 gacela-fixture/legacy-numbering'],
+            BootLog::lines(),
+        );
+    }
+
+    public function test_the_resolved_list_is_written_to_the_cache_directory(): void
+    {
+        $this->installed->install(['AuditTrail']);
+        $cacheDir = $this->installed->cacheDir();
+        $cacheFile = $cacheDir . DIRECTORY_SEPARATOR . PackageConfigCache::FILENAME;
+        $this->installed->alsoRemove($cacheFile);
+
+        $this->bootstrap(static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->enableFileCache($cacheDir);
+        });
+
+        self::assertTrue(is_file($cacheFile), 'the resolved list was not cached');
+
+        $cached = (array) require $cacheFile;
+
+        self::assertSame(
+            [['name' => 'gacela-fixture/audit-trail', 'declaredPath' => 'config/gacela.php', 'configFile' => $this->auditTrailConfigFile()]],
+            $cached['packages'],
+        );
+    }
+
+    /**
+     * An application root that Composer never installed against.
+     */
+    public function test_without_installed_json_nothing_is_discovered_and_nothing_complains(): void
+    {
+        $this->bootstrap();
+
+        self::assertSame([], $this->discoveredNames());
+        self::assertSame([], PackageDiscoveryRegistry::refused());
+        self::assertFalse(PackageDiscoveryRegistry::isDisabled());
+    }
+
+    private function bootstrap(?callable $extra = null): void
+    {
+        Gacela::bootstrap($this->installed->appRoot, static function (GacelaConfig $config) use ($extra): void {
+            $config->resetInMemoryCache();
+            $config->setFileCache(false);
+
+            if ($extra !== null) {
+                $extra($config);
+            }
+        });
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function discoveredNames(): array
+    {
+        return array_map(
+            static fn (object $package): string => (string) $package->name,
+            PackageDiscoveryRegistry::discovered(),
+        );
+    }
+
+    /**
+     * @return list<PackageRefusal>
+     */
+    private function refusalReasons(): array
+    {
+        return array_map(
+            static fn (object $package): PackageRefusal => $package->reason,
+            PackageDiscoveryRegistry::refused(),
+        );
+    }
+
+    private function auditTrailConfigFile(): string
+    {
+        return __DIR__ . DIRECTORY_SEPARATOR . 'Packages' . DIRECTORY_SEPARATOR . 'AuditTrail'
+            . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'gacela.php';
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditOverride/composer.json
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditOverride/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "gacela-fixture/audit-override",
+    "description": "A third Gacela package, here to disagree: it declares the same config key and the same binding `gacela-fixture/audit-trail` declares, so which of the two an application ends up with is decided by Composer's installed order and by nothing else. It ships no classes of its own, because the disagreement is the whole of it.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditOverride/config/gacela.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditOverride/config/gacela.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditSinkInterface;
+
+/**
+ * The same key and the same binding `gacela-fixture/audit-trail` declares, with
+ * the other answer -- which is what an add-on for another package looks like.
+ *
+ * Whichever of the two Composer installed later is the one an application gets,
+ * which is why a package that *needs* to win must not ship a declaration and
+ * hope: it should give the consuming project something to call.
+ */
+return static function (GacelaConfig $config): void {
+    $config->addAppConfigKeyValue('audit.enabled', false);
+
+    $config->addBinding(
+        AuditSinkInterface::class,
+        static fn (): AuditSinkInterface => new class() implements AuditSinkInterface {
+            public function label(): string
+            {
+                return 'the later-installed package decided';
+            }
+        },
+    );
+};

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/composer.json
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "gacela-fixture/audit-trail",
+    "description": "A Gacela package. The `extra.gacela.config` key below is the whole of how it wires itself into a consuming application: nothing in that application names this package. The psr-4 map is what a real package ships; in this repository the classes are autoloaded by the root `GacelaTest\\` map, which is why the namespace follows the path.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "GacelaTest\\Feature\\Framework\\PackageDiscovery\\Packages\\AuditTrail\\": "src"
+        }
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/config/gacela.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/config/gacela.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditChannelInterface;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditRecorder;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\AuditSinkInterface;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\FileAuditSink;
+use GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail\LogAuditChannel;
+
+/**
+ * What this package contributes to whatever application installs it.
+ *
+ * The same shape a project's own `gacela.php` returns, and the same
+ * `GacelaConfig` surface: there is no second config format for packages.
+ */
+return static function (GacelaConfig $config): void {
+    // The extension point, and the one member this package ships. An
+    // application adding its own channel appends to this stack rather than
+    // replacing it.
+    $config->addPluginStack(AuditChannelInterface::class, [LogAuditChannel::class]);
+
+    // A default. The application's `gacela.php` is merged after every package,
+    // so binding this again there wins.
+    $config->addBinding(AuditSinkInterface::class, FileAuditSink::class);
+
+    $config->addAppConfigKeyValue('audit.enabled', true);
+
+    $config->registerSpecificListener(
+        GacelaBootstrapFinishedEvent::class,
+        static fn (GacelaBootstrapFinishedEvent $event): null => AuditRecorder::record('booted'),
+    );
+};

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/AuditChannelInterface.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/AuditChannelInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail;
+
+/**
+ * The extension point this package publishes.
+ *
+ * The package declares the stack and ships one member; the consuming application
+ * adds its own by naming this interface, which is the only thing it has to know
+ * about the package.
+ */
+interface AuditChannelInterface
+{
+    public function write(string $message): void;
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/AuditRecorder.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/AuditRecorder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail;
+
+/**
+ * Where this package's channel and its listener write, so a test can see that
+ * both of them ran.
+ */
+final class AuditRecorder
+{
+    /** @var list<string> */
+    private static array $records = [];
+
+    public static function record(string $message): void
+    {
+        self::$records[] = $message;
+    }
+
+    public static function reset(): void
+    {
+        self::$records = [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function records(): array
+    {
+        return self::$records;
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/AuditSinkInterface.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/AuditSinkInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail;
+
+/**
+ * A default this package binds and a consuming application is expected to
+ * replace. The replacement is one `addBinding()` in the application's own
+ * `gacela.php`, which is merged after every package.
+ */
+interface AuditSinkInterface
+{
+    public function label(): string;
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/FileAuditSink.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/FileAuditSink.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail;
+
+final class FileAuditSink implements AuditSinkInterface
+{
+    public function label(): string
+    {
+        return 'file (the package default)';
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/LogAuditChannel.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/AuditTrail/src/LogAuditChannel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\Packages\AuditTrail;
+
+use function sprintf;
+
+/**
+ * The member this package puts on its own stack.
+ */
+final class LogAuditChannel implements AuditChannelInterface
+{
+    public function write(string $message): void
+    {
+        AuditRecorder::record(sprintf('log: %s', $message));
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/LegacyNumbering/composer.json
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/LegacyNumbering/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "gacela-fixture/legacy-numbering",
+    "description": "A second Gacela package, here to be refused: the application names it in `dontDiscover()` and the config below is never read.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/LegacyNumbering/config/gacela.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/LegacyNumbering/config/gacela.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->addAppConfigKeyValue('legacy.numbering', 'roman');
+};

--- a/tests/Feature/Framework/PackageDiscovery/Packages/MissingConfig/composer.json
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/MissingConfig/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "gacela-fixture/missing-config",
+    "description": "Declares a Gacela config it does not ship. Installing it must not stop an application from booting, and `doctor` is where that is reported -- so this directory deliberately has no `config/` in it.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/NotCallable/composer.json
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/NotCallable/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "gacela-fixture/not-callable",
+    "description": "Ships a Gacela config that returns an array instead of a `callable(GacelaConfig)`. Same contract as the package above: the application still boots, and `doctor` names the file.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/Framework/PackageDiscovery/Packages/NotCallable/config/gacela.php
+++ b/tests/Feature/Framework/PackageDiscovery/Packages/NotCallable/config/gacela.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+// Wrong on purpose: a Gacela config returns `callable(GacelaConfig): void`, and
+// this returns an array. What a package author writes when they forget the
+// `return static function (...)`.
+return ['audit' => true];

--- a/tests/Feature/Framework/PackageDiscovery/Support/InstalledPackages.php
+++ b/tests/Feature/Framework/PackageDiscovery/Support/InstalledPackages.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\Framework\PackageDiscovery\Support;
+
+use PHPUnit\Framework\Assert;
+use RuntimeException;
+
+use function array_reverse;
+use function bin2hex;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function json_decode;
+use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sprintf;
+use function str_starts_with;
+use function sys_get_temp_dir;
+use function unlink;
+
+/**
+ * An application root with packages installed against it.
+ *
+ * The root is a throwaway directory, because each test wants a different
+ * `gacela.php` beside the same packages. The packages themselves are committed
+ * under `Packages/`, and the `installed.json` written here is *generated from
+ * their own manifests* -- so a fixture package declares `extra.gacela.config`
+ * in exactly one place, the way a real one does, and this class only plays the
+ * part `composer install` plays.
+ */
+final class InstalledPackages
+{
+    private const string PREFIX = 'gacela-package-discovery-';
+
+    public readonly string $appRoot;
+
+    /** @var list<string> every file this created, in creation order */
+    private array $files = [];
+
+    /** @var list<string> every directory this created, in creation order */
+    private array $directories = [];
+
+    public function __construct()
+    {
+        $this->appRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . self::PREFIX . bin2hex(random_bytes(5));
+        $this->makeDirectory($this->appRoot);
+    }
+
+    /**
+     * @param list<string> $packageDirectories directory names under `Packages/`,
+     *                                         in the order Composer would have
+     *                                         installed them
+     */
+    public function install(array $packageDirectories): void
+    {
+        $packages = [];
+
+        foreach ($packageDirectories as $directory) {
+            $packageRoot = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Packages' . DIRECTORY_SEPARATOR . $directory;
+            $manifest = $packageRoot . DIRECTORY_SEPARATOR . 'composer.json';
+
+            if (!is_file($manifest)) {
+                throw new RuntimeException(sprintf('No fixture package at "%s".', $manifest));
+            }
+
+            /** @var array{name: string, extra: array<string, mixed>} $decoded */
+            $decoded = (array) json_decode((string) file_get_contents($manifest), true);
+
+            $packages[] = [
+                'name' => $decoded['name'],
+                'extra' => $decoded['extra'],
+                // Composer writes this relative to `vendor/composer`. Absolute is
+                // as valid, and it is what lets the packages stay committed while
+                // the root that installs them is a temp directory. The relative
+                // form is covered by PackageConfigFinderTest.
+                'install-path' => $packageRoot,
+            ];
+        }
+
+        $this->write(
+            $this->appRoot . DIRECTORY_SEPARATOR . 'vendor'
+                . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json',
+            (string) json_encode(['packages' => $packages, 'dev' => true]),
+        );
+    }
+
+    /**
+     * The application's own configuration -- the file that must not have to
+     * mention any of the packages above.
+     */
+    public function writeGacelaPhp(string $body): void
+    {
+        $this->write(
+            $this->appRoot . DIRECTORY_SEPARATOR . 'gacela.php',
+            "<?php\n\ndeclare(strict_types=1);\n\n" . $body,
+        );
+    }
+
+    public function cacheDir(): string
+    {
+        $dir = $this->appRoot . DIRECTORY_SEPARATOR . 'cache';
+        $this->makeDirectory($dir);
+
+        return $dir;
+    }
+
+    /**
+     * Removes exactly what was created, named one path at a time and each
+     * asserted to sit under the temp root this built.
+     */
+    public function remove(): void
+    {
+        foreach (array_reverse($this->files) as $file) {
+            $this->assertOwned($file);
+
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        foreach (array_reverse($this->directories) as $directory) {
+            $this->assertOwned($directory);
+
+            if (is_dir($directory)) {
+                rmdir($directory);
+            }
+        }
+
+        $this->files = [];
+        $this->directories = [];
+    }
+
+    /**
+     * A file discovery wrote, so `remove()` can name it too.
+     */
+    public function alsoRemove(string $file): void
+    {
+        $this->files[] = $file;
+    }
+
+    private function write(string $path, string $contents): void
+    {
+        $this->makeDirectory(dirname($path));
+
+        file_put_contents($path, $contents);
+        $this->files[] = $path;
+    }
+
+    private function makeDirectory(string $directory): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+
+        // Recorded innermost-last so the reversal below removes children first.
+        $parent = dirname($directory);
+
+        if (str_starts_with($parent, $this->appRoot) || $parent === $this->appRoot) {
+            $this->makeDirectory($parent);
+        }
+
+        mkdir($directory);
+        $this->directories[] = $directory;
+    }
+
+    private function assertOwned(string $path): void
+    {
+        Assert::assertStringStartsWith(
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR . self::PREFIX,
+            $path,
+            'refusing to remove a path this fixture did not create',
+        );
+    }
+}

--- a/tests/Feature/ReferenceApp/Invoicing/gacela.php
+++ b/tests/Feature/ReferenceApp/Invoicing/gacela.php
@@ -78,6 +78,23 @@ return static function (GacelaConfig $config): void {
     // `config/app-prod.php`, and an unset APP_REGION ends the chain there.
     $config->addConfigDimension('APP_REGION');
 
+    // Two packages are installed against this application (see
+    // `vendor/composer/installed.json`), and each of them declares a Gacela
+    // config that runs during `Gacela::bootstrap()`. This is the one line that
+    // decides which of them may.
+    //
+    // `gacela-fixture/invoice-audit` is kept: it adds a delivery channel and a
+    // reaction to `InvoiceIssuedEvent`, neither of which is written anywhere in
+    // this application -- and both of which `debug:container` and `debug:events`
+    // will attribute to it.
+    //
+    // `gacela-fixture/legacy-numbering` is refused: it would replace the invoice
+    // number format `BillingProvider` decides, and this application has an
+    // opinion about how its own invoices are numbered. Refusing it means its
+    // file is never opened, which is also the answer to "what runs at boot" for
+    // a package this application has not read.
+    $config->dontDiscover(['gacela-fixture/legacy-numbering']);
+
     // ------------------------------------------------------------------
     // What the configuration must contain
     // ------------------------------------------------------------------

--- a/tests/Feature/ReferenceApp/Invoicing/vendor/composer/installed.json
+++ b/tests/Feature/ReferenceApp/Invoicing/vendor/composer/installed.json
@@ -1,0 +1,26 @@
+{
+    "_note": "Hand-written, like the composer.json beside this application: nothing is installed here. It is what package discovery reads, so it is what makes the two packages under ../../Packages real -- one contributes a delivery channel and a listener, the other is refused by name in gacela.php. install-path is relative to this directory, exactly as Composer writes it.",
+    "packages": [
+        {
+            "name": "gacela-fixture/invoice-audit",
+            "version": "1.0.0",
+            "install-path": "../../../Packages/invoice-audit",
+            "extra": {
+                "gacela": {
+                    "config": "config/gacela.php"
+                }
+            }
+        },
+        {
+            "name": "gacela-fixture/legacy-numbering",
+            "version": "1.0.0",
+            "install-path": "../../../Packages/legacy-numbering",
+            "extra": {
+                "gacela": {
+                    "config": "config/gacela.php"
+                }
+            }
+        }
+    ],
+    "dev": true
+}

--- a/tests/Feature/ReferenceApp/InvoicingFlowTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingFlowTest.php
@@ -49,6 +49,16 @@ final class InvoicingFlowTest extends TestCase
         // some other application on this machine left in the system temp dir.
         $this->cacheDir = ReferenceApp::createTempDirectory('flow-cache');
         putenv('GACELA_CACHE_DIR=' . $this->cacheDir);
+
+        // Here as well as in tearDown, and not only for symmetry: the trail is
+        // process-global, every test in this class issues an invoice, and each
+        // one numbers its first invoice `01001` because the numbering starts
+        // from the same place on a fresh bootstrap. So anything left behind is
+        // indistinguishable from what this test produced itself, and a tearDown
+        // that did not run -- an error before it, or a test added elsewhere that
+        // writes here -- becomes a count this test asserts. Resetting on the way
+        // in owes nothing to whatever ran before.
+        AuditTrail::reset();
     }
 
     protected function tearDown(): void

--- a/tests/Feature/ReferenceApp/InvoicingFlowTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingFlowTest.php
@@ -17,6 +17,7 @@ use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Infrastructure\Resolv
 use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\NotificationFacade;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Payment\PaymentApi;
 use GacelaTest\Feature\ReferenceApp\Invoicing\Reporting\ReportingFacade;
+use GacelaTest\Feature\ReferenceApp\Packages\InvoiceAudit\AuditTrail;
 use GacelaTest\Feature\ReferenceApp\Support\RecordingEventDispatcher;
 use GacelaTest\Feature\ReferenceApp\Support\RecordingPsr14Bus;
 use GacelaTest\Feature\ReferenceApp\Support\ReferenceApp;
@@ -54,6 +55,30 @@ final class InvoicingFlowTest extends TestCase
     {
         ReferenceApp::reset();
         ReferenceApp::removeTempDirectory($this->cacheDir);
+        AuditTrail::reset();
+    }
+
+    /**
+     * Two packages are installed against this application and neither is named
+     * anywhere in it except once, to refuse one of them.
+     *
+     * The kept one reacts to `InvoiceIssuedEvent` -- an event `Billing`
+     * announces to nobody in particular -- so a package extends this application
+     * on exactly the terms another module would. The refused one would have
+     * replaced the invoice number format, and the number below is the proof that
+     * `dontDiscover()` stopped its file from being read at all.
+     */
+    public function test_an_installed_package_contributes_and_a_refused_one_does_not(): void
+    {
+        ReferenceApp::bootstrap();
+
+        (new CustomerFacade())->registerCustomer('acme-nl', 'Acme BV', 'NL');
+        $invoice = (new BillingFacade())->issueInvoice('acme-nl', 10_000);
+
+        self::assertSame(['ACME-INV-01001 12100 EUR'], AuditTrail::entries());
+
+        // `gacela-fixture/legacy-numbering` formats this as `ACME-INV/1001`.
+        self::assertSame('ACME-INV-01001', $invoice->getNumber());
     }
 
     public function test_an_invoice_goes_out_taxed_notified_paid_and_reported(): void
@@ -72,9 +97,17 @@ final class InvoicingFlowTest extends TestCase
         self::assertSame('EUR', $invoice->getCurrency());
         self::assertSame(ReferenceApp::FIXED_TODAY, $invoice->getIssuedOn());
 
-        // Email only: the webhook is a production channel.
+        // Audit first, then email: the webhook is a production channel, and the
+        // audit channel is not this application's at all -- it arrived with the
+        // `gacela-fixture/invoice-audit` package, which `gacela.php` never
+        // mentions. Package configuration is merged before the project's own, so
+        // what a package appends to a stack sits in front of what the project
+        // appends.
         self::assertSame(
-            ['email:Acme BV:Invoice ACME-INV-01001'],
+            [
+                'audit:Acme BV:Invoice ACME-INV-01001',
+                'email:Acme BV:Invoice ACME-INV-01001',
+            ],
             (new NotificationFacade())->deliveries(),
         );
 
@@ -114,10 +147,12 @@ final class InvoicingFlowTest extends TestCase
         self::assertSame(2_200, $invoice->getTaxCents());
         self::assertSame(12_200, $invoice->getGrossCents());
 
-        // The webhook channel is added by the same production config, and both
-        // channels see the header the application appended with extendService().
+        // The webhook channel is added by the same production config, and all
+        // three channels see the header the application appended with
+        // extendService() -- including the one an installed package contributed.
         self::assertSame(
             [
+                'audit:Acme BV:Invoice ACME-INV-01001',
                 'email:Acme BV:Invoice ACME-INV-01001',
                 'webhook:Acme BV:X-Invoicing-Source,X-Invoicing-App',
             ],
@@ -245,7 +280,10 @@ final class InvoicingFlowTest extends TestCase
         // both ran, and neither is known to Billing.
         self::assertSame(['Invoice ACME-INV-01001 issued: 12100 EUR due'], $heard);
         self::assertSame(
-            ['email:Acme BV:Invoice ACME-INV-01001'],
+            [
+                'audit:Acme BV:Invoice ACME-INV-01001',
+                'email:Acme BV:Invoice ACME-INV-01001',
+            ],
             (new NotificationFacade())->deliveries(),
         );
     }
@@ -377,7 +415,7 @@ final class InvoicingFlowTest extends TestCase
 
         self::assertSame('sandbox.acme-pay.test', (new PaymentApi())->gatewayEndpoint());
         self::assertSame('EUR', (new BillingFacade())->currency());
-        self::assertSame(['email'], (new NotificationFacade())->channelNames());
+        self::assertSame(['audit', 'email'], (new NotificationFacade())->channelNames());
     }
 
     /**

--- a/tests/Feature/ReferenceApp/InvoicingToolingTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingToolingTest.php
@@ -387,7 +387,12 @@ final class InvoicingToolingTest extends TestCase
         // command reports on the same terms as the framework's -- the report
         // would otherwise contradict the very use it exists to support.
         self::assertStringContainsString('5 with listeners', $display);
-        self::assertStringContainsString('1 listener via InvoiceIssuedEvent', $display);
+        // Two: the one `gacela.php` registers to reach Notification, and the one
+        // the installed `gacela-fixture/invoice-audit` package registers. A
+        // listener that arrived with a package is a listener like any other
+        // here, which is the point -- "what is listening" must not have a
+        // blind spot for code nothing in the application names.
+        self::assertStringContainsString('2 listeners via InvoiceIssuedEvent', $display);
         self::assertStringContainsString('1 declared by this project', $display);
     }
 

--- a/tests/Feature/ReferenceApp/InvoicingToolingTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingToolingTest.php
@@ -354,13 +354,18 @@ final class InvoicingToolingTest extends TestCase
 
         $tester = $this->execute(new DebugContainerCommand(), ['--stats' => true, '--json' => true]);
 
-        /** @var array{packages: array{installedJson: bool, discoveryDisabled: bool, declared: list<string>, discovered: list<array{name: string, position: int}>, refused: list<array{name: string, reason: string}>}} $report */
+        /** @var array{packages: array{installedJson: bool, discoveryDisabled: bool, declared: list<string>, optedOut: list<string>, discovered: list<array{name: string, position: int}>, refused: list<array{name: string, reason: string}>}} $report */
         $report = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
         $packages = $report['packages'];
 
         self::assertTrue($packages['installedJson']);
         self::assertFalse($packages['discoveryDisabled']);
         self::assertSame(['gacela-fixture/invoice-audit', 'gacela-fixture/legacy-numbering'], $packages['declared']);
+        // The one line of this application's `gacela.php` that decided the two
+        // lists below, read back off the merged setup: an opt-out written there
+        // has to survive being merged into the bootstrap's own setup, and until
+        // it did, `doctor` judged every project as having refused nothing.
+        self::assertSame(['gacela-fixture/legacy-numbering'], $packages['optedOut']);
         self::assertSame('gacela-fixture/invoice-audit', $packages['discovered'][0]['name']);
         self::assertSame(1, $packages['discovered'][0]['position']);
         self::assertSame('gacela-fixture/legacy-numbering', $packages['refused'][0]['name']);

--- a/tests/Feature/ReferenceApp/InvoicingToolingTest.php
+++ b/tests/Feature/ReferenceApp/InvoicingToolingTest.php
@@ -325,6 +325,64 @@ final class InvoicingToolingTest extends TestCase
         self::assertStringContainsString('ClockInterface', $display);
     }
 
+    /**
+     * The one thing in this application a reader cannot find by searching it:
+     * the notification channel nothing here registers. `debug:container` names
+     * the package, the file that ran, and what that file declared -- and names
+     * the refused one as refused, so an operator can tell "opted out" apart from
+     * "not installed".
+     */
+    public function test_debug_container_attributes_what_the_installed_packages_contributed(): void
+    {
+        ReferenceApp::bootstrap();
+
+        $tester = $this->execute(new DebugContainerCommand(), ['--stats' => true]);
+        $display = $tester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $display);
+        self::assertStringContainsString('Discovered packages:', $display);
+        self::assertStringContainsString('1. gacela-fixture/invoice-audit', $display);
+        self::assertStringContainsString('invoice-audit' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'gacela.php', $display);
+        self::assertStringContainsString('AuditChannel', $display);
+        self::assertStringContainsString('InvoiceIssuedEvent', $display);
+        self::assertStringContainsString('gacela-fixture/legacy-numbering — opted out', $display);
+    }
+
+    public function test_debug_container_reports_the_packages_as_a_document(): void
+    {
+        ReferenceApp::bootstrap();
+
+        $tester = $this->execute(new DebugContainerCommand(), ['--stats' => true, '--json' => true]);
+
+        /** @var array{packages: array{installedJson: bool, discoveryDisabled: bool, declared: list<string>, discovered: list<array{name: string, position: int}>, refused: list<array{name: string, reason: string}>}} $report */
+        $report = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        $packages = $report['packages'];
+
+        self::assertTrue($packages['installedJson']);
+        self::assertFalse($packages['discoveryDisabled']);
+        self::assertSame(['gacela-fixture/invoice-audit', 'gacela-fixture/legacy-numbering'], $packages['declared']);
+        self::assertSame('gacela-fixture/invoice-audit', $packages['discovered'][0]['name']);
+        self::assertSame(1, $packages['discovered'][0]['position']);
+        self::assertSame('gacela-fixture/legacy-numbering', $packages['refused'][0]['name']);
+        self::assertSame('opted out', $packages['refused'][0]['reason']);
+    }
+
+    /**
+     * The refusal is a decision, not a fault, and the check that reports broken
+     * declarations has to say so -- a `doctor` that warned about a working
+     * opt-out would train people to ignore it.
+     */
+    public function test_doctor_passes_the_discovered_packages_check(): void
+    {
+        ReferenceApp::bootstrap();
+
+        $tester = $this->execute(new DoctorCommand(), []);
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('✓ discovered packages', $display);
+        self::assertStringContainsString('1 of 2 declared package config(s) merged', $display);
+    }
+
     public function test_debug_config_marks_every_key_as_declared(): void
     {
         ReferenceApp::bootstrap();

--- a/tests/Feature/ReferenceApp/Packages/invoice-audit/composer.json
+++ b/tests/Feature/ReferenceApp/Packages/invoice-audit/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "gacela-fixture/invoice-audit",
+    "description": "A Gacela package the reference application installs and keeps. `extra.gacela.config` below is the only wiring: `Invoicing/gacela.php` never names this package, and the channel it adds still delivers.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "GacelaTest\\Feature\\ReferenceApp\\Packages\\InvoiceAudit\\": "src"
+        }
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/ReferenceApp/Packages/invoice-audit/config/gacela.php
+++ b/tests/Feature/ReferenceApp/Packages/invoice-audit/config/gacela.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\Event\InvoiceIssuedEvent;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\Channel\NotificationChannelInterface;
+use GacelaTest\Feature\ReferenceApp\Packages\InvoiceAudit\AuditChannel;
+use GacelaTest\Feature\ReferenceApp\Packages\InvoiceAudit\AuditTrail;
+
+/**
+ * What this package contributes to the application that installs it.
+ *
+ * Same shape and same surface as the application's own `gacela.php`. Two
+ * contributions, both of which the application would otherwise have had to
+ * write itself and keep in step by hand:
+ *
+ *  - a delivery channel, appended to a stack the `Notification` module declared;
+ *  - a reaction to an event the `Billing` module announces.
+ */
+return static function (GacelaConfig $config): void {
+    $config->addPluginStack(NotificationChannelInterface::class, [AuditChannel::class]);
+
+    $config->registerSpecificListener(
+        InvoiceIssuedEvent::class,
+        static fn (InvoiceIssuedEvent $event): null => AuditTrail::record(
+            \sprintf('%s %d %s', $event->invoiceNumber(), $event->grossCents(), $event->currency()),
+        ),
+    );
+};

--- a/tests/Feature/ReferenceApp/Packages/invoice-audit/src/AuditChannel.php
+++ b/tests/Feature/ReferenceApp/Packages/invoice-audit/src/AuditChannel.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\ReferenceApp\Packages\InvoiceAudit;
+
+use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\Channel\NotificationChannelInterface;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Notification\Domain\NotificationMessage;
+
+use function sprintf;
+
+/**
+ * A delivery channel the application never registered.
+ *
+ * It implements the extension point the `Notification` module publishes, and
+ * the package's `config/gacela.php` puts it on the stack. Everything else --
+ * the header the application appends with `extendService()`, the order of the
+ * receipts -- it gets for free by being on the stack like any other channel.
+ */
+final class AuditChannel implements NotificationChannelInterface
+{
+    public function name(): string
+    {
+        return 'audit';
+    }
+
+    public function deliver(NotificationMessage $message): string
+    {
+        return sprintf('audit:%s:%s', $message->recipient, $message->subject);
+    }
+}

--- a/tests/Feature/ReferenceApp/Packages/invoice-audit/src/AuditTrail.php
+++ b/tests/Feature/ReferenceApp/Packages/invoice-audit/src/AuditTrail.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Feature\ReferenceApp\Packages\InvoiceAudit;
+
+/**
+ * Where this package's listener writes, so the application can be asked whether
+ * a package's listener ran without the application registering it.
+ */
+final class AuditTrail
+{
+    /** @var list<string> */
+    private static array $entries = [];
+
+    public static function record(string $entry): void
+    {
+        self::$entries[] = $entry;
+    }
+
+    public static function reset(): void
+    {
+        self::$entries = [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function entries(): array
+    {
+        return self::$entries;
+    }
+}

--- a/tests/Feature/ReferenceApp/Packages/legacy-numbering/composer.json
+++ b/tests/Feature/ReferenceApp/Packages/legacy-numbering/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "gacela-fixture/legacy-numbering",
+    "description": "A Gacela package the reference application installs and refuses. It would overwrite the invoice number format the application decides for itself, which is what `dontDiscover()` in `Invoicing/gacela.php` is there to stop -- the config below is never read.",
+    "require": {
+        "gacela-project/gacela": "*"
+    },
+    "extra": {
+        "gacela": {
+            "config": "config/gacela.php"
+        }
+    }
+}

--- a/tests/Feature/ReferenceApp/Packages/legacy-numbering/config/gacela.php
+++ b/tests/Feature/ReferenceApp/Packages/legacy-numbering/config/gacela.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use GacelaTest\Feature\ReferenceApp\Invoicing\Billing\BillingProvider;
+
+/**
+ * Never executed while `Invoicing/gacela.php` names this package in
+ * `dontDiscover()`. It is here so that the refusal is a refusal of something
+ * real: remove the opt-out and every invoice number in the application changes.
+ */
+return static function (GacelaConfig $config): void {
+    $config->addProtected(
+        BillingProvider::NUMBER_FORMAT,
+        static fn (string $prefix, int $sequence): string => \sprintf('%s/%d', $prefix, $sequence),
+    );
+};

--- a/tests/Integration/Architecture/NoCircularDependenciesTest.php
+++ b/tests/Integration/Architecture/NoCircularDependenciesTest.php
@@ -66,8 +66,19 @@ final class NoCircularDependenciesTest extends TestCase
         //     types, and SetupMerger alone reads 17 of its constants.
         //   - Container + Locator: a container and its service locator, both
         //     @internal, one concept split across two classes.
+        //
+        // Package discovery joined it rather than widened it: it is one more
+        // reader of a file that returns a `callable(GacelaConfig)`, so it points
+        // at the same factory `ConfigFactory` does and produces the same
+        // `SetupGacela`. Its own edges (Package\* -> SetupGacela, ConfigFactory ->
+        // Package\PackageDiscovery) both close through the knot above, and cutting
+        // that knot cuts these with it.
         \Gacela\Framework\Bootstrap\AbstractSetupGacela::class
             . ' | Gacela\Framework\Bootstrap\GacelaConfig'
+            . ' | Gacela\Framework\Bootstrap\Package\DiscoveredPackage'
+            . ' | Gacela\Framework\Bootstrap\Package\PackageContribution'
+            . ' | Gacela\Framework\Bootstrap\Package\PackageDiscovery'
+            . ' | Gacela\Framework\Bootstrap\Package\PackageDiscoveryRegistry'
             . ' | Gacela\Framework\Bootstrap\SetupEventDispatcher'
             . ' | Gacela\Framework\Bootstrap\SetupGacela'
             . ' | Gacela\Framework\Bootstrap\SetupGacelaInterface'
@@ -115,6 +126,7 @@ final class NoCircularDependenciesTest extends TestCase
         'Gacela\Framework'
             . ' | Gacela\Framework\Attribute'
             . ' | Gacela\Framework\Bootstrap'
+            . ' | Gacela\Framework\Bootstrap\Package'
             . ' | Gacela\Framework\Bootstrap\Setup'
             . ' | Gacela\Framework\ClassResolver'
             . ' | Gacela\Framework\ClassResolver\Cache'

--- a/tests/Unit/Console/Application/Doctor/Check/DiscoveredPackagesCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/DiscoveredPackagesCheckTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Console\Application\Doctor\Check;
+
+use Gacela\Console\Application\Debug\PackageDiscoveryReport;
+use Gacela\Console\Application\Doctor\Check\DiscoveredPackagesCheck;
+use Gacela\Console\Application\Doctor\CheckStatus;
+use Gacela\Framework\Bootstrap\Package\DiscoveredPackage;
+use Gacela\Framework\Bootstrap\Package\PackageConfigDeclaration;
+use Gacela\Framework\Bootstrap\Package\PackageContribution;
+use Gacela\Framework\Bootstrap\Package\RefusedPackage;
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+
+final class DiscoveredPackagesCheckTest extends TestCase
+{
+    private const string MISSING = '/no/such/place/config/gacela.php';
+
+    public function test_it_is_named_after_what_it_reports_on(): void
+    {
+        self::assertSame('discovered packages', $this->check($this->report())->name());
+    }
+
+    public function test_without_installed_json_there_is_nothing_to_judge(): void
+    {
+        $result = $this->check($this->report(hasInstalledJson: false))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no vendor/composer/installed.json — nothing to discover'], $result->details);
+    }
+
+    public function test_an_installation_where_no_package_declares_a_config(): void
+    {
+        $result = $this->check($this->report())->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['no installed package declares `extra.gacela.config`'], $result->details);
+    }
+
+    public function test_it_counts_what_was_merged_against_what_was_declared(): void
+    {
+        $declaration = $this->declaration('acme/audit');
+
+        $result = $this->check($this->report(
+            declarations: [$declaration, $this->declaration('acme/other')],
+            discovered: [$this->discovered($declaration)],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['1 of 2 declared package config(s) merged'], $result->details);
+    }
+
+    public function test_a_declaration_pointing_at_a_file_that_is_not_there(): void
+    {
+        $declaration = $this->declaration('acme/audit', self::MISSING);
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            refused: [RefusedPackage::missingFile($declaration)],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['acme/audit declares ' . self::MISSING . ', which file not found'], $result->details);
+        self::assertStringContainsString('fix the `extra.gacela.config` path', $result->remediation);
+    }
+
+    public function test_a_config_that_does_not_return_a_callable(): void
+    {
+        $declaration = $this->declaration('acme/audit');
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            refused: [RefusedPackage::notCallable($declaration)],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(['acme/audit declares ' . __FILE__ . ', which does not return a callable'], $result->details);
+    }
+
+    /**
+     * The refusal is the project getting what it asked for. Reporting it would
+     * teach people to ignore this check.
+     */
+    public function test_a_working_opt_out_is_not_a_finding(): void
+    {
+        $declaration = $this->declaration('acme/legacy');
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            refused: [RefusedPackage::optedOut($declaration)],
+            optedOut: ['acme/legacy'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['0 of 1 declared package config(s) merged'], $result->details);
+    }
+
+    /**
+     * Still worth naming: an opt-out is a package installed for its config, and
+     * whoever removes the entry will meet the broken declaration then.
+     */
+    public function test_an_opted_out_package_whose_config_is_missing_is_still_named(): void
+    {
+        $declaration = $this->declaration('acme/legacy', self::MISSING);
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            refused: [RefusedPackage::optedOut($declaration)],
+            optedOut: ['acme/legacy'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertStringContainsString('not read: this project opted out of it', implode("\n", $result->details));
+    }
+
+    public function test_dont_discover_everything_reads_nothing_and_says_so(): void
+    {
+        $result = $this->check($this->report(
+            discoveryDisabled: true,
+            declarations: [$this->declaration('acme/audit')],
+            optedOut: ['*'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(["1 package(s) declare a config and none was read — `dontDiscover(['*'])`"], $result->details);
+    }
+
+    /**
+     * `'*'` names no package, so the "refuses nothing" rule below must not fire
+     * on it.
+     */
+    public function test_the_wildcard_is_not_reported_as_an_entry_that_refuses_nothing(): void
+    {
+        $result = $this->check($this->report(
+            discoveryDisabled: true,
+            declarations: [$this->declaration('acme/audit', self::MISSING)],
+            optedOut: ['*'],
+        ))->run();
+
+        self::assertSame(
+            ['acme/audit declares ' . self::MISSING . ', which file not found (not read: this project opted out of it)'],
+            $result->details,
+        );
+    }
+
+    /**
+     * The only way an opt-out can be in the merged setup and the package be
+     * merged anyway: it was written in `gacela-{APP_ENV}.php`, which is read
+     * after the packages.
+     */
+    public function test_an_opt_out_that_arrived_after_the_package_had_already_run(): void
+    {
+        $declaration = $this->declaration('acme/audit');
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            discovered: [$this->discovered($declaration)],
+            optedOut: ['acme/audit'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['dontDiscover() names acme/audit and its config was merged anyway — an environment file is read after the packages, so the opt-out arrived too late'],
+            $result->details,
+        );
+    }
+
+    public function test_an_opt_out_naming_a_package_that_declares_nothing(): void
+    {
+        $declaration = $this->declaration('acme/audit');
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            discovered: [$this->discovered($declaration)],
+            optedOut: ['acme/never-installed'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['dontDiscover() names acme/never-installed, which declares no `extra.gacela.config` — the entry refuses nothing'],
+            $result->details,
+        );
+    }
+
+    private function check(PackageDiscoveryReport $report): DiscoveredPackagesCheck
+    {
+        return new DiscoveredPackagesCheck($report);
+    }
+
+    /**
+     * @param list<PackageConfigDeclaration> $declarations
+     * @param list<DiscoveredPackage>        $discovered
+     * @param list<RefusedPackage>           $refused
+     * @param list<string>                   $optedOut
+     */
+    private function report(
+        bool $hasInstalledJson = true,
+        bool $discoveryDisabled = false,
+        array $declarations = [],
+        array $discovered = [],
+        array $refused = [],
+        array $optedOut = [],
+    ): PackageDiscoveryReport {
+        return new PackageDiscoveryReport(
+            $hasInstalledJson,
+            $discoveryDisabled,
+            $declarations,
+            $discovered,
+            $refused,
+            $optedOut,
+        );
+    }
+
+    /**
+     * Defaults to this very file, which is the cheapest path that certainly
+     * exists — the check only ever asks whether it is there.
+     */
+    private function declaration(string $name, string $configFile = __FILE__): PackageConfigDeclaration
+    {
+        return new PackageConfigDeclaration($name, 'config/gacela.php', $configFile);
+    }
+
+    private function discovered(PackageConfigDeclaration $declaration): DiscoveredPackage
+    {
+        return new DiscoveredPackage(
+            $declaration->name,
+            $declaration->configFile,
+            1,
+            PackageContribution::fromArray([]),
+        );
+    }
+}

--- a/tests/Unit/Console/Application/Doctor/Check/DiscoveredPackagesCheckTest.php
+++ b/tests/Unit/Console/Application/Doctor/Check/DiscoveredPackagesCheckTest.php
@@ -19,6 +19,8 @@ final class DiscoveredPackagesCheckTest extends TestCase
 {
     private const string MISSING = '/no/such/place/config/gacela.php';
 
+    private const string ALSO_MISSING = '/no/such/other/place/config/gacela.php';
+
     public function test_it_is_named_after_what_it_reports_on(): void
     {
         self::assertSame('discovered packages', $this->check($this->report())->name());
@@ -81,6 +83,48 @@ final class DiscoveredPackagesCheckTest extends TestCase
     }
 
     /**
+     * Every broken declaration, not the first one: a package author who
+     * mistyped one path has usually mistyped the other, and a check that
+     * reported one of two would send them round the loop twice.
+     */
+    public function test_every_broken_declaration_is_reported_and_not_just_the_first(): void
+    {
+        $missing = $this->declaration('acme/audit', self::MISSING);
+        $notCallable = $this->declaration('acme/legacy');
+
+        $result = $this->check($this->report(
+            declarations: [$missing, $notCallable],
+            refused: [RefusedPackage::missingFile($missing), RefusedPackage::notCallable($notCallable)],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame([
+            'acme/audit declares ' . self::MISSING . ', which file not found',
+            'acme/legacy declares ' . __FILE__ . ', which does not return a callable',
+        ], $result->details);
+    }
+
+    /**
+     * A package whose config was merged is described as merged, whatever the
+     * disk says by the time this runs. The `is_file()` question below is only
+     * asked about declarations discovery never opened -- asking it about one it
+     * did would report a package that ran as a package this project refused,
+     * which is the opposite of what happened.
+     */
+    public function test_a_merged_package_is_never_reported_as_one_the_project_refused(): void
+    {
+        $declaration = $this->declaration('acme/audit', self::MISSING);
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            discovered: [$this->discovered($declaration)],
+        ))->run();
+
+        self::assertSame(CheckStatus::Ok, $result->status);
+        self::assertSame(['1 of 1 declared package config(s) merged'], $result->details);
+    }
+
+    /**
      * The refusal is the project getting what it asked for. Reporting it would
      * teach people to ignore this check.
      */
@@ -114,6 +158,67 @@ final class DiscoveredPackagesCheckTest extends TestCase
 
         self::assertSame(CheckStatus::Warn, $result->status);
         self::assertStringContainsString('not read: this project opted out of it', implode("\n", $result->details));
+    }
+
+    /**
+     * Two opt-outs are two answers, and the second one is not the first one's
+     * business: whoever removes either entry meets that package's broken
+     * declaration then.
+     */
+    public function test_every_opted_out_package_with_a_missing_config_is_named(): void
+    {
+        $first = $this->declaration('acme/legacy', self::MISSING);
+        $second = $this->declaration('acme/older', self::ALSO_MISSING);
+
+        $result = $this->check($this->report(
+            declarations: [$first, $second],
+            refused: [RefusedPackage::optedOut($first), RefusedPackage::optedOut($second)],
+            optedOut: ['acme/legacy', 'acme/older'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame([
+            'acme/legacy declares ' . self::MISSING . ', which file not found (not read: this project opted out of it)',
+            'acme/older declares ' . self::ALSO_MISSING . ', which file not found (not read: this project opted out of it)',
+        ], $result->details);
+    }
+
+    /**
+     * `'*'` is the one entry that names no package, so it is passed over --
+     * passed over, not treated as the end of the list. An application that
+     * refuses everything and still carries a stale name has both, and the stale
+     * name is the one worth telling it about.
+     */
+    public function test_the_wildcard_does_not_stop_the_entries_after_it_being_judged(): void
+    {
+        $result = $this->check($this->report(
+            discoveryDisabled: true,
+            declarations: [$this->declaration('acme/audit')],
+            optedOut: ['*', 'acme/never-installed'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame(
+            ['dontDiscover() names acme/never-installed, which declares no `extra.gacela.config` — the entry refuses nothing'],
+            $result->details,
+        );
+    }
+
+    public function test_an_opt_out_that_arrived_too_late_does_not_hide_the_next_one(): void
+    {
+        $declaration = $this->declaration('acme/audit');
+
+        $result = $this->check($this->report(
+            declarations: [$declaration],
+            discovered: [$this->discovered($declaration)],
+            optedOut: ['acme/audit', 'acme/never-installed'],
+        ))->run();
+
+        self::assertSame(CheckStatus::Warn, $result->status);
+        self::assertSame([
+            'dontDiscover() names acme/audit and its config was merged anyway — an environment file is read after the packages, so the opt-out arrived too late',
+            'dontDiscover() names acme/never-installed, which declares no `extra.gacela.config` — the entry refuses nothing',
+        ], $result->details);
     }
 
     public function test_dont_discover_everything_reads_nothing_and_says_so(): void

--- a/tests/Unit/Framework/Bootstrap/Package/InstalledPackagesReaderTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/InstalledPackagesReaderTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Bootstrap\Package\InstalledPackagesReader;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+use function touch;
+use function unlink;
+
+final class InstalledPackagesReaderTest extends TestCase
+{
+    /** Pinned so a fingerprint comparison is about the half the test is about. */
+    private const int FIXED_MTIME = 1_600_000_000;
+
+    private string $appRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->appRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-installed-reader-' . bin2hex(random_bytes(4));
+        mkdir($this->appRoot, 0o777, true);
+    }
+
+    /**
+     * Names every file and directory it created, in creation order reversed.
+     * Nothing here is derived from a glob or from configuration.
+     */
+    protected function tearDown(): void
+    {
+        $installedJson = $this->appRoot . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json';
+
+        foreach ([$installedJson] as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        foreach ([dirname($installedJson), dirname($installedJson, 2), $this->appRoot] as $dir) {
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
+    }
+
+    public function test_it_names_the_file_composer_writes(): void
+    {
+        $reader = new InstalledPackagesReader($this->appRoot);
+
+        self::assertSame(
+            $this->appRoot . DIRECTORY_SEPARATOR . 'vendor'
+                . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json',
+            $reader->path(),
+        );
+    }
+
+    public function test_an_absent_file_reads_as_nothing_to_read(): void
+    {
+        $reader = new InstalledPackagesReader($this->appRoot);
+
+        self::assertNull($reader->read());
+        self::assertNull($reader->fingerprint());
+    }
+
+    public function test_it_reads_the_packages_key_composer_2_writes(): void
+    {
+        $this->writeInstalledJson([
+            'packages' => [
+                ['name' => 'acme/first'],
+                ['name' => 'acme/second'],
+            ],
+            'dev' => true,
+        ]);
+
+        self::assertSame(
+            [['name' => 'acme/first'], ['name' => 'acme/second']],
+            (new InstalledPackagesReader($this->appRoot))->read(),
+        );
+    }
+
+    /**
+     * Composer 1 wrote the list at the top level. Still read, because what is on
+     * disk is whatever last wrote it.
+     */
+    public function test_it_reads_a_top_level_list(): void
+    {
+        $this->writeInstalledJson([['name' => 'acme/only']]);
+
+        self::assertSame(
+            [['name' => 'acme/only']],
+            (new InstalledPackagesReader($this->appRoot))->read(),
+        );
+    }
+
+    /**
+     * Keys are dropped, not preserved: every caller iterates, and a map with
+     * numeric-string keys is not the `list` the annotation promises.
+     */
+    public function test_it_returns_a_list_whatever_the_keys_were(): void
+    {
+        $this->writeInstalledJson(['packages' => ['7' => ['name' => 'acme/keyed']]]);
+
+        self::assertSame(
+            [['name' => 'acme/keyed']],
+            (new InstalledPackagesReader($this->appRoot))->read(),
+        );
+    }
+
+    public function test_malformed_json_reads_as_nothing_to_read(): void
+    {
+        $this->writeRaw('{not json');
+
+        self::assertNull((new InstalledPackagesReader($this->appRoot))->read());
+    }
+
+    public function test_a_packages_key_that_is_not_a_list_reads_as_nothing_to_read(): void
+    {
+        $this->writeInstalledJson(['packages' => 'acme/first']);
+
+        self::assertNull((new InstalledPackagesReader($this->appRoot))->read());
+    }
+
+    public function test_the_fingerprint_answers_for_a_file_that_exists(): void
+    {
+        $this->writeInstalledJson(['packages' => [['name' => 'acme/first']]]);
+
+        $reader = new InstalledPackagesReader($this->appRoot);
+        $fingerprint = $reader->fingerprint();
+
+        self::assertNotNull($fingerprint);
+        self::assertSame($fingerprint, $reader->fingerprint(), 'the same file fingerprints the same way twice');
+    }
+
+    /**
+     * The whole point: a reinstall has to invalidate the cache keyed on this.
+     * Both halves of the fingerprint are pinned, one per test, because a
+     * fingerprint that quietly dropped one would still answer this one.
+     */
+    public function test_a_file_of_a_different_size_fingerprints_differently(): void
+    {
+        $this->writeInstalledJson(['packages' => [['name' => 'acme/first']]]);
+        touch($this->installedJsonPath(), self::FIXED_MTIME);
+        $before = (new InstalledPackagesReader($this->appRoot))->fingerprint();
+
+        $this->writeInstalledJson(['packages' => [['name' => 'acme/first'], ['name' => 'acme/second']]]);
+        touch($this->installedJsonPath(), self::FIXED_MTIME);
+
+        self::assertNotSame($before, (new InstalledPackagesReader($this->appRoot))->fingerprint());
+    }
+
+    /**
+     * `composer install` rewriting the same set of packages leaves a file of the
+     * same size. Only the modification time says it was written again.
+     */
+    public function test_a_rewritten_file_of_the_same_size_fingerprints_differently(): void
+    {
+        $this->writeInstalledJson(['packages' => [['name' => 'acme/first']]]);
+        touch($this->installedJsonPath(), self::FIXED_MTIME);
+        $before = (new InstalledPackagesReader($this->appRoot))->fingerprint();
+
+        touch($this->installedJsonPath(), self::FIXED_MTIME + 60);
+
+        self::assertNotSame($before, (new InstalledPackagesReader($this->appRoot))->fingerprint());
+    }
+
+    /**
+     * @param array<array-key, mixed> $decoded
+     */
+    private function writeInstalledJson(array $decoded): void
+    {
+        $this->writeRaw((string)json_encode($decoded));
+    }
+
+    private function writeRaw(string $contents): void
+    {
+        $path = $this->installedJsonPath();
+        $dir = dirname($path);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function installedJsonPath(): string
+    {
+        return $this->appRoot . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'installed.json';
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/Package/PackageConfigCacheTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/PackageConfigCacheTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Bootstrap\Package\PackageConfigCache;
+use Gacela\Framework\Bootstrap\Package\PackageConfigDeclaration;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sprintf;
+use function sys_get_temp_dir;
+use function unlink;
+use function var_export;
+
+final class PackageConfigCacheTest extends TestCase
+{
+    private const string FINGERPRINT = '1600000000-4096';
+
+    private string $cacheDir = '';
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-package-cache-' . bin2hex(random_bytes(4));
+        mkdir($this->cacheDir, 0o777, true);
+    }
+
+    /**
+     * Names the one file this can create, and the one directory.
+     */
+    protected function tearDown(): void
+    {
+        $file = $this->cacheDir . DIRECTORY_SEPARATOR . PackageConfigCache::FILENAME;
+
+        if (is_file($file)) {
+            unlink($file);
+        }
+
+        if (is_dir($this->cacheDir)) {
+            rmdir($this->cacheDir);
+        }
+    }
+
+    public function test_the_file_sits_in_the_cache_directory_under_a_stable_name(): void
+    {
+        self::assertSame(
+            $this->cacheDir . DIRECTORY_SEPARATOR . 'gacela-discovered-packages.php',
+            $this->cache()->path(),
+        );
+    }
+
+    public function test_nothing_written_is_nothing_to_read(): void
+    {
+        self::assertNull($this->cache()->read(self::FINGERPRINT));
+    }
+
+    public function test_what_was_written_comes_back_in_order(): void
+    {
+        $declarations = [
+            new PackageConfigDeclaration('acme/first', 'config/gacela.php', '/vendor/acme/first/config/gacela.php'),
+            new PackageConfigDeclaration('acme/second', 'gacela.php', '/vendor/acme/second/gacela.php'),
+        ];
+
+        $this->cache()->write(self::FINGERPRINT, $declarations);
+
+        self::assertEquals($declarations, $this->cache()->read(self::FINGERPRINT));
+    }
+
+    /**
+     * The whole point of the key: a `composer install` moves the fingerprint and
+     * the previous answer stops being an answer.
+     */
+    public function test_an_entry_written_for_another_fingerprint_is_not_read(): void
+    {
+        $this->cache()->write(self::FINGERPRINT, [
+            new PackageConfigDeclaration('acme/first', 'config/gacela.php', '/vendor/acme/first/config/gacela.php'),
+        ]);
+
+        self::assertNull($this->cache()->read('1600000001-4096'));
+    }
+
+    public function test_an_empty_list_is_an_answer_and_not_a_miss(): void
+    {
+        $this->cache()->write(self::FINGERPRINT, []);
+
+        self::assertSame([], $this->cache()->read(self::FINGERPRINT));
+    }
+
+    /**
+     * @param mixed $payload what the cache file returns
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('unusablePayloads')]
+    public function test_an_unusable_entry_is_discarded_rather_than_repaired(mixed $payload): void
+    {
+        $this->writeRaw($payload);
+
+        self::assertNull($this->cache()->read(self::FINGERPRINT));
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function unusablePayloads(): iterable
+    {
+        yield 'not an array' => ['nope'];
+        yield 'no fingerprint' => [['packages' => []]];
+        yield 'fingerprint is not a string' => [['fingerprint' => 1_600_000_000, 'packages' => []]];
+        yield 'no packages' => [['fingerprint' => self::FINGERPRINT]];
+        yield 'packages is not an array' => [['fingerprint' => self::FINGERPRINT, 'packages' => 'acme/first']];
+        yield 'a row is not an array' => [['fingerprint' => self::FINGERPRINT, 'packages' => ['acme/first']]];
+        yield 'a row is missing a field' => [['fingerprint' => self::FINGERPRINT, 'packages' => [['name' => 'acme/first']]]];
+    }
+
+    /**
+     * One unreadable row makes the whole entry untrustworthy: booting with some
+     * of an application's packages is worse than reading the manifest again.
+     */
+    public function test_one_unreadable_row_discards_the_whole_entry(): void
+    {
+        $this->writeRaw([
+            'fingerprint' => self::FINGERPRINT,
+            'packages' => [
+                ['name' => 'acme/first', 'declaredPath' => 'config/gacela.php', 'configFile' => '/vendor/acme/first/config/gacela.php'],
+                ['name' => 'acme/second'],
+            ],
+        ]);
+
+        self::assertNull($this->cache()->read(self::FINGERPRINT));
+    }
+
+    private function cache(): PackageConfigCache
+    {
+        return new PackageConfigCache($this->cacheDir);
+    }
+
+    private function writeRaw(mixed $payload): void
+    {
+        file_put_contents(
+            $this->cacheDir . DIRECTORY_SEPARATOR . PackageConfigCache::FILENAME,
+            sprintf('<?php return %s;', var_export($payload, true)),
+        );
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/Package/PackageConfigDeclarationTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/PackageConfigDeclarationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Bootstrap\Package\PackageConfigDeclaration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The shape the resolved declaration list is remembered in.
+ *
+ * `fromArray()` reads a row back out of the cache file, which is a file on disk
+ * that nothing stops anyone from editing -- so every field is checked, and a row
+ * that is not three strings is not a declaration.
+ */
+final class PackageConfigDeclarationTest extends TestCase
+{
+    public function test_a_declaration_survives_the_round_trip_through_an_array(): void
+    {
+        $declaration = new PackageConfigDeclaration(
+            'acme/audit',
+            'config/gacela.php',
+            '/app/vendor/acme/audit/config/gacela.php',
+        );
+
+        self::assertEquals($declaration, PackageConfigDeclaration::fromArray($declaration->toArray()));
+    }
+
+    public function test_the_declared_path_and_the_resolved_one_are_both_kept(): void
+    {
+        $declaration = PackageConfigDeclaration::fromArray([
+            'name' => 'acme/audit',
+            'declaredPath' => './config/gacela.php',
+            'configFile' => '/app/vendor/acme/audit/config/gacela.php',
+        ]);
+
+        self::assertInstanceOf(PackageConfigDeclaration::class, $declaration);
+        self::assertSame('acme/audit', $declaration->name);
+        self::assertSame('./config/gacela.php', $declaration->declaredPath);
+        self::assertSame('/app/vendor/acme/audit/config/gacela.php', $declaration->configFile);
+    }
+
+    /**
+     * One field at a time, because each of the three is checked for itself: a
+     * row carrying a usable name and a usable path is still not a declaration
+     * when the third field is not a string, and the answer must be null rather
+     * than a half-built declaration.
+     *
+     * @param array<array-key, mixed> $row
+     */
+    #[DataProvider('unusableRows')]
+    public function test_a_row_that_is_not_three_strings_is_not_a_declaration(array $row): void
+    {
+        self::assertNull(PackageConfigDeclaration::fromArray($row));
+    }
+
+    /**
+     * @return iterable<string, array{array<array-key, mixed>}>
+     */
+    public static function unusableRows(): iterable
+    {
+        yield 'the name is not a string' => [[
+            'name' => 42,
+            'declaredPath' => 'config/gacela.php',
+            'configFile' => '/app/vendor/acme/audit/config/gacela.php',
+        ]];
+
+        yield 'the declared path is not a string' => [[
+            'name' => 'acme/audit',
+            'declaredPath' => ['config/gacela.php'],
+            'configFile' => '/app/vendor/acme/audit/config/gacela.php',
+        ]];
+
+        yield 'the resolved file is not a string' => [[
+            'name' => 'acme/audit',
+            'declaredPath' => 'config/gacela.php',
+            'configFile' => null,
+        ]];
+
+        yield 'nothing at all' => [[]];
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/Package/PackageConfigFinderTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/PackageConfigFinderTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Bootstrap\Package\InstalledPackagesReader;
+use Gacela\Framework\Bootstrap\Package\PackageConfigDeclaration;
+use Gacela\Framework\Bootstrap\Package\PackageConfigFinder;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function bin2hex;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function str_replace;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class PackageConfigFinderTest extends TestCase
+{
+    private string $appRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->appRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gacela-config-finder-' . bin2hex(random_bytes(4));
+        mkdir($this->appRoot, 0o777, true);
+    }
+
+    /**
+     * Names every path it created, in reverse.
+     */
+    protected function tearDown(): void
+    {
+        $installedJson = $this->installedJsonPath();
+
+        if (is_file($installedJson)) {
+            unlink($installedJson);
+        }
+
+        foreach ([dirname($installedJson), dirname($installedJson, 2), $this->appRoot] as $dir) {
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
+    }
+
+    public function test_without_installed_json_there_is_nothing_to_find(): void
+    {
+        self::assertSame([], $this->find());
+    }
+
+    public function test_only_packages_carrying_the_key_are_considered(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/plain'],
+            ['name' => 'acme/other-extra', 'extra' => ['laravel' => ['providers' => []]]],
+            ['name' => 'acme/gacela-but-empty', 'extra' => ['gacela' => []]],
+            ['name' => 'acme/audit', 'extra' => ['gacela' => ['config' => 'config/gacela.php']]],
+        ]);
+
+        self::assertSame(['acme/audit'], $this->names());
+    }
+
+    public function test_declarations_keep_composers_installed_order(): void
+    {
+        $this->writeInstalled([
+            $this->entry('acme/first'),
+            $this->entry('acme/second'),
+            $this->entry('acme/third'),
+        ]);
+
+        self::assertSame(['acme/first', 'acme/second', 'acme/third'], $this->names());
+    }
+
+    /**
+     * Composer writes `install-path` relative to `vendor/composer`, and it is
+     * `..`-heavy for anything installed outside the vendor tree.
+     */
+    public function test_a_relative_install_path_resolves_against_vendor_composer(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'install-path' => '../acme/audit', 'extra' => ['gacela' => ['config' => 'config/gacela.php']]],
+        ]);
+
+        self::assertSame(
+            $this->path($this->appRoot, 'vendor', 'acme', 'audit', 'config', 'gacela.php'),
+            $this->find()[0]->configFile,
+        );
+    }
+
+    public function test_a_relative_install_path_may_climb_out_of_the_vendor_tree(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'install-path' => '../../../packages/audit', 'extra' => ['gacela' => ['config' => 'config/gacela.php']]],
+        ]);
+
+        self::assertSame(
+            $this->path(dirname($this->appRoot), 'packages', 'audit', 'config', 'gacela.php'),
+            $this->find()[0]->configFile,
+        );
+    }
+
+    public function test_an_absolute_install_path_is_taken_as_it_is(): void
+    {
+        $absolute = $this->path($this->appRoot, 'elsewhere', 'audit');
+
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'install-path' => $absolute, 'extra' => ['gacela' => ['config' => 'config/gacela.php']]],
+        ]);
+
+        self::assertSame($absolute . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'gacela.php', $this->find()[0]->configFile);
+    }
+
+    /**
+     * Composer 1 recorded no install path, and a package installed where its
+     * name says it is needs none.
+     */
+    public function test_without_an_install_path_the_package_name_says_where_it_is(): void
+    {
+        $this->writeInstalled([$this->entry('acme/audit')]);
+
+        self::assertSame(
+            $this->path($this->appRoot, 'vendor', 'acme', 'audit', 'config', 'gacela.php'),
+            $this->find()[0]->configFile,
+        );
+    }
+
+    public function test_the_declared_path_is_kept_as_the_package_wrote_it(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'extra' => ['gacela' => ['config' => './config/gacela.php']]],
+        ]);
+
+        $declaration = $this->find()[0];
+
+        self::assertSame('./config/gacela.php', $declaration->declaredPath);
+        self::assertSame(
+            $this->path($this->appRoot, 'vendor', 'acme', 'audit', 'config', 'gacela.php'),
+            $declaration->configFile,
+            'the resolved path drops the `.` segment the declaration kept',
+        );
+    }
+
+    /**
+     * A manifest is data nobody here owns, so every shape that is not the one
+     * expected has to be survivable rather than fatal.
+     *
+     * @param array<array-key, mixed> $entry
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('unusableEntries')]
+    public function test_an_unusable_entry_is_skipped(array $entry): void
+    {
+        $this->writeInstalled([$entry, $this->entry('acme/usable')]);
+
+        self::assertSame(['acme/usable'], $this->names());
+    }
+
+    /**
+     * @return iterable<string, array{array<array-key, mixed>}>
+     */
+    public static function unusableEntries(): iterable
+    {
+        yield 'no name' => [['extra' => ['gacela' => ['config' => 'config/gacela.php']]]];
+        yield 'empty name' => [['name' => '', 'extra' => ['gacela' => ['config' => 'config/gacela.php']]]];
+        yield 'name is not a string' => [['name' => 42, 'extra' => ['gacela' => ['config' => 'config/gacela.php']]]];
+        yield 'extra is not an array' => [['name' => 'acme/x', 'extra' => 'gacela']];
+        yield 'gacela is not an array' => [['name' => 'acme/x', 'extra' => ['gacela' => 'config/gacela.php']]];
+        yield 'config is not a string' => [['name' => 'acme/x', 'extra' => ['gacela' => ['config' => ['a']]]]];
+        yield 'config is empty' => [['name' => 'acme/x', 'extra' => ['gacela' => ['config' => '']]]];
+        yield 'not an object at all' => [['acme/x']];
+    }
+
+    public function test_an_entry_that_is_not_an_array_is_skipped(): void
+    {
+        $this->writeRaw((string) json_encode(['packages' => ['acme/audit', $this->entry('acme/usable')]]));
+
+        self::assertSame(['acme/usable'], $this->names());
+    }
+
+    /**
+     * @return list<PackageConfigDeclaration>
+     */
+    private function find(): array
+    {
+        return (new PackageConfigFinder(new InstalledPackagesReader($this->appRoot)))->find();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function names(): array
+    {
+        return array_map(
+            static fn (PackageConfigDeclaration $declaration): string => $declaration->name,
+            $this->find(),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function entry(string $name): array
+    {
+        return ['name' => $name, 'extra' => ['gacela' => ['config' => 'config/gacela.php']]];
+    }
+
+    /**
+     * @param list<mixed> $packages
+     */
+    private function writeInstalled(array $packages): void
+    {
+        $this->writeRaw((string) json_encode(['packages' => $packages]));
+    }
+
+    private function writeRaw(string $contents): void
+    {
+        $path = $this->installedJsonPath();
+        $dir = dirname($path);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function installedJsonPath(): string
+    {
+        return $this->path($this->appRoot, 'vendor', 'composer', 'installed.json');
+    }
+
+    private function path(string ...$segments): string
+    {
+        return str_replace('/', DIRECTORY_SEPARATOR, implode('/', $segments));
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/Package/PackageConfigFinderTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/PackageConfigFinderTest.php
@@ -119,6 +119,58 @@ final class PackageConfigFinderTest extends TestCase
     }
 
     /**
+     * A windows drive is a root of its own, and the separators a manifest was
+     * written with are folded to the local ones.
+     *
+     * Asserted on every platform rather than only on the windows matrix: what
+     * the drive letter does to the resolution is decided by this class, not by
+     * the filesystem it happens to be running on.
+     */
+    public function test_a_windows_drive_install_path_is_a_root_of_its_own(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'install-path' => 'C:\\packages\\audit', 'extra' => ['gacela' => ['config' => 'config/gacela.php']]],
+        ]);
+
+        self::assertSame(
+            $this->path('C:', 'packages', 'audit', 'config', 'gacela.php'),
+            $this->find()[0]->configFile,
+        );
+    }
+
+    /**
+     * A declaration climbing above the drive keeps the drive, the way one
+     * climbing above a unix root keeps the root: what is left is a path
+     * pointing outside the package, which is what the package declared and what
+     * `doctor` has to be able to quote back.
+     */
+    public function test_a_declaration_that_climbs_above_a_windows_drive_keeps_the_drive(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'install-path' => 'C:\\packages\\audit', 'extra' => ['gacela' => ['config' => '../../../../gacela.php']]],
+        ]);
+
+        self::assertSame($this->path('C:', '..', '..', 'gacela.php'), $this->find()[0]->configFile);
+    }
+
+    /**
+     * Only a *leading* drive letter is a root. A directory called `c:` further
+     * along is a directory, and taking the path for an absolute one would drop
+     * the whole vendor directory in front of it.
+     */
+    public function test_a_drive_letter_inside_a_relative_install_path_is_not_a_root(): void
+    {
+        $this->writeInstalled([
+            ['name' => 'acme/audit', 'install-path' => 'sub/c:/pkg', 'extra' => ['gacela' => ['config' => 'config/gacela.php']]],
+        ]);
+
+        self::assertSame(
+            $this->path($this->appRoot, 'vendor', 'composer', 'sub', 'c:', 'pkg', 'config', 'gacela.php'),
+            $this->find()[0]->configFile,
+        );
+    }
+
+    /**
      * Composer 1 recorded no install path, and a package installed where its
      * name says it is needs none.
      */

--- a/tests/Unit/Framework/Bootstrap/Package/PackageContributionTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/PackageContributionTest.php
@@ -72,6 +72,36 @@ final class PackageContributionTest extends TestCase
     }
 
     /**
+     * A kind a package declared, with every suffix it declared for it -- and
+     * not the four kinds every assembled configuration carries, which no
+     * package added.
+     */
+    public function test_a_resolvable_kind_is_named_with_every_suffix_the_package_added(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addResolvableType('Beacon', null, ['Beacon', 'Signal']);
+        });
+
+        self::assertSame([
+            'resolvable kinds' => ['Beacon => Beacon', 'Beacon => Signal'],
+        ], $contribution->items());
+    }
+
+    /**
+     * PHP turns a numeric-string array key into an integer, so a map declared
+     * `array<string, ...>` can hand this an integer key anyway -- and a label is
+     * a string whatever the key turned out to be.
+     */
+    public function test_a_key_php_turned_into_an_integer_is_still_reported_as_a_label(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('42', 'answered');
+        });
+
+        self::assertSame(['config keys' => ['42']], $contribution->items());
+    }
+
+    /**
      * A plugin is a class-string or a closure, and a closure has no name.
      */
     public function test_a_closure_plugin_is_labelled_rather_than_named(): void

--- a/tests/Unit/Framework/Bootstrap/Package/PackageContributionTest.php
+++ b/tests/Unit/Framework/Bootstrap/Package/PackageContributionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit\Framework\Bootstrap\Package;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Bootstrap\Package\PackageContribution;
+use Gacela\Framework\Bootstrap\SetupGacela;
+use Gacela\Framework\Config\GacelaFileConfig\Factory\GacelaConfigFileAssembler;
+use Gacela\Framework\Event\Bootstrap\GacelaBootstrapFinishedEvent;
+use GacelaTest\Fixtures\StringValue;
+use GacelaTest\Fixtures\StringValueInterface;
+use PHPUnit\Framework\TestCase;
+
+use function array_keys;
+
+/**
+ * What `debug:container` prints under a package's name.
+ */
+final class PackageContributionTest extends TestCase
+{
+    public function test_a_config_that_declares_nothing_says_so(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+        });
+
+        self::assertTrue($contribution->isEmpty());
+        self::assertSame([], $contribution->items());
+        self::assertSame('nothing', $contribution->summary());
+    }
+
+    public function test_a_binding_is_named_by_the_id_it_answers(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addBinding(StringValueInterface::class, StringValue::class);
+        });
+
+        self::assertFalse($contribution->isEmpty());
+        self::assertSame(['bindings' => [StringValueInterface::class]], $contribution->items());
+    }
+
+    /**
+     * One entry per member, not per contract: the contract is the extension
+     * point, and what a reader is looking for is what was added to it.
+     */
+    public function test_every_plugin_stack_member_is_named_with_its_contract(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addPluginStack(StringValueInterface::class, [StringValue::class, StringValue::class]);
+        });
+
+        self::assertSame([
+            'plugin stacks' => [
+                StringValueInterface::class . ' => ' . StringValue::class,
+                StringValueInterface::class . ' => ' . StringValue::class,
+            ],
+        ], $contribution->items());
+    }
+
+    public function test_listeners_are_counted_per_event_and_the_generic_ones_together(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->registerSpecificListener(GacelaBootstrapFinishedEvent::class, static fn (): null => null);
+            $config->registerSpecificListener(GacelaBootstrapFinishedEvent::class, static fn (): null => null);
+            $config->registerGenericListener(static fn (): null => null);
+        });
+
+        self::assertSame([
+            'listeners' => [GacelaBootstrapFinishedEvent::class . ' (2)', 'every event (1)'],
+        ], $contribution->items());
+    }
+
+    /**
+     * A plugin is a class-string or a closure, and a closure has no name.
+     */
+    public function test_a_closure_plugin_is_labelled_rather_than_named(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addPlugin(static fn (): null => null);
+        });
+
+        self::assertSame(['plugins' => ['closure']], $contribution->items());
+    }
+
+    public function test_the_summary_counts_each_kind(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addBinding(StringValueInterface::class, StringValue::class);
+            $config->addAppConfigKeyValue('audit.enabled', true);
+            $config->addAppConfigKeyValue('audit.level', 'debug');
+        });
+
+        self::assertSame(['bindings', 'config keys'], array_keys($contribution->items()));
+        self::assertSame('1 bindings, 2 config keys', $contribution->summary());
+    }
+
+    /**
+     * A config path resolves against the *application* root, which a package
+     * cannot know anything about, so it is deliberately not one of the kinds.
+     */
+    public function test_an_app_config_path_is_not_reported_as_a_contribution(): void
+    {
+        $contribution = $this->contributionOf(static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        });
+
+        self::assertTrue($contribution->isEmpty());
+    }
+
+    /**
+     * @param callable(GacelaConfig):void $configFn
+     */
+    private function contributionOf(callable $configFn): PackageContribution
+    {
+        $setup = SetupGacela::fromCallable($configFn);
+
+        return PackageContribution::of($setup, GacelaConfigFileAssembler::assemble($setup));
+    }
+}

--- a/tests/Unit/Framework/Bootstrap/Setup/PropertyMergerTest.php
+++ b/tests/Unit/Framework/Bootstrap/Setup/PropertyMergerTest.php
@@ -42,6 +42,26 @@ final class PropertyMergerTest extends TestCase
         );
     }
 
+    /**
+     * Accumulated, deduplicated, and still a list.
+     *
+     * Two sources refusing the same package are agreeing rather than refusing it
+     * twice, and what comes out is read back by `doctor` and `debug:container`:
+     * a repeated name reads there as a mistake, and the holes `array_unique()`
+     * leaves in the keys are not the list the callers are handed.
+     */
+    public function test_merge_dont_discover_accumulates_without_repeating_a_name(): void
+    {
+        $setup = SetupGacela::fromGacelaConfig(
+            (new GacelaConfig())->dontDiscover(['acme/legacy', 'acme/older']),
+        );
+
+        $merger = new PropertyMerger($setup);
+        $merger->mergeDontDiscover(['acme/legacy', 'acme/newer']);
+
+        self::assertSame(['acme/legacy', 'acme/older', 'acme/newer'], $setup->getDontDiscover());
+    }
+
     public function test_merge_gacela_configs_to_extend_keeps_existing_when_empty_list_passed(): void
     {
         $setup = SetupGacela::fromGacelaConfig(

--- a/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
+++ b/tests/Unit/Framework/Bootstrap/Setup/SetupMergerTest.php
@@ -368,6 +368,40 @@ final class SetupMergerTest extends TestCase
         self::assertSame(['src/Billing'], $setup1->merge($setup2)->getAppModulePaths());
     }
 
+    /**
+     * The opposite of the app module paths above: `dontDiscover()` accumulates.
+     *
+     * A bootstrap closure and a `gacela.php` that each refuse a package are
+     * refusing both, and the one that ran second is not overruling the other --
+     * a refusal is not a list of everything to refuse, it is one decision. A
+     * name both of them wrote appears once.
+     */
+    public function test_dont_discover_accumulates_across_two_setups(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['acme/legacy']);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['acme/legacy', 'acme/older']);
+        });
+
+        self::assertSame(['acme/legacy', 'acme/older'], $setup1->merge($setup2)->getDontDiscover());
+    }
+
+    public function test_a_setup_that_refuses_nothing_does_not_drop_the_refusals_already_made(): void
+    {
+        $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->dontDiscover(['acme/legacy']);
+        });
+
+        $setup2 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('unrelated', true);
+        });
+
+        self::assertSame(['acme/legacy'], $setup1->merge($setup2)->getDontDiscover());
+    }
+
     public function test_merge_handler_registries_from_two_setups(): void
     {
         $setup1 = SetupGacela::fromCallable(static function (GacelaConfig $config): void {


### PR DESCRIPTION
## 📚 Description

A Composer package could not contribute to a Gacela application by being installed. Laravel packages register providers through `extra.laravel.providers`, Symfony applies a Flex recipe, a Spryker module ships its own dependency provider — in Gacela the only configuration read was the project's own `gacela.php`, so every listener, plugin member, `#[Provides]` provider, suffix type, DTO schema or doctor check a package wanted to add had to be pasted into each consuming project by hand and kept in sync by hand.

```json
{
    "extra": { "gacela": { "config": "config/gacela.php" } }
}
```

The file returns the same `callable(GacelaConfig)` a project's `gacela.php` returns — no second config format. Package configs merge **before** the project's, so the project always has the last word.

Closes #879

## 🔖 Changes

- **Discovery** — `vendor/composer/installed.json` is read once and the resolved declaration list is cached in the cache directory, fingerprinted by that file's mtime and size. Only packages declaring the key are considered; `vendor/` is never scanned for config files, a cost this repo has measured and rejected before. The `installed.json` reader is shared with `PackageManifestCheck` rather than written twice
- **`dontDiscover(['vendor/pkg'])`** opts a package out; `dontDiscover(['*'])` refuses everything and is checked *before* the disk is touched. Opt-outs accumulate across the bootstrap closure and `gacela.php`
- **A broken declaration never stops the boot.** A config file a package did not ship, or one that does not return a callable, is recorded and skipped — `composer require` must not be able to break an application. The new `discovered packages` doctor check is where it is reported
- **Observability**, because a feature that runs arbitrary code at bootstrap has to be inspectable: a `PackageConfigMergedEvent` per package in merge order, `debug:container` attributing what each package put in the container, and the doctor check above
- **Merge order** is Composer's installed order, then the project. Between two packages the later-installed wins — documented, along with the warning that installed order is Composer's and not something a project controls, so a package that *needs* to win should not rely on it
- Docs: [shipping a Gacela package](docs/packages.md), including the plain statement that a discovered config runs arbitrary code at bootstrap exactly as a Laravel provider does, and that `dontDiscover` is the control

### Demonstration

Fixture packages under `tests/Feature/Framework/PackageDiscovery/Packages/` — a working one, one naming a file it did not ship, one whose config returns no callable — plus two in the reference application. Eleven feature tests cover: a package contributing **without the project naming it**, the project overriding a binding the package set, `dontDiscover` from the closure and from `gacela.php` and both accumulating, `dontDiscover(['*'])`, both broken declarations booting anyway, the merge order observed from the project's own listener, the cache being written, and no `installed.json` discovering nothing quietly.

Verified non-vacuous: against `main`'s `src/` the suite errors with `Call to undefined method GacelaConfig::dontDiscover()`.

### Cost

`BootstrapBench` (gate group, ±10%), interleaved with `main` on one machine, a warmup run discarded each side because the first run after a checkout reads cold:

| round | main cold | branch cold | main warm | branch warm |
|---|---|---|---|---|
| 1 | 42.334μs | 44.464μs | 28.351μs | 30.122μs |
| 2 | 42.620μs | 43.838μs | 28.335μs | 30.159μs |
| 3 | 43.074μs | 44.091μs | 28.489μs | 29.882μs |

**+3.4% cold, +5.9% warm** — inside the gate, and consistent rather than noise, so reporting it as real. Confirmed independently by timing 200 bootstraps directly: ~32.6μs against ~34.6μs. The ~2μs is one read of the cached declaration list per bootstrap; a project with no `installed.json` under its root pays a single `is_file()`. It is a once-per-process cost on a 30μs operation, which I judged the right trade for the feature — but it does spend half the gate's headroom, so it is worth knowing before the next change to this path.
